### PR TITLE
fix(ui): force remount of AgentPageContent when switching between create and edit mode

### DIFF
--- a/ui/src/app/agents/new/page.tsx
+++ b/ui/src/app/agents/new/page.tsx
@@ -30,15 +30,15 @@ interface ValidationErrors {
   memory?: string;
 }
 
-// Inner component that uses useSearchParams, wrapped in Suspense
-function AgentPageContent() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const { models, tools, loading, error, createNewAgent, updateAgent, getAgentById, validateAgentData } = useAgents();
+interface AgentPageContentProps {
+  isEditMode: boolean;
+  agentId: string | null;
+}
 
-  // Determine if in edit mode
-  const isEditMode = searchParams.get("edit") === "true";
-  const agentId = searchParams.get("id");
+// Inner component that uses useSearchParams, wrapped in Suspense
+function AgentPageContent({ isEditMode, agentId }: AgentPageContentProps) {
+  const router = useRouter();
+  const { models, tools, loading, error, createNewAgent, updateAgent, getAgentById, validateAgentData } = useAgents();
 
   // Basic form state
   const [name, setName] = useState("");
@@ -335,9 +335,17 @@ function AgentPageContent() {
 
 // Main component that wraps the content in a Suspense boundary
 export default function AgentPage() {
+  // Determine if in edit mode
+  const searchParams = useSearchParams();
+  const isEditMode = searchParams.get("edit") === "true";
+  const agentId = searchParams.get("id");
+  
+  // Create a key based on the edit mode and agent ID
+  const formKey = isEditMode ? `edit-${agentId}` : 'create';
+  
   return (
     <Suspense fallback={<LoadingState />}>
-      <AgentPageContent />
+      <AgentPageContent key={formKey} isEditMode={isEditMode} agentId={agentId} />
     </Suspense>
   );
 }


### PR DESCRIPTION
## Problem
When navigating directly from editing an agent to creating a new one without refreshing the page, the form state isn't being properly reset. This creates an issue where form field values from the agent previously selected for edit mode would persist when creating a new agent.

## Solution
- Moved route parameters from inside the component to being passed as props
- Added a unique key to the AgentPageContent element based on the current mode (edit/create) and agent ID
- This forces component to remount when switching between create/edit modes, ensuring clean state initialization
