### PR TITLE
refactor(app): remove sensitive Authorization header logging from SteamableHttp MCP server

### DIFF
--- a/python/src/autogenstudio/database/db_manager.py
+++ b/python/src/autogenstudio/database/db_manager.py
@@ -1,6 +1,6 @@
 import json
 import threading
-from datetime import datetime, timedelta, date
+from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Optional, Union
 

--- a/python/src/kagent/tool_servers/_streamable_http_mcp_tool_server.py
+++ b/python/src/kagent/tool_servers/_streamable_http_mcp_tool_server.py
@@ -20,7 +20,7 @@ class StreamableHttpMcpToolServer(ToolServer, Component[StreamableHttpMcpToolSer
 
     async def discover_tools(self) -> list[Component]:
         try:
-            logger.debug(f"Discovering tools from streamable http server: {self.config}")
+            logger.debug(f"Discovering tools from streamable http server: {self._sanitize_config(self.config)}")
             tools = await mcp_server_tools(self.config)
             return tools
         except Exception as e:
@@ -32,3 +32,11 @@ class StreamableHttpMcpToolServer(ToolServer, Component[StreamableHttpMcpToolSer
     @classmethod
     def _from_config(cls, config: StreamableHttpMcpToolServerConfig):
         return cls(config)
+
+    @staticmethod
+    def _sanitize_config(config: StreamableHttpServerParams) -> dict:
+        config_dict = config.model_dump()
+        headers = config_dict.get("headers")
+        if headers and "Authorization" in headers:
+            headers["Authorization"] = "***REDACTED***"
+        return config_dict


### PR DESCRIPTION
# Description
Authorization decoded secrets is logged freely in kagent app, which is serious security violation.

## Example
With GitHub MCP Server I have logged PAT token
```
2025-06-27 13:22:31.989 | DEBUG    | kagent.tool_servers._streamable_http_mcp_tool_server:discover_tools:23 - Discovering tools from streamable http server: type='StreamableHttpServerParams' url='https://api.githubcopilot.com/mcp/' headers={'Authorization': '<my unencrypted PAT>'} timeout=datetime.timedelta(seconds=30) sse_read_timeout=datetime.timedelta(seconds=300) terminate_on_close=True
```

# Fix
Add config wrapper function that obfuscates Authorization header
