### PR TITLE
fix(controller): ensure live state for agents matches desired state

### DIFF
--- a/go/controller/internal/reconciler/reconciler.go
+++ b/go/controller/internal/reconciler/reconciler.go
@@ -458,11 +458,6 @@ func (a *kagentReconciler) upsertAgent(ctx context.Context, agent *v1alpha1.Agen
 		return fmt.Errorf("failed to store agent %s: %v", agentOutputs.Config.Name, err)
 	}
 
-	// If the config hash has not changed, we can skip the patch
-	if bytes.Equal(agentOutputs.ConfigHash[:], agent.Status.ConfigHash) {
-		return nil
-	}
-
 	for _, obj := range agentOutputs.Manifest {
 		if err := a.kube.Patch(ctx, obj, client.Apply, &client.PatchOptions{
 			FieldManager: "kagent-controller",


### PR DESCRIPTION
At present, the controller will ignore any changes to the live state of resources it owns due to the check that's being removed in this PR. This means that, for example, if the deployment for an agent is deleted, it will not be recreated until:
- The agent specification changes
- The agent is recreated
- The controller is restarted (and this is only true because the database is not persistent). 

However, removing this optimisation will increase load on the Kube API and also surfaces other issues with the controller code (e.g. controllers are currently updating objects they do not own). Opening this PR in draft for now so the issue is visible and we can discuss how best to proceed. I have also started looking into and will try to open smaller, related PRs that aim to minimise unnecessary reconciliation, thereby diminishing the impact of removing this check. 