### PR TITLE
(Feat) Disable mcpServer reconciliation via `kagent.dev/discovery-disabled` annotation

### DIFF
--- a/go/internal/controller/mcp_server_controller.go
+++ b/go/internal/controller/mcp_server_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/kagent-dev/kagent/go/internal/controller/predicates"
 	"github.com/kagent-dev/kagent/go/internal/controller/reconciler"
 	"github.com/kagent-dev/kmcp/api/v1alpha1"
 
@@ -55,7 +56,10 @@ func (r *MCPServerController) SetupWithManager(mgr ctrl.Manager) error {
 		WithOptions(controller.Options{
 			NeedLeaderElection: ptr.To(true),
 		}).
-		For(&v1alpha1.MCPServer{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		For(&v1alpha1.MCPServer{}, builder.WithPredicates(
+			predicate.GenerationChangedPredicate{},
+			predicates.DiscoveryDisabledPredicate{},
+		)).
 		Named("toolserver").
 		Complete(r)
 }

--- a/go/internal/controller/predicates/discovery_disabled.go
+++ b/go/internal/controller/predicates/discovery_disabled.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package predicates
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// DiscoveryDisabledPredicate filters out resources with the discovery disabled annotation set to true
+type DiscoveryDisabledPredicate struct {
+	predicate.Funcs
+}
+
+func (DiscoveryDisabledPredicate) Create(e event.CreateEvent) bool {
+	return !isDiscoveryDisabled(e.Object)
+}
+
+func (DiscoveryDisabledPredicate) Update(e event.UpdateEvent) bool {
+	return !isDiscoveryDisabled(e.ObjectNew)
+}
+
+func (DiscoveryDisabledPredicate) Delete(e event.DeleteEvent) bool {
+	return !isDiscoveryDisabled(e.Object)
+}
+
+func (DiscoveryDisabledPredicate) Generic(e event.GenericEvent) bool {
+	return !isDiscoveryDisabled(e.Object)
+}
+
+func isDiscoveryDisabled(obj client.Object) bool {
+	if obj == nil {
+		return false
+	}
+
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+
+	discoveryDisabled, exists := annotations["kagent.dev/discovery-disabled"]
+	return exists && discoveryDisabled == "true"
+}

--- a/go/internal/controller/predicates/discovery_disabled_test.go
+++ b/go/internal/controller/predicates/discovery_disabled_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package predicates
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+func TestDiscoveryDisabledPredicate(t *testing.T) {
+	predicate := DiscoveryDisabledPredicate{}
+
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    bool
+	}{
+		{
+			name:        "no annotation - should process",
+			annotations: nil,
+			expected:    true,
+		},
+		{
+			name:        "discovery disabled set to true - should not process",
+			annotations: map[string]string{"kagent.dev/discovery-disabled": "true"},
+			expected:    false,
+		},
+		{
+			name:        "discovery disabled set to false - should process",
+			annotations: map[string]string{"kagent.dev/discovery-disabled": "false"},
+			expected:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testObj := &unstructured.Unstructured{}
+			testObj.SetAnnotations(tt.annotations)
+
+			// Test all event types with the same test cases
+			createEvent := event.CreateEvent{Object: testObj}
+			updateEvent := event.UpdateEvent{ObjectNew: testObj}
+			deleteEvent := event.DeleteEvent{Object: testObj}
+			genericEvent := event.GenericEvent{Object: testObj}
+
+			assert.Equal(t, tt.expected, predicate.Create(createEvent), "Create event should match expected result")
+			assert.Equal(t, tt.expected, predicate.Update(updateEvent), "Update event should match expected result")
+			assert.Equal(t, tt.expected, predicate.Delete(deleteEvent), "Delete event should match expected result")
+			assert.Equal(t, tt.expected, predicate.Generic(genericEvent), "Generic event should match expected result")
+		})
+	}
+}


### PR DESCRIPTION
This PR enables disabling reconciliation of `mcpServer` CRDs that explicitly set the  `kagent.dev/discovery-disabled=true` annotation.

Resolves https://github.com/kagent-dev/kagent/issues/853 