### PR TITLE
feat(controller) read DefaultResourceNamespace from the env variable

### DIFF
--- a/go/controller/internal/httpserver/handlers/modelconfig.go
+++ b/go/controller/internal/httpserver/handlers/modelconfig.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kagent-dev/kagent/go/controller/api/v1alpha1"
 	"github.com/kagent-dev/kagent/go/controller/internal/httpserver/errors"
+	common "github.com/kagent-dev/kagent/go/controller/internal/utils"
 	"k8s.io/apimachinery/pkg/types"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -57,7 +58,7 @@ func (h *ModelConfigHandler) HandleGetModelConfig(w ErrorResponseWriter, r *http
 	modelConfig := &v1alpha1.ModelConfig{}
 	if err := h.KubeClient.Get(r.Context(), types.NamespacedName{
 		Name:      configName,
-		Namespace: DefaultResourceNamespace,
+		Namespace: common.GetResourceNamespace(),
 	}, modelConfig); err != nil {
 		w.RespondWithError(errors.NewInternalServerError("Failed to get model config", err))
 		return

--- a/go/controller/internal/httpserver/handlers/teams.go
+++ b/go/controller/internal/httpserver/handlers/teams.go
@@ -9,14 +9,12 @@ import (
 	"github.com/kagent-dev/kagent/go/controller/internal/autogen"
 	"github.com/kagent-dev/kagent/go/controller/internal/client_wrapper"
 	"github.com/kagent-dev/kagent/go/controller/internal/httpserver/errors"
+	common "github.com/kagent-dev/kagent/go/controller/internal/utils"
 	"k8s.io/apimachinery/pkg/types"
 
 	autogen_client "github.com/kagent-dev/kagent/go/autogen/client"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 )
-
-// DefaultResourceNamespace is the default namespace for resources
-const DefaultResourceNamespace = "kagent"
 
 // TeamsHandler handles team-related requests
 type TeamsHandler struct {
@@ -67,7 +65,7 @@ func (h *TeamsHandler) HandleListTeams(w ErrorResponseWriter, r *http.Request) {
 		modelConfig := &v1alpha1.ModelConfig{}
 		if err := h.KubeClient.Get(r.Context(), types.NamespacedName{
 			Name:      team.Spec.ModelConfigRef,
-			Namespace: DefaultResourceNamespace,
+			Namespace: common.GetResourceNamespace(),
 		}, modelConfig); err != nil {
 			log.Error(err, "Failed to get model config", "modelConfigRef", team.Spec.ModelConfigRef)
 			continue
@@ -105,7 +103,7 @@ func (h *TeamsHandler) HandleUpdateTeam(w ErrorResponseWriter, r *http.Request) 
 	existingTeam := &v1alpha1.Agent{}
 	if err := h.KubeClient.Get(r.Context(), types.NamespacedName{
 		Name:      teamRequest.Name,
-		Namespace: DefaultResourceNamespace,
+		Namespace: common.GetResourceNamespace(),
 	}, existingTeam); err != nil {
 		w.RespondWithError(errors.NewInternalServerError("Failed to get team", err))
 		return
@@ -136,7 +134,7 @@ func (h *TeamsHandler) HandleCreateTeam(w ErrorResponseWriter, r *http.Request) 
 	log = log.WithValues("teamName", teamRequest.Name)
 
 	// Default to kagent namespace
-	teamRequest.Namespace = DefaultResourceNamespace
+	teamRequest.Namespace = common.GetResourceNamespace()
 
 	kubeClientWrapper := client_wrapper.NewKubeClientWrapper(h.KubeClient)
 	kubeClientWrapper.AddInMemory(teamRequest)
@@ -233,7 +231,7 @@ func (h *TeamsHandler) HandleGetTeam(w ErrorResponseWriter, r *http.Request) {
 	team := &v1alpha1.Agent{}
 	if err := h.KubeClient.Get(r.Context(), types.NamespacedName{
 		Name:      teamLabel,
-		Namespace: DefaultResourceNamespace,
+		Namespace: common.GetResourceNamespace(),
 	}, team); err != nil {
 		w.RespondWithError(errors.NewNotFoundError("Team not found in Kubernetes", err))
 		return
@@ -244,7 +242,7 @@ func (h *TeamsHandler) HandleGetTeam(w ErrorResponseWriter, r *http.Request) {
 	modelConfig := &v1alpha1.ModelConfig{}
 	if err := h.KubeClient.Get(r.Context(), types.NamespacedName{
 		Name:      team.Spec.ModelConfigRef,
-		Namespace: DefaultResourceNamespace,
+		Namespace: common.GetResourceNamespace(),
 	}, modelConfig); err != nil {
 		w.RespondWithError(errors.NewInternalServerError("Failed to get model config", err))
 		return
@@ -278,7 +276,7 @@ func (h *TeamsHandler) HandleDeleteTeam(w ErrorResponseWriter, r *http.Request) 
 	team := &v1alpha1.Agent{}
 	if err := h.KubeClient.Get(r.Context(), types.NamespacedName{
 		Name:      teamLabel,
-		Namespace: DefaultResourceNamespace,
+		Namespace: common.GetResourceNamespace(),
 	}, team); err != nil {
 		w.RespondWithError(errors.NewNotFoundError("Team not found in Kubernetes", err))
 		return

--- a/go/controller/internal/httpserver/handlers/toolservers.go
+++ b/go/controller/internal/httpserver/handlers/toolservers.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kagent-dev/kagent/go/controller/api/v1alpha1"
 	"github.com/kagent-dev/kagent/go/controller/internal/httpserver/errors"
+	common "github.com/kagent-dev/kagent/go/controller/internal/utils"
 	"k8s.io/apimachinery/pkg/types"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -55,7 +56,7 @@ func (h *ToolServersHandler) HandleCreateToolServer(w ErrorResponseWriter, r *ht
 	}
 
 	log = log.WithValues("toolServerName", toolServerRequest.Name)
-	toolServerRequest.Namespace = DefaultResourceNamespace
+	toolServerRequest.Namespace = common.GetResourceNamespace()
 
 	if err := h.KubeClient.Create(r.Context(), toolServerRequest); err != nil {
 		w.RespondWithError(errors.NewInternalServerError("Failed to create tool server in Kubernetes", err))
@@ -80,7 +81,7 @@ func (h *ToolServersHandler) HandleDeleteToolServer(w ErrorResponseWriter, r *ht
 	toolServer := &v1alpha1.ToolServer{}
 	if err := h.KubeClient.Get(r.Context(), types.NamespacedName{
 		Name:      toolServerName,
-		Namespace: DefaultResourceNamespace,
+		Namespace: common.GetResourceNamespace(),
 	}, toolServer); err != nil {
 		w.RespondWithError(errors.NewNotFoundError("Tool server not found in Kubernetes", err))
 		return

--- a/go/controller/internal/httpserver/server.go
+++ b/go/controller/internal/httpserver/server.go
@@ -8,15 +8,13 @@ import (
 	"github.com/gorilla/mux"
 	autogen_client "github.com/kagent-dev/kagent/go/autogen/client"
 	"github.com/kagent-dev/kagent/go/controller/internal/httpserver/handlers"
+	common "github.com/kagent-dev/kagent/go/controller/internal/utils"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
-	// Default namespace for resources
-	DefaultResourceNamespace = "kagent"
-
 	// API Path constants
 	APIPathHealth      = "/health"
 	APIPathModelConfig = "/api/modelconfigs"
@@ -30,7 +28,7 @@ const (
 
 var defaultModelConfig = types.NamespacedName{
 	Name:      "default-model-config",
-	Namespace: DefaultResourceNamespace,
+	Namespace: common.GetResourceNamespace(),
 }
 
 // ServerConfig holds the configuration for the HTTP server

--- a/go/controller/internal/utils/common.go
+++ b/go/controller/internal/utils/common.go
@@ -1,0 +1,10 @@
+package common
+
+import "os"
+
+func GetResourceNamespace() string {
+	if val := os.Getenv("KAGENT_NAMESPACE"); val != "" {
+		return val
+	}
+	return "kagent"
+}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -58,6 +58,10 @@ spec:
               value: {{ .Values.otel.tracing.exporter.otlp.timeout | quote }}
             - name: OTEL_EXPORTER_OTLP_TRACES_INSECURE
               value: {{ .Values.otel.tracing.exporter.otlp.insecure | quote }}
+            - name: KAGENT_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           ports:
             - name: http
               containerPort: {{ .Values.service.ports.app.targetPort }}


### PR DESCRIPTION
Fixes #191
- Reads the resource namespace from environment variable and removes hardcoded value from code.
- Update the helm deployment controller container to inject namespace as environment variable