### PR TITLE
Support for extending of controller manager config

### DIFF
--- a/go/pkg/app/app.go
+++ b/go/pkg/app/app.go
@@ -157,12 +157,14 @@ type BootstrapConfig struct {
 	Manager manager.Manager
 }
 
+type CtrlManagerConfigFunc func(manager.Manager) error
+
 type ExtensionConfig struct {
 	Authenticator             auth.AuthProvider
 	Authorizer                auth.Authorizer
 	AgentPlugins              []translator.TranslatorPlugin
 	MCPServerPlugins          []transportadapter.TranslatorPlugin
-	ExtendedCtrlManagerConfig []func(manager.Manager) error
+	ExtendedCtrlManagerConfig []CtrlManagerConfigFunc
 }
 
 type GetExtensionConfig func(bootstrap BootstrapConfig) (*ExtensionConfig, error)


### PR DESCRIPTION
This can be done now by supplying config functions to `ExtensionConfig`, for example:

```
app.Start(func(bootstrap app.BootstrapConfig) (*app.ExtensionConfig, error) {
	return &app.ExtensionConfig{
		Authenticator:    &auth.UnsecureAuthenticator{},
		Authorizer:          &auth.NoopAuthorizer{},
		AgentPlugins:     nil,
		MCPServerPlugins: nil,
		ExtendedCtrlManagerConfig: []app.CtrlManagerConfigFunc {
			my_controller.SetupWithManager,
			my_other_controller.SetupWithManager
		},
	}, nil
})
```