### PR TITLE
[BUG] fix helm templates for kagent

### DIFF
--- a/helm/kagent/templates/modelconfig.yaml
+++ b/helm/kagent/templates/modelconfig.yaml
@@ -26,6 +26,8 @@ spec:
   defaultHeaders:
     {{- toYaml $model.defaultHeaders | nindent 4 }}
   {{- end }}
+  {{- if $model.config }}
   {{ $dot.Values.providers.default }}:
   {{- toYaml $model.config | nindent 4 }}
+  {{- end }}
   {{- end }}


### PR DESCRIPTION
### Description 
Fixes issue with kagent template logic for default ModelConfig resource. The issue occured because template was using `model.config` but that field only exist on some providers.

Locally you can see this issue if you template the chart

```
helm template oci://ghcr.io/kagent-dev/kagent/helm/kagent | yq 'select(.kind == "ModelConfig")'
Pulled: ghcr.io/kagent-dev/kagent/helm/kagent:0.6.0
Digest: sha256:2f7b505e2474e52aabb5abdb8ba5b529a88b8ba4a23f065c909643b4b3a8dfd6
# Source: kagent/templates/modelconfig.yaml
apiVersion: kagent.dev/v1alpha2
kind: ModelConfig
metadata:
  name: "default-model-config"
  namespace: default
  labels:
    helm.sh/chart: kagent-0.6.0
    app.kubernetes.io/name: kagent
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.6.0"
    app.kubernetes.io/managed-by: Helm
spec:
  provider: "OpenAI"
  model: "gpt-4.1-mini"
  apiKeySecret: kagent-openai
  apiKeySecretKey: OPENAI_API_KEY
  openAI: null
```
