### PR TITLE
fix(cli): update dashboard service name to kagent-ui

### DIFF
--- a/go/cli/internal/cli/dashboard.go
+++ b/go/cli/internal/cli/dashboard.go
@@ -13,6 +13,6 @@ import (
 func DashboardCmd(ctx context.Context, cfg *config.Config) {
 	fmt.Fprintln(os.Stderr, "Dashboard is not available on this platform")
 	fmt.Fprintln(os.Stderr, "You can easily start the dashboard by running:")
-	fmt.Fprintln(os.Stderr, "kubectl port-forward -n kagent service/kagent 8082:80")
+	fmt.Fprintln(os.Stderr, "kubectl port-forward -n kagent service/kagent-ui 8082:80")
 	fmt.Fprintln(os.Stderr, "and then opening http://localhost:8082 in your browser")
 }

--- a/go/cli/internal/cli/dashboard_darwin.go
+++ b/go/cli/internal/cli/dashboard_darwin.go
@@ -15,7 +15,7 @@ import (
 
 func DashboardCmd(ctx context.Context, cfg *config.Config) {
 	ctx, cancel := context.WithCancel(ctx)
-	cmd := exec.CommandContext(ctx, "kubectl", "-n", cfg.Namespace, "port-forward", "service/kagent", "8082:80")
+	cmd := exec.CommandContext(ctx, "kubectl", "-n", cfg.Namespace, "port-forward", "service/kagent-ui", "8082:80")
 
 	defer func() {
 		cancel()


### PR DESCRIPTION
Dashboard command was referencing the old service name 'kagent' instead of the correct UI service name 'kagent-ui'