### PR TITLE
fix: improve local kind cluster creation process and add kmcp version var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,15 @@ TOOLS_IMAGE_BUILD_ARGS += --build-arg TOOLS_BUN_VERSION=$(TOOLS_BUN_VERSION)
 TOOLS_IMAGE_BUILD_ARGS += --build-arg TOOLS_PYTHON_VERSION=$(TOOLS_PYTHON_VERSION)
 TOOLS_IMAGE_BUILD_ARGS += --build-arg TOOLS_NODE_VERSION=$(TOOLS_NODE_VERSION)
 
+# KMCP chart version: latest GitHub release (no 'v' prefix)
+KMCP_REPO ?= kagent-dev/kmcp
+KMCP_VERSION ?= $(shell \
+	URL=https://api.github.com/repos/$(KMCP_REPO)/releases/latest; \
+	RESP=$$(curl -fsSL $$URL 2>/dev/null || true); \
+	VALUE=$$(printf '%s' "$$RESP" | sed -nE 's/.*"tag_name":\s*"v?([^"]+)".*/\1/p'); \
+	if [ -n "$$VALUE" ]; then echo "$$VALUE"; else echo "0.1.3"; fi \
+)
+
 HELM_ACTION=upgrade --install
 
 # Helm chart variables
@@ -76,6 +85,7 @@ print-tools-versions:
 	@echo "Tools Node   : $(TOOLS_NODE_VERSION)"
 	@echo "Tools Istio  : $(TOOLS_ISTIO_VERSION)"
 	@echo "Tools Argo CD: $(TOOLS_ARGO_CD_VERSION)"
+	@echo "KMCP Version : $(KMCP_VERSION)"
 
 # Check if OPENAI_API_KEY is set
 check-openai-key:
@@ -243,7 +253,7 @@ helm-install-provider: helm-version check-openai-key
 		--history-max 2    \
 		--timeout 5m 			\
 		--kube-context kind-$(KIND_CLUSTER_NAME) \
-		--version 0.1.3 \
+		--version $(KMCP_VERSION) \
 		--wait
 	helm $(HELM_ACTION) kagent-crds helm/kagent-crds \
 		--namespace kagent \

--- a/Makefile
+++ b/Makefile
@@ -65,11 +65,12 @@ TOOLS_IMAGE_BUILD_ARGS += --build-arg TOOLS_NODE_VERSION=$(TOOLS_NODE_VERSION)
 
 # KMCP chart version: latest GitHub release (no 'v' prefix)
 KMCP_REPO ?= kagent-dev/kmcp
+KMCP_FALLBACK_VERSION ?= 0.1.3
 KMCP_VERSION ?= $(shell \
 	URL=https://api.github.com/repos/$(KMCP_REPO)/releases/latest; \
 	RESP=$$(curl -fsSL $$URL 2>/dev/null || true); \
 	VALUE=$$(printf '%s' "$$RESP" | sed -nE 's/.*"tag_name":\s*"v?([^"]+)".*/\1/p'); \
-	if [ -n "$$VALUE" ]; then echo "$$VALUE"; else echo "0.1.3"; fi \
+	if [ -n "$$VALUE" ]; then echo "$$VALUE"; else echo "$(KMCP_FALLBACK_VERSION)"; fi \
 )
 
 HELM_ACTION=upgrade --install

--- a/Makefile
+++ b/Makefile
@@ -63,15 +63,8 @@ TOOLS_IMAGE_BUILD_ARGS += --build-arg TOOLS_BUN_VERSION=$(TOOLS_BUN_VERSION)
 TOOLS_IMAGE_BUILD_ARGS += --build-arg TOOLS_PYTHON_VERSION=$(TOOLS_PYTHON_VERSION)
 TOOLS_IMAGE_BUILD_ARGS += --build-arg TOOLS_NODE_VERSION=$(TOOLS_NODE_VERSION)
 
-# KMCP chart version: latest GitHub release (no 'v' prefix)
-KMCP_REPO ?= kagent-dev/kmcp
-KMCP_FALLBACK_VERSION ?= 0.1.3
-KMCP_VERSION ?= $(shell \
-	URL=https://api.github.com/repos/$(KMCP_REPO)/releases/latest; \
-	RESP=$$(curl -fsSL $$URL 2>/dev/null || true); \
-	VALUE=$$(printf '%s' "$$RESP" | sed -nE 's/.*"tag_name":\s*"v?([^"]+)".*/\1/p'); \
-	if [ -n "$$VALUE" ]; then echo "$$VALUE"; else echo "$(KMCP_FALLBACK_VERSION)"; fi \
-)
+# kmcp version extraction from go.mod
+KMCP_VERSION ?= $(shell $(AWK) '/github\.com\/kagent-dev\/kmcp/ { print substr($$2, 2) }' go/go.mod)
 
 HELM_ACTION=upgrade --install
 

