### PR TITLE
[FIX] Add `kmcp-crds` to cmd installation

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -2,9 +2,14 @@ BUILD_DATE := $(shell date -u '+%Y-%m-%d')
 GIT_COMMIT := $(shell git rev-parse --short HEAD || echo "unknown")
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null | sed 's/-dirty//' | grep v || echo "v0.0.0-$(GIT_COMMIT)")
 
+# get kmcp version from go.mod
+AWK ?= $(shell command -v gawk || command -v awk)
+KMCP_VERSION ?= $(shell $(AWK) '/github\.com\/kagent-dev\/kmcp/ { print substr($$2, 2) }' go.mod)
+
 LDFLAGS := -X github.com/kagent-dev/kagent/go/internal/version.Version=$(VERSION)    \
            -X github.com/kagent-dev/kagent/go/internal/version.GitCommit=$(GIT_COMMIT) \
-           -X github.com/kagent-dev/kagent/go/internal/version.BuildDate=$(BUILD_DATE)
+           -X github.com/kagent-dev/kagent/go/internal/version.BuildDate=$(BUILD_DATE) \
+           -X github.com/kagent-dev/kagent/go/internal/version.KmcpVersion=$(KMCP_VERSION)
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/go/cli/Makefile
+++ b/go/cli/Makefile
@@ -2,9 +2,13 @@ VERSION ?= dev
 GIT_COMMIT := $(shell git rev-parse --short HEAD || echo "unknown")
 BUILD_DATE := $(shell date -u '+%Y-%m-%d')
 
-LDFLAGS := -X github.com/kagent-dev/kagent/go/internal/version=$(VERSION)    \
-           -X github.com/kagent-dev/kagent/go/internal/version=$(GIT_COMMIT) \
-           -X github.com/kagent-dev/kagent/go/internal/version=$(BUILD_DATE)
+# get kmcp version from go.mod
+KMCP_VERSION ?= $(shell $(AWK) '/github\.com\/kagent-dev\/kmcp/ { print substr($$2, 2) }' go/go.mod)
+
+LDFLAGS := -X github.com/kagent-dev/kagent/go/internal/version.Version=$(VERSION)    \
+           -X github.com/kagent-dev/kagent/go/internal/version.GitCommit=$(GIT_COMMIT) \
+           -X github.com/kagent-dev/kagent/go/internal/version.BuildDate=$(BUILD_DATE) \
+           -X github.com/kagent-dev/kagent/go/internal/version.KmcpVersion=$(KMCP_VERSION)
 
 .PHONY: build
 build:

