### PR TITLE
refactor(ui): consistently use term `agent` instead of `team`

### DIFF
--- a/ui/src/app/actions/agents.ts
+++ b/ui/src/app/actions/agents.ts
@@ -101,21 +101,21 @@ function fromAgentFormDataToAgent(agentFormData: AgentFormData): Agent {
 
 export async function getAgent(agentName: string, namespace: string): Promise<BaseResponse<AgentResponse>> {
   try { 
-    const teamData = await fetchApi<BaseResponse<AgentResponse>>(`/agents/${namespace}/${agentName}`);
+    const agentData = await fetchApi<BaseResponse<AgentResponse>>(`/agents/${namespace}/${agentName}`);
 
-    // Fetch all teams to get descriptions for agent tools
-    // We use fetchApi directly to avoid circular dependency/logic issues with calling getTeams() here
-    const allTeamsData = await fetchApi<BaseResponse<AgentResponse[]>>(`/agents`);
+    // Fetch all agents to get descriptions for agent tools
+    // We use fetchApi directly to avoid circular dependency/logic issues with calling getAgents() here
+    const allAgentsData = await fetchApi<BaseResponse<AgentResponse[]>>(`/agents`);
     
-    // Extract and augment tools using the list of all teams
-    const tools = extractToolsFromResponse(teamData.data!, allTeamsData.data!);
+    // Extract and augment tools using the list of all agents
+    const tools = extractToolsFromResponse(agentData.data!, allAgentsData.data!);
 
     const response: AgentResponse = {
-      ...teamData.data!,
+      ...agentData.data!,
       agent: {
-        ...teamData.data!.agent,
+        ...agentData.data!.agent,
         spec: {
-          ...teamData.data!.agent.spec,
+          ...agentData.data!.agent.spec,
           tools,
         },
       },
@@ -123,13 +123,13 @@ export async function getAgent(agentName: string, namespace: string): Promise<Ba
 
     return { message: "Successfully fetched agent", data: response };
   } catch (error) {
-    return createErrorResponse<AgentResponse>(error, "Error getting team");
+    return createErrorResponse<AgentResponse>(error, "Error getting agent");
   }
 }
 
 /**
- * Deletes a team
- * @param teamLabel The team label
+ * Deletes a agent
+ * @param agentName The agent name
  * @returns A promise with the delete result
  */
 export async function deleteAgent(agentName: string): Promise<BaseResponse<void>> {
@@ -142,9 +142,9 @@ export async function deleteAgent(agentName: string): Promise<BaseResponse<void>
     });
 
     revalidatePath("/");
-    return { message: "Successfully deleted team" };
+    return { message: "Successfully deleted agent" };
   } catch (error) {
-    return createErrorResponse<void>(error, "Error deleting team");
+    return createErrorResponse<void>(error, "Error deleting agent");
   }
 }
 
