### PR TITLE
fix(controller): don't fail entire call to list agents based on results for one/more agents

### DIFF
--- a/go/internal/httpserver/handlers/agents.go
+++ b/go/internal/httpserver/handlers/agents.go
@@ -46,8 +46,11 @@ func (h *AgentsHandler) HandleListAgents(w ErrorResponseWriter, r *http.Request)
 
 		agent, err := h.DatabaseService.GetAgent(teamRef)
 		if err != nil {
-			w.RespondWithError(errors.NewNotFoundError("Agent not found", err))
-			return
+			// TODO: Rather than excluding the agent completely we should
+			// probably return it but mark it as "unhealthy" in some way so this
+			// is visible to callers (e.g. in the UI)
+			log.Error(err, "failed to load agent from database", "agent", teamRef)
+			continue
 		}
 
 		agentResponse, err := h.getAgentResponse(r.Context(), log, &team, agent)


### PR DESCRIPTION
Currently, every agent must exist in both Kubernetes and the database for this call to succeed. Thus, if for whatever reason an agent fails to reconcile on creation, any calls to this endpoint will fail. This, in turn, breaks all agents in the UI. This solution is a bit of a hack/workaround, and I do think issues should be surfaced; however, it at least ensures that the UI stays functional in this scenario for the time being.

<img width="1482" height="1084" alt="image" src="https://github.com/user-attachments/assets/2ba1bd80-59f3-4b79-90f1-6cd30cd201df" />

<img width="1482" height="1084" alt="image" src="https://github.com/user-attachments/assets/e461936a-6e47-4e66-a383-45083ec3c294" />

```
$ k get agents                
NAME           ACCEPTED   MODELCONFIG
k8s-agent      True       default-model-config
promql-agent   False      default-model-config
```



