### PR TITLE
fix: valid STOP completion results in an error being returned 

### DIFF
--- a/python/packages/kagent-adk/src/kagent/adk/converters/error_mappings.py
+++ b/python/packages/kagent-adk/src/kagent/adk/converters/error_mappings.py
@@ -1,0 +1,75 @@
+"""Error code to user-friendly message mappings for ADK events.
+
+This module provides mappings from Google GenAI finish reasons to user-friendly
+error messages, excluding STOP which is a normal completion reason.
+"""
+
+from typing import Dict, Optional
+
+from google.genai import types as genai_types
+
+# Error code to user-friendly message mappings
+# Based on Google GenAI types.py FinishReason enum (excluding STOP)
+ERROR_CODE_MESSAGES: Dict[str, str] = {
+    # Length and token limits
+    genai_types.FinishReason.MAX_TOKENS: "Response was truncated due to maximum token limit. Try asking a shorter question or breaking it into parts.",
+    
+    # Safety and content filtering
+    genai_types.FinishReason.SAFETY: "Response was blocked due to safety concerns. Please rephrase your request to avoid potentially harmful content.",
+    genai_types.FinishReason.RECITATION: "Response was blocked due to unauthorized citations. Please rephrase your request.",
+    genai_types.FinishReason.BLOCKLIST: "Response was blocked due to restricted terminology. Please rephrase your request using different words.",
+    genai_types.FinishReason.PROHIBITED_CONTENT: "Response was blocked due to prohibited content. Please rephrase your request.",
+    genai_types.FinishReason.SPII: "Response was blocked due to sensitive personal information concerns. Please avoid including personal details.",
+    
+    # Function calling errors
+    genai_types.FinishReason.MALFORMED_FUNCTION_CALL: "The agent generated an invalid function call. This may be due to complex input data. Try rephrasing your request or breaking it into simpler steps.",
+    
+    # Generic fallback
+    genai_types.FinishReason.OTHER: "An unexpected error occurred during processing. Please try again or rephrase your request.",
+}
+
+# Normal completion reasons that should not be treated as errors
+NORMAL_COMPLETION_REASONS = {
+    genai_types.FinishReason.STOP,  # Normal completion
+}
+
+# Default error message when no specific mapping exists
+DEFAULT_ERROR_MESSAGE = "An error occurred during processing"
+
+
+def is_normal_completion(error_code: Optional[str]) -> bool:
+    """Check if the error code represents normal completion rather than an error.
+    
+    Args:
+        error_code: The error code to check
+        
+    Returns:
+        True if this is a normal completion reason, False otherwise
+    """
+    return error_code in NORMAL_COMPLETION_REASONS
+
+
+def get_error_message(error_code: Optional[str]) -> str:
+    """Get a user-friendly error message for the given error code.
+    
+    Args:
+        error_code: The error code from the ADK event (e.g., finish_reason)
+        
+    Returns:
+        User-friendly error message string
+    """
+    
+    # Return mapped message or default
+    return ERROR_CODE_MESSAGES.get(error_code, DEFAULT_ERROR_MESSAGE)
+
+
+def is_normal_completion(error_code: Optional[str]) -> bool:
+    """Check if the error code represents normal completion rather than an error.
+    
+    Args:
+        error_code: The error code to check
+        
+    Returns:
+        True if this is a normal completion reason, False otherwise
+    """
+    return error_code in NORMAL_COMPLETION_REASONS

