### PR TITLE
fix(ui): drop `solo.io` from page titles

### DIFF
--- a/ui/src/app/layout.tsx
+++ b/ui/src/app/layout.tsx
@@ -15,7 +15,7 @@ const geistSans = Geist({
 });
 
 export const metadata: Metadata = {
-  title: "kagent.dev | Solo.io",
+  title: "kagent.dev",
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
Noticed this when screenshotting UI issues. Not sure if this was missed when the project was donated or whether this is intentionally (potentially related to #669) still there?