### PR TITLE
fix(ui): ensure markdown URLs render correctly

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -39,6 +39,7 @@
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.58.1",
         "react-markdown": "^9.1.0",
+        "rehype-external-links": "^3.0.0",
         "remark-gfm": "^4.0.1",
         "sonner": "^2.0.5",
         "tailwind-merge": "^2.6.0",
@@ -8270,6 +8271,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.2.tgz",
@@ -8568,6 +8582,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-absolute-url": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-4.0.1.tgz",
+      "integrity": "sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-alphabetical": {
@@ -13256,6 +13282,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rehype-external-links": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-external-links/-/rehype-external-links-3.0.0.tgz",
+      "integrity": "sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "is-absolute-url": "^4.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-gfm": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -42,6 +42,7 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.58.1",
     "react-markdown": "^9.1.0",
+    "rehype-external-links": "^3.0.0",
     "remark-gfm": "^4.0.1",
     "sonner": "^2.0.5",
     "tailwind-merge": "^2.6.0",

--- a/ui/src/components/chat/TruncatableText.tsx
+++ b/ui/src/components/chat/TruncatableText.tsx
@@ -23,11 +23,6 @@ const components = {
     return <code className={className}>{children}</code>;
   },
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  a: (props: any) => {
-    const { children, className } = props;
-    return <a href={children} target="_blank" rel="noopener noreferrer" className={className}>{children}</a>;
-  },
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   table: (props: any) => {
     const { children } = props;
     return <table className="min-w-full divide-y divide-gray-300 table-fixed">{children}</table>;

--- a/ui/src/components/chat/TruncatableText.tsx
+++ b/ui/src/components/chat/TruncatableText.tsx
@@ -2,6 +2,7 @@ import React, { memo, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import CodeBlock from "./CodeBlock";
 import gfm from 'remark-gfm'
+import rehypeExternalLinks from 'rehype-external-links'
 import HTMLPreviewDialog from "./HTMLPreviewDialog";
 
 interface TruncatableTextProps {
@@ -65,7 +66,8 @@ export const TruncatableText = memo(({ content, isJson = false, className = "", 
         <ReactMarkdown
           className={`prose-md prose max-w-none dark:prose-invert dark:text-primary-foreground ${isStreaming ? "streaming-content" : ""}`}
           components={components}
-          remarkPlugins={[gfm]}>
+          remarkPlugins={[gfm]}
+          rehypePlugins={[[rehypeExternalLinks, {target: '_blank'}]]}>
           {content.trim()}
         </ReactMarkdown>
 


### PR DESCRIPTION
Regression introduced in #357 - not sure what the intention there was, though, as from what I can tell it doesn't seem related to the rest of the changes in that PR. cc @peterj 

Currently:

<img width="1408" height="1056" alt="image" src="https://github.com/user-attachments/assets/ec1973b6-8bbd-4f0c-9486-52b66e347bb6" />

vs with fix

<img width="1408" height="1288" alt="image" src="https://github.com/user-attachments/assets/5656dcb5-0daa-4897-bc48-4bf25754ac6a" />

(Note difference in links in bottom-left of screenshots above)