### PR TITLE
fix product_name for the dbs which dont match whats in the db themselves

### DIFF
--- a/python/.gitignore
+++ b/python/.gitignore
@@ -169,3 +169,5 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+.DS_Store

--- a/python/src/kagent/tools/docs/query_documentation.py
+++ b/python/src/kagent/tools/docs/query_documentation.py
@@ -19,8 +19,8 @@ DEFAULT_DB_URL = "https://doc-sqlite-db.s3.sa-east-1.amazonaws.com"
 PRODUCT_DB_MAP = {
     "kubernetes": "kubernetes.db",
     "istio": "istio.db",
-    "argo cd": "argo.db",
-    "argo rollouts": "argo-rollouts.db",
+    "argo": "argo.db",
+    "argo-rollouts": "argo-rollouts.db",
     "helm": "helm.db",
     "prometheus": "prometheus.db",
     "gateway-api": "gateway-api.db",
@@ -28,7 +28,7 @@ PRODUCT_DB_MAP = {
     "gloo-edge": "gloo-edge.db",
     "otel": "otel.db",
     "cilium": "cilium.db",
-    "istio ambient mesh": "ambient.db",
+    "ambient": "ambient.db",
 }
 
 


### PR DESCRIPTION
Fix the incorrect "product_name" in the dbs themselves. When we do a QueryTool query, we filter by product_name and the names don't line up without this PR. 