### PR TITLE
update the cluster role for kagent.dev group and specific kagent resources

### DIFF
--- a/helm/templates/clusterrole.yaml
+++ b/helm/templates/clusterrole.yaml
@@ -84,8 +84,12 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  - kagent.dev
   resources:
   - "*"
+  - agents
+  - modelconfigs
+  - teams
   verbs:
   - create
   - update


### PR DESCRIPTION
Agent creation was failing with:

```
 failed to create the team       {"team": "agents.kagent.dev is forbidden: User \"system:serviceaccount:kagent:kagent\" cannot create resource \"agents\" in API group \"kagent.dev\" in the namespace \"kagent\""}
 ```
 
 this fix adds the necessary permissions.