### PR TITLE
feat(helm): add custom labels support to all Kubernetes resources

### DIFF
--- a/helm/kagent/templates/_helpers.tpl
+++ b/helm/kagent/templates/_helpers.tpl
@@ -24,6 +24,9 @@ app.kubernetes.io/version: {{ .Chart.Version | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: kagent
+{{- with .Values.labels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/helm/kagent/templates/_helpers.tpl
+++ b/helm/kagent/templates/_helpers.tpl
@@ -25,7 +25,7 @@ app.kubernetes.io/version: {{ .Chart.Version | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: kagent
 {{- with .Values.labels }}
-{{ toYaml . }}
+{{ toYaml . | nindent 0 }}
 {{- end }}
 {{- end }}
 

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -18,6 +18,9 @@ fullnameOverride: ""
 # @default -- `.Release.Namespace`
 namespaceOverride: ""
 
+# -- Additional labels to add to all resources
+labels: {}
+
 podAnnotations: {}
 
 podSecurityContext: {}


### PR DESCRIPTION
- Adds `labels` configuration option in values.yaml
- Custom labels are applied to all Kubernetes resources via the `kagent.labels` helper template
- Maintains existing standard labels (app.kubernetes.io/*, helm.sh/chart, etc.)

  ## Usage
  ```yaml
  labels:
    environment: production
    team: platform
