### PR TITLE
fix(adk): set correct URL for remote agent card

### DIFF
--- a/python/packages/kagent-adk/src/kagent_adk/models.py
+++ b/python/packages/kagent-adk/src/kagent_adk/models.py
@@ -4,7 +4,7 @@ from typing import Literal, Self, Union
 from google.adk.agents import Agent
 from google.adk.agents.base_agent import BaseAgent
 from google.adk.agents.llm_agent import ToolUnion
-from google.adk.agents.remote_a2a_agent import RemoteA2aAgent
+from google.adk.agents.remote_a2a_agent import RemoteA2aAgent, AGENT_CARD_WELL_KNOWN_PATH
 from google.adk.agents.run_config import RunConfig, StreamingMode
 from google.adk.models.anthropic_llm import Claude as ClaudeLLM
 from google.adk.models.google_llm import Gemini as GeminiLLM
@@ -94,7 +94,7 @@ class AgentConfig(BaseModel):
                 remote_agents.append(
                     RemoteA2aAgent(
                         name=remote_agent.name,
-                        agent_card=remote_agent.url,
+                        agent_card=f"{remote_agent.url}/{AGENT_CARD_WELL_KNOWN_PATH}",
                         description=remote_agent.description,
                     )
                 )


### PR DESCRIPTION
Addresses issue whereby agent->agent calls are currently failing with errors like this in the UI:


``` json
{"id":"call_xx": "name": "transfor_to_agent", "response":{"result": null}}
```

Agent pods show the following errors:
```
ERROR:google_adk.google.adk.agents.remote_a2a_agent:Failed to resolve remote A2A agent kagent__NS__my_agent: Failed to resolve AgentCard from URL http://my-agent.kagent:8080/: HTTP Error 405: Failed to fetch agent card from http://my-agent.kagent:8080/: Client error '405 Method Not Allowed' for url 'http://my-agent.kagent:8080/'
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/405
```

I guess this was my bad, and it's related to the upgrade in #816.