### PR TITLE
fix(ui): prevent Arguments dropdown from overlapping UI elements

### DIFF
--- a/ui/src/components/ToolDisplay.tsx
+++ b/ui/src/components/ToolDisplay.tsx
@@ -102,9 +102,13 @@ const ToolDisplay = ({ call, result, status = "requested", isError = false }: To
             {areArgumentsExpanded ? <ChevronUp className="w-4 h-4 ml-auto" /> : <ChevronDown className="w-4 h-4 ml-auto" />}
           </Button>
           {areArgumentsExpanded && (
-            <ScrollArea className="mt-2 p-4 w-full max-h-96">
-              <pre className="text-xs whitespace-pre-wrap break-words">{JSON.stringify(call.args, null, 2)}</pre>
-            </ScrollArea>
+            <div className="relative">
+              <ScrollArea className="max-h-96 overflow-y-auto p-4 w-full mt-2 bg-muted/50">
+                <pre className="text-sm whitespace-pre-wrap break-words">
+                  {JSON.stringify(call.args, null, 2)}
+                </pre>
+              </ScrollArea>
+            </div>
           )}
         </div>
         <div className="mt-4 w-full">


### PR DESCRIPTION
Fixes UI overlap issue where the Arguments dropdown in ToolDisplay component was overlapping with elements below when expanded.

<img width="867" height="585" alt="Screenshot 2025-08-29 at 7 52 57 AM" src="https://github.com/user-attachments/assets/c1185d85-a3a7-4207-8eb1-b9628cfd9f68" />

