### PR TITLE
fix(controller): fix status reconcile

### DIFF
--- a/go/autogen/client/team.go
+++ b/go/autogen/client/team.go
@@ -33,7 +33,7 @@ func (c *client) GetTeam(teamLabel string, userID string) (*Team, error) {
 		}
 	}
 
-	return nil, nil
+	return nil, NotFoundError
 }
 
 func (c *client) DeleteTeam(teamID int, userID string) error {

--- a/go/controller/internal/httpserver/handlers/teams.go
+++ b/go/controller/internal/httpserver/handlers/teams.go
@@ -63,12 +63,12 @@ func (h *TeamsHandler) HandleListTeams(w ErrorResponseWriter, r *http.Request) {
 
 		autogenTeam, err := h.AutogenClient.GetTeam(teamRef, userID)
 		if err != nil {
+			if err == autogen_client.NotFoundError {
+				log.V(1).Info("Team not found in Autogen", "teamRef", teamRef)
+				continue
+			}
 			w.RespondWithError(errors.NewInternalServerError("Failed to get Team from Autogen", err))
 			return
-		}
-		if autogenTeam == nil {
-			log.V(1).Info("Team not found in Autogen", "teamName", teamRef)
-			continue
 		}
 
 		// Get the ModelConfig for the team
@@ -93,7 +93,7 @@ func (h *TeamsHandler) HandleListTeams(w ErrorResponseWriter, r *http.Request) {
 		memoryRefs := make([]string, 0, len(team.Spec.Memory))
 		for _, memory := range team.Spec.Memory {
 			memoryRef, err := common.ParseRefString(memory, team.Namespace)
-			if err != nil  {
+			if err != nil {
 				log.Error(err, "Failed to parse memory reference", "memoryRef", memory)
 				continue
 			}
@@ -172,7 +172,7 @@ func (h *TeamsHandler) HandleUpdateTeam(w ErrorResponseWriter, r *http.Request) 
 			"namespace", teamRequest.Namespace)
 	}
 	teamRef, err := common.ParseRefString(teamRequest.Name, teamRequest.Namespace)
-    if err != nil {
+	if err != nil {
 		w.RespondWithError(errors.NewBadRequestError("Invalid Agent metadata", err))
 	}
 
@@ -231,7 +231,7 @@ func (h *TeamsHandler) HandleCreateTeam(w ErrorResponseWriter, r *http.Request) 
 			"namespace", teamRequest.Namespace)
 	}
 	teamRef, err := common.ParseRefString(teamRequest.Name, teamRequest.Namespace)
-    if err != nil {
+	if err != nil {
 		w.RespondWithError(errors.NewBadRequestError("Invalid agent metadata", err))
 	}
 
@@ -366,7 +366,7 @@ func (h *TeamsHandler) HandleGetTeam(w ErrorResponseWriter, r *http.Request) {
 	memoryRefs := make([]string, 0, len(team.Spec.Memory))
 	for _, memory := range team.Spec.Memory {
 		memoryRef, err := common.ParseRefString(memory, team.Namespace)
-		if err != nil  {
+		if err != nil {
 			log.Error(err, "Failed to parse memory reference", "memoryRef", memory)
 			continue
 		}

--- a/go/test/e2e/e2e_test.go
+++ b/go/test/e2e/e2e_test.go
@@ -56,8 +56,6 @@ func TestE2E(t *testing.T) {
 		agentTeam, err := agentClient.GetTeam(agentName, GlobalUserID)
 		require.NoError(t, err)
 
-		require.NotNil(t, agentTeam, fmt.Sprintf("Agent with label %s not found", agentName))
-
 		// reuse existing sessions if available
 		existingSessions, err := agentClient.ListSessions(GlobalUserID)
 		require.NoError(t, err)

--- a/helm/kagent/templates/deployment.yaml
+++ b/helm/kagent/templates/deployment.yaml
@@ -69,6 +69,8 @@ spec:
               value: {{ .Values.otel.tracing.exporter.otlp.timeout | quote }}
             - name: OTEL_EXPORTER_OTLP_TRACES_INSECURE
               value: {{ .Values.otel.tracing.exporter.otlp.insecure | quote }}
+            - name: AUTOGEN_DISABLE_RUNTIME_TRACING
+              value: "true"
           {{- with .Values.app.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
This PR properly hooks up the failure statuses for agents. They still aren't as useful as they could be, but they are at least pointing in the right direction now :)

for example:
```
status:
  conditions:
  - lastTransitionTime: "2025-06-24T19:59:30Z"
    message: 'failed to translate agent kagent/everything: tool add not found in discovered
      tools in ToolServer kagent/everything'
    reason: AgentReconcileFailed
    status: "False"
    type: Accepted
  observedGeneration: 1
```