### PR TITLE
introduces createApiKeySecret for #633

### DIFF
--- a/helm/kagent/templates/deployment.yaml
+++ b/helm/kagent/templates/deployment.yaml
@@ -1,3 +1,5 @@
+{{- $dot := . }}
+{{- $model := index $dot.Values.providers $dot.Values.providers.default  }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -159,12 +161,15 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
-            - name: OPENAI_API_KEY
+            {{- if and $model.apiKeySecretRef $model.apiKey }}
+            {{- $apiKeyEnv := default "OPENAI_API_KEY" (default (printf "%s_API_KEY" $model.provider | upper) $model.apiKeySecretKey) }}
+            - name: {{ $apiKeyEnv }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "kagent.fullname" . }}-openai
-                  key: OPENAI_API_KEY
+                  name: {{ $model.apiKeySecretRef }}
+                  key: {{ $apiKeyEnv }}
                   optional: true # if the secret is not found, the tool will not be available
+            {{- end }}
             - name: OTEL_TRACING_ENABLED
               value: {{ .Values.otel.tracing.enabled | quote }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT

--- a/helm/kagent/templates/secret.yaml
+++ b/helm/kagent/templates/secret.yaml
@@ -1,6 +1,7 @@
 {{- $dot := . }}
 {{- $model := index $dot.Values.providers $dot.Values.providers.default  }}
-{{- if and $model.apiKeySecretRef $model.apiKey }}
+{{- $createSecret := default true $model.createApiKeySecret }}
+{{- if and $createSecret $model.apiKeySecretRef $model.apiKey }}
 ---
 apiVersion: v1
 kind: Secret

--- a/helm/kagent/tests/deployment_test.yaml
+++ b/helm/kagent/tests/deployment_test.yaml
@@ -300,3 +300,38 @@ tests:
             value: AI
             effect: NoSchedule
             operator: Equal
+
+  # manages the secret references
+  - it: should reference the default secret name when no custom secret name is given
+    set:
+      providers:
+        openAI:
+          apiKeySecretKey: OPENAI_API_KEY
+          apiKey: "sk-test-key"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[3].env
+          content:
+            name: OPENAI_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: kagent-openai
+                key: OPENAI_API_KEY
+                optional: true
+  - it: should reference the correct secret when the default secret name is overriden
+    set:
+      providers:
+        openAI:
+          apiKeySecretRef: random-secret
+          apiKeySecretKey: OPENAI_API_KEY
+          apiKey: "sk-test-key"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[3].env
+          content:
+            name: OPENAI_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: random-secret
+                key: OPENAI_API_KEY
+                optional: true

--- a/helm/kagent/tests/secret_test.yaml
+++ b/helm/kagent/tests/secret_test.yaml
@@ -100,3 +100,8 @@ tests:
       - equal:
           path: metadata.namespace
           value: custom-namespace 
+
+  - it: should not render secret if user has set createApiKeySecret=false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -7,6 +7,7 @@ global:
 # https://kagent.dev/docs/getting-started/configuring-providers
 providers:
   default: openAI
+  createApiKeySecret: true
   openAI:
     provider: OpenAI
     model: "gpt-4.1-mini"


### PR DESCRIPTION
- adding flag `createApiKeySecret` to override the default secret injection. Users can opt out and inject their own secrets using external tools such as external-secret operator.
- also fixes a minor bug not allowing users to set a custom secret name.