--- a/Makefile
+++ b/Makefile
@@ -99,8 +99,8 @@ build-all: buildx-create
 
 .PHONY: create-kind-cluster
 create-kind-cluster:
-	sh ./scripts/kind/setup-kind.sh
-	sh ./scripts/kind/setup-metallb.sh
+	bash ./scripts/kind/setup-kind.sh
+	bash ./scripts/kind/setup-metallb.sh
 
 .PHONY: use-kind-cluster
 use-kind-cluster:
@@ -243,7 +243,7 @@ helm-install-provider: helm-version check-openai-key
 		--history-max 2    \
 		--timeout 5m 			\
 		--kube-context kind-$(KIND_CLUSTER_NAME) \
-		--version 0.1.2 \
+		--version 0.1.3 \
 		--wait
 	helm $(HELM_ACTION) kagent-crds helm/kagent-crds \
 		--namespace kagent \

--- a/go/go.mod
+++ b/go/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/jedib0t/go-pretty/v6 v6.6.8
-	github.com/kagent-dev/kmcp v0.1.1
+	github.com/kagent-dev/kmcp v0.1.4
 	github.com/mark3labs/mcp-go v0.34.0
 	github.com/prometheus/client_golang v1.23.0
 	github.com/spf13/cobra v1.9.1

--- a/go/go.sum
+++ b/go/go.sum
@@ -128,8 +128,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kagent-dev/a2a-go v0.0.0-20250806145931-0fab01f644c3 h1:NrQCHyIOsQTtq9u7fpfQuDOMQAGVOa+n5Km/8csdqOM=
 github.com/kagent-dev/a2a-go v0.0.0-20250806145931-0fab01f644c3/go.mod h1:lu052zH/pTlTBwWMU/E3UckR0U9ajL1NlhiRkIF9R6A=
-github.com/kagent-dev/kmcp v0.1.1 h1:2QGJ4+IR7mTVvI+Gc22XP9T4S5dpF4ZvnW6ZdEITmS4=
-github.com/kagent-dev/kmcp v0.1.1/go.mod h1:aPwM1QtoAackdbQqLrPaNSSg/KZa0fFjbTJyOZFJNK8=
+github.com/kagent-dev/kmcp v0.1.4 h1:LozbTJYZCdPh8JDkFiCihevV4+l+eS1+cvmjD+1BpdI=
+github.com/kagent-dev/kmcp v0.1.4/go.mod h1:aPwM1QtoAackdbQqLrPaNSSg/KZa0fFjbTJyOZFJNK8=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=

--- a/scripts/kind/setup-kind.sh
+++ b/scripts/kind/setup-kind.sh
@@ -1,5 +1,7 @@
-#!/bin/env bash
+#!/usr/bin/env bash
+
 set -o errexit
+set -o pipefail
 
 KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-kagent}
 KIND_IMAGE_VERSION=${KIND_IMAGE_VERSION:-1.33.2}
@@ -17,15 +19,19 @@ fi
 #
 # NOTE: the containerd config patch is not necessary with images from kind v0.27.0+
 # It may enable some older images to work similarly.
-# If you're only supporting newer relases, you can just use `kind create cluster` here.
+# If you're only supporting newer releases, you can just use `kind create cluster` here.
 #
 # See:
 # https://github.com/kubernetes-sigs/kind/issues/2875
 # https://github.com/containerd/containerd/blob/main/docs/cri/config.md#registry-configuration
 # See: https://github.com/containerd/containerd/blob/main/docs/hosts.md
-kind create cluster --name "${KIND_CLUSTER_NAME}" \
-  --config scripts/kind/kind-config.yaml \
-  --image="kindest/node:v${KIND_IMAGE_VERSION}"
+if kind get clusters | grep -qx "${KIND_CLUSTER_NAME}"; then
+  echo "Kind cluster '${KIND_CLUSTER_NAME}' already exists; skipping create."
+else
+  kind create cluster --name "${KIND_CLUSTER_NAME}" \
+    --config scripts/kind/kind-config.yaml \
+    --image="kindest/node:v${KIND_IMAGE_VERSION}"
+fi
 
 # 3. Add the registry config to the nodes
 #

--- a/scripts/kind/setup-metallb.sh
+++ b/scripts/kind/setup-metallb.sh
@@ -1,6 +1,7 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 set -o errexit
+set -o pipefail
 set -o nounset
 
 METALLB_VERSION=${METALLB_VERSION:-v0.13.7}


### PR DESCRIPTION
When running `make create-kind-cluster` from main branch, the following error occurs

```sh
sh ./scripts/kind/setup-metallb.sh
./scripts/kind/setup-metallb.sh: 4: set: Illegal option -o pipefail
make: *** [Makefile:107: create-kind-cluster] Error 2
```

This PR makes KIND cluster creation idempotent and applies a minor script update to use `bash` over `sh` and shebang update to be more portable. 

Also dynamically resolve the KMCP chart version from the latest GitHub release (strip leading “v”), use it in Helm, and print it in tools output. 