### PR TITLE
ci: add automatic labeling for enhancement proposals (EP) PullRequests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,3 @@
+enhancement-proposal:
+  - 'design/**/*'
+  - '!design/template.md'

--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -1,0 +1,16 @@
+name: Label Enhancement Proposals
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+jobs:
+  label-by-files:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
- Adds automatic labeling workflow for enhancement proposals
- PRs with changes in `design/` directory (excluding `template.md`) get labeled as `enhancement-proposal`
- Supports external forks using `pull_request_target` trigger
- Can be easily extended by new labels. To add more labeling rules go edit .github/labeler.yml file.

**Repository maintainers should create labels manually in GitHub repository settings to set custom colors before first use**