### PR TITLE
[FIX] disable agent name input when in edit mode

### DIFF
--- a/ui/src/app/agents/new/page.tsx
+++ b/ui/src/app/agents/new/page.tsx
@@ -233,7 +233,7 @@ function AgentPageContent({ isEditMode, agentId }: AgentPageContentProps) {
                     onBlur={() => validateField('name', name)}
                     className={`${errors.name ? "border-red-500" : ""}`}
                     placeholder="Enter agent name..."
-                    disabled={isSubmitting || isLoading}
+                    disabled={isSubmitting || isLoading || isEditMode}
                   />
                   {errors.name && <p className="text-red-500 text-sm mt-1">{errors.name}</p>}
                 </div>


### PR DESCRIPTION
Disables the input field in Edit mode, because if edited the update request will fail as it cannot find the agent.