### PR TITLE
CLI: Minor fixes and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ test_results
 # Go workspace file
 go.work
 
+# Go CLI binary
+go/cli/bin/*
+
 ### Python template
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -102,6 +105,9 @@ docs/_build/
 # PyBuilder
 .pybuilder/
 target/
+
+# Package lock
+package-lock.json
 
 # Jupyter Notebook
 .ipynb_checkpoints

--- a/go/autogen/client/run.go
+++ b/go/autogen/client/run.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/google/uuid"
 )
@@ -12,9 +13,15 @@ func (c *Client) CreateRun(req *CreateRunRequest) (*CreateRunResult, error) {
 	return &run, err
 }
 
-func (c *Client) GetRun(runID string) (*Run, error) {
+func (c *Client) GetRun(runIDStr string) (*Run, error) {
+	// Convert to integer runID
+	runID, err := strconv.Atoi(runIDStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid run ID: %s, must be a number: %w", runIDStr, err)
+	}
+
 	var run Run
-	err := c.doRequest("GET", fmt.Sprintf("/runs/%s", runID), nil, &run)
+	err = c.doRequest("GET", fmt.Sprintf("/runs/%d", runID), nil, &run)
 	return &run, err
 }
 

--- a/go/autogen/client/run.go
+++ b/go/autogen/client/run.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/google/uuid"
 )
@@ -13,15 +12,10 @@ func (c *Client) CreateRun(req *CreateRunRequest) (*CreateRunResult, error) {
 	return &run, err
 }
 
-func (c *Client) GetRun(runIDStr string) (*Run, error) {
-	// Convert to integer runID
-	runID, err := strconv.Atoi(runIDStr)
-	if err != nil {
-		return nil, fmt.Errorf("invalid run ID: %s, must be a number: %w", runIDStr, err)
-	}
+func (c *Client) GetRun(runID int) (*Run, error) {
 
 	var run Run
-	err = c.doRequest("GET", fmt.Sprintf("/runs/%d", runID), nil, &run)
+	err := c.doRequest("GET", fmt.Sprintf("/runs/%d", runID), nil, &run)
 	return &run, err
 }
 

--- a/go/autogen/client/types.go
+++ b/go/autogen/client/types.go
@@ -96,7 +96,7 @@ type SessionRuns struct {
 }
 
 type Run struct {
-	ID           string        `json:"id"`
+	ID           int           `json:"id"`
 	SessionID    int           `json:"session_id"`
 	CreatedAt    string        `json:"created_at"`
 	Status       string        `json:"status"`

--- a/go/cli/cmd/kagent/main.go
+++ b/go/cli/cmd/kagent/main.go
@@ -138,7 +138,7 @@ Examples:
 
 If no resource name is provided, then a list of available resources will be returned.
 Examples:
-  get session [session_name]
+  get session [session_id]
   get session
   `,
 		Func: func(c *ishell.Context) {
@@ -158,7 +158,7 @@ Examples:
 
 If no resource name is provided, then a list of available resources will be returned.
 Examples:
-  get run [run_name]
+  get run [run_id]
   get run
   `,
 		Func: func(c *ishell.Context) {

--- a/go/cli/internal/cli/chat.go
+++ b/go/cli/internal/cli/chat.go
@@ -55,27 +55,10 @@ func ChatCmd(c *ishell.Context) {
 			c.Println(err)
 			return
 		}
-		if team == nil {
-			c.Printf("Error: Could not find team '%s'\n", teamName)
-			teams, listErr := client.ListTeams(cfg.UserID)
-			if listErr != nil {
-				c.Printf("Failed to list teams: %v\n", listErr)
-				return
-			}
-
-			if len(teams) == 0 {
-				c.Println("No teams found, please create one via the web UI or CRD before chatting.")
-				return
-			}
-
-			c.Println("Available teams:")
-			if err := printTeams(teams); err != nil {
-				c.Printf("Failed to print teams: %v\n", err)
-				return
-			}
-			return
-		}
-	} else {
+	}
+	// If team is not found or not passed as an argument, prompt the user to select from available teams
+	if team == nil {
+		c.Printf("Please select from available teams.\n")
 		// Get the teams based on the input + userID
 		teams, err := client.ListTeams(cfg.UserID)
 		if err != nil {

--- a/go/cli/internal/cli/get.go
+++ b/go/cli/internal/cli/get.go
@@ -68,9 +68,16 @@ func GetRunCmd(c *ishell.Context) {
 			return
 		}
 	} else {
-		run, err := client.GetRun(resourceName)
+		// Convert run ID from string to integer
+		runID, err := strconv.Atoi(resourceName)
 		if err != nil {
-			c.Printf("Failed to get run %s: %v\n", resourceName, err)
+			c.Printf("Invalid run ID: %s, must be a number: %v\n", resourceName, err)
+			return
+		}
+
+		run, err := client.GetRun(runID)
+		if err != nil {
+			c.Printf("Failed to get run %d: %v\n", runID, err)
 			return
 		}
 		byt, _ := json.MarshalIndent(run, "", "  ")

--- a/go/cli/internal/cli/get.go
+++ b/go/cli/internal/cli/get.go
@@ -135,6 +135,7 @@ func GetToolCmd(c *ishell.Context) {
 			return
 		}
 	}
+	// TODO: implement get tool by resource name
 }
 
 func printTools(tools []*autogen_client.Tool) error {
@@ -142,7 +143,7 @@ func printTools(tools []*autogen_client.Tool) error {
 	rows := make([][]string, len(tools))
 	for i, tool := range tools {
 		rows[i] = []string{
-			strconv.Itoa(i),
+			strconv.Itoa(i + 1),
 			strconv.Itoa(tool.Id),
 			tool.Component.Provider,
 			tool.Component.Label,
@@ -156,7 +157,6 @@ func printRuns(runs []*autogen_client.Run) error {
 	headers := []string{"#", "ID", "CONTENT", "MESSAGES", "STATUS", "CREATED"}
 	rows := make([][]string, len(runs))
 	for i, run := range runs {
-
 		contentStr := "[N/A]" // Default content if type assertion fails or content is nil
 		if run.Task.Content != nil {
 			if content, ok := run.Task.Content.(string); ok {
@@ -171,8 +171,8 @@ func printRuns(runs []*autogen_client.Run) error {
 		}
 
 		rows[i] = []string{
-			strconv.Itoa(i),
-			run.ID,
+			strconv.Itoa(i + 1),
+			strconv.Itoa(run.ID),
 			contentStr,
 			strconv.Itoa(len(run.Messages)),
 			run.Status,
@@ -189,7 +189,7 @@ func printTeams(teams []*autogen_client.Team) error {
 	rows := make([][]string, len(teams))
 	for i, team := range teams {
 		rows[i] = []string{
-			strconv.Itoa(i),
+			strconv.Itoa(i + 1),
 			team.Component.Label,
 			strconv.Itoa(team.Id),
 			team.CreatedAt,
@@ -204,7 +204,7 @@ func printSessions(sessions []*autogen_client.Session) error {
 	rows := make([][]string, len(sessions))
 	for i, session := range sessions {
 		rows[i] = []string{
-			strconv.Itoa(i),
+			strconv.Itoa(i + 1),
 			strconv.Itoa(session.ID),
 			session.Name,
 			strconv.Itoa(session.TeamID),


### PR DESCRIPTION
Fixes a couple of small issues.

* `run chat` with args used to result in a SIGSEGV because while getting the `team`, params were passed in the wrong order so we got a **nil** object for team. Also the `-s` flag for session was not respected. 

```
kagent >> run chat blah
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x48 pc=0x1026587c8]

goroutine 1 [running]:
github.com/kagent-dev/kagent/go/cli/internal/cli.ChatCmd.func1(...)
	/Users/nim/src/github.com/nimishamehta5/kagent/go/cli/internal/cli/chat.go:109
github.com/kagent-dev/kagent/go/cli/internal/cli.ChatCmd.Collect[...].func4-range3(...)
...
```

Now, with an incorrect chat name, it prompts the user to select from the available teams:
```
kagent >> run chat blah
Select an agent:
 ❯ my-first-k8s-agent
   promql-agent
   observability-agent
   k8s-agent
   istio-agent
   helm-agent
   argo-rollouts-conversion-agent
   RoundRobin Team
```

With a correct chat name, it now prompts for a session:
```
Select a session:
 ❯ [New Session]
   first
```

And with a session name passed in, the chat just works:
```
kagent >> run chat k8s-agent -s first
Enter a task: List nodes
Closing session, thank you :)
```

* `get run $id` did not work and gave the error:
```
kagent >> get run 20
Failed to get run 20: error unmarshaling into result: json: cannot unmarshal number into Go struct field Run.id of type string
```
This is because the autogen API actually returns an int, but we were trying to store it as a string, so the unmarshaling didn't work.
API response gives an int:
```
 ✗ curl -X GET "http://localhost:8081/api/runs/20" | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  7722  100  7722    0     0   729k      0 --:--:-- --:--:-- --:--:--  754k
{
  "status": true,
  "data": {
    "updated_at": "2025-05-03T19:00:15.975556",
    "status": "error",
    "team_result": {
      "task_result": {
        "messages": [
          {
            "source": "system",
            "models_usage": null,
            "metadata": {}
          }
        ],
        "stop_reason": "An error occurred while processing this run"
      },
      "usage": "",
      "duration": 0.0
    },
    "version": "0.0.1",
    "user_id": "admin@kagent.dev",
    "created_at": "2025-05-03T19:00:13.953835",
    "id": 20,                <----- THIS PART
```

So now we store it as int and this works:
```
kagent >> get run 20
{
  "id": 20,
  "session_id": 13,
  "created_at": "2025-05-03T19:00:13.953835",
  "status": "error",
  "task": {
    "source": "user",
    "content": [
...
```

* In the print formatting, we now print the `#` column starting from human-friendly index 1 instead of 0.
