### PR TITLE
Make shebang more portable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ build-all: buildx-create
 create-kind-cluster:
 	docker pull kindest/node:v$(TOOLS_KIND_IMAGE_VERSION) || true
 	kind create cluster --name $(KIND_CLUSTER_NAME) --image kindest/node:v$(TOOLS_KIND_IMAGE_VERSION) --config ./scripts/kind/kind-config.yaml
-	./scripts/kind/setup-metallb.sh
+	sh ./scripts/kind/setup-metallb.sh
 
 .PHONY: use-kind-cluster
 use-kind-cluster:

--- a/scripts/kind/setup-metallb.sh
+++ b/scripts/kind/setup-metallb.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/env bash
 
 set -o errexit
 set -o pipefail


### PR DESCRIPTION
This PR makes the project's Makefile and setup scripts more portable, enabling them to work on systems with non-standard bash locations (e.g. NixOS).