### PR TITLE
fix(controller): ensure controller name matches managed object

### DIFF
--- a/go/controller/internal/controller/mcp_server_controller.go
+++ b/go/controller/internal/controller/mcp_server_controller.go
@@ -56,6 +56,6 @@ func (r *MCPServerController) SetupWithManager(mgr ctrl.Manager) error {
 			NeedLeaderElection: ptr.To(true),
 		}).
 		For(&v1alpha1.MCPServer{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		Named("toolserver").
+		Named("mcpserver").
 		Complete(r)
 }


### PR DESCRIPTION
Missed in #683.