### PR TITLE
feat: wait for agent deployment ready before enabling UI interactions (closes #734)

### DIFF
--- a/go/internal/httpserver/handlers/agents.go
+++ b/go/internal/httpserver/handlers/agents.go
@@ -78,13 +78,23 @@ func (h *AgentsHandler) getAgentResponse(ctx context.Context, log logr.Logger, a
 		}
 	}
 
+	// Get the Deployment status for the agent
+	deploymentReady := false
+	for _, condition := range agent.Status.Conditions {
+		if condition.Type == "Ready" && condition.Reason == "DeploymentReady" && condition.Status == "True" {
+			deploymentReady = true
+			break
+		}
+	}
+
 	return api.AgentResponse{
-		ID:             common.ConvertToPythonIdentifier(agentRef),
-		Agent:          agent,
-		ModelProvider:  modelConfig.Spec.Provider,
-		Model:          modelConfig.Spec.Model,
-		ModelConfigRef: common.GetObjectRef(modelConfig),
-		Tools:          agent.Spec.Tools,
+		ID:              common.ConvertToPythonIdentifier(agentRef),
+		Agent:           agent,
+		ModelProvider:   modelConfig.Spec.Provider,
+		Model:           modelConfig.Spec.Model,
+		ModelConfigRef:  common.GetObjectRef(modelConfig),
+		Tools:           agent.Spec.Tools,
+		DeploymentReady: deploymentReady,
 	}, nil
 }
 

--- a/go/internal/httpserver/handlers/agents_test.go
+++ b/go/internal/httpserver/handlers/agents_test.go
@@ -49,6 +49,14 @@ func createTestAgent(name string, modelConfig *v1alpha2.ModelConfig) *v1alpha2.A
 	}
 }
 
