### PR TITLE
Template namespace for resources produced by `kagent` Helm chart

### DIFF
--- a/helm/kagent/templates/_helpers.tpl
+++ b/helm/kagent/templates/_helpers.tpl
@@ -59,6 +59,14 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Expand the namespace of the release.
+Allows overriding it for multi-namespace deployments in combined charts.
+*/}}
+{{- define "kagent.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
 Watch namespaces - transforms list of namespaces cached by the controller into comma-separated string
 Removes duplicates
 */}}

--- a/helm/kagent/templates/argo-rollouts-agent.yaml
+++ b/helm/kagent/templates/argo-rollouts-agent.yaml
@@ -125,12 +125,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "kagent.fullname" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "kagent.namespace" . }}
 ---
 apiVersion: kagent.dev/v1alpha1
 kind: Agent
 metadata:
   name: argo-rollouts-conversion-agent
+  namespace: {{ include "kagent.namespace" . }}
   labels:
     {{- include "kagent.labels" . | nindent 4 }}
 spec:

--- a/helm/kagent/templates/clusterrolebinding.yaml
+++ b/helm/kagent/templates/clusterrolebinding.yaml
@@ -11,7 +11,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "kagent.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "kagent.namespace" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -26,4 +26,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "kagent.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "kagent.namespace" . }}

--- a/helm/kagent/templates/deployment.yaml
+++ b/helm/kagent/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "kagent.fullname" . }}
+  namespace: {{ include "kagent.namespace" . }}
   labels:
     {{- include "kagent.labels" . | nindent 4 }}
 spec:

--- a/helm/kagent/templates/helm-agent.yaml
+++ b/helm/kagent/templates/helm-agent.yaml
@@ -4,6 +4,7 @@ apiVersion: kagent.dev/v1alpha1
 kind: Agent
 metadata:
   name: helm-agent
+  namespace: {{ include "kagent.namespace" . }}
   labels:
     {{- include "kagent.labels" . | nindent 4 }}
 spec:

--- a/helm/kagent/templates/istio-agent.yaml
+++ b/helm/kagent/templates/istio-agent.yaml
@@ -135,6 +135,7 @@ apiVersion: kagent.dev/v1alpha1
 kind: Agent
 metadata:
   name: istio-agent
+  namespace: {{ include "kagent.namespace" . }}
   labels:
     {{- include "kagent.labels" . | nindent 4 }}
 spec:

--- a/helm/kagent/templates/kgateway-agent.yaml
+++ b/helm/kagent/templates/kgateway-agent.yaml
@@ -4,6 +4,7 @@ apiVersion: kagent.dev/v1alpha1
 kind: Agent
 metadata:
   name: kgateway-agent
+  namespace: {{ include "kagent.namespace" . }}
   labels:
     {{- include "kagent.labels" . | nindent 4 }}
 spec:

--- a/helm/kagent/templates/kube-agent.yaml
+++ b/helm/kagent/templates/kube-agent.yaml
@@ -4,6 +4,7 @@ apiVersion: kagent.dev/v1alpha1
 kind: Agent
 metadata:
   name: k8s-agent
+  namespace: {{ include "kagent.namespace" . }}
   labels:
     {{- include "kagent.labels" . | nindent 4 }}
 spec:

--- a/helm/kagent/templates/modelconfig.yaml
+++ b/helm/kagent/templates/modelconfig.yaml
@@ -5,6 +5,7 @@ apiVersion: kagent.dev/v1alpha1
 kind: ModelConfig
 metadata:
   name: {{ $dot.Values.providers.default | lower }}-model-config
+  namespace: {{ include "kagent.namespace" . }}
   labels:
     {{- include "kagent.labels" $dot | nindent 4 }}
 spec:

--- a/helm/kagent/templates/observability-agent.yaml
+++ b/helm/kagent/templates/observability-agent.yaml
@@ -4,6 +4,7 @@ apiVersion: kagent.dev/v1alpha1
 kind: Agent
 metadata:
   name: observability-agent
+  namespace: {{ include "kagent.namespace" . }}
   labels:
     {{- include "kagent.labels" . | nindent 4 }}
 spec:

--- a/helm/kagent/templates/promql-agent.yaml
+++ b/helm/kagent/templates/promql-agent.yaml
@@ -4,6 +4,7 @@ apiVersion: kagent.dev/v1alpha1
 kind: Agent
 metadata:
   name: promql-agent
+  namespace: {{ include "kagent.namespace" . }}
   labels:
     {{- include "kagent.labels" . | nindent 4 }}
 spec:

--- a/helm/kagent/templates/secret.yaml
+++ b/helm/kagent/templates/secret.yaml
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $model.apiKeySecretRef | quote }}
+  namespace: {{ include "kagent.namespace" . }}
   labels:
     {{- include "kagent.labels" $dot | nindent 4 }}
 type: Opaque

--- a/helm/kagent/templates/service.yaml
+++ b/helm/kagent/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "kagent.fullname" . }}
+  namespace: {{ include "kagent.namespace" . }}
   labels:
     {{- include "kagent.labels" . | nindent 4 }}
 spec:

--- a/helm/kagent/templates/serviceaccount.yaml
+++ b/helm/kagent/templates/serviceaccount.yaml
@@ -2,5 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kagent.fullname" . }}
+  namespace: {{ include "kagent.namespace" . }}
   labels:
     {{- include "kagent.labels" . | nindent 4 }}

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -107,6 +107,10 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# -- Override the namespace
+# @default -- `.Release.Namespace`
+namespaceOverride: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}


### PR DESCRIPTION
Ensures that rendered manifests have `namespace` set as per the value of the `namespace` flag used when running `helm template` (or optionally overriden via `values.yaml`). Enables deployment of manifests with commands like:

```
helm template --release-name kagent --namespace kagent . | kubectl apply -f -
```

FWIW, this is a fairly common pattern across a number of open source charts. Several examples can be seen within the [bitnami charts](https://github.com/search?q=repo%3Abitnami%2Fcharts%20namespaceOverride&type=code).