### PR TITLE
Update SelectToolsDialog.tsx bumping value of MAX_TOOLS_LIMIT from 10…

### DIFF
--- a/ui/src/components/create/SelectToolsDialog.tsx
+++ b/ui/src/components/create/SelectToolsDialog.tsx
@@ -11,7 +11,7 @@ import Link from "next/link";
 import { getToolCategory, getToolDisplayName, getToolDescription, getToolIdentifier, getToolProvider, isAgentTool, isMcpTool, isMcpProvider, componentToAgentTool } from "@/lib/toolUtils";
 import KagentLogo from "../kagent-logo";
 // Maximum number of tools that can be selected
-const MAX_TOOLS_LIMIT = 10;
+const MAX_TOOLS_LIMIT = 20;
 
 interface SelectedToolEntry {
   originalItemIdentifier: string;


### PR DESCRIPTION
This is an update to the UI bumping MAX_TOOLS_LIMIT from 10 to 20 to allow more tool selection in the UI. 

Issue link: https://github.com/kagent-dev/kagent/issues/367