### PR TITLE
Make it possible to emit input/output as log events

### DIFF
--- a/helm/kagent/templates/controller-deployment.yaml
+++ b/helm/kagent/templates/controller-deployment.yaml
@@ -72,10 +72,20 @@ spec:
               value: {{ .Values.otel.tracing.enabled | quote }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: {{ .Values.otel.tracing.exporter.otlp.endpoint | quote }}
+            - name: OTEL_TRACING_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.otel.tracing.exporter.otlp.endpoint | quote }}
             - name: OTEL_EXPORTER_OTLP_TRACES_TIMEOUT
               value: {{ .Values.otel.tracing.exporter.otlp.timeout | quote }}
             - name: OTEL_EXPORTER_OTLP_TRACES_INSECURE
               value: {{ .Values.otel.tracing.exporter.otlp.insecure | quote }}
+            - name: OTEL_LOGGING_ENABLED
+              value: {{ .Values.otel.logging.enabled | quote }}
+            - name: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
+              value: {{ .Values.otel.logging.exporter.otlp.endpoint | quote }}
+            - name: OTEL_EXPORTER_OTLP_LOGS_TIMEOUT
+              value: {{ .Values.otel.logging.exporter.otlp.timeout | quote }}
+            - name: OTEL_EXPORTER_OTLP_LOGS_INSECURE
+              value: {{ .Values.otel.logging.exporter.otlp.insecure | quote }}
             {{- with .Values.controller.env }}
               {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -225,3 +225,10 @@ otel:
         endpoint: http://host.docker.internal:4317
         timeout: 15
         insecure: true
+  logging:
+    enabled: true
+    exporter:
+      otlp:
+        endpoint: http://host.docker.internal:4317
+        timeout: 15
+        insecure: true

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -226,7 +226,7 @@ otel:
         timeout: 15
         insecure: true
   logging:
-    enabled: true
+    enabled: false
     exporter:
       otlp:
         endpoint: http://host.docker.internal:4317

--- a/python/packages/kagent/src/kagent/cli.py
+++ b/python/packages/kagent/src/kagent/cli.py
@@ -38,9 +38,9 @@ def static(
 ):
     tracing_enabled = os.getenv("OTEL_TRACING_ENABLED", "false").lower() == "true"
     logging_enabled = os.getenv("OTEL_LOGGING_ENABLED", "false").lower() == "true"
-    
+
     resource = Resource({"service.name": "kagent"})
-    
+
     # Configure tracing if enabled
     if tracing_enabled:
         logging.info("Enabling tracing")
@@ -54,28 +54,28 @@ def static(
         tracer_provider.add_span_processor(processor)
         trace.set_tracer_provider(tracer_provider)
         HTTPXClientInstrumentor().instrument()
-    
+
     # Configure logging if enabled
     if logging_enabled:
         logging.info("Enabling logging for GenAI events")
         logger_provider = LoggerProvider(resource=resource)
         log_endpoint = os.getenv("OTEL_LOGGING_EXPORTER_OTLP_ENDPOINT")
         logging.info(f"Log endpoint configured: {log_endpoint}")
-        
+
         # Add OTLP exporter
         if log_endpoint:
             log_processor = BatchLogRecordProcessor(OTLPLogExporter(endpoint=log_endpoint))
         else:
             log_processor = BatchLogRecordProcessor(OTLPLogExporter())
         logger_provider.add_log_record_processor(log_processor)
-        
+
         # Add console exporter for debugging
         console_processor = BatchLogRecordProcessor(ConsoleLogExporter())
         logger_provider.add_log_record_processor(console_processor)
-        
+
         _logs.set_logger_provider(logger_provider)
         logging.info("Log provider configured with OTLP and console exporters")
-    
+
     # Configure OpenAI instrumentation based on logging preference
     if tracing_enabled or logging_enabled:
         if logging_enabled:
@@ -83,9 +83,7 @@ def static(
             logging.info("OpenAI instrumentation configured with event logging capability")
             # Create event logger provider using the configured logger provider
             event_logger_provider = EventLoggerProvider(get_logger_provider())
-            OpenAIInstrumentor(use_legacy_attributes=False).instrument(
-                event_logger_provider=event_logger_provider
-            )
+            OpenAIInstrumentor(use_legacy_attributes=False).instrument(event_logger_provider=event_logger_provider)
         else:
             # Use legacy attributes (input/output as GenAI span attributes)
             logging.info("OpenAI instrumentation configured with legacy GenAI span attributes")

--- a/python/packages/kagent/src/kagent/cli.py
+++ b/python/packages/kagent/src/kagent/cli.py
@@ -9,12 +9,19 @@ import typer
 import uvicorn
 from kagent_adk import AgentConfig, KAgentApp
 from opentelemetry import trace
+from opentelemetry import _logs
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
 from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 from opentelemetry.instrumentation.openai import OpenAIInstrumentor
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+from opentelemetry.sdk._logs.export import ConsoleLogExporter
+from opentelemetry.sdk._events import EventLoggerProvider
+from opentelemetry._logs import get_logger_provider
 
 logger = logging.getLogger(__name__)
 
@@ -30,14 +37,59 @@ def static(
     reload: Annotated[bool, typer.Option("--reload")] = False,
 ):
     tracing_enabled = os.getenv("OTEL_TRACING_ENABLED", "false").lower() == "true"
+    logging_enabled = os.getenv("OTEL_LOGGING_ENABLED", "false").lower() == "true"
+    
+    resource = Resource({"service.name": "kagent"})
+    
+    # Configure tracing if enabled
     if tracing_enabled:
         logging.info("Enabling tracing")
-        tracer_provider = TracerProvider(resource=Resource({"service.name": "kagent"}))
-        processor = BatchSpanProcessor(OTLPSpanExporter())
+        tracer_provider = TracerProvider(resource=resource)
+        # Check new env var first, fall back to old one for backward compatibility
+        trace_endpoint = os.getenv("OTEL_TRACING_EXPORTER_OTLP_ENDPOINT") or os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+        if trace_endpoint:
+            processor = BatchSpanProcessor(OTLPSpanExporter(endpoint=trace_endpoint))
+        else:
+            processor = BatchSpanProcessor(OTLPSpanExporter())
         tracer_provider.add_span_processor(processor)
         trace.set_tracer_provider(tracer_provider)
         HTTPXClientInstrumentor().instrument()
-        OpenAIInstrumentor().instrument()
+    
+    # Configure logging if enabled
+    if logging_enabled:
+        logging.info("Enabling logging for GenAI events")
+        logger_provider = LoggerProvider(resource=resource)
+        log_endpoint = os.getenv("OTEL_LOGGING_EXPORTER_OTLP_ENDPOINT")
+        logging.info(f"Log endpoint configured: {log_endpoint}")
+        
+        # Add OTLP exporter
+        if log_endpoint:
+            log_processor = BatchLogRecordProcessor(OTLPLogExporter(endpoint=log_endpoint))
+        else:
+            log_processor = BatchLogRecordProcessor(OTLPLogExporter())
+        logger_provider.add_log_record_processor(log_processor)
+        
+        # Add console exporter for debugging
+        console_processor = BatchLogRecordProcessor(ConsoleLogExporter())
+        logger_provider.add_log_record_processor(console_processor)
+        
+        _logs.set_logger_provider(logger_provider)
+        logging.info("Log provider configured with OTLP and console exporters")
+    
+    # Configure OpenAI instrumentation based on logging preference
+    if tracing_enabled or logging_enabled:
+        if logging_enabled:
+            # When logging is enabled, use new event-based approach (input/output as log events in Body)
+            logging.info("OpenAI instrumentation configured with event logging capability")
+            # Create event logger provider using the configured logger provider
+            event_logger_provider = EventLoggerProvider(get_logger_provider())
+            OpenAIInstrumentor(use_legacy_attributes=False).instrument(
+                event_logger_provider=event_logger_provider
+            )
+        else:
+            # Use legacy attributes (input/output as GenAI span attributes)
+            logging.info("OpenAI instrumentation configured with legacy GenAI span attributes")
+            OpenAIInstrumentor().instrument()
 
     with open(filepath, "r") as f:
         config = json.load(f)


### PR DESCRIPTION
This PR makes it configurable to emit input/output messages as events if OTel logging is configured to be compliant with https://github.com/open-telemetry/semantic-conventions/pull/2179. By default, input/output is being emitted as span attributes.

Fixes https://github.com/kagent-dev/kagent/issues/637