### PR TITLE
(Fix) Chat History Deletion

### DIFF
--- a/go/internal/database/client.go
+++ b/go/internal/database/client.go
@@ -122,10 +122,10 @@ func (c *clientImpl) DeleteTask(taskID string) error {
 	return delete[Task](c.db, Clause{Key: "id", Value: taskID})
 }
 
-// DeleteSession deletes a session by name and user ID
+// DeleteSession deletes a session by id and user ID
 func (c *clientImpl) DeleteSession(sessionName string, userID string) error {
 	return delete[Session](c.db,
-		Clause{Key: "name", Value: sessionName},
+		Clause{Key: "id", Value: sessionName},
 		Clause{Key: "user_id", Value: userID})
 }
 


### PR DESCRIPTION
This PR fixes chat history not being able to be deleted and closes #627. It updates the database client to use the "id" key instead of "name" when deleting a session because "id" is the proper primary key of the sessions table and is passed by the frontend and the handler.