### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Kagent has 4 core components:
   ```
 3. Port-forward the UI: 
   ```bash
-  kubectl port-forward svc/kagent-ui 8080:80
+  kubectl port-forward svc/kagent 8080:80
   ```
 Then open [http://localhost:8080](http://localhost:8080) in your browser.
 


### PR DESCRIPTION
Randomly launched this on my cluster ,   the kagent-ui k8s service name  does not get created  for me ,   but  port-forward svc/kagent 8080:80 works. 

I can access the UI,   used the agent etc. 