### PR TITLE
fix(ui): enable editing for Not Accepted/Not Ready agents

### DIFF
--- a/ui/src/components/AgentCard.tsx
+++ b/ui/src/components/AgentCard.tsx
@@ -31,7 +31,7 @@ export function AgentCard({ id, agentResponse: { agent, model, modelProvider, de
     <Card className={`group transition-colors ${
       deploymentReady && accepted
         ? 'cursor-pointer hover:border-violet-500' 
-        : 'cursor-not-allowed opacity-60 border-gray-300'
+        : 'border-gray-300'
     }`}>
       <CardHeader className="flex flex-row items-start justify-between space-y-0 pb-2">
         <CardTitle className="flex items-center gap-2">
@@ -48,20 +48,18 @@ export function AgentCard({ id, agentResponse: { agent, model, modelProvider, de
             </span>
           )}
         </CardTitle>
-        <div className={`flex items-center space-x-2 ${deploymentReady && accepted ? 'invisible group-hover:visible' : 'invisible'}`}>
+        <div className="flex items-center space-x-2 invisible group-hover:visible">
           <Button 
             variant="ghost" 
             size="icon" 
             onClick={handleEditClick} 
             aria-label="Edit Agent"
-            disabled={!deploymentReady || !accepted}
           >
             <Pencil className="h-4 w-4" />
           </Button>
           <DeleteButton 
             agentName={agent.metadata.name} 
             namespace={agent.metadata.namespace || ''} 
-            disabled={!deploymentReady || !accepted}
           />
         </div>
       </CardHeader>


### PR DESCRIPTION
## Description

This PR fixes the issue where agents in "Not Ready" state were completely disabled in the UI, preventing users from editing them to fix the underlying problems.

## Changes Made

- **Removed disabled state** from Edit and Delete buttons in `AgentCard.tsx` for Not Accepted/Not Ready agents
- **Updated card styling** to remove the faded appearance (`opacity-60`) and `cursor-not-allowed` for non-ready agents
- **Preserved chat protection** - the Link wrapper for chat navigation is still only applied when `deploymentReady && accepted`
- **Maintained proper filtering** in AgentSwitcher to hide non-ready agents from chat dropdown

## Behavior After Fix

### ✅ What Works (Fixed)
- **Edit button is clickable** - users can now edit any agent regardless of status
- **Delete button is clickable** - users can delete any agent regardless of status  
- **Card has normal appearance** - no longer faded or obviously disabled

### 🚫 What's Protected
- **Chat functionality remains disabled** - clicking the card body does nothing for non-ready agents
- **No hover effects for chat** - no violet border on hover for non-ready agents
- **Agent switcher filtering** - non-ready agents are still filtered out of chat dropdown menus

## Issues Resolved

Closes #825
