### PR TITLE
docs: fix documentation links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@
 
 ## Get started
 
-- [Quick Start](https://kagent.dev/docs/getting-started/quickstart)
-- [Installation guide](https://kagent.dev/docs/introduction/installation)
+- [Quick Start](https://kagent.dev/docs/kagent/getting-started/quickstart)
+- [Installation guide](https://kagent.dev/docs/kagent/introduction/installation)
 
 
 ## Documentation


### PR DESCRIPTION
- Fixed broken documentation links in REAME.md file that were returing 404 errors. The "Quick Start" and "Instllation guide" links have been updated to point to the correct documentation resources.
