### PR TITLE
fix: resolve kagent-querydoc Service Toolserver issues

### DIFF
--- a/helm/tools/querydoc/templates/service.yaml
+++ b/helm/tools/querydoc/templates/service.yaml
@@ -3,6 +3,8 @@ kind: Service
 metadata:
   name: {{ include "querydoc.fullname" . }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    kagent.dev/mcp-service-protocol: "sse"
   labels:
     kagent.dev/mcp-service: "true"
     {{- include "querydoc.labels" . | nindent 4 }}

--- a/ui/src/app/actions/agents.ts
+++ b/ui/src/app/actions/agents.ts
@@ -70,6 +70,9 @@ function fromAgentFormDataToAgent(agentFormData: AgentFormData): Agent {
         let kind = mcpServer.kind;
         if (mcpServer.name.toLocaleLowerCase().includes("kagent-tool-server")) {
           kind = "RemoteMCPServer";
+        } else if (mcpServer.name.toLocaleLowerCase().includes("kagent-querydoc")) {
+          mcpServer.apiGroup = "";
+          kind = "Service";
         }
 
         return {


### PR DESCRIPTION
## Description

This PR fixes two related issues with the kagent-querydoc Service Toolserver that was 1. returning no tools and no description and 2. could not be selected when creating an Agent.

## Root Cause

The kagent-querydoc service uses the doc2vec MCP server which only supports SSE protocol, but the kagent controller defaults to streamableHTTP for Service-based toolservers. This protocol mismatch caused tool discovery to fail silently.

## Key Changes

### 1. Fix Helm Template (helm/tools/querydoc)
- Added `kagent.dev/mcp-service-protocol: "sse"` annotation to the service template
- Ensures the controller uses the correct SSE protocol for MCP communication
- Prevents empty `discoveredTools` arrays in API responses

### 2. Fix UI Agent Creation (ui/src/app/actions/agents.ts)  
- Added special case to automatically set `kind: "Service"` for kagent-querydoc
- Prevents "Failed to translate Agent to ADK format" errors when creating agents
- Follows existing pattern used for kagent-tool-server special case
