### PR TITLE
fix(build): use build metadata instead of prerelease identifier in Makefile VERSION fallback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ HELM_DIST_FOLDER ?= dist
 
 BUILD_DATE := $(shell date -u '+%Y-%m-%d')
 GIT_COMMIT := $(shell git rev-parse --short HEAD || echo "unknown")
-VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null | sed 's/-dirty//' | grep v || echo "v0.0.0-$(GIT_COMMIT)")
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null | sed 's/-dirty//' | grep v || echo "v0.0.0+$(GIT_COMMIT)")
 
 # Local architecture detection to build for the current platform
 LOCALARCH ?= $(shell uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')


### PR DESCRIPTION
Right... The probability of this scenario is about **0.233%**, but it had to be me 😆

**_SemVer is violent, Semver is mad
release identifier made me sad_**

From the [semver v2.0 spec](https://semver.org/#spec-item-9) we can read
<img width="791" height="183" alt="Screenshot from 2025-07-10 23-49-28" src="https://github.com/user-attachments/assets/d3d21e11-7064-4228-b578-b451707fa922" />

But in the **Makefile** we were using this line to compose the `VERSION`
```bash
VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null | sed 's/-dirty//' | grep v || echo "v0.0.0+$(GIT_COMMIT)")
```

And it happened LoL:
<img width="778" height="217" alt="Screenshot from 2025-07-10 23-50-20" src="https://github.com/user-attachments/assets/75e55306-e51e-4d30-844b-7a283c2af2f4" />


So the change is basically switching from a **pre-release identifier** to [build metadata](https://semver.org/#spec-item-10) and it will save lucky devils like me in the future 