@@ -166,7 +166,7 @@ export async function createAgent(agentConfig: AgentFormData, update: boolean = 
     });
 
     if (!response) {
-      throw new Error("Failed to create team");
+      throw new Error("Failed to create agent");
     }
 
     const agentRef = k8sRefUtils.toRef(
@@ -177,22 +177,22 @@ export async function createAgent(agentConfig: AgentFormData, update: boolean = 
     revalidatePath(`/agents/${agentRef}/chat`);
     return { message: "Successfully created agent", data: response.data };
   } catch (error) {
-    return createErrorResponse<Agent>(error, "Error creating team");
+    return createErrorResponse<Agent>(error, "Error creating agent");
   }
 }
 
 /**
- * Gets all teams
- * @returns A promise with all teams
+ * Gets all agents
+ * @returns A promise with all agents
  */
 export async function getAgents(): Promise<BaseResponse<AgentResponse[]>> {
   try {
     const data = await fetchApi<BaseResponse<AgentResponse[]>>(`/agents`);
-    const validTeams = data.data?.filter(team => !!team.agent);
-    const agentMap = new Map(validTeams?.map(agentResp => [agentResp.agent.metadata.name, agentResp]));
+    const validAgents = data.data?.filter(agent => !!agent.agent);
+    const agentMap = new Map(validAgents?.map(agentResp => [agentResp.agent.metadata.name, agentResp]));
 
-    const convertedData: AgentResponse[] = validTeams!.map(team => {
-      const augmentedTools = team.tools?.map(tool => {
+    const convertedData: AgentResponse[] = validAgents!.map(agent => {
+      const augmentedTools = agent.tools?.map(tool => {
         // Check if it's an Agent tool reference needing description
         if (isAgentTool(tool)) {
           const agentRef = tool.agent.ref;
@@ -211,11 +211,11 @@ export async function getAgents(): Promise<BaseResponse<AgentResponse[]>> {
       }) || [];
 
       return {
-        ...team,
+        ...agent,
         agent: { 
-          ...team.agent,
+          ...agent.agent,
           spec: { 
-            ...team.agent.spec,
+            ...agent.agent.spec,
             tools: augmentedTools
           }
         },
@@ -231,6 +231,6 @@ export async function getAgents(): Promise<BaseResponse<AgentResponse[]>> {
     
     return { message: "Successfully fetched agents", data: sortedData || [] };
   } catch (error) {
-    return createErrorResponse<AgentResponse[]>(error, "Error getting teams");
+    return createErrorResponse<AgentResponse[]>(error, "Error getting agents");
   }
 }

--- a/ui/src/app/agents/[namespace]/[name]/chat/layout.tsx
+++ b/ui/src/app/agents/[namespace]/[name]/chat/layout.tsx
@@ -7,21 +7,21 @@ import ChatLayoutUI from "@/components/chat/ChatLayoutUI";
 
 async function getData(agentName: string, namespace: string) {
   try {
-    const [teamResponse, teamsResponse, toolsResponse] = await Promise.all([
+    const [agentResponse, agentsResponse, toolsResponse] = await Promise.all([
       getAgent(agentName, namespace),
       getAgents(),
       getTools()
     ]);
 
-    if (teamResponse.error || !teamResponse.data) {
-      return { error: teamResponse.error || "Agent not found" };
+    if (agentResponse.error || !agentResponse.data) {
+      return { error: agentResponse.error || "Agent not found" };
     }
-    if (teamsResponse.error || !teamsResponse.data) {
-      return { error: teamsResponse.error || "Failed to fetch agents" };
+    if (agentsResponse.error || !agentsResponse.data) {
+      return { error: agentsResponse.error || "Failed to fetch agents" };
     }
 
-    const currentAgent = teamResponse.data;
-    const allAgents = teamsResponse.data || [];
+    const currentAgent = agentResponse.data;
+    const allAgents = agentsResponse.data || [];
     const allTools = toolsResponse || [];
 
     return {

--- a/ui/src/app/agents/new/page.tsx
+++ b/ui/src/app/agents/new/page.tsx
@@ -117,7 +117,7 @@ function AgentPageContent({ isEditMode, agentName, agentNamespace }: AgentPageCo
               }
             } catch (extractError) {
               console.error("Error extracting assistant data:", extractError);
-              toast.error("Failed to extract agent data from team structure");
+              toast.error("Failed to extract agent data");
             }
           } else {
             toast.error("Agent not found");

--- a/ui/src/components/AgentCard.tsx
+++ b/ui/src/components/AgentCard.tsx
@@ -37,7 +37,7 @@ export function AgentCard({ id, agentResponse: { agent, model, modelProvider } }
             <Button variant="ghost" size="icon" onClick={handleEditClick} aria-label="Edit Agent">
               <Pencil className="h-4 w-4" />
             </Button>
-            <DeleteButton teamLabel={agentRef} />
+            <DeleteButton agentName={agentRef} />
           </div>
         </CardHeader>
         <CardContent className="flex flex-col justify-between h-32">

--- a/ui/src/components/AgentsProvider.tsx
+++ b/ui/src/components/AgentsProvider.tsx
@@ -35,7 +35,7 @@ interface AgentsContextType {
   loading: boolean;
   error: string;
   tools: Component<ToolConfig>[];
-  refreshTeams: () => Promise<void>;
+  refreshAgents: () => Promise<void>;
   createNewAgent: (agentData: AgentFormData) => Promise<BaseResponse<Agent>>;
   updateAgent: (agentData: AgentFormData) => Promise<BaseResponse<Agent>>;
   getAgent: (name: string, namespace: string) => Promise<AgentResponse | null>;
@@ -63,13 +63,13 @@ export function AgentsProvider({ children }: AgentsProviderProps) {
   const [tools, setTools] = useState<Component<ToolConfig>[]>([]);
   const [models, setModels] = useState<ModelConfig[]>([]);
 
-  const fetchTeams = async () => {
+  const fetchAgents = async () => {
     try {
       setLoading(true);
       const agentsResult = await getAgents();
 
       if (!agentsResult.data || agentsResult.error) {
-        throw new Error(agentsResult.error || "Failed to fetch teams");
+        throw new Error(agentsResult.error || "Failed to fetch agents");
       }
 
       setAgents(agentsResult.data);
@@ -151,7 +151,7 @@ export function AgentsProvider({ children }: AgentsProviderProps) {
   // Get agent by ID function
   const getAgent = async (name: string, namespace: string): Promise<AgentResponse | null> => {
     try {
-      // Fetch all teams
+      // Fetch all agents
       const agentResult = await getAgentAction(name, namespace);
       if (!agentResult.data || agentResult.error) {
         console.error("Failed to get agent:", agentResult.error);
@@ -184,8 +184,8 @@ export function AgentsProvider({ children }: AgentsProviderProps) {
       const result = await createAgent(agentData);
 
       if (!result.error) {
-        // Refresh teams to get the newly created one
-        await fetchTeams();
+        // Refresh agents to get the newly created one
+        await fetchAgents();
       }
 
       return result;
@@ -208,12 +208,12 @@ export function AgentsProvider({ children }: AgentsProviderProps) {
         return { message: "Validation failed", error: "Validation failed", data: {} as Agent };
       }
 
-      // Use the same createTeam endpoint for updates
+      // Use the same createAgent endpoint for updates
       const result = await createAgent(agentData, true);
 
       if (!result.error) {
-        // Refresh teams to get the updated one
-        await fetchTeams();
+        // Refresh agents to get the updated one
+        await fetchAgents();
       }
 
       return result;
@@ -228,7 +228,7 @@ export function AgentsProvider({ children }: AgentsProviderProps) {
 
   // Initial fetches
   useEffect(() => {
-    fetchTeams();
+    fetchAgents();
     fetchTools();
     fetchModels();
   }, []);
@@ -239,7 +239,7 @@ export function AgentsProvider({ children }: AgentsProviderProps) {
     loading,
     error,
     tools,
-    refreshTeams: fetchTeams,
+    refreshAgents: fetchAgents,
     createNewAgent,
     updateAgent,
     getAgent,

--- a/ui/src/components/DeleteAgentButton.tsx
+++ b/ui/src/components/DeleteAgentButton.tsx
@@ -8,13 +8,13 @@ import { deleteAgent } from "@/app/actions/agents";
 import { useAgents } from "./AgentsProvider";
 
 interface DeleteButtonProps {
-  teamLabel: string;
+  agentName: string;
 }
 
-export function DeleteButton({ teamLabel }: DeleteButtonProps) {
+export function DeleteButton({ agentName }: DeleteButtonProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
-  const { refreshTeams } = useAgents();
+  const { refreshAgents } = useAgents();
 
   const handleDelete = async (e: React.MouseEvent) => {
     // Prevent the event from bubbling up to the Card component
@@ -23,9 +23,9 @@ export function DeleteButton({ teamLabel }: DeleteButtonProps) {
 
     try {
       setIsDeleting(true);
-      await deleteAgent(teamLabel);
+      await deleteAgent(agentName);
 
-      await refreshTeams();
+      await refreshAgents();
     } catch (error) {
       console.error("Error deleting agent:", error);
     } finally {


### PR DESCRIPTION
This started as a simple fix to the following error message in the UI, as I found the use of autogen terminology, Team, within the agents _section_ of the UI somewhat confusing... It blossomed into trying to be consistent in the use of the term `agent` instead of `team` within code related to agents. However, the mixed usage between agent and team extends far beyond the UI as well so not sure if there's a bigger plan/picture here. Related to #495. 

<img width="1504" height="1041" alt="image" src="https://github.com/user-attachments/assets/c23e0165-50e2-4ce8-b49d-89f350227e7e" />

vs

<img width="1468" height="1039" alt="image" src="https://github.com/user-attachments/assets/9292ad37-75e9-423e-8e0e-3b5896e6be7b" />
