### PR TITLE
feat: surface tool server errors in API and UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,3 +198,6 @@ go/bin/
 
 ## Helm
 *.tgz
+
+# asdf node manager
+.tool-versions

--- a/go/controller/api/v1alpha1/autogenagent_types.go
+++ b/go/controller/api/v1alpha1/autogenagent_types.go
@@ -126,6 +126,8 @@ type AgentStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Accepted",type="string",JSONPath=".status.conditions[0].status",description="Whether or not the agent has been accepted by the system."
 // +kubebuilder:printcolumn:name="ModelConfig",type="string",JSONPath=".spec.modelConfig",description="The ModelConfig resource referenced by this agent."
+// +genclient
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Agent is the Schema for the agents API.
 type Agent struct {
@@ -137,6 +139,7 @@ type Agent struct {
 }
 
 // +kubebuilder:object:root=true
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // AgentList contains a list of Agent.
 type AgentList struct {

--- a/go/controller/api/v1alpha1/autogenmemory_types.go
+++ b/go/controller/api/v1alpha1/autogenmemory_types.go
@@ -80,6 +80,8 @@ type MemoryStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Provider",type="string",JSONPath=".spec.provider"
+// +genclient
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Memory is the Schema for the memories API.
 type Memory struct {
@@ -91,8 +93,9 @@ type Memory struct {
 }
 
 // +kubebuilder:object:root=true
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// MemoryList contains a list of Memory resources.
+// MemoryList contains a list of Memory.
 type MemoryList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/go/controller/api/v1alpha1/autogenmodelconfig_types.go
+++ b/go/controller/api/v1alpha1/autogenmodelconfig_types.go
@@ -216,9 +216,10 @@ type ModelConfigStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Provider",type="string",JSONPath=".spec.provider"
 // +kubebuilder:printcolumn:name="Model",type="string",JSONPath=".spec.model"
 // +kubebuilder:resource:shortName=mc
+// +genclient
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ModelConfig is the Schema for the modelconfigs API.
 type ModelConfig struct {
@@ -230,6 +231,7 @@ type ModelConfig struct {
 }
 
 // +kubebuilder:object:root=true
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ModelConfigList contains a list of ModelConfig.
 type ModelConfigList struct {

--- a/go/controller/api/v1alpha1/autogenteam_types.go
+++ b/go/controller/api/v1alpha1/autogenteam_types.go
@@ -95,6 +95,8 @@ type TeamStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +genclient
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Team is the Schema for the teams API.
 type Team struct {
@@ -106,6 +108,7 @@ type Team struct {
 }
 
 // +kubebuilder:object:root=true
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // TeamList contains a list of Team.
 type TeamList struct {

--- a/go/controller/api/v1alpha1/toolserver_types.go
+++ b/go/controller/api/v1alpha1/toolserver_types.go
@@ -53,7 +53,7 @@ type ToolServerStatus struct {
 	ObservedGeneration int64              `json:"observedGeneration"`
 	Conditions         []metav1.Condition `json:"conditions"`
 	// +kubebuilder:validation:Optional
-	DiscoveredTools []*MCPTool `json:"discoveredTools"`
+	Tools []*MCPTool `json:"tools"`
 }
 
 type MCPTool struct {
@@ -82,6 +82,8 @@ type MCPToolServerParams struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=ts
+// +genclient
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ToolServer is the Schema for the toolservers API.
 type ToolServer struct {
@@ -93,6 +95,7 @@ type ToolServer struct {
 }
 
 // +kubebuilder:object:root=true
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ToolServerList contains a list of ToolServer.
 type ToolServerList struct {

--- a/go/controller/api/v1alpha1/zz_generated.deepcopy.go
+++ b/go/controller/api/v1alpha1/zz_generated.deepcopy.go
@@ -1212,8 +1212,8 @@ func (in *ToolServerStatus) DeepCopyInto(out *ToolServerStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.DiscoveredTools != nil {
-		in, out := &in.DiscoveredTools, &out.DiscoveredTools
+	if in.Tools != nil {
+		in, out := &in.Tools, &out.Tools
 		*out = make([]*MCPTool, len(*in))
 		for i := range *in {
 			if (*in)[i] != nil {

--- a/go/controller/internal/autogen/autogen_api_translator.go
+++ b/go/controller/internal/autogen/autogen_api_translator.go
@@ -637,7 +637,7 @@ func translateToolServerTool(
 	}
 
 	// requires the tool to have been discovered
-	for _, discoveredTool := range toolServer.Status.DiscoveredTools {
+	for _, discoveredTool := range toolServer.Status.Tools {
 		if discoveredTool.Name == toolName {
 			return convertComponent(discoveredTool.Component)
 		}

--- a/go/controller/internal/httpserver/handlers/tools.go
+++ b/go/controller/internal/httpserver/handlers/tools.go
@@ -56,16 +56,17 @@ func (h *ToolsHandler) HandleListTools(w ErrorResponseWriter, r *http.Request) {
 	}
 
 	discoveredTools := make([]*api.Component, 0)
+
 	for _, toolServer := range allToolServers.Items {
-		for _, t := range toolServer.Status.DiscoveredTools {
-			// Set the server name in the component label
-			t.Component.Label = toolServer.Name
+		for _, t := range toolServer.Status.Tools {
 			discoveredTools = append(discoveredTools, &api.Component{
 				Provider:      t.Component.Provider,
-				Label:         t.Component.Label,
-				Description:   t.Component.Description,
-				Config:        convertAnyTypeMapToInterfaceMap(t.Component.Config),
 				ComponentType: t.Component.ComponentType,
+				Config:        convertAnyTypeMapToInterfaceMap(t.Component.Config),
+				Label:         toolServer.Name,
+				Version:       t.Component.Version,
+				ComponentVersion: t.Component.ComponentVersion,
+				Description:   t.Component.Description,
 			})
 		}
 	}

--- a/go/controller/internal/httpserver/handlers/toolservers.go
+++ b/go/controller/internal/httpserver/handlers/toolservers.go
@@ -48,21 +48,20 @@ func (h *ToolServersHandler) HandleListToolServers(w ErrorResponseWriter, r *htt
 
 		errorMsg := getErrorFromConditions(toolServer.Status.Conditions)
 		if errorMsg != nil {
-			log.Info("Tool server has error condition", "toolServerName", toolServer.Name, "error", *errorMsg)
+			log.V(1).Info("Tool server has error condition", "toolServerName", toolServer.Name, "error", *errorMsg)
 		}
 
-		discoveredTools := toolServer.Status.DiscoveredTools
+		discoveredTools := toolServer.Status.Tools
 		if discoveredTools == nil {
 			discoveredTools = []*v1alpha1.MCPTool{}
 		}
-		toolServerWithTools = append(toolServerWithTools, map[string]interface{}{ 
-			"name":            toolServer.Name,
-			"config":          toolServer.Spec.Config,
-			"discoveredTools": discoveredTools,
-			"status": map[string]interface{}{
-				"conditions": toolServer.Status.Conditions,
-				"error":     errorMsg,
-			},
+		toolServerWithTools = append(toolServerWithTools, map[string]interface{}{
+			"name":       toolServer.Name,
+			"namespace":  toolServer.Namespace,
+			"status":     toolServer.Status,
+			"conditions": toolServer.Status.Conditions,
+			"tools":      discoveredTools,
+			"config":     toolServer.Spec.Config,
 		})
 	}
 

--- a/go/controller/internal/httpserver/handlers/toolservers_test.go
+++ b/go/controller/internal/httpserver/handlers/toolservers_test.go
@@ -126,9 +126,9 @@ func TestHandleListToolServers(t *testing.T) {
 			},
 			expectedStatus: http.StatusOK,
 			expectedBody: map[string]interface{}{
-				"name":            "test-server-1",
-				"config":          map[string]interface{}{},
-				"discoveredTools": []interface{}{},
+				"name": "test-server-1",
+				"config": map[string]interface{}{},
+				"tools": []interface{}{},
 				"status": map[string]interface{}{
 					"conditions": []interface{}{
 						map[string]interface{}{
@@ -146,7 +146,8 @@ func TestHandleListToolServers(t *testing.T) {
 			toolServers: []v1alpha1.ToolServer{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "test-server-2",
+						Name:      "test-server-2",
+						Namespace: "default",
 					},
 					Spec: v1alpha1.ToolServerSpec{
 						Config: v1alpha1.ToolServerConfig{},
@@ -164,9 +165,8 @@ func TestHandleListToolServers(t *testing.T) {
 			},
 			expectedStatus: http.StatusOK,
 			expectedBody: map[string]interface{}{
-				"name":            "test-server-2",
-				"config":          map[string]interface{}{},
-				"discoveredTools": []interface{}{},
+				"name":       "test-server-2",
+				"namespace":  "default",
 				"status": map[string]interface{}{
 					"conditions": []interface{}{
 						map[string]interface{}{
@@ -175,8 +175,15 @@ func TestHandleListToolServers(t *testing.T) {
 							"message": "Failed to reconcile",
 						},
 					},
-					"error": "Failed to reconcile",
 				},
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":    "Accepted",
+						"status":  "False",
+						"message": "Failed to reconcile",
+					},
+				},
+				"tools": []interface{}{},
 			},
 		},
 	}

--- a/go/controller/internal/httpserver/handlers/toolservers_test.go
+++ b/go/controller/internal/httpserver/handlers/toolservers_test.go
@@ -1,0 +1,302 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kagent-dev/kagent/go/controller/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+type mockErrorResponseWriter struct {
+	*httptest.ResponseRecorder
+	errorResponse error
+}
+
+func newMockErrorResponseWriter() *mockErrorResponseWriter {
+	return &mockErrorResponseWriter{
+		ResponseRecorder: httptest.NewRecorder(),
+	}
+}
+
+func (m *mockErrorResponseWriter) RespondWithError(err error) {
+	m.errorResponse = err
+	if httpErr, ok := err.(interface{ StatusCode() int }); ok {
+		m.WriteHeader(httpErr.StatusCode())
+	} else {
+		m.WriteHeader(http.StatusInternalServerError)
+	}
+	json.NewEncoder(m).Encode(map[string]string{"error": err.Error()})
+}
+
+func TestGetErrorFromConditions(t *testing.T) {
+	tests := []struct {
+		name       string
+		conditions []metav1.Condition
+		want       *string
+	}{
+		{
+			name: "no error conditions",
+			conditions: []metav1.Condition{
+				{
+					Type:    "Accepted",
+					Status:  metav1.ConditionTrue,
+					Message: "All good",
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "has error condition",
+			conditions: []metav1.Condition{
+				{
+					Type:    "Accepted",
+					Status:  metav1.ConditionFalse,
+					Message: "Failed to reconcile",
+				},
+			},
+			want: stringPtr("Failed to reconcile"),
+		},
+		{
+			name: "multiple conditions with error",
+			conditions: []metav1.Condition{
+				{
+					Type:    "Accepted",
+					Status:  metav1.ConditionTrue,
+					Message: "All good",
+				},
+				{
+					Type:    "Error",
+					Status:  metav1.ConditionFalse,
+					Message: "Something went wrong",
+				},
+			},
+			want: stringPtr("Something went wrong"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getErrorFromConditions(tt.conditions)
+			if (got == nil) != (tt.want == nil) {
+				t.Errorf("getErrorFromConditions() = %v, want %v", got, tt.want)
+				return
+			}
+			if got != nil && tt.want != nil && *got != *tt.want {
+				t.Errorf("getErrorFromConditions() = %v, want %v", *got, *tt.want)
+			}
+		})
+	}
+}
+
+func TestHandleListToolServers(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = v1alpha1.AddToScheme(scheme)
+
+	tests := []struct {
+		name           string
+		toolServers    []v1alpha1.ToolServer
+		expectedStatus int
+		expectedBody   map[string]interface{}
+	}{
+		{
+			name: "successful tool servers",
+			toolServers: []v1alpha1.ToolServer{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-server-1",
+					},
+					Spec: v1alpha1.ToolServerSpec{
+						Config: v1alpha1.ToolServerConfig{},
+					},
+					Status: v1alpha1.ToolServerStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:    "Accepted",
+								Status:  metav1.ConditionTrue,
+								Message: "All good",
+							},
+						},
+					},
+				},
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody: map[string]interface{}{
+				"name":            "test-server-1",
+				"config":          map[string]interface{}{},
+				"discoveredTools": []interface{}{},
+				"status": map[string]interface{}{
+					"conditions": []interface{}{
+						map[string]interface{}{
+							"type":    "Accepted",
+							"status":  "True",
+							"message": "All good",
+						},
+					},
+					"error": nil,
+				},
+			},
+		},
+		{
+			name: "tool server with error",
+			toolServers: []v1alpha1.ToolServer{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-server-2",
+					},
+					Spec: v1alpha1.ToolServerSpec{
+						Config: v1alpha1.ToolServerConfig{},
+					},
+					Status: v1alpha1.ToolServerStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:    "Accepted",
+								Status:  metav1.ConditionFalse,
+								Message: "Failed to reconcile",
+							},
+						},
+					},
+				},
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody: map[string]interface{}{
+				"name":            "test-server-2",
+				"config":          map[string]interface{}{},
+				"discoveredTools": []interface{}{},
+				"status": map[string]interface{}{
+					"conditions": []interface{}{
+						map[string]interface{}{
+							"type":    "Accepted",
+							"status":  "False",
+							"message": "Failed to reconcile",
+						},
+					},
+					"error": "Failed to reconcile",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create fake client with test data
+			client := fake.NewClientBuilder().WithScheme(scheme).Build()
+			for _, ts := range tt.toolServers {
+				if err := client.Create(nil, &ts); err != nil {
+					t.Fatalf("Failed to create test tool server: %v", err)
+				}
+			}
+
+			// Create handler
+			handler := NewToolServersHandler(&Base{
+				KubeClient: client,
+			})
+
+			// Create request
+			req := httptest.NewRequest(http.MethodGet, "/api/toolservers", nil)
+			w := newMockErrorResponseWriter()
+
+			// Call handler
+			handler.HandleListToolServers(w, req)
+
+			// Check status code
+			if w.Code != tt.expectedStatus {
+				t.Errorf("HandleListToolServers() status = %v, want %v", w.Code, tt.expectedStatus)
+			}
+
+			// Parse response body
+			var response []map[string]interface{}
+			if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+				t.Fatalf("Failed to decode response: %v", err)
+			}
+
+			// Check response
+			if len(response) != len(tt.toolServers) {
+				t.Errorf("HandleListToolServers() returned %d tool servers, want %d", len(response), len(tt.toolServers))
+			}
+
+			// Compare first tool server response with expected
+			if len(response) > 0 {
+				compareToolServerResponse(t, response[0], tt.expectedBody)
+			}
+		})
+	}
+}
+
+func compareToolServerResponse(t *testing.T, got, want map[string]interface{}) {
+	// Compare basic fields
+	for key, wantVal := range want {
+		gotVal, exists := got[key]
+		if !exists {
+			t.Errorf("Response missing key: %s", key)
+			continue
+		}
+
+		if key == "status" {
+			gotStatus := gotVal.(map[string]interface{})
+			wantStatus := wantVal.(map[string]interface{})
+			compareStatus(t, gotStatus, wantStatus)
+		} else {
+			if !compareValues(gotVal, wantVal) {
+				t.Errorf("Field %s = %v, want %v", key, gotVal, wantVal)
+			}
+		}
+	}
+}
+
+func compareStatus(t *testing.T, got, want map[string]interface{}) {
+	gotConditions := got["conditions"].([]interface{})
+	wantConditions := want["conditions"].([]interface{})
+	if len(gotConditions) != len(wantConditions) {
+		t.Errorf("Status conditions length = %d, want %d", len(gotConditions), len(wantConditions))
+		return
+	}
+	
+	gotError := got["error"]
+	wantError := want["error"]
+	if !compareValues(gotError, wantError) {
+		t.Errorf("Status error = %v, want %v", gotError, wantError)
+	}
+}
+
+func compareValues(got, want interface{}) bool {
+	switch v := want.(type) {
+	case nil:
+		return got == nil
+	case string:
+		return got == v
+	case []interface{}:
+		gotSlice, ok := got.([]interface{})
+		if !ok || len(gotSlice) != len(v) {
+			return false
+		}
+		for i := range v {
+			if !compareValues(gotSlice[i], v[i]) {
+				return false
+			}
+		}
+		return true
+	case map[string]interface{}:
+		gotMap, ok := got.(map[string]interface{})
+		if !ok {
+			return false
+		}
+		for k, wantVal := range v {
+			gotVal, exists := gotMap[k]
+			if !exists || !compareValues(gotVal, wantVal) {
+				return false
+			}
+		}
+		return true
+	default:
+		return got == want
+	}
+}
+
+func stringPtr(s string) *string {
+	return &s
+} 

--- a/ui/src/app/servers/page.tsx
+++ b/ui/src/app/servers/page.tsx
@@ -1,26 +1,48 @@
-"use client";
+'use client';
 
-import { useState, useEffect } from "react";
-import { Server, Globe, Trash2, ChevronDown, ChevronRight, MoreHorizontal, Plus, FunctionSquare } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { getToolDescription, getToolDisplayName, getToolIdentifier } from "@/lib/toolUtils";
-import {  ToolServer, ToolServerWithTools } from "@/types/datamodel";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
-import { createServer, deleteServer, getServers } from "../actions/servers";
-import { AddServerDialog } from "@/components/AddServerDialog";
-import { ConfirmDialog } from "@/components/ConfirmDialog";
-import Link from "next/link";
-import { toast } from "sonner";
+import { AddServerDialog } from '@/components/AddServerDialog';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  getToolDescription,
+  getToolDisplayName,
+  getToolIdentifier,
+} from '@/lib/toolUtils';
+import { ToolServer, ToolServerWithTools } from '@/types/datamodel';
+import {
+  ChevronDown,
+  ChevronRight,
+  FunctionSquare,
+  Globe,
+  MoreHorizontal,
+  Plus,
+  Server,
+  Trash2,
+} from 'lucide-react';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import { createServer, deleteServer, getServers } from '../actions/servers';
 
 export default function ServersPage() {
   // State for servers and tools
   const [servers, setServers] = useState<ToolServerWithTools[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [expandedServers, setExpandedServers] = useState<Set<string>>(new Set());
+  const [expandedServers, setExpandedServers] = useState<Set<string>>(
+    new Set()
+  );
 
   // Dialog states
   const [showAddServer, setShowAddServer] = useState(false);
-  const [showConfirmDelete, setShowConfirmDelete] = useState<string | null>(null);
+  const [showConfirmDelete, setShowConfirmDelete] = useState<string | null>(
+    null
+  );
   const [openDropdownMenu, setOpenDropdownMenu] = useState<string | null>(null);
 
   // Fetch data on component mount
@@ -39,16 +61,18 @@ export default function ServersPage() {
         setServers(serversResponse.data);
 
         // Initially expand all servers
-        const serverNames = serversResponse.data.map((server) => server.name).filter((name): name is string => name !== undefined);
+        const serverNames = serversResponse.data
+          .map((server) => server.name)
+          .filter((name): name is string => name !== undefined);
 
         setExpandedServers(new Set(serverNames));
       } else {
-        console.error("Failed to fetch servers:", serversResponse);
-        toast.error(serversResponse.error || "Failed to fetch servers data.");
+        console.error('Failed to fetch servers:', serversResponse);
+        toast.error(serversResponse.error || 'Failed to fetch servers data.');
       }
     } catch (error) {
-      console.error("Error fetching servers:", error);
-      toast.error("An error occurred while fetching servers.");
+      console.error('Error fetching servers:', error);
+      toast.error('An error occurred while fetching servers.');
     } finally {
       setIsLoading(false);
     }
@@ -62,14 +86,14 @@ export default function ServersPage() {
       const response = await deleteServer(serverName);
 
       if (response.success) {
-        toast.success("Server deleted successfully");
+        toast.success('Server deleted successfully');
         fetchServers();
       } else {
-        toast.error(response.error || "Failed to delete server");
+        toast.error(response.error || 'Failed to delete server');
       }
     } catch (error) {
-      console.error("Error deleting server:", error);
-      toast.error("Failed to delete server");
+      console.error('Error deleting server:', error);
+      toast.error('Failed to delete server');
     } finally {
       setIsLoading(false);
       setShowConfirmDelete(null);
@@ -84,15 +108,16 @@ export default function ServersPage() {
       const response = await createServer(server);
 
       if (!response.success) {
-        throw new Error(response.error || "Failed to add server");
+        throw new Error(response.error || 'Failed to add server');
       }
 
-      toast.success("Server added successfully");
+      toast.success('Server added successfully');
       setShowAddServer(false);
       fetchServers();
     } catch (error) {
-      console.error("Error adding server:", error);
-      const errorMessage = error instanceof Error ? error.message : "Unknown error";
+      console.error('Error adding server:', error);
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
       toast.error(`Failed to add server: ${errorMessage}`);
       throw error; // Re-throw to be caught by the dialog
     } finally {
@@ -105,7 +130,10 @@ export default function ServersPage() {
       <div className="flex justify-between items-center mb-6">
         <div className="flex items-center gap-4">
           <h1 className="text-2xl font-bold">Tool Servers</h1>
-          <Link href="/tools" className="text-blue-600 hover:text-blue-800 text-sm">
+          <Link
+            href="/tools"
+            className="text-blue-600 hover:text-blue-800 text-sm"
+          >
             View Tools Library →
           </Link>
         </div>
@@ -130,12 +158,19 @@ export default function ServersPage() {
             const isExpanded = expandedServers.has(serverName);
 
             return (
-              <div key={server.name} className="border rounded-md overflow-hidden">
+              <div
+                key={server.name}
+                className="border rounded-md overflow-hidden"
+              >
                 {/* Server Header */}
                 <div className="bg-secondary/10 p-4">
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-3 cursor-pointer">
-                      {isExpanded ? <ChevronDown className="h-5 w-5" /> : <ChevronRight className="h-5 w-5" />}
+                      {isExpanded ? (
+                        <ChevronDown className="h-5 w-5" />
+                      ) : (
+                        <ChevronRight className="h-5 w-5" />
+                      )}
                       <div className="flex items-center gap-2">
                         <Globe className="h-5 w-5 text-green-500" />
                         <div>
@@ -148,26 +183,32 @@ export default function ServersPage() {
                     </div>
 
                     <div className="flex items-center gap-2">
-                      <DropdownMenu 
-                        open={openDropdownMenu === serverName} 
-                        onOpenChange={(isOpen) => setOpenDropdownMenu(isOpen ? serverName : null)}
+                      <DropdownMenu
+                        open={openDropdownMenu === serverName}
+                        onOpenChange={(isOpen) =>
+                          setOpenDropdownMenu(isOpen ? serverName : null)
+                        }
                       >
                         <DropdownMenuTrigger asChild>
-                          <Button variant="ghost" size="icon" className="h-8 w-8">
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-8 w-8"
+                          >
                             <MoreHorizontal className="h-4 w-4" />
                           </Button>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end">
-                           <DropdownMenuItem 
-                             className="text-red-600 focus:text-red-700 focus:bg-red-50"
-                             onSelect={(e) => {
-                               e.preventDefault();
-                               setOpenDropdownMenu(null);
-                                setShowConfirmDelete(serverName);
-                             }}
-                           >
-                             <Trash2 className="h-4 w-4 mr-2" />
-                             Remove Server
+                          <DropdownMenuItem
+                            className="text-red-600 focus:text-red-700 focus:bg-red-50"
+                            onSelect={(e) => {
+                              e.preventDefault();
+                              setOpenDropdownMenu(null);
+                              setShowConfirmDelete(serverName);
+                            }}
+                          >
+                            <Trash2 className="h-4 w-4 mr-2" />
+                            Remove Server
                           </DropdownMenuItem>
                         </DropdownMenuContent>
                       </DropdownMenu>
@@ -178,29 +219,46 @@ export default function ServersPage() {
                 {/* Server Tools List */}
                 {isExpanded && (
                   <div className="p-4">
-                    {server.discoveredTools && server.discoveredTools.length > 0 ? (
+                    {server.status.error ? (
+                      <div className="p-3 border border-red-200 bg-red-50 rounded-md text-red-700">
+                        <div className="font-medium">Error</div>
+                        <div className="text-sm">{server.status.error}</div>
+                      </div>
+                    ) : server.discoveredTools &&
+                      server.discoveredTools.length > 0 ? (
                       <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                         {server.discoveredTools
                           .sort((a, b) => {
-                            const aName = getToolDisplayName(a.component) || "";
-                            const bName = getToolDisplayName(b.component) || "";
+                            const aName = getToolDisplayName(a.component) || '';
+                            const bName = getToolDisplayName(b.component) || '';
                             return aName.localeCompare(bName);
                           })
                           .map((tool) => (
-                            <div key={getToolIdentifier(tool.component)} className="p-3 border rounded-md hover:bg-secondary/5 transition-colors">
+                            <div
+                              key={getToolIdentifier(tool.component)}
+                              className="p-3 border rounded-md hover:bg-secondary/5 transition-colors"
+                            >
                               <div className="flex items-start gap-2">
                                 <FunctionSquare className="h-4 w-4 text-blue-500 mt-0.5" />
                                 <div>
-                                  <div className="font-medium text-sm">{getToolDisplayName(tool.component)}</div>
-                                  <div className="text-xs text-muted-foreground mt-1">{getToolDescription(tool.component)}</div>
-                                  <div className="text-xs text-muted-foreground mt-1 font-mono">{getToolIdentifier(tool.component)}</div>
+                                  <div className="font-medium text-sm">
+                                    {getToolDisplayName(tool.component)}
+                                  </div>
+                                  <div className="text-xs text-muted-foreground mt-1">
+                                    {getToolDescription(tool.component)}
+                                  </div>
+                                  <div className="text-xs text-muted-foreground mt-1 font-mono">
+                                    {getToolIdentifier(tool.component)}
+                                  </div>
                                 </div>
                               </div>
                             </div>
                           ))}
                       </div>
                     ) : (
-                      <div className="text-center p-4 text-sm text-muted-foreground">No tools available for this server.</div>
+                      <div className="text-muted-foreground">
+                        No tools found
+                      </div>
                     )}
                   </div>
                 )}
@@ -212,7 +270,9 @@ export default function ServersPage() {
         <div className="flex flex-col items-center justify-center h-[300px] text-center p-4 border rounded-lg bg-secondary/5">
           <Server className="h-12 w-12 text-muted-foreground mb-4 opacity-20" />
           <h3 className="font-medium text-lg">No servers connected</h3>
-          <p className="text-muted-foreground mt-1 mb-4">Add a tool server to discover and use tools.</p>
+          <p className="text-muted-foreground mt-1 mb-4">
+            Add a tool server to discover and use tools.
+          </p>
           <Button onClick={() => setShowAddServer(true)} variant="default">
             <Plus className="h-4 w-4 mr-2" />
             Add Server
@@ -221,9 +281,9 @@ export default function ServersPage() {
       )}
 
       {/* Add server dialog */}
-      <AddServerDialog 
-        open={showAddServer} 
-        onOpenChange={setShowAddServer} 
+      <AddServerDialog
+        open={showAddServer}
+        onOpenChange={setShowAddServer}
         onAddServer={handleAddServer}
       />
 
@@ -237,7 +297,9 @@ export default function ServersPage() {
         }}
         title="Delete Server"
         description="Are you sure you want to delete this server? This will also delete all associated tools and cannot be undone."
-        onConfirm={() => showConfirmDelete !== null && handleDeleteServer(showConfirmDelete)}
+        onConfirm={() =>
+          showConfirmDelete !== null && handleDeleteServer(showConfirmDelete)
+        }
       />
     </div>
   );

--- a/ui/src/app/servers/page.tsx
+++ b/ui/src/app/servers/page.tsx
@@ -219,15 +219,22 @@ export default function ServersPage() {
                 {/* Server Tools List */}
                 {isExpanded && (
                   <div className="p-4">
-                    {server.status.error ? (
+                    {server.status.conditions &&
+                    server.status.conditions.some(
+                      (c) => c.status === 'False'
+                    ) ? (
                       <div className="p-3 border border-red-200 bg-red-50 rounded-md text-red-700">
                         <div className="font-medium">Error</div>
-                        <div className="text-sm">{server.status.error}</div>
+                        <div className="text-sm">
+                          {server.status.conditions
+                            .filter((c) => c.status === 'False')
+                            .map((c) => c.message)
+                            .join(', ')}
+                        </div>
                       </div>
-                    ) : server.discoveredTools &&
-                      server.discoveredTools.length > 0 ? (
+                    ) : server.tools && server.tools.length > 0 ? (
                       <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                        {server.discoveredTools
+                        {server.tools
                           .sort((a, b) => {
                             const aName = getToolDisplayName(a.component) || '';
                             const bName = getToolDisplayName(b.component) || '';

--- a/ui/src/app/tools/page.tsx
+++ b/ui/src/app/tools/page.tsx
@@ -1,42 +1,74 @@
-"use client";
+'use client';
 
-import { useState, useEffect, useMemo } from "react";
-import { Search, FunctionSquare, Filter, Info, AlertCircle, Server, ChevronDown, ChevronRight } from "lucide-react";
-import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
-import { ScrollArea } from "@/components/ui/scroll-area";
-import { Badge } from "@/components/ui/badge";
-import { getToolCategory, getToolDescription, getToolDisplayName, getToolIdentifier, getToolProvider, isMcpProvider } from "@/lib/toolUtils";
-import {  Component, ToolConfig, ToolServerConfiguration } from "@/types/datamodel";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { getTools } from "../actions/tools";
-import { getServers } from "../actions/servers";
-import Link from "next/link";
-import CategoryFilter from "@/components/tools/CategoryFilter";
-import McpIcon from "@/components/icons/McpIcon";
+import McpIcon from '@/components/icons/McpIcon';
+import CategoryFilter from '@/components/tools/CategoryFilter';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import {
+  getToolCategory,
+  getToolDescription,
+  getToolDisplayName,
+  getToolIdentifier,
+  getToolProvider,
+  isMcpProvider,
+} from '@/lib/toolUtils';
+import {
+  Component,
+  ToolConfig,
+  ToolServerConfiguration,
+} from '@/types/datamodel';
+import {
+  AlertCircle,
+  ChevronDown,
+  ChevronRight,
+  Filter,
+  FunctionSquare,
+  Info,
+  Search,
+  Server,
+} from 'lucide-react';
+import Link from 'next/link';
+import { useEffect, useMemo, useState } from 'react';
+import { getServers } from '../actions/servers';
+import { getTools } from '../actions/tools';
 
 export default function ToolsPage() {
   // Consolidated state
   const [toolsData, setToolsData] = useState<{
     tools: Component<ToolConfig>[];
-    serversMap: Map<string, { name: string; label: string; config: ToolServerConfiguration }>;
+    serversMap: Map<
+      string,
+      { name: string; label: string; config: ToolServerConfiguration }
+    >;
     categories: Set<string>;
     isLoading: boolean;
     error: string | null;
   }>({
-    tools: [],                 // Normalized tools from both sources
-    serversMap: new Map(),     // Map of server_id to server name/label
-    categories: new Set(),     // Unique categories
+    tools: [], // Normalized tools from both sources
+    serversMap: new Map(), // Map of server_id to server name/label
+    categories: new Set(), // Unique categories
     isLoading: true,
-    error: null
+    error: null,
   });
-  
+
   // UI state
-  const [searchTerm, setSearchTerm] = useState<string>("");
+  const [searchTerm, setSearchTerm] = useState<string>('');
   const [showFilters, setShowFilters] = useState<boolean>(false);
-  const [selectedCategories, setSelectedCategories] = useState<Set<string>>(new Set());
-  const [expandedCategories, setExpandedCategories] = useState<{ [key: string]: boolean }>({});
+  const [selectedCategories, setSelectedCategories] = useState<Set<string>>(
+    new Set()
+  );
+  const [expandedCategories, setExpandedCategories] = useState<{
+    [key: string]: boolean;
+  }>({});
 
   // Fetch data on component mount
   useEffect(() => {
@@ -46,32 +78,35 @@ export default function ToolsPage() {
   // Fetch and consolidate tools data
   const fetchData = async () => {
     try {
-      setToolsData(prev => ({ ...prev, isLoading: true, error: null }));
+      setToolsData((prev) => ({ ...prev, isLoading: true, error: null }));
 
       // Fetch both data sources in parallel
       const [serversResponse, toolsResponse] = await Promise.all([
         getServers(),
-        getTools()
+        getTools(),
       ]);
 
       // Process servers
-      const serversMap = new Map<string, { name: string; label: string; config: ToolServerConfiguration }>();
+      const serversMap = new Map<
+        string,
+        { name: string; label: string; config: ToolServerConfiguration }
+      >();
       const toolsFromServers: Component<ToolConfig>[] = [];
 
       if (serversResponse.success && serversResponse.data) {
-        serversResponse.data.forEach(server => {
+        serversResponse.data.forEach((server) => {
           serversMap.set(server.name, {
             name: server.name,
             label: server.name,
-            config: server.config
+            config: server.config,
           });
-          
+
           // Process discovered tools from this server
-          if (server.discoveredTools && Array.isArray(server.discoveredTools)) {
-            server.discoveredTools.forEach(tool => {
+          if (server.tools && Array.isArray(server.tools)) {
+            server.tools.forEach((tool) => {
               const labeledTool = {
                 ...tool.component,
-                label: server.name
+                label: server.name,
               };
               toolsFromServers.push(labeledTool);
             });
@@ -84,32 +119,32 @@ export default function ToolsPage() {
       if (toolsResponse.success && toolsResponse.data) {
         allTools = [...toolsResponse.data];
       }
-      
+
       // Combine tools from both sources (prioritizing DB tools if there are duplicates)
       // This assumes getToolIdentifier returns a unique identifier for each tool
       const toolMap = new Map<string, Component<ToolConfig>>();
-      
+
       // First add all DB tools
-      allTools.forEach(tool => {
+      allTools.forEach((tool) => {
         const toolId = getToolIdentifier(tool);
         toolMap.set(toolId, tool);
       });
-      
+
       // Then add server tools only if they don't already exist
-      toolsFromServers.forEach(tool => {
+      toolsFromServers.forEach((tool) => {
         const toolId = getToolIdentifier(tool);
         if (!toolMap.has(toolId)) {
           toolMap.set(toolId, tool);
         }
       });
-      
+
       // Convert map back to array
       const consolidatedTools = Array.from(toolMap.values());
-      
+
       // Extract unique categories and initialize expanded state
       const uniqueCategories = new Set<string>();
       const initialExpandedState: { [key: string]: boolean } = {};
-      consolidatedTools.forEach(tool => {
+      consolidatedTools.forEach((tool) => {
         const category = getToolCategory(tool);
         uniqueCategories.add(category);
         initialExpandedState[category] = true;
@@ -121,23 +156,22 @@ export default function ToolsPage() {
         serversMap,
         categories: uniqueCategories,
         isLoading: false,
-        error: null
+        error: null,
       });
       setExpandedCategories(initialExpandedState);
-
     } catch (error) {
-      console.error("Error fetching data:", error);
-      setToolsData(prev => ({
+      console.error('Error fetching data:', error);
+      setToolsData((prev) => ({
         ...prev,
         isLoading: false,
-        error: "An error occurred while fetching data."
+        error: 'An error occurred while fetching data.',
       }));
     }
   };
 
   // Category filter handlers
   const handleToggleCategory = (category: string) => {
-    setSelectedCategories(prev => {
+    setSelectedCategories((prev) => {
       const newSelection = new Set(prev);
       if (newSelection.has(category)) {
         newSelection.delete(category);
@@ -148,12 +182,13 @@ export default function ToolsPage() {
     });
   };
 
-  const selectAllCategories = () => setSelectedCategories(new Set(toolsData.categories));
+  const selectAllCategories = () =>
+    setSelectedCategories(new Set(toolsData.categories));
   const clearCategories = () => setSelectedCategories(new Set());
 
   // Filter tools based on search and categories
   const filteredTools = useMemo(() => {
-    return toolsData.tools.filter(tool => {
+    return toolsData.tools.filter((tool) => {
       const searchLower = searchTerm.toLowerCase();
       const matchesSearch =
         getToolDisplayName(tool)?.toLowerCase().includes(searchLower) ||
@@ -162,7 +197,8 @@ export default function ToolsPage() {
         getToolIdentifier(tool)?.toLowerCase().includes(searchLower);
 
       const toolCategory = getToolCategory(tool);
-      const matchesCategory = selectedCategories.size === 0 || selectedCategories.has(toolCategory);
+      const matchesCategory =
+        selectedCategories.size === 0 || selectedCategories.has(toolCategory);
 
       return matchesSearch && matchesCategory;
     });
@@ -172,21 +208,25 @@ export default function ToolsPage() {
   const toolsByCategory = useMemo(() => {
     const groups: Record<string, Component<ToolConfig>[]> = {};
     const sortedTools = [...filteredTools].sort((a, b) => {
-      const aName = getToolDisplayName(a) || "";
-      const bName = getToolDisplayName(b) || "";
+      const aName = getToolDisplayName(a) || '';
+      const bName = getToolDisplayName(b) || '';
       return aName.localeCompare(bName);
     });
 
-    sortedTools.forEach(tool => {
+    sortedTools.forEach((tool) => {
       const category = getToolCategory(tool);
       if (!groups[category]) {
         groups[category] = [];
       }
       groups[category].push(tool);
     });
-    
-    return Object.entries(groups).sort(([catA], [catB]) => catA.localeCompare(catB))
-           .reduce((acc, [key, value]) => { acc[key] = value; return acc; }, {} as typeof groups);
+
+    return Object.entries(groups)
+      .sort(([catA], [catB]) => catA.localeCompare(catB))
+      .reduce((acc, [key, value]) => {
+        acc[key] = value;
+        return acc;
+      }, {} as typeof groups);
   }, [filteredTools]);
 
   // Handler to toggle category expansion
@@ -195,11 +235,20 @@ export default function ToolsPage() {
   };
 
   // Helper to highlight search term
-  const highlightMatch = (text: string | undefined | null, highlight: string) => {
+  const highlightMatch = (
+    text: string | undefined | null,
+    highlight: string
+  ) => {
     if (!text || !highlight) return text;
     const parts = text.split(new RegExp(`(${highlight})`, 'gi'));
     return parts.map((part, i) =>
-      part.toLowerCase() === highlight.toLowerCase() ? <mark key={i} className="bg-yellow-200 px-0 py-0 rounded">{part}</mark> : part
+      part.toLowerCase() === highlight.toLowerCase() ? (
+        <mark key={i} className="bg-yellow-200 px-0 py-0 rounded">
+          {part}
+        </mark>
+      ) : (
+        part
+      )
     );
   };
 
@@ -207,7 +256,10 @@ export default function ToolsPage() {
     <div className="mt-12 mx-auto max-w-6xl px-6 pb-12">
       <div className="flex justify-between items-center mb-6">
         <h1 className="text-2xl font-bold">Tools Library</h1>
-        <Link href="/servers" className="text-blue-600 hover:text-blue-800 text-sm">
+        <Link
+          href="/servers"
+          className="text-blue-600 hover:text-blue-800 text-sm"
+        >
           Manage tool servers →
         </Link>
       </div>
@@ -225,18 +277,18 @@ export default function ToolsPage() {
       <div className="flex gap-2 mb-4">
         <div className="relative flex-1">
           <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
-          <Input 
-            placeholder="Search tools by name, description or provider..." 
-            value={searchTerm} 
-            onChange={(e) => setSearchTerm(e.target.value)} 
-            className="pl-10" 
+          <Input
+            placeholder="Search tools by name, description or provider..."
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            className="pl-10"
           />
         </div>
-        <Button 
-          variant="outline" 
-          size="icon" 
-          onClick={() => setShowFilters(!showFilters)} 
-          className={showFilters ? "bg-secondary" : ""}
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={() => setShowFilters(!showFilters)}
+          className={showFilters ? 'bg-secondary' : ''}
         >
           <Filter className="h-4 w-4" />
         </Button>
@@ -256,7 +308,8 @@ export default function ToolsPage() {
       {/* Tools counter */}
       <div className="flex justify-end items-center mb-4">
         <div className="text-sm text-muted-foreground">
-          {filteredTools.length} tool{filteredTools.length !== 1 ? "s" : ""} found
+          {filteredTools.length} tool{filteredTools.length !== 1 ? 's' : ''}{' '}
+          found
         </div>
       </div>
 
@@ -268,70 +321,116 @@ export default function ToolsPage() {
       ) : filteredTools.length > 0 ? (
         <ScrollArea className="h-[calc(100vh-300px)] pr-4 -mr-4">
           <div className="space-y-4">
-            {Object.entries(toolsByCategory)
-              .map(([category, categoryTools]) => {
+            {Object.entries(toolsByCategory).map(
+              ([category, categoryTools]) => {
                 // Check if any tool in this category is an MCP tool
-                const hasMcpTool = categoryTools.some(tool => isMcpProvider(tool.provider));
+                const hasMcpTool = categoryTools.some((tool) =>
+                  isMcpProvider(tool.provider)
+                );
                 return (
-                  <div key={category} className="border rounded-lg overflow-hidden bg-card shadow-sm">
+                  <div
+                    key={category}
+                    className="border rounded-lg overflow-hidden bg-card shadow-sm"
+                  >
                     <div
                       className="flex items-center justify-between p-3 bg-secondary/50 cursor-pointer hover:bg-secondary/70"
                       onClick={() => toggleCategory(category)}
                     >
                       <div className="flex items-center gap-2">
-                        {expandedCategories[category] ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
-                        {hasMcpTool && <McpIcon className="w-3.5 h-3.5 text-purple-600" />}
-                        <h3 className="font-semibold capitalize text-sm">{highlightMatch(category, searchTerm)}</h3>
-                        <Badge variant="secondary" className="font-mono text-xs">{categoryTools.length}</Badge>
+                        {expandedCategories[category] ? (
+                          <ChevronDown className="w-4 h-4" />
+                        ) : (
+                          <ChevronRight className="w-4 h-4" />
+                        )}
+                        {hasMcpTool && (
+                          <McpIcon className="w-3.5 h-3.5 text-purple-600" />
+                        )}
+                        <h3 className="font-semibold capitalize text-sm">
+                          {highlightMatch(category, searchTerm)}
+                        </h3>
+                        <Badge
+                          variant="secondary"
+                          className="font-mono text-xs"
+                        >
+                          {categoryTools.length}
+                        </Badge>
                       </div>
                     </div>
 
                     {expandedCategories[category] && (
                       <div className="divide-y border-t">
-                        {categoryTools
-                          .map(tool => (
-                            <div
-                              key={getToolIdentifier(tool)}
-                              className="p-3 transition-colors hover:bg-muted/50"
-                            >
-                              <div className="flex items-start justify-between gap-3">
-                                <div className="flex items-start gap-3 flex-1 min-w-0">
-                                  <FunctionSquare className="h-5 w-5 text-blue-500 mt-0.5 flex-shrink-0" />
-                                  <div className="flex-1 min-w-0">
-                                    <div className="font-medium text-sm truncate">{highlightMatch(getToolDisplayName(tool), searchTerm)}</div>
-                                    <div className="text-xs text-muted-foreground mt-1 line-clamp-2">
-                                      {highlightMatch(getToolDescription(tool), searchTerm)}
-                                    </div>
-                                    <div className="text-xs text-muted-foreground/80 mt-1.5 flex items-center gap-1.5 font-mono">
-                                       <Server className="h-3 w-3" />
-                                       <span className="truncate">{highlightMatch(tool.label || 'Unknown Server', searchTerm)}</span>
-                                    </div>
-                                    <div className="text-xs text-muted-foreground/80 mt-1 flex items-center gap-1.5 font-mono">
-                                      Provider: <span className="truncate">{highlightMatch(getToolProvider(tool), searchTerm)}</span>
-                                    </div>
+                        {categoryTools.map((tool) => (
+                          <div
+                            key={getToolIdentifier(tool)}
+                            className="p-3 transition-colors hover:bg-muted/50"
+                          >
+                            <div className="flex items-start justify-between gap-3">
+                              <div className="flex items-start gap-3 flex-1 min-w-0">
+                                <FunctionSquare className="h-5 w-5 text-blue-500 mt-0.5 flex-shrink-0" />
+                                <div className="flex-1 min-w-0">
+                                  <div className="font-medium text-sm truncate">
+                                    {highlightMatch(
+                                      getToolDisplayName(tool),
+                                      searchTerm
+                                    )}
+                                  </div>
+                                  <div className="text-xs text-muted-foreground mt-1 line-clamp-2">
+                                    {highlightMatch(
+                                      getToolDescription(tool),
+                                      searchTerm
+                                    )}
+                                  </div>
+                                  <div className="text-xs text-muted-foreground/80 mt-1.5 flex items-center gap-1.5 font-mono">
+                                    <Server className="h-3 w-3" />
+                                    <span className="truncate">
+                                      {highlightMatch(
+                                        tool.label || 'Unknown Server',
+                                        searchTerm
+                                      )}
+                                    </span>
+                                  </div>
+                                  <div className="text-xs text-muted-foreground/80 mt-1 flex items-center gap-1.5 font-mono">
+                                    Provider:{' '}
+                                    <span className="truncate">
+                                      {highlightMatch(
+                                        getToolProvider(tool),
+                                        searchTerm
+                                      )}
+                                    </span>
                                   </div>
                                 </div>
-
-                                <TooltipProvider delayDuration={200}>
-                                  <Tooltip>
-                                    <TooltipTrigger asChild>
-                                      <Button variant="ghost" size="icon" className="h-7 w-7 flex-shrink-0">
-                                        <Info className="h-4 w-4" />
-                                      </Button>
-                                    </TooltipTrigger>
-                                    <TooltipContent side="left" className="max-w-xs">
-                                      <p className="font-mono text-xs break-all">{getToolIdentifier(tool)}</p>
-                                    </TooltipContent>
-                                  </Tooltip>
-                                </TooltipProvider>
                               </div>
+
+                              <TooltipProvider delayDuration={200}>
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <Button
+                                      variant="ghost"
+                                      size="icon"
+                                      className="h-7 w-7 flex-shrink-0"
+                                    >
+                                      <Info className="h-4 w-4" />
+                                    </Button>
+                                  </TooltipTrigger>
+                                  <TooltipContent
+                                    side="left"
+                                    className="max-w-xs"
+                                  >
+                                    <p className="font-mono text-xs break-all">
+                                      {getToolIdentifier(tool)}
+                                    </p>
+                                  </TooltipContent>
+                                </Tooltip>
+                              </TooltipProvider>
                             </div>
-                          ))}
+                          </div>
+                        ))}
                       </div>
                     )}
                   </div>
                 );
-              })}
+              }
+            )}
           </div>
         </ScrollArea>
       ) : (
@@ -339,16 +438,16 @@ export default function ToolsPage() {
           <FunctionSquare className="h-12 w-12 text-muted-foreground mb-4 opacity-20" />
           <h3 className="font-medium text-lg">No tools found</h3>
           <p className="text-muted-foreground mt-1 mb-4">
-            {searchTerm || selectedCategories.size > 0 
-              ? "Try adjusting your search or filters to find tools." 
-              : "Connect a server to discover tools."}
+            {searchTerm || selectedCategories.size > 0
+              ? 'Try adjusting your search or filters to find tools.'
+              : 'Connect a server to discover tools.'}
           </p>
           {searchTerm || selectedCategories.size > 0 ? (
             <div className="flex gap-3">
               <Button
                 variant="outline"
                 onClick={() => {
-                  setSearchTerm("");
+                  setSearchTerm('');
                   clearCategories();
                 }}
               >

--- a/ui/src/types/datamodel.ts
+++ b/ui/src/types/datamodel.ts
@@ -426,9 +426,19 @@ export interface ToolComponent {
 
 export interface ToolServerWithTools {
   name: string;
-  config: any;
-  discoveredTools: any[];
+  namespace: string;
   status: {
-    error?: string;
+    conditions: Array<{
+      type: string;
+      status: string;
+      message: string;
+      lastTransitionTime: string;
+      observedGeneration: number;
+    }>;
   };
+  tools: Array<{
+    name: string;
+    component: Component<ToolConfig>;
+  }>;
+  config: ToolServerConfiguration;
 }

--- a/ui/src/types/datamodel.ts
+++ b/ui/src/types/datamodel.ts
@@ -50,7 +50,7 @@ export interface BaseMessageConfig {
   metadata?: Record<string, string>;
 }
 
-export interface BaseAgentEvent extends BaseMessageConfig {}
+export interface BaseAgentEvent extends BaseMessageConfig { }
 
 export interface MemoryQueryEventContent {
   content: string;
@@ -93,7 +93,7 @@ export interface ToolCallSummaryMessage extends BaseMessageConfig {
   type: "ToolCallSummaryMessage";
 }
 
-export interface ModelClientStreamingChunkEvent extends BaseAgentEvent { 
+export interface ModelClientStreamingChunkEvent extends BaseAgentEvent {
   content: string;
   type: "ModelClientStreamingChunkEvent";
 }
@@ -426,6 +426,9 @@ export interface ToolComponent {
 
 export interface ToolServerWithTools {
   name: string;
-  config: ToolServerConfiguration;
-  discoveredTools: ToolComponent[];
+  config: any;
+  discoveredTools: any[];
+  status: {
+    error?: string;
+  };
 }


### PR DESCRIPTION
**Summary:**  
- enhances backend (`HandleListToolServers` in Go) to include a `status.error` field for each tool server, surfacing reconciliation and other errors from the controller
- updated the UI to display these errors prominently in the tool server card, so users are aware of issues (e.g., failed auth, misconfiguration) directly in the tool server list
- added status.error field to tool server API response for reconciliation and other errors
- improves visibility of tool server issues for users

Note: @peterj I could use help testing error display in the UI. I wasn't able to add a tool server in localhost