### PR TITLE
fix(models): update model names and add new model info for gemini-2.5…

### DIFF
--- a/python/src/kagent/models/vertexai/_model_info.py
+++ b/python/src/kagent/models/vertexai/_model_info.py
@@ -6,7 +6,7 @@ from .types import ModelInfoDict
 
 # https://ai.google.dev/gemini-api/docs/models
 _MODEL_INFO: ModelInfoDict = {
-    "gemini-2.5-flash-preview-05-20": {
+    "gemini-2.5-flash": {
         "vision": False,
         "function_calling": True,
         "json_output": True,
@@ -14,11 +14,19 @@ _MODEL_INFO: ModelInfoDict = {
         "structured_output": True,
         "multiple_system_messages": False,
     },
-    "gemini-2.5-pro-preview-05-06": {
+    "gemini-2.5-pro": {
         "vision": False,
         "function_calling": True,
         "json_output": True,
         "family": "gemini-2.5-pro",
+        "structured_output": True,
+        "multiple_system_messages": False,
+    },
+    "gemini-2.5-flash-lite-preview-06-17": {
+        "vision": False,
+        "function_calling": True,
+        "json_output": True,
+        "family": "gemini-2.5-flash-lite",
         "structured_output": True,
         "multiple_system_messages": False,
     },
@@ -106,8 +114,9 @@ _MODEL_INFO: ModelInfoDict = {
 
 # Model token limits (context window size)
 _MODEL_TOKEN_LIMITS: Dict[str, int] = {
-    "gemini-2.5-flash-preview-05-20": 1_048_576,
-    "gemini-2.5-pro-preview-05-06": 1_048_576,
+    "gemini-2.5-flash": 1_048_576,
+    "gemini-2.5-pro": 1_048_576,
+    "gemini-2.5-flash-lite-preview-06-17": 1_048_576,
     "gemini-2.0-flash": 1_048_576,
     "gemini-2.0-flash-lite": 1_048_576,
     "claude-sonnet-4@20250514": 64_000,

--- a/python/src/kagent/models/vertexai/_model_info.py
+++ b/python/src/kagent/models/vertexai/_model_info.py
@@ -26,7 +26,7 @@ _MODEL_INFO: ModelInfoDict = {
         "vision": False,
         "function_calling": True,
         "json_output": True,
-        "family": "gemini-2.5-flash-lite",
+        "family": "gemini-2.5-flash",
         "structured_output": True,
         "multiple_system_messages": False,
     },

--- a/python/src/kagent/models/vertexai/_model_info.py
+++ b/python/src/kagent/models/vertexai/_model_info.py
@@ -10,7 +10,7 @@ _MODEL_INFO: ModelInfoDict = {
         "vision": False,
         "function_calling": True,
         "json_output": True,
-        "family": "gemini-2.0-flash",
+        "family": "gemini-2.5-flash",
         "structured_output": True,
         "multiple_system_messages": False,
     },


### PR DESCRIPTION
This pull request updates the `_MODEL_INFO` and `_MODEL_TOKEN_LIMITS` dictionaries in `python/src/kagent/models/vertexai/_model_info.py` to reflect changes in model naming conventions and add support for a new model.

Updates to model information:

* [`_MODEL_INFO`](diffhunk://#diff-0f8b7bad27621654aac4260eb443cd935b307440bee000790ce0d4e76d03dc00L9-R32): Renamed `gemini-2.5-flash-preview-05-20` to `gemini-2.5-flash` and `gemini-2.5-pro-preview-05-06` to `gemini-2.5-pro`. Added a new model entry for `gemini-2.5-flash-lite-preview-06-17`.

Updates to token limits:

* [`_MODEL_TOKEN_LIMITS`](diffhunk://#diff-0f8b7bad27621654aac4260eb443cd935b307440bee000790ce0d4e76d03dc00L109-R119): Updated model names to match the new naming conventions (`gemini-2.5-flash` and `gemini-2.5-pro`) and added token limit support for the new `gemini-2.5-flash-lite-preview-06-17` model.