### PR TITLE
fix(kagent-ui): write PID to /tmp to avoid permission error

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -76,12 +76,13 @@ RUN mkdir -p $BUN_INSTALL  \
     && curl -fsSL https://bun.sh/install | bash -s "bun-v$TOOLS_BUN_VERSION" \
     && bun --version
 
-RUN mkdir -p /app/ui/public /run/nginx/ /var/lib/nginx/tmp/ /var/lib/nginx/logs/  \
+RUN mkdir -p /app/ui/public /run/nginx/ /var/run/nginx/ /var/lib/nginx/tmp/ /var/lib/nginx/logs/  \
     && addgroup -g 1001    nginx                        \
     && adduser  -u 1001 -G nginx -s /bin/bash -D nextjs \
     && adduser  -u 1002 -G nginx -s /bin/bash -D nginx  \
     && chown    -vR nextjs:nginx /app/ui                \
     && chown    -vR nextjs:nginx /run/nginx             \
+    && chown    -vR nextjs:nginx /var/run/nginx         \
     && chown    -vR nextjs:nginx /var/lib/nginx/
 
 WORKDIR /app

--- a/ui/conf/nginx.conf
+++ b/ui/conf/nginx.conf
@@ -1,3 +1,5 @@
+pid /var/run/nginx/nginx.pid;
+
 events {
     worker_connections 1024;
 }


### PR DESCRIPTION
Noticed an issue when attempting to build and run the containers from main branch. 

The kagent-ui pod wasn’t coming online because nginx exited on startup with a permission error writing its PID file to `/run/nginx.pid`.

Observed logs:

```
2025-08-13 03:04:43,571 INFO spawned: 'nginx' with pid 209
2025-08-13 03:04:43,581 DEBG 'nginx' stderr output:
nginx: [emerg] open() "/run/nginx.pid" failed (13: Permission denied)
...
2025-08-13 03:04:43,582 WARN exited: nginx (exit status 1; not expected)
```

The kagent-ui pod goes into crash loop and never becomes Ready and the UI is unreachable.

With the container is running nginx as non-root and/or with a read-only root filesystem, `/run` isn’t writable to the nginx process. nginx tries to create `/run/nginx.pid` by default and fails. So this change configures nginx to write its pid to the `/var/run/ngninx` directory and chown to the non-root user so it has permissions to write.
