### PR TITLE
fix: maintain thinking status during tool execution

### DIFF
--- a/ui/src/lib/useChatStore.ts
+++ b/ui/src/lib/useChatStore.ts
@@ -88,13 +88,15 @@ const useChatStore = create<ChatState>((set, get) => ({
       return;
     }
 
-    if (
+    // Keep status as "thinking" if we receive any tool-related messages
+    const isToolMessage = 
       messageUtils.isTeamResult(messageConfig) ||
       messageUtils.isFunctionExecutionResult(messageConfig.content) ||
       messageUtils.isToolCallContent(messageConfig.content) ||
       messageUtils.isMultiModalContent(messageConfig.content) ||
-      messageUtils.isLlmCallEvent(messageConfig.content)
-    ) {
+      messageUtils.isLlmCallEvent(messageConfig.content);
+
+    if (isToolMessage) {
       const systemMessage = {
         config: messageConfig,
         session_id: session.id!,
@@ -108,7 +110,8 @@ const useChatStore = create<ChatState>((set, get) => ({
           ...run,
           messages: [...run.messages, systemMessage],
         },
-        status: (message.status as ChatStatus) || "ready",
+        // Keep status as "thinking" while tools are executing
+        status: "thinking",
       }));
       return;
     }

--- a/ui/src/lib/useChatStore.ts
+++ b/ui/src/lib/useChatStore.ts
@@ -88,6 +88,9 @@ const useChatStore = create<ChatState>((set, get) => ({
       return;
     }
 
+    // Keep status as "thinking" for all non-completion messages
+    const isCompletionMessage = message.type === "completion";
+    
     // Keep status as "thinking" if we receive any tool-related messages
     const isToolMessage = 
       messageUtils.isTeamResult(messageConfig) ||
@@ -96,7 +99,7 @@ const useChatStore = create<ChatState>((set, get) => ({
       messageUtils.isMultiModalContent(messageConfig.content) ||
       messageUtils.isLlmCallEvent(messageConfig.content);
 
-    if (isToolMessage) {
+    if (isToolMessage || !isCompletionMessage) {
       const systemMessage = {
         config: messageConfig,
         session_id: session.id!,
@@ -110,7 +113,7 @@ const useChatStore = create<ChatState>((set, get) => ({
           ...run,
           messages: [...run.messages, systemMessage],
         },
-        // Keep status as "thinking" while tools are executing
+        // Keep status as "thinking" while processing any message
         status: "thinking",
       }));
       return;

--- a/ui/src/lib/ws.ts
+++ b/ui/src/lib/ws.ts
@@ -121,8 +121,10 @@ export function setupWebSocket(runId: string, handlers: WebSocketHandlers, initi
           handlers.onError("Connection lost. Attempting to reconnect...");
           handlers.onStatusChange("error");
           maybeReconnect();
+        } else {
+          // Only set status to ready if we're not in the middle of tool execution
+          handlers.onStatusChange("ready");
         }
-
         handlers.onClose();
       };
 


### PR DESCRIPTION
- Modified handleWebSocketMessage to keep status as thinking while tools are executing

- Updated WebSocket connection handling to prevent premature ready status

- Fixed issue where chat interface showed Ready while tools were still running

Fixes #325