### PR TITLE
fix(install): do not add --set for an empty string

### DIFF
--- a/go/cli/internal/cli/install.go
+++ b/go/cli/internal/cli/install.go
@@ -35,7 +35,9 @@ func installChart(ctx context.Context, chartName string, namespace string, regis
 
 	// Add set values if any
 	for _, setValue := range setValues {
-		args = append(args, "--set", setValue)
+		if setValue != "" {
+			args = append(args, "--set", setValue)
+		}
 	}
 
 	cmd := exec.CommandContext(ctx, "helm", args...)
@@ -45,8 +47,7 @@ func installChart(ctx context.Context, chartName string, namespace string, regis
 	return "", nil
 }
 
-func InstallCmd(ctx context.Context, cfg *config.Config) *PortForward {
-
+func InstallCmd(ctx context.Context, cfg *config.Config) *PortForward { 
 	if version.Version == "dev" {
 		fmt.Fprintln(os.Stderr, "Installation requires released version of kagent")
 		return nil


### PR DESCRIPTION
`kagent install` would construct an invalid `helm upgrade` command due to a missing `--set` parameter.

When invoking `kagent install` (with no specified config params or other `kagent` env vars) & running a `ps aux` in parallel I can see that `kagent` runs the following command 
```go
helm upgrade --install kagent oci://ghcr.io/kagent-dev/kagent/helm/kagent --version 0.6.3 --namespace kagent --create-namespace --wait --history-max 2 --timeout 5m --set providers.default=openAI --set providers.openAI.apiKey=<REDACTED> --set `
```

This command is invalid and errors with `Error: flag needs an argument: --set`. 

The reason that we pass `[]{""}` to `installChart()` is because we obtain the values from [here](https://github.com/kagent-dev/kagent/blob/main/go/cli/internal/cli/install.go#L78): 

```go
helmExtraArgs := GetEnvVarWithDefault(KAGENT_HELM_EXTRA_ARGS, "")
```

where if `KAGENT_HELM_EXTRA_ARGS` is not present we return `""`.

This PR simply checks if the value is `!= ""` before appending to `helm upgrade`