### PR TITLE
Fix warning from values.yaml

### DIFF
--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -58,7 +58,7 @@ controller:
     limits:
       cpu: 500m
       memory: 512Mi
-  env: {} # Additional environment variables for the controller can be added here
+  env: [] # Additional environment variables for the controller can be added here
 
 app:
   image:
@@ -73,7 +73,7 @@ app:
     limits:
       cpu: 1000m
       memory: 1Gi
-  env: {} # Additional environment variables for the app can be added here
+  env: [] # Additional environment variables for the app can be added here
 
 ui:
   image:
@@ -88,7 +88,7 @@ ui:
     limits:
       cpu: 1000m
       memory: 1Gi
-  env: {} # Additional environment variables for the ui can be added here
+  env: [] # Additional environment variables for the ui can be added here
 
 service:
   type: ClusterIP


### PR DESCRIPTION
fix the following warning when new env are defined

```
coalesce.go:286: warning: cannot overwrite table with non table for kagent.kagent.app.env (map[])
```