### PR TITLE
Added a new `bug-report` command to the kagent CLI to help gather debug information.

### DIFF
--- a/go/cli/cmd/kagent/main.go
+++ b/go/cli/cmd/kagent/main.go
@@ -212,6 +212,32 @@ Examples:
 
 	shell.AddCmd(getCmd)
 
+	bugReportCmd := &ishell.Cmd{
+		Name:    "bug-report",
+		Aliases: []string{"br"},
+		Help:    "Generate a bug report with system information",
+		LongHelp: `Generate a bug report containing:
+- Agent, ModelConfig, and ToolServers YAMLs
+- Secret names (without values)
+- Pod logs
+- Versions and images used
+
+The report will be saved in a new directory with timestamp.
+
+Example:
+  bug-report
+`,
+		Func: func(c *ishell.Context) {
+			if err := checkServerConnection(client); err != nil {
+				c.Println(err)
+				return
+			}
+			cli.BugReportCmd(c)
+		},
+	}
+
+	shell.AddCmd(bugReportCmd)
+
 	shell.NotFound(func(c *ishell.Context) {
 		// Hidden create command
 		if len(c.Args) > 0 && c.Args[0] == "create" {

--- a/go/cli/internal/cli/bug_report.go
+++ b/go/cli/internal/cli/bug_report.go
@@ -1,0 +1,93 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/abiosoft/ishell/v2"
+)
+
+func BugReportCmd(c *ishell.Context) {
+	// Create a temporary directory for bug report
+	timestamp := time.Now().Format("20060102-150405")
+	reportDir := fmt.Sprintf("kagent-bug-report-%s", timestamp)
+	if err := os.MkdirAll(reportDir, 0755); err != nil {
+		c.Println("Error creating report directory:", err)
+		return
+	}
+
+	c.Println("Gathering bug report information...")
+
+	// Get Agent, ModelConfig, and ToolServers YAMLs
+	resources := []string{"agent", "modelconfig", "toolserver"}
+	for _, resource := range resources {
+		cmd := exec.Command("kubectl", "get", resource, "-n", "kagent", "-o", "yaml")
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			c.Printf("Error getting %s resources: %v\n", resource, err)
+			continue
+		}
+
+		filename := filepath.Join(reportDir, fmt.Sprintf("%s.yaml", resource))
+		if err := os.WriteFile(filename, output, 0644); err != nil {
+			c.Printf("Error writing %s file: %v\n", resource, err)
+			continue
+		}
+	}
+
+	// Get secret names (without values)
+	cmd := exec.Command("kubectl", "get", "secrets", "-n", "kagent", "-o", "custom-columns=NAME:.metadata.name")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		c.Println("Error getting secret names:", err)
+	} else {
+		filename := filepath.Join(reportDir, "secrets.txt")
+		if err := os.WriteFile(filename, output, 0644); err != nil {
+			c.Println("Error writing secrets file:", err)
+		}
+	}
+
+	// Get pod logs
+	cmd = exec.Command("kubectl", "get", "pods", "-n", "kagent", "-o", "name")
+	output, err = cmd.CombinedOutput()
+	if err != nil {
+		c.Println("Error getting pod names:", err)
+	} else {
+		pods := strings.Split(string(output), "\n")
+		for _, pod := range pods {
+			if pod == "" {
+				continue
+			}
+			podName := strings.TrimPrefix(pod, "pod/")
+			cmd = exec.Command("kubectl", "logs", "-n", "kagent", podName)
+			logs, err := cmd.CombinedOutput()
+			if err != nil {
+				c.Printf("Error getting logs for pod %s: %v\n", podName, err)
+				continue
+			}
+
+			filename := filepath.Join(reportDir, fmt.Sprintf("%s-logs.txt", podName))
+			if err := os.WriteFile(filename, logs, 0644); err != nil {
+				c.Printf("Error writing logs for pod %s: %v\n", podName, err)
+			}
+		}
+	}
+
+	// Get versions and images
+	cmd = exec.Command("kubectl", "get", "pods", "-n", "kagent", "-o", "jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{range .spec.containers[*]}{.image}{\"\\n\"}{end}{end}'")
+	output, err = cmd.CombinedOutput()
+	if err != nil {
+		c.Println("Error getting pod images:", err)
+	} else {
+		filename := filepath.Join(reportDir, "versions.txt")
+		if err := os.WriteFile(filename, output, 0644); err != nil {
+			c.Println("Error writing versions file:", err)
+		}
+	}
+
+	c.Printf("Bug report generated in directory: %s\n", reportDir)
+}


### PR DESCRIPTION
This commit adds a new 'bug-report' command to the kagent CLI that:
- Gathers Agent, ModelConfig, and ToolServers YAMLs
- Lists secret names (without values)
- Collects pod logs
- Records versions and images used
- Creates a timestamped directory with all debug information