+func createTestAgentWithStatus(name string, modelConfig *v1alpha2.ModelConfig, conditions []metav1.Condition) *v1alpha2.Agent {
+	agent := createTestAgent(name, modelConfig)
+	agent.Status = v1alpha2.AgentStatus{
+		Conditions: conditions,
+	}
+	return agent
+}
+
 func setupTestHandler(objects ...client.Object) (*handlers.AgentsHandler, string) {
 	kubeClient := fake.NewClientBuilder().
 		WithScheme(setupScheme()).
@@ -101,6 +109,96 @@ func TestHandleGetAgent(t *testing.T) {
 		require.Equal(t, "default/test-model-config", response.Data.ModelConfigRef, w.Body.String())
 		require.Equal(t, "gpt-4", response.Data.Model)
 		require.Equal(t, v1alpha2.ModelProviderOpenAI, response.Data.ModelProvider)
+		require.False(t, response.Data.DeploymentReady) // No status conditions, should be false
+	})
+
+	t.Run("gets agent with DeploymentReady=true", func(t *testing.T) {
+		modelConfig := createTestModelConfig()
+		conditions := []metav1.Condition{
+			{
+				Type:   "Accepted",
+				Status: "True",
+				Reason: "AgentReconciled",
+			},
+			{
+				Type:   "Ready",
+				Status: "True",
+				Reason: "DeploymentReady",
+			},
+		}
+		agent := createTestAgentWithStatus("test-agent-ready", modelConfig, conditions)
+
+		handler, _ := setupTestHandler(agent, modelConfig)
+		createAgent(handler.Base.DatabaseService, agent)
+
+		req := httptest.NewRequest("GET", "/api/agents/default/test-agent-ready", nil)
+		req = mux.SetURLVars(req, map[string]string{"namespace": "default", "name": "test-agent-ready"})
+		w := httptest.NewRecorder()
+
+		handler.HandleGetAgent(&testErrorResponseWriter{w}, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var response api.StandardResponse[api.AgentResponse]
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+		require.True(t, response.Data.DeploymentReady)
+	})
+
+	t.Run("gets agent with DeploymentReady=false when Ready status is False", func(t *testing.T) {
+		modelConfig := createTestModelConfig()
+		conditions := []metav1.Condition{
+			{
+				Type:   "Ready",
+				Status: "False", // Status is False
+				Reason: "DeploymentReady",
+			},
+		}
+		agent := createTestAgentWithStatus("test-agent-not-ready", modelConfig, conditions)
+
+		handler, _ := setupTestHandler(agent, modelConfig)
+		createAgent(handler.Base.DatabaseService, agent)
+
+		req := httptest.NewRequest("GET", "/api/agents/default/test-agent-not-ready", nil)
+		req = mux.SetURLVars(req, map[string]string{"namespace": "default", "name": "test-agent-not-ready"})
+		w := httptest.NewRecorder()
+
+		handler.HandleGetAgent(&testErrorResponseWriter{w}, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var response api.StandardResponse[api.AgentResponse]
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+		require.False(t, response.Data.DeploymentReady)
+	})
+
+	t.Run("gets agent with DeploymentReady=false when reason is not DeploymentReady", func(t *testing.T) {
+		modelConfig := createTestModelConfig()
+		conditions := []metav1.Condition{
+			{
+				Type:   "Ready",
+				Status: "True",
+				Reason: "DifferentReason", // Different reason
+			},
+		}
+		agent := createTestAgentWithStatus("test-agent-different-reason", modelConfig, conditions)
+
+		handler, _ := setupTestHandler(agent, modelConfig)
+		createAgent(handler.Base.DatabaseService, agent)
+
+		req := httptest.NewRequest("GET", "/api/agents/default/test-agent-different-reason", nil)
+		req = mux.SetURLVars(req, map[string]string{"namespace": "default", "name": "test-agent-different-reason"})
+		w := httptest.NewRecorder()
+
+		handler.HandleGetAgent(&testErrorResponseWriter{w}, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var response api.StandardResponse[api.AgentResponse]
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+		require.False(t, response.Data.DeploymentReady)
 	})
 
 	t.Run("returns 404 for missing agent", func(t *testing.T) {
@@ -116,13 +214,26 @@ func TestHandleGetAgent(t *testing.T) {
 	})
 }
 
-func TestHandleListTeams(t *testing.T) {
-	t.Run("lists teams successfully", func(t *testing.T) {
+func TestHandleListAgents(t *testing.T) {
+	t.Run("lists agents successfully", func(t *testing.T) {
 		modelConfig := createTestModelConfig()
-		team := createTestAgent("test-team", modelConfig)
 
-		handler, _ := setupTestHandler(team, modelConfig)
-		createAgent(handler.Base.DatabaseService, team)
+		// Agent with DeploymentReady=true
+		readyConditions := []metav1.Condition{
+			{
+				Type:   "Ready",
+				Status: "True",
+				Reason: "DeploymentReady",
+			},
+		}
+		readyAgent := createTestAgentWithStatus("ready-agent", modelConfig, readyConditions)
+
+		// Agent with DeploymentReady=false
+		notReadyAgent := createTestAgent("not-ready-agent", modelConfig)
+
+		handler, _ := setupTestHandler(readyAgent, notReadyAgent, modelConfig)
+		createAgent(handler.Base.DatabaseService, readyAgent)
+		createAgent(handler.Base.DatabaseService, notReadyAgent)
 
 		req := httptest.NewRequest("GET", "/api/agents", nil)
 		w := httptest.NewRecorder()
@@ -134,11 +245,17 @@ func TestHandleListTeams(t *testing.T) {
 		var response api.StandardResponse[[]api.AgentResponse]
 		err := json.Unmarshal(w.Body.Bytes(), &response)
 		require.NoError(t, err)
-		require.Len(t, response.Data, 1)
-		require.Equal(t, "test-team", response.Data[0].Agent.Name)
+		require.Len(t, response.Data, 2)
+		require.Equal(t, "not-ready-agent", response.Data[0].Agent.Name)
 		require.Equal(t, "default/test-model-config", response.Data[0].ModelConfigRef)
 		require.Equal(t, "gpt-4", response.Data[0].Model)
 		require.Equal(t, v1alpha2.ModelProviderOpenAI, response.Data[0].ModelProvider)
+		require.Equal(t, false, response.Data[0].DeploymentReady)
+		require.Equal(t, "ready-agent", response.Data[1].Agent.Name)
+		require.Equal(t, "default/test-model-config", response.Data[1].ModelConfigRef)
+		require.Equal(t, "gpt-4", response.Data[1].Model)
+		require.Equal(t, v1alpha2.ModelProviderOpenAI, response.Data[1].ModelProvider)
+		require.Equal(t, true, response.Data[1].DeploymentReady)
 	})
 }
 

--- a/go/pkg/client/api/types.go
+++ b/go/pkg/client/api/types.go
@@ -80,11 +80,12 @@ type AgentResponse struct {
 	ID    string          `json:"id"`
 	Agent *v1alpha2.Agent `json:"agent"`
 	// Config         *adk.AgentConfig       `json:"config"`
-	ModelProvider  v1alpha2.ModelProvider `json:"modelProvider"`
-	Model          string                 `json:"model"`
-	ModelConfigRef string                 `json:"modelConfigRef"`
-	MemoryRefs     []string               `json:"memoryRefs"`
-	Tools          []*v1alpha2.Tool       `json:"tools"`
+	ModelProvider   v1alpha2.ModelProvider `json:"modelProvider"`
+	Model           string                 `json:"model"`
+	ModelConfigRef  string                 `json:"modelConfigRef"`
+	MemoryRefs      []string               `json:"memoryRefs"`
+	Tools           []*v1alpha2.Tool       `json:"tools"`
+	DeploymentReady bool                   `json:"deploymentReady"`
 }
 
 // Session types

--- a/ui/src/components/DeleteAgentButton.tsx
+++ b/ui/src/components/DeleteAgentButton.tsx
@@ -10,9 +10,10 @@ import { useAgents } from "./AgentsProvider";
 interface DeleteButtonProps {
   agentName: string;
   namespace: string;
+  disabled?: boolean;
 }
 
-export function DeleteButton({ agentName, namespace }: DeleteButtonProps) {
+export function DeleteButton({ agentName, namespace, disabled = false }: DeleteButtonProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const { refreshAgents } = useAgents();
@@ -50,9 +51,11 @@ export function DeleteButton({ agentName, namespace }: DeleteButtonProps) {
         onClick={(e) => {
           e.stopPropagation();
           e.preventDefault();
-          setIsOpen(true);
+          if (!disabled) {
+            setIsOpen(true);
+          }
         }}
-        disabled={isDeleting}
+        disabled={isDeleting || disabled}
       >
         {isDeleting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
       </Button>

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -263,6 +263,7 @@ export interface AgentResponse {
   modelConfigRef: string;
   memoryRefs: string[];
   tools: Tool[];
+  deploymentReady: boolean;
 }
 
 export interface RemoteMCPServer {


### PR DESCRIPTION
## Description

This PR implements deployment readiness checking for agents in the UI. Agents are now only clickable and interactive when their deployment is ready, preventing users from attempting to interact with agents that haven't finished their deployment process.

## Changes Made

### Backend
- **Added `deploymentReady` field** to `AgentResponse` API type
- **Implemented status checking logic** in `getAgentResponse()` to check for Ready condition with DeploymentReady reason and status="True"
- **Added comprehensive tests** covering all scenarios: ready/not ready, wrong status, wrong reason

### Frontend
- **Enhanced `AgentCard`** to conditionally enable clickability based on `deploymentReady` status
- **Added visual indicators** for non-ready agents:
  - "Not Ready" badge
  - Reduced opacity (60%) 
  - Gray border
  - `cursor-not-allowed` styling
- **Disabled interactions** for non-ready agents:
  - No link to chat interface
  - Disabled edit and delete buttons
- **Updated `DeleteAgentButton`** to accept and respect `disabled` prop

### Type Safety
- **Updated TypeScript types** to include `deploymentReady: boolean` field

## User Experience

### Ready Agents (`deploymentReady: true`)
- ✅ Clickable card linking to chat interface
- ✅ Interactive edit/delete buttons on hover
- ✅ Normal styling with hover effects

### Not Ready Agents (`deploymentReady: false`)
- ❌ Non-clickable card
- ❌ Disabled edit/delete buttons  
- 🟡 Visual indicators: "Not Ready" badge, muted appearance

<img width="399" height="232" alt="Screenshot 2025-08-11 at 3 07 13 PM" src="https://github.com/user-attachments/assets/cb556a33-82cb-43df-aeae-53b88e35d3df" />
<img width="1189" height="842" alt="Screenshot 2025-08-11 at 3 07 16 PM" src="https://github.com/user-attachments/assets/4683046d-1e03-44a0-adba-78a980011d39" />


## Important Note

**⚠️ Page Refresh Required**: When an agent transitions from "not ready" to "ready" status, a page refresh will be needed to detect the change and enable agent interactions. The UI does not currently auto-refresh agent status.

## Testing

All tests pass including new comprehensive test coverage for:
- Agents with proper Ready/DeploymentReady conditions → `deploymentReady: true`
- Agents without conditions → `deploymentReady: false` 
- Agents with wrong status or reason → `deploymentReady: false`
- List endpoint with mixed ready/not-ready agents

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (enhancement to existing functionality)