### PR TITLE
CLI: Fix get run without run ID marshaling

### DIFF
--- a/go/controller/internal/httpserver/handlers/invoke_test.go
+++ b/go/controller/internal/httpserver/handlers/invoke_test.go
@@ -28,7 +28,7 @@ func newMockErrorResponseWriter() *mockErrorResponseWriter {
 
 func (m *mockErrorResponseWriter) RespondWithError(err error) {
 	m.errorReceived = err
-	
+
 	if errWithStatus, ok := err.(interface{ StatusCode() int }); ok {
 		handlers.RespondWithError(m, errWithStatus.StatusCode(), err.Error())
 	} else {
@@ -65,7 +65,7 @@ func (m *mockAutogenClient) ListRuns(userID string) ([]*autogen_client.Run, erro
 	return nil, nil
 }
 
-func (m *mockAutogenClient) GetRun(runID string) (*autogen_client.Run, error) {
+func (m *mockAutogenClient) GetRun(runID int) (*autogen_client.Run, error) {
 	return nil, nil
 }
 
@@ -128,13 +128,13 @@ var _ = Describe("InvokeHandler", func() {
 
 	BeforeEach(func() {
 		mockClient = &mockAutogenClient{}
-		
+
 		base := &handlers.Base{}
-		
+
 		handler = handlers.NewInvokeHandler(base)
-		
+
 		handler.WithClient(mockClient)
-		
+
 		responseRecorder = newMockErrorResponseWriter()
 	})
 
@@ -310,7 +310,7 @@ var _ = Describe("InvokeHandler", func() {
 		It("should panic when no client is available", func() {
 			handlerWithoutClient := handlers.NewInvokeHandler(&handlers.Base{})
 			handlerWithoutClient.WithClient(nil)
-			
+
 			agentID := "1"
 			reqBody := handlers.InvokeRequest{
 				Message: "Test message",
@@ -330,4 +330,4 @@ var _ = Describe("InvokeHandler", func() {
 			router.ServeHTTP(responseRecorder, req)
 		})
 	})
-}) 
+})

--- a/python/src/autogenstudio/web/routes/sessions.py
+++ b/python/src/autogenstudio/web/routes/sessions.py
@@ -94,7 +94,7 @@ async def list_session_runs(session_id: int, user_id: str, db=Depends(get_db)) -
 
                     run_data.append(
                         {
-                            "id": str(run.id),
+                            "id": run.id,
                             "created_at": run.created_at,
                             "status": run.status,
                             "task": run.task,
@@ -107,7 +107,7 @@ async def list_session_runs(session_id: int, user_id: str, db=Depends(get_db)) -
                     # Include run with error state instead of failing entirely
                     run_data.append(
                         {
-                            "id": str(run.id),
+                            "id": run.id,
                             "created_at": run.created_at,
                             "status": "ERROR",
                             "task": run.task,


### PR DESCRIPTION
Previous change to Run ID: https://github.com/kagent-dev/kagent/pull/320 (convert from `string` to `int`) broke the List Session Runs API.

This attempts to make both the APIs (List Session Runs & Get Run) work.
In the autogenstudio server, we will update the `list_session_runs` API to also return the run IDs as ints to stay consistent with how the other APIs are implemented.

Before:
```
kagent >> get run 1
{
  "id": 1,
  "session_id": 1,
  "created_at": "2025-05-06T19:44:13.690563",
  "status": "error",
...


kagent >> get run
Failed to get runs: error unmarshaling into result: json: cannot unmarshal string into Go struct field Run.runs.id of type int
```

After:
```
kagent >> get run 1
{
  "id": 1,
  "session_id": 1,
  "created_at": "2025-05-06T19:44:13.690563",
  "status": "error",
...


kagent >> get run
+---+----+--------------+----------+--------+----------------------------+
| # | ID | CONTENT      | MESSAGES | STATUS | CREATED                    |
+---+----+--------------+----------+--------+----------------------------+
| 1 | 1  | [non-string] | 1        | error  | 2025-05-06T19:44:13.690563 |
+---+----+--------------+----------+--------+----------------------------+
```

