### PR TITLE
feat: make agents to be able include all tools from mcp tool server

### DIFF
--- a/go/config/crd/bases/kagent.dev_agents.yaml
+++ b/go/config/crd/bases/kagent.dev_agents.yaml
@@ -2098,6 +2098,8 @@ spec:
                             to the name of an ToolServer in a different namespace
                             in the form <namespace>/<name>
                           type: string
+                      required:
+                      - toolNames
                       type: object
                     type:
                       allOf:

--- a/go/controller/api/v1alpha1/agent_types.go
+++ b/go/controller/api/v1alpha1/agent_types.go
@@ -109,7 +109,7 @@ type McpServerTool struct {
 	// The names of the tools to be provided by the ToolServer
 	// For a list of all the tools provided by the server,
 	// the client can query the status of the ToolServer object after it has been created
-	ToolNames []string `json:"toolNames,omitempty"`
+	ToolNames []string `json:"toolNames"`
 }
 
 type AnyType struct {

--- a/go/controller/translator/adk_api_translator.go
+++ b/go/controller/translator/adk_api_translator.go
@@ -356,6 +356,9 @@ func (a *adkApiTranslator) translateDeclarativeAgent(ctx context.Context, agent 
 		// Skip tools that are not applicable to the model provider
 		switch {
 		case tool.McpServer != nil:
+			if len(tool.McpServer.ToolNames) == 0 {
+				toolsByServer[tool.McpServer.ToolServer] = []string{}
+			}
 			for _, toolName := range tool.McpServer.ToolNames {
 				toolsByServer[tool.McpServer.ToolServer] = append(toolsByServer[tool.McpServer.ToolServer], toolName)
 			}
@@ -700,7 +703,11 @@ func (a *adkApiTranslator) translateToolServerTool(ctx context.Context, agent *a
 	if err != nil {
 		return err
 	}
-
+	if len(toolNames) == 0 {
+		for _, v := range toolServerObj.Status.DiscoveredTools {
+			toolNames = append(toolNames, v.Name)
+		}
+	}
 	switch {
 	case toolServerObj.Spec.Config.Sse != nil:
 		tool, err := a.translateSseHttpTool(ctx, toolServerObj.Spec.Config.Sse, defaultNamespace)

--- a/go/controller/translator/adk_api_translator_test.go
+++ b/go/controller/translator/adk_api_translator_test.go
@@ -1,0 +1,123 @@
+package translator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kagent-dev/kagent/go/controller/api/v1alpha1"
+	"github.com/kagent-dev/kagent/go/internal/adk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	s := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(s))
+	return s
+}
+
+// createToolServer creates a ToolServer with the given configuration for testing
+func createToolServer(name, namespace string, serverType v1alpha1.ToolServerType, discoveredTools []string) *v1alpha1.ToolServer {
+	ts := &v1alpha1.ToolServer{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: v1alpha1.ToolServerSpec{
+			Config: v1alpha1.ToolServerConfig{
+				Type: serverType,
+			},
+		},
+		Status: v1alpha1.ToolServerStatus{
+			DiscoveredTools: make([]*v1alpha1.MCPTool, len(discoveredTools)),
+		},
+	}
+
+	// Set the appropriate server config based on type
+	switch serverType {
+	case v1alpha1.ToolServerTypeSse:
+		ts.Spec.Config.Sse = &v1alpha1.SseMcpServerConfig{
+			HttpToolServerConfig: v1alpha1.HttpToolServerConfig{URL: "http://example"},
+		}
+	case v1alpha1.ToolServerTypeStreamableHttp:
+		ts.Spec.Config.StreamableHttp = &v1alpha1.StreamableHttpServerConfig{
+			HttpToolServerConfig: v1alpha1.HttpToolServerConfig{URL: "http://example"},
+		}
+	}
+
+	// Convert tool names to MCPTool objects
+	for i, toolName := range discoveredTools {
+		ts.Status.DiscoveredTools[i] = &v1alpha1.MCPTool{Name: toolName}
+	}
+
+	return ts
+}
+
+func TestTranslateToolServerTool(t *testing.T) {
+	tests := []struct {
+		name              string
+		serverType        v1alpha1.ToolServerType
+		discoveredTools   []string
+		providedTools     []string
+		expectedTools     []string
+		expectedSseCount  int
+		expectedHttpCount int
+	}{
+		{
+			name:             "SSE server uses discovered tools when none provided",
+			serverType:       v1alpha1.ToolServerTypeSse,
+			discoveredTools:  []string{"alpha", "beta"},
+			providedTools:    nil,
+			expectedTools:    []string{"alpha", "beta"},
+			expectedSseCount: 1,
+		},
+		{
+			name:             "SSE server keeps provided tools when specified",
+			serverType:       v1alpha1.ToolServerTypeSse,
+			discoveredTools:  []string{"alpha"},
+			providedTools:    []string{"override"},
+			expectedTools:    []string{"override"},
+			expectedSseCount: 1,
+		},
+		{
+			name:              "StreamableHTTP server uses discovered tools when none provided",
+			serverType:        v1alpha1.ToolServerTypeStreamableHttp,
+			discoveredTools:   []string{"one", "two", "three"},
+			providedTools:     nil,
+			expectedTools:     []string{"one", "two", "three"},
+			expectedHttpCount: 1,
+		},
+		{
+			name:              "StreamableHTTP server keeps provided tools when specified",
+			serverType:        v1alpha1.ToolServerTypeStreamableHttp,
+			discoveredTools:   []string{"one", "two"},
+			providedTools:     []string{"custom"},
+			expectedTools:     []string{"custom"},
+			expectedHttpCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newScheme(t)
+			ts := createToolServer("test-server", "test-ns", tt.serverType, tt.discoveredTools)
+			kube := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ts).Build()
+			tr := NewAdkApiTranslator(kube, types.NamespacedName{}).(*adkApiTranslator)
+
+			agent := &adk.AgentConfig{}
+			err := tr.translateToolServerTool(context.Background(), agent, "test-server", tt.providedTools, "test-ns")
+
+			require.NoError(t, err)
+			assert.Len(t, agent.SseTools, tt.expectedSseCount)
+			assert.Len(t, agent.HttpTools, tt.expectedHttpCount)
+
+			if tt.expectedSseCount > 0 {
+				assert.Equal(t, tt.expectedTools, agent.SseTools[0].Tools)
+			}
+			if tt.expectedHttpCount > 0 {
+				assert.Equal(t, tt.expectedTools, agent.HttpTools[0].Tools)
+			}
+		})
+	}
+}

--- a/helm/kagent-crds/templates/kagent.dev_agents.yaml
+++ b/helm/kagent-crds/templates/kagent.dev_agents.yaml
@@ -2098,6 +2098,8 @@ spec:
                             to the name of an ToolServer in a different namespace
                             in the form <namespace>/<name>
                           type: string
+                      required:
+                      - toolNames
                       type: object
                     type:
                       allOf:


### PR DESCRIPTION
Allow agents to automatically include all tools from an MCP Tool Server, simplifying configuration and ensuring new tools are available without manual updates.