### PR TITLE
[CLI] Use subcommands for `kagent get`

### DIFF
--- a/go/cli/cmd/kagent/main.go
+++ b/go/cli/cmd/kagent/main.go
@@ -142,7 +142,7 @@ func main() {
 
 	getSessionCmd := &cobra.Command{
 		Use:   "session [session_id]",
-		Short: "Get a session",
+		Short: "Get a session or list all sessions",
 		Long:  `Get a session by ID or list all sessions`,
 		Run: func(cmd *cobra.Command, args []string) {
 			client := autogen_client.New(cfg.APIURL)
@@ -160,7 +160,7 @@ func main() {
 
 	getRunCmd := &cobra.Command{
 		Use:   "run [run_id]",
-		Short: "Get a run",
+		Short: "Get a run or list all runs",
 		Long:  `Get a run by ID or list all runs`,
 		Run: func(cmd *cobra.Command, args []string) {
 			client := autogen_client.New(cfg.APIURL)
@@ -178,7 +178,7 @@ func main() {
 
 	getAgentCmd := &cobra.Command{
 		Use:   "agent [agent_name]",
-		Short: "Get an agent",
+		Short: "Get an agent or list all agents",
 		Long:  `Get an agent by name or list all agents`,
 		Run: func(cmd *cobra.Command, args []string) {
 			client := autogen_client.New(cfg.APIURL)

--- a/go/cli/cmd/kagent/main.go
+++ b/go/cli/cmd/kagent/main.go
@@ -134,37 +134,81 @@ func main() {
 		Short: "Get a kagent resource",
 		Long:  `Get a kagent resource`,
 		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Fprintf(os.Stderr, "No resource type provided\n\n")
+			cmd.Help()
+			os.Exit(1)
+		},
+	}
+
+	getSessionCmd := &cobra.Command{
+		Use:   "session [session_id]",
+		Short: "Get a session",
+		Long:  `Get a session by ID or list all sessions`,
+		Run: func(cmd *cobra.Command, args []string) {
 			client := autogen_client.New(cfg.APIURL)
 			if err := cli.CheckServerConnection(client); err != nil {
 				pf := cli.NewPortForward(ctx, cfg)
 				defer pf.Stop()
 			}
-			resourceType := ""
 			resourceName := ""
 			if len(args) > 0 {
-				resourceType = args[0]
-			} else {
-				fmt.Fprintf(os.Stderr, "No resource type provided\n")
-				os.Exit(1)
+				resourceName = args[0]
 			}
-			if len(args) > 1 {
-				resourceName = args[1]
-			}
-			switch strings.TrimSuffix(strings.ToLower(resourceType), "s") {
-			case "session":
-				cli.GetSessionCmd(cfg, resourceName)
-			case "run":
-				cli.GetRunCmd(cfg, resourceName)
-			case "agent":
-				cli.GetAgentCmd(cfg, resourceName)
-			case "tool":
-				cli.GetToolCmd(cfg)
-			default:
-				fmt.Fprintf(os.Stderr, "Invalid resource type: %s\n", resourceType)
-				os.Exit(1)
-			}
+			cli.GetSessionCmd(cfg, resourceName)
 		},
 	}
+
+	getRunCmd := &cobra.Command{
+		Use:   "run [run_id]",
+		Short: "Get a run",
+		Long:  `Get a run by ID or list all runs`,
+		Run: func(cmd *cobra.Command, args []string) {
+			client := autogen_client.New(cfg.APIURL)
+			if err := cli.CheckServerConnection(client); err != nil {
+				pf := cli.NewPortForward(ctx, cfg)
+				defer pf.Stop()
+			}
+			resourceName := ""
+			if len(args) > 0 {
+				resourceName = args[0]
+			}
+			cli.GetRunCmd(cfg, resourceName)
+		},
+	}
+
+	getAgentCmd := &cobra.Command{
+		Use:   "agent [agent_name]",
+		Short: "Get an agent",
+		Long:  `Get an agent by name or list all agents`,
+		Run: func(cmd *cobra.Command, args []string) {
+			client := autogen_client.New(cfg.APIURL)
+			if err := cli.CheckServerConnection(client); err != nil {
+				pf := cli.NewPortForward(ctx, cfg)
+				defer pf.Stop()
+			}
+			resourceName := ""
+			if len(args) > 0 {
+				resourceName = args[0]
+			}
+			cli.GetAgentCmd(cfg, resourceName)
+		},
+	}
+
+	getToolCmd := &cobra.Command{
+		Use:   "tool",
+		Short: "Get tools",
+		Long:  `List all available tools`,
+		Run: func(cmd *cobra.Command, args []string) {
+			client := autogen_client.New(cfg.APIURL)
+			if err := cli.CheckServerConnection(client); err != nil {
+				pf := cli.NewPortForward(ctx, cfg)
+				defer pf.Stop()
+			}
+			cli.GetToolCmd(cfg)
+		},
+	}
+
+	getCmd.AddCommand(getSessionCmd, getRunCmd, getAgentCmd, getToolCmd)
 
 	rootCmd.AddCommand(installCmd, uninstallCmd, invokeCmd, bugReportCmd, versionCmd, dashboardCmd, getCmd)
 


### PR DESCRIPTION
# Context

The `kagent get --help` message is not descriptive enough to understand what resource types can be gotten.

# Changes

Restructuring the `kagent get` cobra command to set up the 'resource type' as subcommands instead of internally-defined switch-case.

This:
1. Allows for a more descriptive `help` (automatically).
2. Makes it easier to extend this (ifever done), where added resource types would be added as subcommands and automatically be referenced in the `help`.
3. Allows the `get` and the subsequent resource type to have a single responsibility.

```
$ go run go/cli/cmd/kagent/main.go get --help

Get a kagent resource

Usage:
  kagent get [flags]
  kagent get [command]

Available Commands:
  agent       Get an agent or list all agents
  run         Get a run or list all runs
  session     Get a session or list all sessions
  tool        Get tools

Flags:
  -h, --help   help for get

Global Flags:
      --a2a-url string         A2A URL (default "http://localhost:8083/api/a2a")
      --api-url string         API URL (default "http://localhost:8081/api")
      --config string          config file (default is $HOME/.kagent/config.yaml) (default "/Users/fabiangonz98/.kagent/config.yaml")
  -n, --namespace string       Namespace (default "kagent")
  -o, --output-format string   Output format (default "table")
      --user-id string         User ID (default "admin@kagent.dev")
  -v, --verbose                Verbose output

Use "kagent get [command] --help" for more information about a command.
```

# Personal Thoughts

It _may_ be worth restructuring the cobra cli setup. For instance, setting up `get` as its own package with subcommands defined in it.

The below example structure, `get` and its subcommand would be defined outside of `main.go` and imported. That way the `main.go` file doesn't grow over time and the cli portion of this would hopefully become more easily understandable / maintainable.

```
/cli
  /cmd
    /kagent
      main.go
      /get
        get.go
        /session
        /tool
```

This structure also make it easier to write tests in the future (if wanted), so we can test commands and their expected outputs/actions.

Resolves: https://github.com/kagent-dev/kagent/issues/488
