### PR TITLE
Add shortNames to CRDs, remove Makefile refs to kustomize

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -105,12 +105,12 @@ ifndef ignore-not-found
 endif
 
 .PHONY: install
-install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | $(KUBECTL) apply -f -
+install: manifests
+	$(KUBECTL) apply -f config/crd/bases/
 
 .PHONY: uninstall
-uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/crd | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
+uninstall: manifests
+	$(KUBECTL) delete -f config/crd/bases/ --ignore-not-found=$(ignore-not-found)
 
 ##@ Dependencies
 
@@ -121,24 +121,17 @@ $(LOCALBIN):
 
 ## Tool Binaries
 KUBECTL ?= kubectl
-KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
-KUSTOMIZE_VERSION ?= v5.5.0
 CONTROLLER_TOOLS_VERSION ?= v0.17.1
 #ENVTEST_VERSION is the version of controller-runtime release branch to fetch the envtest setup script (i.e. release-0.20)
 ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
 #ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries (i.e. 1.31)
 ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api | awk -F'[v.]' '{printf "1.%d", $$3}')
 GOLANGCI_LINT_VERSION ?= v1.63.4
-
-.PHONY: kustomize
-kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
-$(KUSTOMIZE): $(LOCALBIN)
-	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v5,$(KUSTOMIZE_VERSION))
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.

--- a/go/config/crd/bases/kagent.dev_modelconfigs.yaml
+++ b/go/config/crd/bases/kagent.dev_modelconfigs.yaml
@@ -11,6 +11,8 @@ spec:
     kind: ModelConfig
     listKind: ModelConfigList
     plural: modelconfigs
+    shortNames:
+    - mc
     singular: modelconfig
   scope: Namespaced
   versions:

--- a/go/config/crd/bases/kagent.dev_toolservers.yaml
+++ b/go/config/crd/bases/kagent.dev_toolservers.yaml
@@ -11,6 +11,8 @@ spec:
     kind: ToolServer
     listKind: ToolServerList
     plural: toolservers
+    shortNames:
+    - ts
     singular: toolserver
   scope: Namespaced
   versions:

--- a/go/controller/api/v1alpha1/autogenmodelconfig_types.go
+++ b/go/controller/api/v1alpha1/autogenmodelconfig_types.go
@@ -218,6 +218,7 @@ type ModelConfigStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Provider",type="string",JSONPath=".spec.provider"
 // +kubebuilder:printcolumn:name="Model",type="string",JSONPath=".spec.model"
+// +kubebuilder:resource:shortName=mc
 
 // ModelConfig is the Schema for the modelconfigs API.
 type ModelConfig struct {

--- a/go/controller/api/v1alpha1/toolserver_types.go
+++ b/go/controller/api/v1alpha1/toolserver_types.go
@@ -81,6 +81,7 @@ type MCPToolServerParams struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:resource:shortName=ts
 
 // ToolServer is the Schema for the toolservers API.
 type ToolServer struct {


### PR DESCRIPTION
Small quality of life improvement to interact with common Kagent CRs.

Removed refs to Kustomize from the Makefile, as that flow is no longer used.