### PR TITLE
[BUG] add kmcp as a subchart to kagent-crds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,6 +232,7 @@ helm-version: helm-cleanup helm-agents helm-tools
 	VERSION=$(VERSION) envsubst < helm/kagent-crds/Chart-template.yaml > helm/kagent-crds/Chart.yaml
 	VERSION=$(VERSION) envsubst < helm/kagent/Chart-template.yaml > helm/kagent/Chart.yaml
 	helm dependency update helm/kagent
+	helm dependency update helm/kagent-crds
 	helm package -d $(HELM_DIST_FOLDER) helm/kagent-crds
 	helm package -d $(HELM_DIST_FOLDER) helm/kagent
 

--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,7 @@ helm-tools:
 
 .PHONY: helm-version
 helm-version: helm-cleanup helm-agents helm-tools
-	VERSION=$(VERSION) envsubst < helm/kagent-crds/Chart-template.yaml > helm/kagent-crds/Chart.yaml
+	VERSION=$(VERSION) KMCP_VERSION=$(KMCP_VERSION) envsubst < helm/kagent-crds/Chart-template.yaml > helm/kagent-crds/Chart.yaml
 	VERSION=$(VERSION) envsubst < helm/kagent/Chart-template.yaml > helm/kagent/Chart.yaml
 	helm dependency update helm/kagent
 	helm dependency update helm/kagent-crds

--- a/helm/kagent-crds/Chart-template.yaml
+++ b/helm/kagent-crds/Chart-template.yaml
@@ -3,3 +3,7 @@ name: kagent-crds
 description: CRDs for kagent
 type: application
 version: ${VERSION}
+dependencies:
+  - name: kmcp-crds
+    version: 0.1.5
+    repository: oci://ghcr.io/kagent-dev/kmcp/helm

--- a/helm/kagent-crds/Chart-template.yaml
+++ b/helm/kagent-crds/Chart-template.yaml
@@ -5,5 +5,5 @@ type: application
 version: ${VERSION}
 dependencies:
   - name: kmcp-crds
-    version: 0.1.5
+    version: ${KMCP_VERSION}
     repository: oci://ghcr.io/kagent-dev/kmcp/helm


### PR DESCRIPTION
Kagent requires `McpServers` resource which comes from kmcp project. This pull request adds those crds as a subchart of kagent-crds to make for easier installation UX.