--- a/python/packages/kagent-adk/src/kagent/adk/converters/error_mappings.py
+++ b/python/packages/kagent-adk/src/kagent/adk/converters/error_mappings.py
@@ -36,7 +36,7 @@ NORMAL_COMPLETION_REASONS = {
 # Default error message when no specific mapping exists
 DEFAULT_ERROR_MESSAGE = "An error occurred during processing"
 
-def get_error_message(error_code: Optional[str]) -> str:
+def _get_error_message(error_code: Optional[str]) -> str:
     """Get a user-friendly error message for the given error code.
     
     Args:
@@ -50,7 +50,7 @@ def get_error_message(error_code: Optional[str]) -> str:
     return ERROR_CODE_MESSAGES.get(error_code, DEFAULT_ERROR_MESSAGE)
 
 
-def is_normal_completion(error_code: Optional[str]) -> bool:
+def _is_normal_completion(error_code: Optional[str]) -> bool:
     """Check if the error code represents normal completion rather than an error.
     
     Args:

--- a/python/packages/kagent-adk/src/kagent/adk/converters/error_mappings.py
+++ b/python/packages/kagent-adk/src/kagent/adk/converters/error_mappings.py
@@ -36,19 +36,6 @@ NORMAL_COMPLETION_REASONS = {
 # Default error message when no specific mapping exists
 DEFAULT_ERROR_MESSAGE = "An error occurred during processing"
 
-
-def is_normal_completion(error_code: Optional[str]) -> bool:
-    """Check if the error code represents normal completion rather than an error.
-    
-    Args:
-        error_code: The error code to check
-        
-    Returns:
-        True if this is a normal completion reason, False otherwise
-    """
-    return error_code in NORMAL_COMPLETION_REASONS
-
-
 def get_error_message(error_code: Optional[str]) -> str:
     """Get a user-friendly error message for the given error code.
     

--- a/python/packages/kagent-adk/src/kagent/adk/converters/error_mappings.py
+++ b/python/packages/kagent-adk/src/kagent/adk/converters/error_mappings.py
@@ -13,17 +13,14 @@ from google.genai import types as genai_types
 ERROR_CODE_MESSAGES: Dict[str, str] = {
     # Length and token limits
     genai_types.FinishReason.MAX_TOKENS: "Response was truncated due to maximum token limit. Try asking a shorter question or breaking it into parts.",
-    
     # Safety and content filtering
     genai_types.FinishReason.SAFETY: "Response was blocked due to safety concerns. Please rephrase your request to avoid potentially harmful content.",
     genai_types.FinishReason.RECITATION: "Response was blocked due to unauthorized citations. Please rephrase your request.",
     genai_types.FinishReason.BLOCKLIST: "Response was blocked due to restricted terminology. Please rephrase your request using different words.",
     genai_types.FinishReason.PROHIBITED_CONTENT: "Response was blocked due to prohibited content. Please rephrase your request.",
     genai_types.FinishReason.SPII: "Response was blocked due to sensitive personal information concerns. Please avoid including personal details.",
-    
     # Function calling errors
     genai_types.FinishReason.MALFORMED_FUNCTION_CALL: "The agent generated an invalid function call. This may be due to complex input data. Try rephrasing your request or breaking it into simpler steps.",
-    
     # Generic fallback
     genai_types.FinishReason.OTHER: "An unexpected error occurred during processing. Please try again or rephrase your request.",
 }
@@ -36,26 +33,27 @@ NORMAL_COMPLETION_REASONS = {
 # Default error message when no specific mapping exists
 DEFAULT_ERROR_MESSAGE = "An error occurred during processing"
 
+
 def _get_error_message(error_code: Optional[str]) -> str:
     """Get a user-friendly error message for the given error code.
-    
+
     Args:
         error_code: The error code from the ADK event (e.g., finish_reason)
-        
+
     Returns:
         User-friendly error message string
     """
-    
+
     # Return mapped message or default
     return ERROR_CODE_MESSAGES.get(error_code, DEFAULT_ERROR_MESSAGE)
 
 
 def _is_normal_completion(error_code: Optional[str]) -> bool:
     """Check if the error code represents normal completion rather than an error.
-    
+
     Args:
         error_code: The error code to check
-        
+
     Returns:
         True if this is a normal completion reason, False otherwise
     """

--- a/python/packages/kagent-adk/src/kagent/adk/converters/event_converter.py
+++ b/python/packages/kagent-adk/src/kagent/adk/converters/event_converter.py
@@ -20,7 +20,7 @@ from kagent.core.a2a import (
     get_kagent_metadata_key,
 )
 
-from .error_mappings import get_error_message, is_normal_completion
+from .error_mappings import _get_error_message, _is_normal_completion
 from .part_converter import (
     convert_genai_part_to_a2a_part,
 )
@@ -199,7 +199,7 @@ def _create_error_status_event(
         event_metadata[get_kagent_metadata_key("error_code")] = str(event.error_code)
 
         if not error_message:
-            error_message = get_error_message(event.error_code)
+            error_message = _get_error_message(event.error_code)
 
     return TaskStatusUpdateEvent(
         task_id=task_id,
@@ -301,7 +301,7 @@ def convert_event_to_a2a_events(
 
     try:
         # Handle error scenarios
-        if event.error_code and not is_normal_completion(event.error_code):
+        if event.error_code and not _is_normal_completion(event.error_code):
             error_event = _create_error_status_event(event, invocation_context, task_id, context_id)
             a2a_events.append(error_event)
 

--- a/python/packages/kagent-adk/src/kagent/adk/converters/event_converter.py
+++ b/python/packages/kagent-adk/src/kagent/adk/converters/event_converter.py
@@ -28,7 +28,6 @@ from .part_converter import (
 # Constants
 
 ARTIFACT_ID_SEPARATOR = "-"
-DEFAULT_ERROR_MESSAGE = "An error occurred during processing"
 
 # Logger
 logger = logging.getLogger("kagent_adk." + __name__)

--- a/python/tests/test_converters/test_event_converter.py
+++ b/python/tests/test_converters/test_event_converter.py
@@ -36,41 +36,81 @@ class TestEventConverter:
 
     def test_convert_event_to_a2a_events(self):
         """Test that STOP error codes with empty content don't create any events, while actual error codes create error events."""
-        
+
         invocation_context = _create_mock_invocation_context()
-        
+
         # Test case 1: Empty content with STOP error code
-        event1 = _create_mock_event(error_code=genai_types.FinishReason.STOP, content=None, invocation_id="test_invocation_1")
-        result1 = convert_event_to_a2a_events(event1, invocation_context, task_id="test_task_1", context_id="test_context_1")
-        error_events1 = [e for e in result1 if isinstance(e, TaskStatusUpdateEvent) and e.status.state == TaskState.failed]
-        working_events1 = [e for e in result1 if isinstance(e, TaskStatusUpdateEvent) and e.status.state == TaskState.working]
-        assert len(error_events1) == 0, f"Expected no error events for STOP with empty content, got {len(error_events1)}"
-        assert len(working_events1) == 0, f"Expected no working events for STOP with empty content (no content to convert), got {len(working_events1)}"
-        
+        event1 = _create_mock_event(
+            error_code=genai_types.FinishReason.STOP, content=None, invocation_id="test_invocation_1"
+        )
+        result1 = convert_event_to_a2a_events(
+            event1, invocation_context, task_id="test_task_1", context_id="test_context_1"
+        )
+        error_events1 = [
+            e for e in result1 if isinstance(e, TaskStatusUpdateEvent) and e.status.state == TaskState.failed
+        ]
+        working_events1 = [
+            e for e in result1 if isinstance(e, TaskStatusUpdateEvent) and e.status.state == TaskState.working
+        ]
+        assert len(error_events1) == 0, (
+            f"Expected no error events for STOP with empty content, got {len(error_events1)}"
+        )
+        assert len(working_events1) == 0, (
+            f"Expected no working events for STOP with empty content (no content to convert), got {len(working_events1)}"
+        )
+
         # Test case 2: Empty parts with STOP error code
         content_mock = Mock()
         content_mock.parts = []
-        event2 = _create_mock_event(error_code=genai_types.FinishReason.STOP, content=content_mock, invocation_id="test_invocation_2")
-        result2 = convert_event_to_a2a_events(event2, invocation_context, task_id="test_task_2", context_id="test_context_2")
-        error_events2 = [e for e in result2 if isinstance(e, TaskStatusUpdateEvent) and e.status.state == TaskState.failed]
-        working_events2 = [e for e in result2 if isinstance(e, TaskStatusUpdateEvent) and e.status.state == TaskState.working]
+        event2 = _create_mock_event(
+            error_code=genai_types.FinishReason.STOP, content=content_mock, invocation_id="test_invocation_2"
+        )
+        result2 = convert_event_to_a2a_events(
+            event2, invocation_context, task_id="test_task_2", context_id="test_context_2"
+        )
+        error_events2 = [
+            e for e in result2 if isinstance(e, TaskStatusUpdateEvent) and e.status.state == TaskState.failed
+        ]
+        working_events2 = [
+            e for e in result2 if isinstance(e, TaskStatusUpdateEvent) and e.status.state == TaskState.working
+        ]
         assert len(error_events2) == 0, f"Expected no error events for STOP with empty parts, got {len(error_events2)}"
-        assert len(working_events2) == 0, f"Expected no working events for STOP with empty parts (no content to convert), got {len(working_events2)}"
-        
+        assert len(working_events2) == 0, (
+            f"Expected no working events for STOP with empty parts (no content to convert), got {len(working_events2)}"
+        )
+
         # Test case 3: Missing content with STOP error code
-        event3 = _create_mock_event(error_code=genai_types.FinishReason.STOP, content=None, invocation_id="test_invocation_3")
-        result3 = convert_event_to_a2a_events(event3, invocation_context, task_id="test_task_3", context_id="test_context_3")
-        error_events3 = [e for e in result3 if isinstance(e, TaskStatusUpdateEvent) and e.status.state == TaskState.failed]
-        working_events3 = [e for e in result3 if isinstance(e, TaskStatusUpdateEvent) and e.status.state == TaskState.working]
-        assert len(error_events3) == 0, f"Expected no error events for STOP with missing content, got {len(error_events3)}"
-        assert len(working_events3) == 0, f"Expected no working events for STOP with missing content (no content to convert), got {len(working_events3)}"
-        
+        event3 = _create_mock_event(
+            error_code=genai_types.FinishReason.STOP, content=None, invocation_id="test_invocation_3"
+        )
+        result3 = convert_event_to_a2a_events(
+            event3, invocation_context, task_id="test_task_3", context_id="test_context_3"
+        )
+        error_events3 = [
+            e for e in result3 if isinstance(e, TaskStatusUpdateEvent) and e.status.state == TaskState.failed
+        ]
+        working_events3 = [
+            e for e in result3 if isinstance(e, TaskStatusUpdateEvent) and e.status.state == TaskState.working
+        ]
+        assert len(error_events3) == 0, (
+            f"Expected no error events for STOP with missing content, got {len(error_events3)}"
+        )
+        assert len(working_events3) == 0, (
+            f"Expected no working events for STOP with missing content (no content to convert), got {len(working_events3)}"
+        )
+
         # Test case 4: Actual error code should create error event
-        event4 = _create_mock_event(error_code=genai_types.FinishReason.MALFORMED_FUNCTION_CALL, content=None, invocation_id="test_invocation_4")
-        result4 = convert_event_to_a2a_events(event4, invocation_context, task_id="test_task_4", context_id="test_context_4")
-        error_events4 = [e for e in result4 if isinstance(e, TaskStatusUpdateEvent) and e.status.state == TaskState.failed]
+        event4 = _create_mock_event(
+            error_code=genai_types.FinishReason.MALFORMED_FUNCTION_CALL, content=None, invocation_id="test_invocation_4"
+        )
+        result4 = convert_event_to_a2a_events(
+            event4, invocation_context, task_id="test_task_4", context_id="test_context_4"
+        )
+        error_events4 = [
+            e for e in result4 if isinstance(e, TaskStatusUpdateEvent) and e.status.state == TaskState.failed
+        ]
         assert len(error_events4) == 1, f"Expected 1 error event for MALFORMED_FUNCTION_CALL, got {len(error_events4)}"
-        
+
         # Check that the error event has the correct error code in metadata
         error_event = error_events4[0]
         error_code_key = get_kagent_metadata_key("error_code")

--- a/python/tests/test_converters/test_event_converter.py
+++ b/python/tests/test_converters/test_event_converter.py
@@ -1,0 +1,78 @@
+import pytest
+from unittest.mock import Mock
+from a2a.types import TaskStatusUpdateEvent, TaskState
+from google.genai import types as genai_types
+
+from kagent.adk.converters.event_converter import convert_event_to_a2a_events
+from kagent.core.a2a import get_kagent_metadata_key
+
+
+def _create_mock_invocation_context():
+    """Create a mock invocation context for testing."""
+    context = Mock()
+    context.app_name = "test_app"
+    context.user_id = "test_user"
+    context.session.id = "test_session"
+    return context
+
+
+def _create_mock_event(error_code=None, content=None, invocation_id="test_invocation", author="test_author"):
+    """Create a mock event for testing."""
+    event = Mock()
+    event.error_code = error_code
+    event.content = content
+    event.invocation_id = invocation_id
+    event.author = author
+    event.branch = None
+    event.grounding_metadata = None
+    event.custom_metadata = None
+    event.usage_metadata = None
+    event.error_message = None
+    return event
+
+
+class TestEventConverter:
+    """Test cases for event converter functions."""
+
+    def test_convert_event_to_a2a_events(self):
+        """Test that STOP error codes with empty content don't create any events, while actual error codes create error events."""
+        
+        invocation_context = _create_mock_invocation_context()
+        
+        # Test case 1: Empty content with STOP error code
+        event1 = _create_mock_event(error_code=genai_types.FinishReason.STOP, content=None, invocation_id="test_invocation_1")
+        result1 = convert_event_to_a2a_events(event1, invocation_context, task_id="test_task_1", context_id="test_context_1")
+        error_events1 = [e for e in result1 if isinstance(e, TaskStatusUpdateEvent) and e.status.state == TaskState.failed]
+        working_events1 = [e for e in result1 if isinstance(e, TaskStatusUpdateEvent) and e.status.state == TaskState.working]
+        assert len(error_events1) == 0, f"Expected no error events for STOP with empty content, got {len(error_events1)}"
+        assert len(working_events1) == 0, f"Expected no working events for STOP with empty content (no content to convert), got {len(working_events1)}"
+        
+        # Test case 2: Empty parts with STOP error code
+        content_mock = Mock()
+        content_mock.parts = []
+        event2 = _create_mock_event(error_code=genai_types.FinishReason.STOP, content=content_mock, invocation_id="test_invocation_2")
+        result2 = convert_event_to_a2a_events(event2, invocation_context, task_id="test_task_2", context_id="test_context_2")
+        error_events2 = [e for e in result2 if isinstance(e, TaskStatusUpdateEvent) and e.status.state == TaskState.failed]
+        working_events2 = [e for e in result2 if isinstance(e, TaskStatusUpdateEvent) and e.status.state == TaskState.working]
+        assert len(error_events2) == 0, f"Expected no error events for STOP with empty parts, got {len(error_events2)}"
+        assert len(working_events2) == 0, f"Expected no working events for STOP with empty parts (no content to convert), got {len(working_events2)}"
+        
+        # Test case 3: Missing content with STOP error code
+        event3 = _create_mock_event(error_code=genai_types.FinishReason.STOP, content=None, invocation_id="test_invocation_3")
+        result3 = convert_event_to_a2a_events(event3, invocation_context, task_id="test_task_3", context_id="test_context_3")
+        error_events3 = [e for e in result3 if isinstance(e, TaskStatusUpdateEvent) and e.status.state == TaskState.failed]
+        working_events3 = [e for e in result3 if isinstance(e, TaskStatusUpdateEvent) and e.status.state == TaskState.working]
+        assert len(error_events3) == 0, f"Expected no error events for STOP with missing content, got {len(error_events3)}"
+        assert len(working_events3) == 0, f"Expected no working events for STOP with missing content (no content to convert), got {len(working_events3)}"
+        
+        # Test case 4: Actual error code should create error event
+        event4 = _create_mock_event(error_code=genai_types.FinishReason.MALFORMED_FUNCTION_CALL, content=None, invocation_id="test_invocation_4")
+        result4 = convert_event_to_a2a_events(event4, invocation_context, task_id="test_task_4", context_id="test_context_4")
+        error_events4 = [e for e in result4 if isinstance(e, TaskStatusUpdateEvent) and e.status.state == TaskState.failed]
+        assert len(error_events4) == 1, f"Expected 1 error event for MALFORMED_FUNCTION_CALL, got {len(error_events4)}"
+        
+        # Check that the error event has the correct error code in metadata
+        error_event = error_events4[0]
+        error_code_key = get_kagent_metadata_key("error_code")
+        assert error_code_key in error_event.metadata
+        assert error_event.metadata[error_code_key] == str(genai_types.FinishReason.MALFORMED_FUNCTION_CALL)


### PR DESCRIPTION
- There's currently a [bug](https://github.com/google/adk-python/blob/14484065c64396cebc4a1dde84d6b8b51439b990/src/google/adk/models/llm_response.py#L133C1-L134C1) in ADK where a valid finish reason ie: `STOP` is passed as the `error_code` in the llm response when there is no content. This results in kagent-adk picking up the valid finish reason as an error and emits a generic `An error occurred during processing` message to the user.
- This PR fixes this issue in kagent-adk and improves the error messaging by only emitting an error status event for completion reasons that represent actual failures. 