### PR TITLE
fix(controller): set correct controller names in setup error logs

### DIFF
--- a/go/pkg/app/app.go
+++ b/go/pkg/app/app.go
@@ -340,7 +340,7 @@ func Start(authenticator auth.AuthProvider, authorizer auth.Authorizer) {
 		Scheme:     mgr.GetScheme(),
 		Reconciler: rcnclr,
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "RemoteMCPServer")
+		setupLog.Error(err, "unable to create controller", "controller", "MCPServer")
 		os.Exit(1)
 	}
 
@@ -362,7 +362,7 @@ func Start(authenticator auth.AuthProvider, authorizer auth.Authorizer) {
 		Scheme:     mgr.GetScheme(),
 		Reconciler: rcnclr,
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "ToolServer")
+		setupLog.Error(err, "unable to create controller", "controller", "RemoteMCPServer")
 		os.Exit(1)
 	}
 	if err = (&controller.MemoryController{


### PR DESCRIPTION
Ran into this when some changes I was making caused conflicts, and I ended up wasting time looking at the wrong controllers at first :sweat_smile: 