### PR TITLE
fix(controller): ensure tool server headers are applied when reconciling tools

### DIFF
--- a/go/internal/utils/config_map.go
+++ b/go/internal/utils/config_map.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetConfigMapValue fetches a value from a ConfigMap
+func GetConfigMapValue(ctx context.Context, c client.Client, ref client.ObjectKey, key string) (string, error) {
+	configMap := &corev1.ConfigMap{}
+	err := c.Get(ctx, ref, configMap)
+	if err != nil {
+		return "", fmt.Errorf("failed to find ConfigMap for %s: %v", ref.String(), err)
+	}
+
+	value, exists := configMap.Data[key]
+	if !exists {
+		return "", fmt.Errorf("key %s not found in ConfigMap %s", key, ref)
+	}
+	return value, nil
+}

--- a/go/internal/utils/secret.go
+++ b/go/internal/utils/secret.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetSecretValue fetches a value from a Secret
+func GetSecretValue(ctx context.Context, c client.Client, ref client.ObjectKey, key string) (string, error) {
+	secret := &corev1.Secret{}
+	err := c.Get(ctx, ref, secret)
+	if err != nil {
+		return "", fmt.Errorf("failed to find Secret %s: %v", ref.String(), err)
+	}
+
+	value, exists := secret.Data[key]
+	if !exists {
+		return "", fmt.Errorf("key %s not found in Secret %s", key, ref.String())
+	}
+	return string(value), nil
+}


### PR DESCRIPTION
The headers configured on a tool server will often be things like an `Authorization` header and should be applied when attempting to list tools as part of the tool server reconciliation process. Currently, if the remote MCP server requires authorization, reconciliation will fail with a status like:

```
Status:
  Conditions:
    Last Transition Time:  2025-08-15T10:54:11Z
    Message:               failed to upsert tool server kagent/foo: failed to fetch tools for toolServer kagent/foo: failed to initialize client for toolServer kagent/foo: Unauthorized: Missing or invalid Authorization header
    Reason:                AgentReconcileFailed
    Status:                False
    Type:                  Accepted
```