### PR TITLE
fix(controller): prevent panic on shutdown due to nil pointer

### DIFF
--- a/go/internal/database/manager.go
+++ b/go/internal/database/manager.go
@@ -141,6 +141,10 @@ func (m *Manager) Reset(recreateTables bool) error {
 
 // Close closes the database connection
 func (m *Manager) Close() error {
+	if m.db == nil {
+		return nil
+	}
+
 	sqlDB, err := m.db.DB()
 	if err != nil {
 		return err


### PR DESCRIPTION
Prevents following error if controller fails to initialise database on startup (e.g. if it happens to run out of memory when loading the db).

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1a3158e]

goroutine 107 [running]:
github.com/kagent-dev/kagent/go/internal/database.(*Manager).Close(0xc00024ea00?)
	/workspace/internal/database/manager.go:144 +0xe
github.com/kagent-dev/kagent/go/internal/httpserver.(*HTTPServer).Start.func2()
	/workspace/internal/httpserver/server.go:110 +0x116
created by github.com/kagent-dev/kagent/go/internal/httpserver.(*HTTPServer).Start in goroutine 104
	/workspace/internal/httpserver/server.go:101 +0x288
```