### PR TITLE
feat: add VertexAI machine identity support (#477)

### DIFF
--- a/go/controller/translator/testdata/inputs/anthropic_vertex_ai_agent.yaml
+++ b/go/controller/translator/testdata/inputs/anthropic_vertex_ai_agent.yaml
@@ -1,0 +1,27 @@
+operation: translateAgent
+targetObject: anthropic-vertex-ai-agent
+namespace: test
+objects:
+  - apiVersion: kagent.dev/v1alpha1
+    kind: ModelConfig
+    metadata:
+      name: anthropic-vertex-ai-model
+      namespace: test
+    spec:
+      provider: AnthropicVertexAI
+      model: claude-3-5-sonnet-v2@20241022
+      anthropicVertexAI:
+        projectID: my-gcp-project
+        location: us-east5
+        temperature: "0.3"
+        maxTokens: 4096
+  - apiVersion: kagent.dev/v1alpha1
+    kind: Agent
+    metadata:
+      name: anthropic-vertex-ai-agent
+      namespace: test
+    spec:
+      description: An Anthropic Vertex AI test agent using machine identity
+      systemMessage: You are a helpful assistant powered by Anthropic's Claude model.
+      modelConfig: anthropic-vertex-ai-model
+      tools: []

--- a/go/controller/translator/testdata/inputs/gemini_vertex_ai_agent.yaml
+++ b/go/controller/translator/testdata/inputs/gemini_vertex_ai_agent.yaml
@@ -1,0 +1,27 @@
+operation: translateAgent
+targetObject: gemini-vertex-ai-agent
+namespace: test
+objects:
+  - apiVersion: kagent.dev/v1alpha1
+    kind: ModelConfig
+    metadata:
+      name: gemini-vertex-ai-model
+      namespace: test
+    spec:
+      provider: GeminiVertexAI
+      model: gemini-1.5-pro
+      geminiVertexAI:
+        projectID: my-gcp-project
+        location: us-central1
+        temperature: "0.5"
+        maxOutputTokens: 2048
+  - apiVersion: kagent.dev/v1alpha1
+    kind: Agent
+    metadata:
+      name: gemini-vertex-ai-agent
+      namespace: test
+    spec:
+      description: A Gemini Vertex AI test agent using machine identity
+      systemMessage: You are a helpful assistant powered by Google's Gemini model.
+      modelConfig: gemini-vertex-ai-model
+      tools: []

--- a/go/controller/translator/testdata/inputs/gemini_vertex_ai_with_creds_agent.yaml
+++ b/go/controller/translator/testdata/inputs/gemini_vertex_ai_with_creds_agent.yaml
@@ -1,0 +1,36 @@
+operation: translateAgent
+targetObject: gemini-vertex-ai-with-creds-agent
+namespace: test
+objects:
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: vertex-ai-secret
+      namespace: test
+    data:
+      credentials.json: ewogICJ0eXBlIjogInNlcnZpY2VfYWNjb3VudCIsCiAgInByb2plY3RfaWQiOiAibXktZ2NwLXByb2plY3QiCn0K  # base64 encoded service account JSON
+  - apiVersion: kagent.dev/v1alpha1
+    kind: ModelConfig
+    metadata:
+      name: gemini-vertex-ai-with-creds-model
+      namespace: test
+    spec:
+      provider: GeminiVertexAI
+      model: gemini-1.5-pro
+      apiKeySecretRef: vertex-ai-secret
+      apiKeySecretKey: credentials.json
+      geminiVertexAI:
+        projectID: my-gcp-project
+        location: us-central1
+        temperature: "0.5"
+        maxOutputTokens: 2048
+  - apiVersion: kagent.dev/v1alpha1
+    kind: Agent
+    metadata:
+      name: gemini-vertex-ai-with-creds-agent
+      namespace: test
+    spec:
+      description: A Gemini Vertex AI test agent using explicit credentials
+      systemMessage: You are a helpful assistant powered by Google's Gemini model.
+      modelConfig: gemini-vertex-ai-with-creds-model
+      tools: []

--- a/go/controller/translator/testdata/outputs/anthropic_vertex_ai_agent.json
+++ b/go/controller/translator/testdata/outputs/anthropic_vertex_ai_agent.json
@@ -1,0 +1,278 @@
+{
+  "config": {
+    "agent_card": {
+      "capabilities": {
+        "pushNotifications": false,
+        "stateTransitionHistory": true,
+        "streaming": true
+      },
+      "defaultInputModes": [
+        "text"
+      ],
+      "defaultOutputModes": [
+        "text"
+      ],
+      "description": "An Anthropic Vertex AI test agent using machine identity",
+      "name": "anthropic-vertex-ai-agent",
+      "skills": null,
+      "url": "http://anthropic-vertex-ai-agent.test.svc:8080",
+      "version": ""
+    },
+    "agents": null,
+    "description": "An Anthropic Vertex AI test agent using machine identity",
+    "http_tools": null,
+    "instruction": "You are a helpful assistant powered by Anthropic's Claude model.",
+    "kagent_url": "http://kagent-controller.kagent.svc:8083",
+    "model": {
+      "model": "claude-3-5-sonnet-v2@20241022",
+      "type": "gemini_anthropic"
+    },
+    "name": "test__NS__anthropic_vertex_ai_agent",
+    "sse_tools": null
+  },
+  "configHash": [
+    207,
+    178,
+    9,
+    116,
+    37,
+    99,
+    110,
+    118,
+    222,
+    66,
+    69,
+    54,
+    12,
+    86,
+    218,
+    111,
+    187,
+    139,
+    242,
+    124,
+    63,
+    23,
+    98,
+    207,
+    101,
+    43,
+    194,
+    220,
+    209,
+    118,
+    161,
+    154
+  ],
+  "manifest": [
+    {
+      "apiVersion": "v1",
+      "kind": "ServiceAccount",
+      "metadata": {
+        "creationTimestamp": null,
+        "labels": {
+          "app": "kagent",
+          "kagent": "anthropic-vertex-ai-agent"
+        },
+        "name": "anthropic-vertex-ai-agent",
+        "namespace": "test",
+        "ownerReferences": [
+          {
+            "apiVersion": "kagent.dev/v1alpha1",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "Agent",
+            "name": "anthropic-vertex-ai-agent",
+            "uid": ""
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "v1",
+      "data": {
+        "config.json": "{\"kagent_url\":\"http://kagent-controller.kagent.svc:8083\",\"agent_card\":{\"name\":\"anthropic-vertex-ai-agent\",\"description\":\"An Anthropic Vertex AI test agent using machine identity\",\"url\":\"http://anthropic-vertex-ai-agent.test.svc:8080\",\"version\":\"\",\"capabilities\":{\"streaming\":true,\"pushNotifications\":false,\"stateTransitionHistory\":true},\"defaultInputModes\":[\"text\"],\"defaultOutputModes\":[\"text\"],\"skills\":[]},\"name\":\"test__NS__anthropic_vertex_ai_agent\",\"model\":{\"model\":\"claude-3-5-sonnet-v2@20241022\",\"type\":\"gemini_anthropic\"},\"description\":\"An Anthropic Vertex AI test agent using machine identity\",\"instruction\":\"You are a helpful assistant powered by Anthropic's Claude model.\",\"http_tools\":null,\"sse_tools\":null,\"agents\":null}"
+      },
+      "kind": "ConfigMap",
+      "metadata": {
+        "creationTimestamp": null,
+        "labels": {
+          "app": "kagent",
+          "kagent": "anthropic-vertex-ai-agent"
+        },
+        "name": "anthropic-vertex-ai-agent",
+        "namespace": "test",
+        "ownerReferences": [
+          {
+            "apiVersion": "kagent.dev/v1alpha1",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "Agent",
+            "name": "anthropic-vertex-ai-agent",
+            "uid": ""
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "apps/v1",
+      "kind": "Deployment",
+      "metadata": {
+        "creationTimestamp": null,
+        "labels": {
+          "app": "kagent",
+          "kagent": "anthropic-vertex-ai-agent"
+        },
+        "name": "anthropic-vertex-ai-agent",
+        "namespace": "test",
+        "ownerReferences": [
+          {
+            "apiVersion": "kagent.dev/v1alpha1",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "Agent",
+            "name": "anthropic-vertex-ai-agent",
+            "uid": ""
+          }
+        ]
+      },
+      "spec": {
+        "replicas": 1,
+        "selector": {
+          "matchLabels": {
+            "app": "kagent",
+            "kagent": "anthropic-vertex-ai-agent"
+          }
+        },
+        "strategy": {},
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "app": "kagent",
+              "config.kagent.dev/hash": "14966034906153709174",
+              "kagent": "anthropic-vertex-ai-agent"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "command": [
+                  "kagent",
+                  "static",
+                  "--host",
+                  "0.0.0.0",
+                  "--port",
+                  "8080",
+                  "--filepath",
+                  "/config/config.json"
+                ],
+                "env": [
+                  {
+                    "name": "GOOGLE_CLOUD_PROJECT",
+                    "value": "my-gcp-project"
+                  },
+                  {
+                    "name": "GOOGLE_CLOUD_LOCATION",
+                    "value": "us-east5"
+                  },
+                  {
+                    "name": "KAGENT_NAMESPACE",
+                    "valueFrom": {
+                      "fieldRef": {
+                        "fieldPath": "metadata.namespace"
+                      }
+                    }
+                  }
+                ],
+                "image": "cr.kagent.dev/kagent-dev/kagent/app:dev",
+                "imagePullPolicy": "IfNotPresent",
+                "name": "kagent",
+                "ports": [
+                  {
+                    "containerPort": 8080,
+                    "name": "http"
+                  }
+                ],
+                "readinessProbe": {
+                  "httpGet": {
+                    "path": "/health",
+                    "port": "http"
+                  },
+                  "initialDelaySeconds": 15,
+                  "periodSeconds": 3
+                },
+                "resources": {
+                  "limits": {
+                    "cpu": "1",
+                    "memory": "1Gi"
+                  },
+                  "requests": {
+                    "cpu": "100m",
+                    "memory": "256Mi"
+                  }
+                },
+                "volumeMounts": [
+                  {
+                    "mountPath": "/config",
+                    "name": "config"
+                  }
+                ]
+              }
+            ],
+            "serviceAccountName": "anthropic-vertex-ai-agent",
+            "volumes": [
+              {
+                "configMap": {
+                  "name": "anthropic-vertex-ai-agent"
+                },
+                "name": "config"
+              }
+            ]
+          }
+        }
+      },
+      "status": {}
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "Service",
+      "metadata": {
+        "creationTimestamp": null,
+        "labels": {
+          "app": "kagent",
+          "kagent": "anthropic-vertex-ai-agent"
+        },
+        "name": "anthropic-vertex-ai-agent",
+        "namespace": "test",
+        "ownerReferences": [
+          {
+            "apiVersion": "kagent.dev/v1alpha1",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "Agent",
+            "name": "anthropic-vertex-ai-agent",
+            "uid": ""
+          }
+        ]
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "http",
+            "port": 8080,
+            "targetPort": 8080
+          }
+        ],
+        "selector": {
+          "app": "kagent",
+          "kagent": "anthropic-vertex-ai-agent"
+        },
+        "type": "ClusterIP"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    }
+  ]
+}

--- a/go/controller/translator/testdata/outputs/gemini_vertex_ai_agent.json
+++ b/go/controller/translator/testdata/outputs/gemini_vertex_ai_agent.json
@@ -1,0 +1,278 @@
+{
+  "config": {
+    "agent_card": {
+      "capabilities": {
+        "pushNotifications": false,
+        "stateTransitionHistory": true,
+        "streaming": true
+      },
+      "defaultInputModes": [
+        "text"
+      ],
+      "defaultOutputModes": [
+        "text"
+      ],
+      "description": "A Gemini Vertex AI test agent using machine identity",
+      "name": "gemini-vertex-ai-agent",
+      "skills": null,
+      "url": "http://gemini-vertex-ai-agent.test.svc:8080",
+      "version": ""
+    },
+    "agents": null,
+    "description": "A Gemini Vertex AI test agent using machine identity",
+    "http_tools": null,
+    "instruction": "You are a helpful assistant powered by Google's Gemini model.",
+    "kagent_url": "http://kagent-controller.kagent.svc:8083",
+    "model": {
+      "model": "gemini-1.5-pro",
+      "type": "gemini_vertex_ai"
+    },
+    "name": "test__NS__gemini_vertex_ai_agent",
+    "sse_tools": null
+  },
+  "configHash": [
+    242,
+    132,
+    151,
+    12,
+    111,
+    15,
+    244,
+    153,
+    64,
+    145,
+    244,
+    44,
+    200,
+    0,
+    204,
+    162,
+    8,
+    29,
+    46,
+    196,
+    227,
+    83,
+    250,
+    234,
+    248,
+    221,
+    234,
+    189,
+    92,
+    225,
+    160,
+    97
+  ],
+  "manifest": [
+    {
+      "apiVersion": "v1",
+      "kind": "ServiceAccount",
+      "metadata": {
+        "creationTimestamp": null,
+        "labels": {
+          "app": "kagent",
+          "kagent": "gemini-vertex-ai-agent"
+        },
+        "name": "gemini-vertex-ai-agent",
+        "namespace": "test",
+        "ownerReferences": [
+          {
+            "apiVersion": "kagent.dev/v1alpha1",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "Agent",
+            "name": "gemini-vertex-ai-agent",
+            "uid": ""
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "v1",
+      "data": {
+        "config.json": "{\"kagent_url\":\"http://kagent-controller.kagent.svc:8083\",\"agent_card\":{\"name\":\"gemini-vertex-ai-agent\",\"description\":\"A Gemini Vertex AI test agent using machine identity\",\"url\":\"http://gemini-vertex-ai-agent.test.svc:8080\",\"version\":\"\",\"capabilities\":{\"streaming\":true,\"pushNotifications\":false,\"stateTransitionHistory\":true},\"defaultInputModes\":[\"text\"],\"defaultOutputModes\":[\"text\"],\"skills\":[]},\"name\":\"test__NS__gemini_vertex_ai_agent\",\"model\":{\"model\":\"gemini-1.5-pro\",\"type\":\"gemini_vertex_ai\"},\"description\":\"A Gemini Vertex AI test agent using machine identity\",\"instruction\":\"You are a helpful assistant powered by Google's Gemini model.\",\"http_tools\":null,\"sse_tools\":null,\"agents\":null}"
+      },
+      "kind": "ConfigMap",
+      "metadata": {
+        "creationTimestamp": null,
+        "labels": {
+          "app": "kagent",
+          "kagent": "gemini-vertex-ai-agent"
+        },
+        "name": "gemini-vertex-ai-agent",
+        "namespace": "test",
+        "ownerReferences": [
+          {
+            "apiVersion": "kagent.dev/v1alpha1",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "Agent",
+            "name": "gemini-vertex-ai-agent",
+            "uid": ""
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "apps/v1",
+      "kind": "Deployment",
+      "metadata": {
+        "creationTimestamp": null,
+        "labels": {
+          "app": "kagent",
+          "kagent": "gemini-vertex-ai-agent"
+        },
+        "name": "gemini-vertex-ai-agent",
+        "namespace": "test",
+        "ownerReferences": [
+          {
+            "apiVersion": "kagent.dev/v1alpha1",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "Agent",
+            "name": "gemini-vertex-ai-agent",
+            "uid": ""
+          }
+        ]
+      },
+      "spec": {
+        "replicas": 1,
+        "selector": {
+          "matchLabels": {
+            "app": "kagent",
+            "kagent": "gemini-vertex-ai-agent"
+          }
+        },
+        "strategy": {},
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "app": "kagent",
+              "config.kagent.dev/hash": "17475258533763085465",
+              "kagent": "gemini-vertex-ai-agent"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "command": [
+                  "kagent",
+                  "static",
+                  "--host",
+                  "0.0.0.0",
+                  "--port",
+                  "8080",
+                  "--filepath",
+                  "/config/config.json"
+                ],
+                "env": [
+                  {
+                    "name": "GOOGLE_CLOUD_PROJECT",
+                    "value": "my-gcp-project"
+                  },
+                  {
+                    "name": "GOOGLE_CLOUD_LOCATION",
+                    "value": "us-central1"
+                  },
+                  {
+                    "name": "KAGENT_NAMESPACE",
+                    "valueFrom": {
+                      "fieldRef": {
+                        "fieldPath": "metadata.namespace"
+                      }
+                    }
+                  }
+                ],
+                "image": "cr.kagent.dev/kagent-dev/kagent/app:dev",
+                "imagePullPolicy": "IfNotPresent",
+                "name": "kagent",
+                "ports": [
+                  {
+                    "containerPort": 8080,
+                    "name": "http"
+                  }
+                ],
+                "readinessProbe": {
+                  "httpGet": {
+                    "path": "/health",
+                    "port": "http"
+                  },
+                  "initialDelaySeconds": 15,
+                  "periodSeconds": 3
+                },
+                "resources": {
+                  "limits": {
+                    "cpu": "1",
+                    "memory": "1Gi"
+                  },
+                  "requests": {
+                    "cpu": "100m",
+                    "memory": "256Mi"
+                  }
+                },
+                "volumeMounts": [
+                  {
+                    "mountPath": "/config",
+                    "name": "config"
+                  }
+                ]
+              }
+            ],
+            "serviceAccountName": "gemini-vertex-ai-agent",
+            "volumes": [
+              {
+                "configMap": {
+                  "name": "gemini-vertex-ai-agent"
+                },
+                "name": "config"
+              }
+            ]
+          }
+        }
+      },
+      "status": {}
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "Service",
+      "metadata": {
+        "creationTimestamp": null,
+        "labels": {
+          "app": "kagent",
+          "kagent": "gemini-vertex-ai-agent"
+        },
+        "name": "gemini-vertex-ai-agent",
+        "namespace": "test",
+        "ownerReferences": [
+          {
+            "apiVersion": "kagent.dev/v1alpha1",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "Agent",
+            "name": "gemini-vertex-ai-agent",
+            "uid": ""
+          }
+        ]
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "http",
+            "port": 8080,
+            "targetPort": 8080
+          }
+        ],
+        "selector": {
+          "app": "kagent",
+          "kagent": "gemini-vertex-ai-agent"
+        },
+        "type": "ClusterIP"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    }
+  ]
+}

--- a/go/controller/translator/testdata/outputs/gemini_vertex_ai_with_creds_agent.json
+++ b/go/controller/translator/testdata/outputs/gemini_vertex_ai_with_creds_agent.json
@@ -1,0 +1,287 @@
+{
+  "config": {
+    "agent_card": {
+      "capabilities": {
+        "pushNotifications": false,
+        "stateTransitionHistory": true,
+        "streaming": true
+      },
+      "defaultInputModes": [
+        "text"
+      ],
+      "defaultOutputModes": [
+        "text"
+      ],
+      "description": "A Gemini Vertex AI test agent using explicit credentials",
+      "name": "gemini-vertex-ai-with-creds-agent",
+      "skills": null,
+      "url": "http://gemini-vertex-ai-with-creds-agent.test.svc:8080",
+      "version": ""
+    },
+    "agents": null,
+    "description": "A Gemini Vertex AI test agent using explicit credentials",
+    "http_tools": null,
+    "instruction": "You are a helpful assistant powered by Google's Gemini model.",
+    "kagent_url": "http://kagent-controller.kagent.svc:8083",
+    "model": {
+      "model": "gemini-1.5-pro",
+      "type": "gemini_vertex_ai"
+    },
+    "name": "test__NS__gemini_vertex_ai_with_creds_agent",
+    "sse_tools": null
+  },
+  "configHash": [
+    55,
+    146,
+    100,
+    76,
+    55,
+    93,
+    26,
+    238,
+    197,
+    246,
+    213,
+    100,
+    181,
+    17,
+    24,
+    16,
+    245,
+    72,
+    252,
+    149,
+    250,
+    176,
+    4,
+    4,
+    95,
+    131,
+    18,
+    171,
+    109,
+    10,
+    25,
+    205
+  ],
+  "manifest": [
+    {
+      "apiVersion": "v1",
+      "kind": "ServiceAccount",
+      "metadata": {
+        "creationTimestamp": null,
+        "labels": {
+          "app": "kagent",
+          "kagent": "gemini-vertex-ai-with-creds-agent"
+        },
+        "name": "gemini-vertex-ai-with-creds-agent",
+        "namespace": "test",
+        "ownerReferences": [
+          {
+            "apiVersion": "kagent.dev/v1alpha1",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "Agent",
+            "name": "gemini-vertex-ai-with-creds-agent",
+            "uid": ""
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "v1",
+      "data": {
+        "config.json": "{\"kagent_url\":\"http://kagent-controller.kagent.svc:8083\",\"agent_card\":{\"name\":\"gemini-vertex-ai-with-creds-agent\",\"description\":\"A Gemini Vertex AI test agent using explicit credentials\",\"url\":\"http://gemini-vertex-ai-with-creds-agent.test.svc:8080\",\"version\":\"\",\"capabilities\":{\"streaming\":true,\"pushNotifications\":false,\"stateTransitionHistory\":true},\"defaultInputModes\":[\"text\"],\"defaultOutputModes\":[\"text\"],\"skills\":[]},\"name\":\"test__NS__gemini_vertex_ai_with_creds_agent\",\"model\":{\"model\":\"gemini-1.5-pro\",\"type\":\"gemini_vertex_ai\"},\"description\":\"A Gemini Vertex AI test agent using explicit credentials\",\"instruction\":\"You are a helpful assistant powered by Google's Gemini model.\",\"http_tools\":null,\"sse_tools\":null,\"agents\":null}"
+      },
+      "kind": "ConfigMap",
+      "metadata": {
+        "creationTimestamp": null,
+        "labels": {
+          "app": "kagent",
+          "kagent": "gemini-vertex-ai-with-creds-agent"
+        },
+        "name": "gemini-vertex-ai-with-creds-agent",
+        "namespace": "test",
+        "ownerReferences": [
+          {
+            "apiVersion": "kagent.dev/v1alpha1",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "Agent",
+            "name": "gemini-vertex-ai-with-creds-agent",
+            "uid": ""
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "apps/v1",
+      "kind": "Deployment",
+      "metadata": {
+        "creationTimestamp": null,
+        "labels": {
+          "app": "kagent",
+          "kagent": "gemini-vertex-ai-with-creds-agent"
+        },
+        "name": "gemini-vertex-ai-with-creds-agent",
+        "namespace": "test",
+        "ownerReferences": [
+          {
+            "apiVersion": "kagent.dev/v1alpha1",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "Agent",
+            "name": "gemini-vertex-ai-with-creds-agent",
+            "uid": ""
+          }
+        ]
+      },
+      "spec": {
+        "replicas": 1,
+        "selector": {
+          "matchLabels": {
+            "app": "kagent",
+            "kagent": "gemini-vertex-ai-with-creds-agent"
+          }
+        },
+        "strategy": {},
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "app": "kagent",
+              "config.kagent.dev/hash": "4004373297194932974",
+              "kagent": "gemini-vertex-ai-with-creds-agent"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "command": [
+                  "kagent",
+                  "static",
+                  "--host",
+                  "0.0.0.0",
+                  "--port",
+                  "8080",
+                  "--filepath",
+                  "/config/config.json"
+                ],
+                "env": [
+                  {
+                    "name": "GOOGLE_CLOUD_PROJECT",
+                    "value": "my-gcp-project"
+                  },
+                  {
+                    "name": "GOOGLE_CLOUD_LOCATION",
+                    "value": "us-central1"
+                  },
+                  {
+                    "name": "GOOGLE_APPLICATION_CREDENTIALS",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "key": "credentials.json",
+                        "name": "vertex-ai-secret"
+                      }
+                    }
+                  },
+                  {
+                    "name": "KAGENT_NAMESPACE",
+                    "valueFrom": {
+                      "fieldRef": {
+                        "fieldPath": "metadata.namespace"
+                      }
+                    }
+                  }
+                ],
+                "image": "cr.kagent.dev/kagent-dev/kagent/app:dev",
+                "imagePullPolicy": "IfNotPresent",
+                "name": "kagent",
+                "ports": [
+                  {
+                    "containerPort": 8080,
+                    "name": "http"
+                  }
+                ],
+                "readinessProbe": {
+                  "httpGet": {
+                    "path": "/health",
+                    "port": "http"
+                  },
+                  "initialDelaySeconds": 15,
+                  "periodSeconds": 3
+                },
+                "resources": {
+                  "limits": {
+                    "cpu": "1",
+                    "memory": "1Gi"
+                  },
+                  "requests": {
+                    "cpu": "100m",
+                    "memory": "256Mi"
+                  }
+                },
+                "volumeMounts": [
+                  {
+                    "mountPath": "/config",
+                    "name": "config"
+                  }
+                ]
+              }
+            ],
+            "serviceAccountName": "gemini-vertex-ai-with-creds-agent",
+            "volumes": [
+              {
+                "configMap": {
+                  "name": "gemini-vertex-ai-with-creds-agent"
+                },
+                "name": "config"
+              }
+            ]
+          }
+        }
+      },
+      "status": {}
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "Service",
+      "metadata": {
+        "creationTimestamp": null,
+        "labels": {
+          "app": "kagent",
+          "kagent": "gemini-vertex-ai-with-creds-agent"
+        },
+        "name": "gemini-vertex-ai-with-creds-agent",
+        "namespace": "test",
+        "ownerReferences": [
+          {
+            "apiVersion": "kagent.dev/v1alpha1",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "Agent",
+            "name": "gemini-vertex-ai-with-creds-agent",
+            "uid": ""
+          }
+        ]
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "http",
+            "port": 8080,
+            "targetPort": 8080
+          }
+        ],
+        "selector": {
+          "app": "kagent",
+          "kagent": "gemini-vertex-ai-with-creds-agent"
+        },
+        "type": "ClusterIP"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    }
+  ]
+}

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/kagent-dev/kagent/go
 
-go 1.24.5
+go 1.24.0
 
 require (
 	github.com/abiosoft/ishell/v2 v2.0.2
@@ -11,22 +11,22 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/gorilla/mux v1.8.1
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/jedib0t/go-pretty/v6 v6.6.8
+	github.com/jedib0t/go-pretty/v6 v6.6.7
 	github.com/mark3labs/mcp-go v0.34.0
-	github.com/prometheus/client_golang v1.23.0
+	github.com/prometheus/client_golang v1.22.0
 	github.com/spf13/cobra v1.9.1
-	github.com/spf13/pflag v1.0.7
+	github.com/spf13/pflag v1.0.6
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/automaxprocs v1.6.0
 	gorm.io/driver/postgres v1.6.0
-	gorm.io/gorm v1.30.1
-	k8s.io/api v0.33.3
-	k8s.io/apimachinery v0.33.3
-	k8s.io/client-go v0.33.3
+	gorm.io/gorm v1.30.0
+	k8s.io/api v0.33.2
+	k8s.io/apimachinery v0.33.2
+	k8s.io/client-go v0.33.2
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
 	sigs.k8s.io/controller-runtime v0.21.0
-	sigs.k8s.io/yaml v1.6.0
+	sigs.k8s.io/yaml v1.4.0
 	trpc.group/trpc-go/trpc-a2a-go v0.2.1
 )
 
@@ -118,7 +118,6 @@ require (
 	go.opentelemetry.io/proto/otlp v1.5.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
-	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/crypto v0.39.0 // indirect
 	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394 // indirect
 	golang.org/x/net v0.41.0 // indirect
@@ -136,19 +135,17 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiextensions-apiserver v0.33.3 // indirect
-	k8s.io/apiserver v0.33.3 // indirect
-	k8s.io/component-base v0.33.3 // indirect
+	k8s.io/apiextensions-apiserver v0.33.2 // indirect
+	k8s.io/apiserver v0.33.2 // indirect
+	k8s.io/component-base v0.33.2 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250610211856-8b98d1ed966a // indirect
 	modernc.org/libc v1.22.5 // indirect
 	modernc.org/mathutil v1.5.0 // indirect
 	modernc.org/memory v1.5.0 // indirect
 	modernc.org/sqlite v1.23.1 // indirect
-	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.33.0 // indirect
+	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.32.0 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
 )
-
-replace trpc.group/trpc-go/trpc-a2a-go => github.com/kagent-dev/a2a-go v0.0.0-20250806145931-0fab01f644c3

--- a/go/internal/httpserver/handlers/providers.go
+++ b/go/internal/httpserver/handlers/providers.go
@@ -25,6 +25,10 @@ func getRequiredKeysForModelProvider(providerType v1alpha1.ModelProvider) []stri
 	case v1alpha1.ModelProviderAzureOpenAI:
 		// Based on the +required comments in the AzureOpenAIConfig struct definition
 		return []string{"azureEndpoint", "apiVersion"}
+	case v1alpha1.ModelProviderGeminiVertexAI:
+		return []string{"projectID", "location"}
+	case v1alpha1.ModelProviderAnthropicVertexAI:
+		return []string{"projectID", "location"}
 	case v1alpha1.ModelProviderOpenAI, v1alpha1.ModelProviderAnthropic, v1alpha1.ModelProviderOllama:
 		// These providers currently have no fields marked as strictly required in the API definition
 		return []string{}
@@ -97,6 +101,8 @@ func (h *ProviderHandler) HandleListSupportedModelProviders(w ErrorResponseWrite
 		{v1alpha1.ModelProviderAnthropic, reflect.TypeOf(v1alpha1.AnthropicConfig{})},
 		{v1alpha1.ModelProviderAzureOpenAI, reflect.TypeOf(v1alpha1.AzureOpenAIConfig{})},
 		{v1alpha1.ModelProviderOllama, reflect.TypeOf(v1alpha1.OllamaConfig{})},
+		{v1alpha1.ModelProviderGeminiVertexAI, reflect.TypeOf(v1alpha1.GeminiVertexAIConfig{})},
+		{v1alpha1.ModelProviderAnthropicVertexAI, reflect.TypeOf(v1alpha1.AnthropicVertexAIConfig{})},
 	}
 
 	providersResponse := []map[string]interface{}{}

--- a/ui/src/app/models/new/page.tsx
+++ b/ui/src/app/models/new/page.tsx
@@ -14,6 +14,8 @@ import type {
     AzureOpenAIConfigPayload,
     AnthropicConfigPayload,
     OllamaConfigPayload,
+    GeminiVertexAIConfigPayload,
+    AnthropicVertexAIConfigPayload,
     ProviderModelsResponse
 } from "@/types";
 import { toast } from "sonner";
@@ -444,6 +446,12 @@ function ModelPageContent() {
       case 'Ollama':
         payload.ollama = providerParams as OllamaConfigPayload;
         break;
+      case 'GeminiVertexAI':
+        payload.geminiVertexAI = providerParams as GeminiVertexAIConfigPayload;
+        break;
+      case 'AnthropicVertexAI':
+        payload.anthropicVertexAI = providerParams as AnthropicVertexAIConfigPayload;
+        break;
       default:
         console.error("Unsupported provider type during payload construction:", providerType);
         toast.error("Internal error: Unsupported provider type.");
@@ -462,6 +470,8 @@ function ModelPageContent() {
           anthropic: payload.anthropic,
           azureOpenAI: payload.azureOpenAI,
           ollama: payload.ollama,
+          geminiVertexAI: payload.geminiVertexAI,
+          anthropicVertexAI: payload.anthropicVertexAI,
         };
         const modelConfigRef = k8sRefUtils.toRef(modelConfigNamespace || '', modelConfigName);
         response = await updateModelConfig(modelConfigRef, updatePayload);

--- a/ui/src/lib/__tests__/providers.test.ts
+++ b/ui/src/lib/__tests__/providers.test.ts
@@ -14,6 +14,8 @@ describe('isValidProviderInfoKey', () => {
         expect(isValidProviderInfoKey('azure-openai')).toBe(true);
         expect(isValidProviderInfoKey('anthropic')).toBe(true);
         expect(isValidProviderInfoKey('ollama')).toBe(true);
+        expect(isValidProviderInfoKey('gemini-vertex-ai')).toBe(true);
+        expect(isValidProviderInfoKey('anthropic-vertex-ai')).toBe(true);
     });
 
     it('should return false for invalid provider keys', () => {
@@ -29,6 +31,8 @@ describe('getApiKeyForProviderFormKey', () => {
         expect(getApiKeyForProviderFormKey('azure-openai')).toBe('azureOpenAI');
         expect(getApiKeyForProviderFormKey('anthropic')).toBe('anthropic');
         expect(getApiKeyForProviderFormKey('ollama')).toBe('ollama');
+        expect(getApiKeyForProviderFormKey('gemini-vertex-ai')).toBe('geminiVertexAI');
+        expect(getApiKeyForProviderFormKey('anthropic-vertex-ai')).toBe('anthropicVertexAI');
     });
 
     // Although the type system should prevent invalid keys, we test the default case
@@ -44,6 +48,8 @@ describe('getProviderDisplayName', () => {
         expect(getProviderDisplayName('AzureOpenAI')).toBe('Azure OpenAI');
         expect(getProviderDisplayName('Anthropic')).toBe('Anthropic');
         expect(getProviderDisplayName('Ollama')).toBe('Ollama');
+        expect(getProviderDisplayName('GeminiVertexAI')).toBe('Gemini Vertex AI');
+        expect(getProviderDisplayName('AnthropicVertexAI')).toBe('Anthropic Vertex AI');
     });
 
     it('should return the input type if no matching provider is found', () => {
@@ -57,6 +63,8 @@ describe('getProviderFormKey', () => {
         expect(getProviderFormKey('AzureOpenAI')).toBe('azure-openai');
         expect(getProviderFormKey('Anthropic')).toBe('anthropic');
         expect(getProviderFormKey('Ollama')).toBe('ollama');
+        expect(getProviderFormKey('GeminiVertexAI')).toBe('gemini-vertex-ai');
+        expect(getProviderFormKey('AnthropicVertexAI')).toBe('anthropic-vertex-ai');
     });
 
     it('should return undefined if no matching provider type is found', () => {

--- a/ui/src/lib/providers.ts
+++ b/ui/src/lib/providers.ts
@@ -1,6 +1,6 @@
 
-export type BackendModelProviderType = "OpenAI" | "AzureOpenAI" | "Anthropic" | "Ollama";
-export const modelProviders = ["openai", "azure-openai", "anthropic", "ollama"] as const;
+export type BackendModelProviderType = "OpenAI" | "AzureOpenAI" | "Anthropic" | "Ollama" | "GeminiVertexAI" | "AnthropicVertexAI";
+export const modelProviders = ["openai", "azure-openai", "anthropic", "ollama", "gemini-vertex-ai", "anthropic-vertex-ai"] as const;
 export type ModelProviderKey = typeof modelProviders[number];
 
 
@@ -41,6 +41,18 @@ export const PROVIDERS_INFO: {
         modelDocsLink: "https://github.com/kagent-dev/autogen/blob/main/python/packages/autogen-ext/src/autogen_ext/models/ollama/_model_info.py",
         help: "No API key needed. Ensure Ollama is running and accessible."
     },
+    "gemini-vertex-ai": {
+        name: "Gemini Vertex AI",
+        type: "GeminiVertexAI",
+        apiKeyLink: "https://cloud.google.com/docs/authentication/set-up-adc-containerized-environment",
+        help: "Uses Application Default Credentials (ADC) or JSON credentials. Set up machine identity for containerized environments."
+    },
+    "anthropic-vertex-ai": {
+        name: "Anthropic Vertex AI",
+        type: "AnthropicVertexAI",
+        apiKeyLink: "https://cloud.google.com/docs/authentication/set-up-adc-containerized-environment",
+        help: "Uses Application Default Credentials (ADC) or JSON credentials. Set up machine identity for containerized environments."
+    },
 };
 
 export const isValidProviderInfoKey = (key: string): key is ModelProviderKey => {
@@ -54,6 +66,8 @@ export const getApiKeyForProviderFormKey = (providerFormKey: ModelProviderKey): 
         case 'azure-openai': return 'azureOpenAI';
         case 'anthropic': return 'anthropic';
         case 'ollama': return 'ollama';
+        case 'gemini-vertex-ai': return 'geminiVertexAI';
+        case 'anthropic-vertex-ai': return 'anthropicVertexAI';
         default: return providerFormKey;
     }
 };

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -81,6 +81,26 @@ export interface OllamaConfigPayload {
   options?: Record<string, string>;
 }
 
+export interface GeminiVertexAIConfigPayload {
+  projectID: string;
+  location: string;
+  temperature?: string;
+  topP?: string;
+  topK?: string;
+  maxOutputTokens?: number;
+  candidateCount?: number;
+  responseMimeType?: string;
+}
+
+export interface AnthropicVertexAIConfigPayload {
+  projectID: string;
+  location: string;
+  temperature?: string;
+  topP?: string;
+  topK?: string;
+  maxTokens?: number;
+}
+
 export interface CreateModelConfigPayload {
   ref: string;
   provider: Pick<Provider, "name" | "type">;
@@ -90,6 +110,8 @@ export interface CreateModelConfigPayload {
   anthropic?: AnthropicConfigPayload;
   azureOpenAI?: AzureOpenAIConfigPayload;
   ollama?: OllamaConfigPayload;
+  geminiVertexAI?: GeminiVertexAIConfigPayload;
+  anthropicVertexAI?: AnthropicVertexAIConfigPayload;
 }
 
 export interface UpdateModelConfigPayload {
@@ -100,6 +122,8 @@ export interface UpdateModelConfigPayload {
   anthropic?: AnthropicConfigPayload;
   azureOpenAI?: AzureOpenAIConfigPayload;
   ollama?: OllamaConfigPayload;
+  geminiVertexAI?: GeminiVertexAIConfigPayload;
+  anthropicVertexAI?: AnthropicVertexAIConfigPayload;
 }
 
 export interface MemoryResponse {


### PR DESCRIPTION
Right now, we support only explicit credentials (via a JSON key) for VertexAI providers. This PR adds support for machine identity (ADC) as well essentially letting the provider authenticate via default credentials when no secret ref is provided.

The core logic in the translator was already set up to conditionally inject the `GOOGLE_APPLICATION_CREDENTIALS` env var only when needed, so most of the work here was wiring up the provider config and ensuring the frontend could handle the new shape.

* Added `projectID` and `location` as required fields for the VertexAI providers (Gemini + Anthropic)
* Downgraded Go from 1.24.4 to 1.24.0, some stuff wasn’t working correctly with the newer patch
* Frontend changes mostly involved updating the types, form handling, and provider config mapping
* Golden tests were added for both ADC and JSON-based auth flows

Tested both flows locally and in golden tests, both providers seem to behave as expected now. ADC skips the env var injection entirely, while JSON uses it the same as before. No regressions in existing behavior.

Leaving out screenshots since this is mostly backend/auth-related.

Still ironing out some edge cases, but this should be safe to merge once reviewed.

Fixes #477.

