### PR TITLE
fix: correct CLI API URL to match server endpoint

### DIFF
--- a/go/cli/internal/config/config.go
+++ b/go/cli/internal/config/config.go
@@ -36,7 +36,7 @@ func Init() error {
 	pflag.StringVar(&configFile, "config", configFile, "config file (default is $HOME/.kagent/config.yaml)")
 
 	// Set default values
-	viper.SetDefault("api_url", "http://localhost:8083/api")
+	viper.SetDefault("api_url", "http://localhost:8083")
 	viper.SetDefault("user_id", "admin@kagent.dev")
 	viper.SetDefault("output_format", "table")
 	viper.SetDefault("namespace", "kagent")


### PR DESCRIPTION
- Remove '/api' suffix from default API URL to properly connect to kagent server.
- The server's version endpoint is at '/version', not '/api/version', causing
- CLI connection failures with "Error connecting to server" message.