### PR TITLE
Allow to disable completely openai model

### DIFF
--- a/helm/kagent/templates/argo-rollouts-agent.yaml
+++ b/helm/kagent/templates/argo-rollouts-agent.yaml
@@ -237,7 +237,7 @@ spec:
     should run next to the Deployment before deleting the Deployment or scaling down the Deployment. Not following this
     approach might result in downtime. It also allows the Rollout to be tested before deleting the original Deployment.
     Always follow this recommended approach unless the user specifies otherwise.
-  modelConfigRef: default-model-config
+  modelConfigRef: {{ .Values.contrib.agents.argoRolloutsConversion.modelConfigRef }}
   tools:
     - type: Inline
       inline:

--- a/helm/kagent/templates/helm-agent.yaml
+++ b/helm/kagent/templates/helm-agent.yaml
@@ -144,7 +144,7 @@ spec:
     4. You cannot access external systems outside the Kubernetes cluster unless through configured repositories.
 
     Always prioritize stability and correctness in Helm operations, and provide clear guidance on how to verify the success of operations.
-  modelConfigRef: default-model-config
+  modelConfigRef: {{ .Values.contrib.agents.helm.modelConfigRef }}
   tools:
     - type: Inline
       inline:

--- a/helm/kagent/templates/istio-agent.yaml
+++ b/helm/kagent/templates/istio-agent.yaml
@@ -320,7 +320,7 @@ spec:
     - Multi-cluster connectivity issues
 
       Your primary goal is to provide expert assistance with Kubernetes and Istio environments by leveraging your specialized tools while following best practices for safety, reliability, and performance. Always aim to not just solve immediate issues but to improve the overall system architecture and operational practices.
-  modelConfigRef: default-model-config
+  modelConfigRef: {{ .Values.contrib.agents.istio.modelConfigRef }}
   tools:
     - type: Inline
       inline:

--- a/helm/kagent/templates/kube-agent.yaml
+++ b/helm/kagent/templates/kube-agent.yaml
@@ -117,7 +117,7 @@ spec:
     4. Remember that your suggestions impact production environments - prioritize safety and stability.
 
     Always start with the least intrusive approach, and escalate diagnostics only as needed. When in doubt, gather more information before recommending changes.
-  modelConfigRef: default-model-config
+  modelConfigRef: {{ .Values.contrib.agents.k8s.modelConfigRef }}
   tools:
     - type: Inline
       inline:

--- a/helm/kagent/templates/modelconfig.yaml
+++ b/helm/kagent/templates/modelconfig.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.openai.enabled }}
 apiVersion: kagent.dev/v1alpha1
 kind: ModelConfig
 metadata:
@@ -9,3 +10,4 @@ spec:
   apiKeySecretKey: {{ .Values.openai.secretKey }}
   model: gpt-4o
   provider: OpenAI
+{{ end }}

--- a/helm/kagent/templates/observability-agent.yaml
+++ b/helm/kagent/templates/observability-agent.yaml
@@ -75,7 +75,7 @@ spec:
     - ALWAYS format your response as Markdown
     - Your response will include a summary of actions you took and an explanation of the result
     - If you created any artifacts such as files or resources, you will include those in your response as well
-  modelConfigRef: default-model-config
+  modelConfigRef: {{ .Values.contrib.agents.observability.modelConfigRef }}
   tools:
     - type: Inline
       inline:

--- a/helm/kagent/templates/promql-agent.yaml
+++ b/helm/kagent/templates/promql-agent.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "kagent.labels" . | nindent 4 }}
 spec:
   description: GeneratePromQLTool generates PromQL queries from natural language descriptions.
-  modelConfigRef: default-model-config
+  modelConfigRef: {{ .Values.contrib.agents.promql.modelConfigRef }}
   systemMessage: |-
     # PromQL Query Generator
 

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -5,6 +5,7 @@ global:
   tag: ""
 
 openai:
+  enabled: true
   secretName: "kagent-openai"
   apiKey: ""
   secretKey: "OPENAI_API_KEY"
@@ -83,12 +84,16 @@ contrib:
   agents:
     k8s:
       enabled: true
+      modelConfigRef: default-model-config
     istio:
       enabled: true
+      modelConfigRef: default-model-config
     helm:
       enabled: true
+      modelConfigRef: default-model-config
     promql:
       enabled: true
+      modelConfigRef: default-model-config
     observability:
       prometheus:
         url: ""
@@ -100,8 +105,10 @@ contrib:
         password: ""
         apiKey: ""
       enabled: true
+      modelConfigRef: default-model-config
     argoRolloutsConversion:
       enabled: true
+      modelConfigRef: default-model-config
 
 otel:
   tracing:


### PR DESCRIPTION
This pr goal is to disable totaly openai model one or multiple instead that are local (like ollama)
This also unlock the ability to use different model depending of the agent and thus be able to compare them.

```yaml
# pseudo code for values.yaml

openai:
  enabled: false

contrib:
  agents:
    k8s:
      enabled: true
      modelConfigRef: ollama-model-config # ModelConfig for ollama needs to be define
    helm:
      enabled: true
      modelConfigRef: anthropic-model-config # ModelConfig for anthropic needs to be define
```