### PR TITLE
fix(ui): correctly display args for tool calls in chat

### DIFF
--- a/ui/src/lib/messageHandlers.ts
+++ b/ui/src/lib/messageHandlers.ts
@@ -97,7 +97,7 @@ export interface ToolResponseData {
 export interface ProcessedToolCallData {
   id: string;
   name: string;
-  arguments: string;
+  args: Record<string, unknown>;
 }
 
 export interface ProcessedToolResultData {
@@ -260,7 +260,7 @@ export const createMessageHandlers = (handlers: MessageHandlers) => {
               const toolCallContent: ProcessedToolCallData[] = [{
                 id: toolData.id,
                 name: toolData.name,
-                arguments: JSON.stringify(toolData.args || {})
+                args: toolData.args || {}
               }];
               const source = getSourceFromMetadata(adkMetadata, defaultAgentSource);
               const convertedMessage = createMessage(


### PR DESCRIPTION
Args do not display in active chat sessions at present due to a mismatch between the use of `arguments` and `args` (they display fine when looking at chat history). Card uses `.args` [here](https://github.com/kagent-dev/kagent/blob/3022b2458df9f563f9ea031e736461848f170e75/ui/src/components/ToolDisplay.tsx#L106C101-L106C114). Also, note that JSON.stringify is applied when rendering the `Card` since #679.

Currently:

<img width="1663" height="979" alt="image" src="https://github.com/user-attachments/assets/7dafea1f-bdaa-473f-937f-ede9cc2e55a7" />

vs with fix

<img width="1663" height="894" alt="image" src="https://github.com/user-attachments/assets/88274656-c231-42e0-b953-b2e6ebc55ed1" />
