### PR TITLE
fix: Remove console exporter

### DIFF
--- a/python/packages/kagent/src/kagent/cli.py
+++ b/python/packages/kagent/src/kagent/cli.py
@@ -62,30 +62,23 @@ def static(
         log_endpoint = os.getenv("OTEL_LOGGING_EXPORTER_OTLP_ENDPOINT")
         logging.info(f"Log endpoint configured: {log_endpoint}")
 
-        # Add OTLP exporter
         if log_endpoint:
             log_processor = BatchLogRecordProcessor(OTLPLogExporter(endpoint=log_endpoint))
         else:
             log_processor = BatchLogRecordProcessor(OTLPLogExporter())
         logger_provider.add_log_record_processor(log_processor)
 
-        # Add console exporter for debugging
-        console_processor = BatchLogRecordProcessor(ConsoleLogExporter())
-        logger_provider.add_log_record_processor(console_processor)
-
         _logs.set_logger_provider(logger_provider)
-        logging.info("Log provider configured with OTLP and console exporters")
+        logging.info("Log provider configured with OTLP exporter")
 
-    # Configure OpenAI instrumentation based on logging preference
     if tracing_enabled or logging_enabled:
         if logging_enabled:
             # When logging is enabled, use new event-based approach (input/output as log events in Body)
             logging.info("OpenAI instrumentation configured with event logging capability")
-            # Create event logger provider using the configured logger provider
             event_logger_provider = EventLoggerProvider(get_logger_provider())
             OpenAIInstrumentor(use_legacy_attributes=False).instrument(event_logger_provider=event_logger_provider)
         else:
-            # Use legacy attributes (input/output as GenAI span attributes)
+            # Otherwise, use legacy attributes (input/output as GenAI span attributes)
             logging.info("OpenAI instrumentation configured with legacy GenAI span attributes")
             OpenAIInstrumentor().instrument()
 


### PR DESCRIPTION
This PR removes the console exporter that was used during development. You can still push OTel data to an OTel collector with `debugexporter` configured to see the raw data.