--- a/go/cli/internal/cli/const.go
+++ b/go/cli/internal/cli/const.go
@@ -11,6 +11,7 @@ const (
 	// Version is the current version of the kagent CLI
 	DefaultModelProvider   = v1alpha1.ModelProviderOpenAI
 	DefaultHelmOciRegistry = "oci://ghcr.io/kagent-dev/kagent/helm/"
+	DefaultKmcpHelmRepo    = "oci://ghcr.io/kagent-dev/kmcp/helm/"
 
 	//Provider specific env variables
 	OPENAI_API_KEY      = "OPENAI_API_KEY"
@@ -22,6 +23,8 @@ const (
 	KAGENT_HELM_REPO              = "KAGENT_HELM_REPO"
 	KAGENT_HELM_VERSION           = "KAGENT_HELM_VERSION"
 	KAGENT_HELM_EXTRA_ARGS        = "KAGENT_HELM_EXTRA_ARGS"
+	KMCP_HELM_REPO                = "KMCP_HELM_REPO"
+	KMCP_HELM_VERSION             = "KMCP_HELM_VERSION"
 )
 
 // GetModelProvider returns the model provider from KAGENT_DEFAULT_MODEL_PROVIDER environment variable

--- a/go/cli/internal/cli/install.go
+++ b/go/cli/internal/cli/install.go
@@ -76,6 +76,8 @@ func InstallCmd(ctx context.Context, cfg *config.Config) *PortForward {
 	helmRegistry := GetEnvVarWithDefault(KAGENT_HELM_REPO, DefaultHelmOciRegistry)
 	helmVersion := GetEnvVarWithDefault(KAGENT_HELM_VERSION, version.Version)
 	helmExtraArgs := GetEnvVarWithDefault(KAGENT_HELM_EXTRA_ARGS, "")
+	kmcpHelmRepo := GetEnvVarWithDefault(KMCP_HELM_REPO, DefaultKmcpHelmRepo)
+	kmcpHelmVersion := GetEnvVarWithDefault(KMCP_HELM_VERSION, version.KmcpVersion)
 
 	// split helmExtraArgs by "--set" to get additional values
 	extraValues := strings.Split(helmExtraArgs, "--set")
@@ -86,10 +88,19 @@ func InstallCmd(ctx context.Context, cfg *config.Config) *PortForward {
 	// spinner for installation progress
 	s := spinner.New(spinner.CharSets[35], 100*time.Millisecond)
 
-	// First install kagent-crds
-	s.Suffix = " Installing kagent-crds from " + helmRegistry
+	// First, install kmcp-crds
+	s.Suffix = " Installing kmcp-crds from " + kmcpHelmRepo
 	defer s.Stop()
 	s.Start()
+	if output, err := installChart(ctx, "kmcp-crds", cfg.Namespace, kmcpHelmRepo, kmcpHelmVersion, nil, s); err != nil {
+		// Stop the spinner before printing error messages
+		s.Stop()
+		fmt.Fprintln(os.Stderr, "Error installing kmcp-crds:", output)
+		return nil
+	}
+
+	// Second, install kagent-crds
+	s.Suffix = " Installing kagent-crds from " + helmRegistry
 	if output, err := installChart(ctx, "kagent-crds", cfg.Namespace, helmRegistry, helmVersion, nil, s); err != nil {
 		// Always stop the spinner before printing error messages
 		s.Stop()
@@ -213,6 +224,21 @@ func UninstallCmd(ctx context.Context, cfg *config.Config) {
 			fmt.Fprintln(os.Stderr, "Error uninstalling kagent-crds:", output)
 			return
 		}
+	}
+
+	// Then uninstall kmcp-crds
+	s.Suffix = " Uninstalling kmcp-crds"
+	args = []string{
+		"uninstall",
+		"kmcp-crds",
+		"--namespace",
+		cfg.Namespace,
+	}
+	cmd = exec.CommandContext(ctx, "helm", args...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		s.Stop()
+		fmt.Fprintln(os.Stderr, "Error uninstalling kmcp-crds:", string(out))
+		return
 	}
 
 	s.Stop()

--- a/go/internal/version/version.go
+++ b/go/internal/version/version.go
@@ -7,37 +7,40 @@ import (
 
 var (
 	// These variables should be set during build time using -ldflags
-	Version   = "dev"
-	GitCommit = "none"
-	BuildDate = "unknown"
+	Version     = "dev"
+	GitCommit   = "none"
+	BuildDate   = "unknown"
+	KmcpVersion = "unknown"
 )
 
 // Info contains version information
 type Info struct {
-	Version   string `json:"version"`
-	GitCommit string `json:"gitCommit"`
-	BuildDate string `json:"buildDate"`
-	GoVersion string `json:"goVersion"`
-	Compiler  string `json:"compiler"`
-	Platform  string `json:"platform"`
+	Version     string `json:"version"`
+	GitCommit   string `json:"gitCommit"`
+	BuildDate   string `json:"buildDate"`
+	KmcpVersion string `json:"kmcpVersion"`
+	GoVersion   string `json:"goVersion"`
+	Compiler    string `json:"compiler"`
+	Platform    string `json:"platform"`
 }
 
 // Get returns version information
 func Get() Info {
 	return Info{
-		Version:   Version,
-		GitCommit: GitCommit,
-		BuildDate: BuildDate,
-		GoVersion: runtime.Version(),
-		Compiler:  runtime.Compiler,
-		Platform:  fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+		Version:     Version,
+		GitCommit:   GitCommit,
+		BuildDate:   BuildDate,
+		KmcpVersion: KmcpVersion,
+		GoVersion:   runtime.Version(),
+		Compiler:    runtime.Compiler,
+		Platform:    fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 	}
 }
 
 // String returns a human-readable version string
 func (i Info) String() string {
-	return fmt.Sprintf("Version: %s\nGit Commit: %s\nBuild Date: %s\nGo Version: %s\nCompiler: %s\nPlatform: %s",
-		i.Version, i.GitCommit, i.BuildDate, i.GoVersion, i.Compiler, i.Platform)
+	return fmt.Sprintf("Version: %s\nGit Commit: %s\nBuild Date: %s\nKmcp Version: %s\nGo Version: %s\nCompiler: %s\nPlatform: %s",
+		i.Version, i.GitCommit, i.BuildDate, i.KmcpVersion, i.GoVersion, i.Compiler, i.Platform)
 }
 
 // Short returns a short version string


### PR DESCRIPTION
Fixed issue with CLI's `install` command which was missing the `kmcp-crds`.

`install`: Added kmcp-crd installation step with configurable repo & version.
`uninstall`: Added kmcp-crd uninstallation.

In order to keep this up to date based on `go.mod` I've added the kmcp version information to build flags.

_quick install/uninstall demo of the cli_

https://github.com/user-attachments/assets/87de3ac9-991b-4783-b9d3-aca45dfdc4b0

