### PR TITLE
fix(ui): accumulate streaming content instead of replacing it

### DIFF
--- a/ui/src/components/chat/ChatInterface.tsx
+++ b/ui/src/components/chat/ChatInterface.tsx
@@ -141,6 +141,7 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
     setChatStatus("thinking");
     setStoredMessages(prev => [...prev, ...streamingMessages]);
     setStreamingMessages([]);
+    setStreamingContent(""); // Reset streaming content for new message
 
     // For new sessions or when no stored messages exist, show the user message immediately
     const userMessage: Message = {

--- a/ui/src/lib/messageHandlers.ts
+++ b/ui/src/lib/messageHandlers.ts
@@ -241,7 +241,7 @@ export const createMessageHandlers = (handlers: MessageHandlers) => {
               }
             } else {
               handlers.setIsStreaming(true);
-              handlers.setStreamingContent(() => textContent);
+              handlers.setStreamingContent(prevContent => prevContent + textContent);
               if (handlers.setChatStatus) {
                 handlers.setChatStatus("generating_response");
               }


### PR DESCRIPTION
when a non-final status update comes with text content we currently replace the streaming content with the current text content. This results in scenarios where the agent's thinking process is being streamed only the latest text content would be streamed. Ideally before the final status update we want to stream all of the text content instead of the latest text content. This PR fixes this issue by accumulating the streaming content prior to a final status update.