### PR TITLE
fix(helm): regenerate CRDs

### DIFF
--- a/go/config/crd/bases/kagent.dev_agents.yaml
+++ b/go/config/crd/bases/kagent.dev_agents.yaml
@@ -118,8 +118,9 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
                           description: |-
@@ -175,6 +176,43 @@ spec:
                                   type: string
                               required:
                               - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -934,15 +972,13 @@ spec:
                                         volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                         If specified, the CSI driver will create or update the volume with the attributes defined
                                         in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                        it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                        will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                        If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                        will be set by the persistentvolume controller if it exists.
+                                        it can be changed after the claim is created. An empty string or nil value indicates that no
+                                        VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                        this field can be reset to its previous value (including nil) to cancel the modification.
                                         If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                         set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                         exists.
                                         More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                        (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                       type: string
                                     volumeMode:
                                       description: |-
@@ -1124,12 +1160,10 @@ spec:
                           description: |-
                             glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                             Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md
                           properties:
                             endpoints:
-                              description: |-
-                                endpoints is the endpoint name that details Glusterfs topology.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                              description: endpoints is the endpoint name that details
+                                Glusterfs topology.
                               type: string
                             path:
                               description: |-
@@ -1208,7 +1242,7 @@ spec:
                           description: |-
                             iscsi represents an ISCSI Disk resource that is attached to a
                             kubelet's host machine and then exposed to the pod.
-                            More info: https://examples.k8s.io/volumes/iscsi/README.md
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                           properties:
                             chapAuthDiscovery:
                               description: chapAuthDiscovery defines whether support
@@ -1630,6 +1664,111 @@ spec:
                                         type: array
                                         x-kubernetes-list-type: atomic
                                     type: object
+                                  podCertificate:
+                                    description: |-
+                                      Projects an auto-rotating credential bundle (private key and certificate
+                                      chain) that the pod can use either as a TLS client or server.
+
+                                      Kubelet generates a private key and uses it to send a
+                                      PodCertificateRequest to the named signer.  Once the signer approves the
+                                      request and issues a certificate chain, Kubelet writes the key and
+                                      certificate chain to the pod filesystem.  The pod does not start until
+                                      certificates have been issued for each podCertificate projected volume
+                                      source in its spec.
+
+                                      Kubelet will begin trying to rotate the certificate at the time indicated
+                                      by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                      timestamp.
+
+                                      Kubelet can write a single file, indicated by the credentialBundlePath
+                                      field, or separate files, indicated by the keyPath and
+                                      certificateChainPath fields.
+
+                                      The credential bundle is a single file in PEM format.  The first PEM
+                                      entry is the private key (in PKCS#8 format), and the remaining PEM
+                                      entries are the certificate chain issued by the signer (typically,
+                                      signers will return their certificate chain in leaf-to-root order).
+
+                                      Prefer using the credential bundle format, since your application code
+                                      can read it atomically.  If you use keyPath and certificateChainPath,
+                                      your application must make two separate file reads. If these coincide
+                                      with a certificate rotation, it is possible that the private key and leaf
+                                      certificate you read may not correspond to each other.  Your application
+                                      will need to check for this condition, and re-read until they are
+                                      consistent.
+
+                                      The named signer controls chooses the format of the certificate it
+                                      issues; consult the signer implementation's documentation to learn how to
+                                      use the certificates it issues.
+                                    properties:
+                                      certificateChainPath:
+                                        description: |-
+                                          Write the certificate chain at this path in the projected volume.
+
+                                          Most applications should use credentialBundlePath.  When using keyPath
+                                          and certificateChainPath, your application needs to check that the key
+                                          and leaf certificate are consistent, because it is possible to read the
+                                          files mid-rotation.
+                                        type: string
+                                      credentialBundlePath:
+                                        description: |-
+                                          Write the credential bundle at this path in the projected volume.
+
+                                          The credential bundle is a single file that contains multiple PEM blocks.
+                                          The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                          key.
+
+                                          The remaining blocks are CERTIFICATE blocks, containing the issued
+                                          certificate chain from the signer (leaf and any intermediates).
+
+                                          Using credentialBundlePath lets your Pod's application code make a single
+                                          atomic read that retrieves a consistent key and certificate chain.  If you
+                                          project them to separate files, your application code will need to
+                                          additionally check that the leaf certificate was issued to the key.
+                                        type: string
+                                      keyPath:
+                                        description: |-
+                                          Write the key at this path in the projected volume.
+
+                                          Most applications should use credentialBundlePath.  When using keyPath
+                                          and certificateChainPath, your application needs to check that the key
+                                          and leaf certificate are consistent, because it is possible to read the
+                                          files mid-rotation.
+                                        type: string
+                                      keyType:
+                                        description: |-
+                                          The type of keypair Kubelet will generate for the pod.
+
+                                          Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                          "ECDSAP521", and "ED25519".
+                                        type: string
+                                      maxExpirationSeconds:
+                                        description: |-
+                                          maxExpirationSeconds is the maximum lifetime permitted for the
+                                          certificate.
+
+                                          Kubelet copies this value verbatim into the PodCertificateRequests it
+                                          generates for this projection.
+
+                                          If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                          will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                          value is 7862400 (91 days).
+
+                                          The signer implementation is then free to issue a certificate with any
+                                          lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                          seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                          `kubernetes.io` signers will never issue certificates with a lifetime
+                                          longer than 24 hours.
+                                        format: int32
+                                        type: integer
+                                      signerName:
+                                        description: Kubelet's generated CSRs will
+                                          be addressed to this signer.
+                                        type: string
+                                    required:
+                                    - keyType
+                                    - signerName
+                                    type: object
                                   secret:
                                     description: secret information about the secret
                                       data to project
@@ -1764,7 +1903,6 @@ spec:
                           description: |-
                             rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                             Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md
                           properties:
                             fsType:
                               description: |-
@@ -2260,8 +2398,9 @@ spec:
                             in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
+                              description: |-
+                                Name of the environment variable.
+                                May consist of any printable ASCII characters except '='.
                               type: string
                             value:
                               description: |-
@@ -2317,6 +2456,43 @@ spec:
                                       type: string
                                   required:
                                   - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  description: |-
+                                    FileKeyRef selects a key of the env file.
+                                    Requires the EnvFiles feature gate to be enabled.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        The key within the env file. An invalid key will prevent the pod from starting.
+                                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                                        During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                      type: string
+                                    optional:
+                                      default: false
+                                      description: |-
+                                        Specify whether the file or its key must be defined. If the file or key
+                                        does not exist, then the env var is not published.
+                                        If optional is set to true and the specified key does not exist,
+                                        the environment variable will not be set in the Pod's containers.
+
+                                        If optional is set to false and the specified key does not exist,
+                                        an error will be returned during Pod creation.
+                                      type: boolean
+                                    path:
+                                      description: |-
+                                        The path within the volume from which to select the file.
+                                        Must be relative and may not contain the '..' path or start with '..'.
+                                      type: string
+                                    volumeName:
+                                      description: The name of the volume mount containing
+                                        the env file.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  - volumeName
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
@@ -3152,15 +3328,13 @@ spec:
                                             volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                             If specified, the CSI driver will create or update the volume with the attributes defined
                                             in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                            it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                            will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                            If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                            will be set by the persistentvolume controller if it exists.
+                                            it can be changed after the claim is created. An empty string or nil value indicates that no
+                                            VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                            this field can be reset to its previous value (including nil) to cancel the modification.
                                             If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                             set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                             exists.
                                             More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                            (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                           type: string
                                         volumeMode:
                                           description: |-
@@ -3342,12 +3516,10 @@ spec:
                               description: |-
                                 glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                                 Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md
                               properties:
                                 endpoints:
-                                  description: |-
-                                    endpoints is the endpoint name that details Glusterfs topology.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                  description: endpoints is the endpoint name that
+                                    details Glusterfs topology.
                                   type: string
                                 path:
                                   description: |-
@@ -3426,7 +3598,7 @@ spec:
                               description: |-
                                 iscsi represents an ISCSI Disk resource that is attached to a
                                 kubelet's host machine and then exposed to the pod.
-                                More info: https://examples.k8s.io/volumes/iscsi/README.md
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                               properties:
                                 chapAuthDiscovery:
                                   description: chapAuthDiscovery defines whether support
@@ -3852,6 +4024,111 @@ spec:
                                             type: array
                                             x-kubernetes-list-type: atomic
                                         type: object
+                                      podCertificate:
+                                        description: |-
+                                          Projects an auto-rotating credential bundle (private key and certificate
+                                          chain) that the pod can use either as a TLS client or server.
+
+                                          Kubelet generates a private key and uses it to send a
+                                          PodCertificateRequest to the named signer.  Once the signer approves the
+                                          request and issues a certificate chain, Kubelet writes the key and
+                                          certificate chain to the pod filesystem.  The pod does not start until
+                                          certificates have been issued for each podCertificate projected volume
+                                          source in its spec.
+
+                                          Kubelet will begin trying to rotate the certificate at the time indicated
+                                          by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                          timestamp.
+
+                                          Kubelet can write a single file, indicated by the credentialBundlePath
+                                          field, or separate files, indicated by the keyPath and
+                                          certificateChainPath fields.
+
+                                          The credential bundle is a single file in PEM format.  The first PEM
+                                          entry is the private key (in PKCS#8 format), and the remaining PEM
+                                          entries are the certificate chain issued by the signer (typically,
+                                          signers will return their certificate chain in leaf-to-root order).
+
+                                          Prefer using the credential bundle format, since your application code
+                                          can read it atomically.  If you use keyPath and certificateChainPath,
+                                          your application must make two separate file reads. If these coincide
+                                          with a certificate rotation, it is possible that the private key and leaf
+                                          certificate you read may not correspond to each other.  Your application
+                                          will need to check for this condition, and re-read until they are
+                                          consistent.
+
+                                          The named signer controls chooses the format of the certificate it
+                                          issues; consult the signer implementation's documentation to learn how to
+                                          use the certificates it issues.
+                                        properties:
+                                          certificateChainPath:
+                                            description: |-
+                                              Write the certificate chain at this path in the projected volume.
+
+                                              Most applications should use credentialBundlePath.  When using keyPath
+                                              and certificateChainPath, your application needs to check that the key
+                                              and leaf certificate are consistent, because it is possible to read the
+                                              files mid-rotation.
+                                            type: string
+                                          credentialBundlePath:
+                                            description: |-
+                                              Write the credential bundle at this path in the projected volume.
+
+                                              The credential bundle is a single file that contains multiple PEM blocks.
+                                              The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                              key.
+
+                                              The remaining blocks are CERTIFICATE blocks, containing the issued
+                                              certificate chain from the signer (leaf and any intermediates).
+
+                                              Using credentialBundlePath lets your Pod's application code make a single
+                                              atomic read that retrieves a consistent key and certificate chain.  If you
+                                              project them to separate files, your application code will need to
+                                              additionally check that the leaf certificate was issued to the key.
+                                            type: string
+                                          keyPath:
+                                            description: |-
+                                              Write the key at this path in the projected volume.
+
+                                              Most applications should use credentialBundlePath.  When using keyPath
+                                              and certificateChainPath, your application needs to check that the key
+                                              and leaf certificate are consistent, because it is possible to read the
+                                              files mid-rotation.
+                                            type: string
+                                          keyType:
+                                            description: |-
+                                              The type of keypair Kubelet will generate for the pod.
+
+                                              Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                              "ECDSAP521", and "ED25519".
+                                            type: string
+                                          maxExpirationSeconds:
+                                            description: |-
+                                              maxExpirationSeconds is the maximum lifetime permitted for the
+                                              certificate.
+
+                                              Kubelet copies this value verbatim into the PodCertificateRequests it
+                                              generates for this projection.
+
+                                              If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                              will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                              value is 7862400 (91 days).
+
+                                              The signer implementation is then free to issue a certificate with any
+                                              lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                              seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                              `kubernetes.io` signers will never issue certificates with a lifetime
+                                              longer than 24 hours.
+                                            format: int32
+                                            type: integer
+                                          signerName:
+                                            description: Kubelet's generated CSRs
+                                              will be addressed to this signer.
+                                            type: string
+                                        required:
+                                        - keyType
+                                        - signerName
+                                        type: object
                                       secret:
                                         description: secret information about the
                                           secret data to project
@@ -3986,7 +4263,6 @@ spec:
                               description: |-
                                 rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                                 Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
-                                More info: https://examples.k8s.io/volumes/rbd/README.md
                               properties:
                                 fsType:
                                   description: |-
@@ -4342,8 +4618,9 @@ spec:
                             in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
+                              description: |-
+                                Name of the environment variable.
+                                May consist of any printable ASCII characters except '='.
                               type: string
                             value:
                               description: |-
@@ -4399,6 +4676,43 @@ spec:
                                       type: string
                                   required:
                                   - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  description: |-
+                                    FileKeyRef selects a key of the env file.
+                                    Requires the EnvFiles feature gate to be enabled.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        The key within the env file. An invalid key will prevent the pod from starting.
+                                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                                        During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                      type: string
+                                    optional:
+                                      default: false
+                                      description: |-
+                                        Specify whether the file or its key must be defined. If the file or key
+                                        does not exist, then the env var is not published.
+                                        If optional is set to true and the specified key does not exist,
+                                        the environment variable will not be set in the Pod's containers.
+
+                                        If optional is set to false and the specified key does not exist,
+                                        an error will be returned during Pod creation.
+                                      type: boolean
+                                    path:
+                                      description: |-
+                                        The path within the volume from which to select the file.
+                                        Must be relative and may not contain the '..' path or start with '..'.
+                                      type: string
+                                    volumeName:
+                                      description: The name of the volume mount containing
+                                        the env file.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  - volumeName
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
@@ -5233,15 +5547,13 @@ spec:
                                             volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                             If specified, the CSI driver will create or update the volume with the attributes defined
                                             in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                            it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                            will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                            If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                            will be set by the persistentvolume controller if it exists.
+                                            it can be changed after the claim is created. An empty string or nil value indicates that no
+                                            VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                            this field can be reset to its previous value (including nil) to cancel the modification.
                                             If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                             set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                             exists.
                                             More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                            (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                           type: string
                                         volumeMode:
                                           description: |-
@@ -5423,12 +5735,10 @@ spec:
                               description: |-
                                 glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                                 Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md
                               properties:
                                 endpoints:
-                                  description: |-
-                                    endpoints is the endpoint name that details Glusterfs topology.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                  description: endpoints is the endpoint name that
+                                    details Glusterfs topology.
                                   type: string
                                 path:
                                   description: |-
@@ -5507,7 +5817,7 @@ spec:
                               description: |-
                                 iscsi represents an ISCSI Disk resource that is attached to a
                                 kubelet's host machine and then exposed to the pod.
-                                More info: https://examples.k8s.io/volumes/iscsi/README.md
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                               properties:
                                 chapAuthDiscovery:
                                   description: chapAuthDiscovery defines whether support
@@ -5933,6 +6243,111 @@ spec:
                                             type: array
                                             x-kubernetes-list-type: atomic
                                         type: object
+                                      podCertificate:
+                                        description: |-
+                                          Projects an auto-rotating credential bundle (private key and certificate
+                                          chain) that the pod can use either as a TLS client or server.
+
+                                          Kubelet generates a private key and uses it to send a
+                                          PodCertificateRequest to the named signer.  Once the signer approves the
+                                          request and issues a certificate chain, Kubelet writes the key and
+                                          certificate chain to the pod filesystem.  The pod does not start until
+                                          certificates have been issued for each podCertificate projected volume
+                                          source in its spec.
+
+                                          Kubelet will begin trying to rotate the certificate at the time indicated
+                                          by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                          timestamp.
+
+                                          Kubelet can write a single file, indicated by the credentialBundlePath
+                                          field, or separate files, indicated by the keyPath and
+                                          certificateChainPath fields.
+
+                                          The credential bundle is a single file in PEM format.  The first PEM
+                                          entry is the private key (in PKCS#8 format), and the remaining PEM
+                                          entries are the certificate chain issued by the signer (typically,
+                                          signers will return their certificate chain in leaf-to-root order).
+
+                                          Prefer using the credential bundle format, since your application code
+                                          can read it atomically.  If you use keyPath and certificateChainPath,
+                                          your application must make two separate file reads. If these coincide
+                                          with a certificate rotation, it is possible that the private key and leaf
+                                          certificate you read may not correspond to each other.  Your application
+                                          will need to check for this condition, and re-read until they are
+                                          consistent.
+
+                                          The named signer controls chooses the format of the certificate it
+                                          issues; consult the signer implementation's documentation to learn how to
+                                          use the certificates it issues.
+                                        properties:
+                                          certificateChainPath:
+                                            description: |-
+                                              Write the certificate chain at this path in the projected volume.
+
+                                              Most applications should use credentialBundlePath.  When using keyPath
+                                              and certificateChainPath, your application needs to check that the key
+                                              and leaf certificate are consistent, because it is possible to read the
+                                              files mid-rotation.
+                                            type: string
+                                          credentialBundlePath:
+                                            description: |-
+                                              Write the credential bundle at this path in the projected volume.
+
+                                              The credential bundle is a single file that contains multiple PEM blocks.
+                                              The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                              key.
+
+                                              The remaining blocks are CERTIFICATE blocks, containing the issued
+                                              certificate chain from the signer (leaf and any intermediates).
+
+                                              Using credentialBundlePath lets your Pod's application code make a single
+                                              atomic read that retrieves a consistent key and certificate chain.  If you
+                                              project them to separate files, your application code will need to
+                                              additionally check that the leaf certificate was issued to the key.
+                                            type: string
+                                          keyPath:
+                                            description: |-
+                                              Write the key at this path in the projected volume.
+
+                                              Most applications should use credentialBundlePath.  When using keyPath
+                                              and certificateChainPath, your application needs to check that the key
+                                              and leaf certificate are consistent, because it is possible to read the
+                                              files mid-rotation.
+                                            type: string
+                                          keyType:
+                                            description: |-
+                                              The type of keypair Kubelet will generate for the pod.
+
+                                              Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                              "ECDSAP521", and "ED25519".
+                                            type: string
+                                          maxExpirationSeconds:
+                                            description: |-
+                                              maxExpirationSeconds is the maximum lifetime permitted for the
+                                              certificate.
+
+                                              Kubelet copies this value verbatim into the PodCertificateRequests it
+                                              generates for this projection.
+
+                                              If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                              will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                              value is 7862400 (91 days).
+
+                                              The signer implementation is then free to issue a certificate with any
+                                              lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                              seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                              `kubernetes.io` signers will never issue certificates with a lifetime
+                                              longer than 24 hours.
+                                            format: int32
+                                            type: integer
+                                          signerName:
+                                            description: Kubelet's generated CSRs
+                                              will be addressed to this signer.
+                                            type: string
+                                        required:
+                                        - keyType
+                                        - signerName
+                                        type: object
                                       secret:
                                         description: secret information about the
                                           secret data to project
@@ -6067,7 +6482,6 @@ spec:
                               description: |-
                                 rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                                 Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
-                                More info: https://examples.k8s.io/volumes/rbd/README.md
                               properties:
                                 fsType:
                                   description: |-

--- a/helm/kagent-crds/templates/kagent.dev_agents.yaml
+++ b/helm/kagent-crds/templates/kagent.dev_agents.yaml
@@ -118,8 +118,9 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
                           description: |-
@@ -175,6 +176,43 @@ spec:
                                   type: string
                               required:
                               - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -934,15 +972,13 @@ spec:
                                         volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                         If specified, the CSI driver will create or update the volume with the attributes defined
                                         in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                        it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                        will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                        If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                        will be set by the persistentvolume controller if it exists.
+                                        it can be changed after the claim is created. An empty string or nil value indicates that no
+                                        VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                        this field can be reset to its previous value (including nil) to cancel the modification.
                                         If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                         set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                         exists.
                                         More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                        (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                       type: string
                                     volumeMode:
                                       description: |-
@@ -1124,12 +1160,10 @@ spec:
                           description: |-
                             glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                             Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md
                           properties:
                             endpoints:
-                              description: |-
-                                endpoints is the endpoint name that details Glusterfs topology.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                              description: endpoints is the endpoint name that details
+                                Glusterfs topology.
                               type: string
                             path:
                               description: |-
@@ -1208,7 +1242,7 @@ spec:
                           description: |-
                             iscsi represents an ISCSI Disk resource that is attached to a
                             kubelet's host machine and then exposed to the pod.
-                            More info: https://examples.k8s.io/volumes/iscsi/README.md
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                           properties:
                             chapAuthDiscovery:
                               description: chapAuthDiscovery defines whether support
@@ -1630,6 +1664,111 @@ spec:
                                         type: array
                                         x-kubernetes-list-type: atomic
                                     type: object
+                                  podCertificate:
+                                    description: |-
+                                      Projects an auto-rotating credential bundle (private key and certificate
+                                      chain) that the pod can use either as a TLS client or server.
+
+                                      Kubelet generates a private key and uses it to send a
+                                      PodCertificateRequest to the named signer.  Once the signer approves the
+                                      request and issues a certificate chain, Kubelet writes the key and
+                                      certificate chain to the pod filesystem.  The pod does not start until
+                                      certificates have been issued for each podCertificate projected volume
+                                      source in its spec.
+
+                                      Kubelet will begin trying to rotate the certificate at the time indicated
+                                      by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                      timestamp.
+
+                                      Kubelet can write a single file, indicated by the credentialBundlePath
+                                      field, or separate files, indicated by the keyPath and
+                                      certificateChainPath fields.
+
+                                      The credential bundle is a single file in PEM format.  The first PEM
+                                      entry is the private key (in PKCS#8 format), and the remaining PEM
+                                      entries are the certificate chain issued by the signer (typically,
+                                      signers will return their certificate chain in leaf-to-root order).
+
+                                      Prefer using the credential bundle format, since your application code
+                                      can read it atomically.  If you use keyPath and certificateChainPath,
+                                      your application must make two separate file reads. If these coincide
+                                      with a certificate rotation, it is possible that the private key and leaf
+                                      certificate you read may not correspond to each other.  Your application
+                                      will need to check for this condition, and re-read until they are
+                                      consistent.
+
+                                      The named signer controls chooses the format of the certificate it
+                                      issues; consult the signer implementation's documentation to learn how to
+                                      use the certificates it issues.
+                                    properties:
+                                      certificateChainPath:
+                                        description: |-
+                                          Write the certificate chain at this path in the projected volume.
+
+                                          Most applications should use credentialBundlePath.  When using keyPath
+                                          and certificateChainPath, your application needs to check that the key
+                                          and leaf certificate are consistent, because it is possible to read the
+                                          files mid-rotation.
+                                        type: string
+                                      credentialBundlePath:
+                                        description: |-
+                                          Write the credential bundle at this path in the projected volume.
+
+                                          The credential bundle is a single file that contains multiple PEM blocks.
+                                          The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                          key.
+
+                                          The remaining blocks are CERTIFICATE blocks, containing the issued
+                                          certificate chain from the signer (leaf and any intermediates).
+
+                                          Using credentialBundlePath lets your Pod's application code make a single
+                                          atomic read that retrieves a consistent key and certificate chain.  If you
+                                          project them to separate files, your application code will need to
+                                          additionally check that the leaf certificate was issued to the key.
+                                        type: string
+                                      keyPath:
+                                        description: |-
+                                          Write the key at this path in the projected volume.
+
+                                          Most applications should use credentialBundlePath.  When using keyPath
+                                          and certificateChainPath, your application needs to check that the key
+                                          and leaf certificate are consistent, because it is possible to read the
+                                          files mid-rotation.
+                                        type: string
+                                      keyType:
+                                        description: |-
+                                          The type of keypair Kubelet will generate for the pod.
+
+                                          Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                          "ECDSAP521", and "ED25519".
+                                        type: string
+                                      maxExpirationSeconds:
+                                        description: |-
+                                          maxExpirationSeconds is the maximum lifetime permitted for the
+                                          certificate.
+
+                                          Kubelet copies this value verbatim into the PodCertificateRequests it
+                                          generates for this projection.
+
+                                          If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                          will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                          value is 7862400 (91 days).
+
+                                          The signer implementation is then free to issue a certificate with any
+                                          lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                          seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                          `kubernetes.io` signers will never issue certificates with a lifetime
+                                          longer than 24 hours.
+                                        format: int32
+                                        type: integer
+                                      signerName:
+                                        description: Kubelet's generated CSRs will
+                                          be addressed to this signer.
+                                        type: string
+                                    required:
+                                    - keyType
+                                    - signerName
+                                    type: object
                                   secret:
                                     description: secret information about the secret
                                       data to project
@@ -1764,7 +1903,6 @@ spec:
                           description: |-
                             rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                             Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md
                           properties:
                             fsType:
                               description: |-
@@ -2260,8 +2398,9 @@ spec:
                             in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
+                              description: |-
+                                Name of the environment variable.
+                                May consist of any printable ASCII characters except '='.
                               type: string
                             value:
                               description: |-
@@ -2317,6 +2456,43 @@ spec:
                                       type: string
                                   required:
                                   - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  description: |-
+                                    FileKeyRef selects a key of the env file.
+                                    Requires the EnvFiles feature gate to be enabled.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        The key within the env file. An invalid key will prevent the pod from starting.
+                                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                                        During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                      type: string
+                                    optional:
+                                      default: false
+                                      description: |-
+                                        Specify whether the file or its key must be defined. If the file or key
+                                        does not exist, then the env var is not published.
+                                        If optional is set to true and the specified key does not exist,
+                                        the environment variable will not be set in the Pod's containers.
+
+                                        If optional is set to false and the specified key does not exist,
+                                        an error will be returned during Pod creation.
+                                      type: boolean
+                                    path:
+                                      description: |-
+                                        The path within the volume from which to select the file.
+                                        Must be relative and may not contain the '..' path or start with '..'.
+                                      type: string
+                                    volumeName:
+                                      description: The name of the volume mount containing
+                                        the env file.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  - volumeName
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
@@ -3152,15 +3328,13 @@ spec:
                                             volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                             If specified, the CSI driver will create or update the volume with the attributes defined
                                             in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                            it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                            will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                            If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                            will be set by the persistentvolume controller if it exists.
+                                            it can be changed after the claim is created. An empty string or nil value indicates that no
+                                            VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                            this field can be reset to its previous value (including nil) to cancel the modification.
                                             If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                             set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                             exists.
                                             More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                            (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                           type: string
                                         volumeMode:
                                           description: |-
@@ -3342,12 +3516,10 @@ spec:
                               description: |-
                                 glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                                 Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md
                               properties:
                                 endpoints:
-                                  description: |-
-                                    endpoints is the endpoint name that details Glusterfs topology.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                  description: endpoints is the endpoint name that
+                                    details Glusterfs topology.
                                   type: string
                                 path:
                                   description: |-
@@ -3426,7 +3598,7 @@ spec:
                               description: |-
                                 iscsi represents an ISCSI Disk resource that is attached to a
                                 kubelet's host machine and then exposed to the pod.
-                                More info: https://examples.k8s.io/volumes/iscsi/README.md
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                               properties:
                                 chapAuthDiscovery:
                                   description: chapAuthDiscovery defines whether support
@@ -3852,6 +4024,111 @@ spec:
                                             type: array
                                             x-kubernetes-list-type: atomic
                                         type: object
+                                      podCertificate:
+                                        description: |-
+                                          Projects an auto-rotating credential bundle (private key and certificate
+                                          chain) that the pod can use either as a TLS client or server.
+
+                                          Kubelet generates a private key and uses it to send a
+                                          PodCertificateRequest to the named signer.  Once the signer approves the
+                                          request and issues a certificate chain, Kubelet writes the key and
+                                          certificate chain to the pod filesystem.  The pod does not start until
+                                          certificates have been issued for each podCertificate projected volume
+                                          source in its spec.
+
+                                          Kubelet will begin trying to rotate the certificate at the time indicated
+                                          by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                          timestamp.
+
+                                          Kubelet can write a single file, indicated by the credentialBundlePath
+                                          field, or separate files, indicated by the keyPath and
+                                          certificateChainPath fields.
+
+                                          The credential bundle is a single file in PEM format.  The first PEM
+                                          entry is the private key (in PKCS#8 format), and the remaining PEM
+                                          entries are the certificate chain issued by the signer (typically,
+                                          signers will return their certificate chain in leaf-to-root order).
+
+                                          Prefer using the credential bundle format, since your application code
+                                          can read it atomically.  If you use keyPath and certificateChainPath,
+                                          your application must make two separate file reads. If these coincide
+                                          with a certificate rotation, it is possible that the private key and leaf
+                                          certificate you read may not correspond to each other.  Your application
+                                          will need to check for this condition, and re-read until they are
+                                          consistent.
+
+                                          The named signer controls chooses the format of the certificate it
+                                          issues; consult the signer implementation's documentation to learn how to
+                                          use the certificates it issues.
+                                        properties:
+                                          certificateChainPath:
+                                            description: |-
+                                              Write the certificate chain at this path in the projected volume.
+
+                                              Most applications should use credentialBundlePath.  When using keyPath
+                                              and certificateChainPath, your application needs to check that the key
+                                              and leaf certificate are consistent, because it is possible to read the
+                                              files mid-rotation.
+                                            type: string
+                                          credentialBundlePath:
+                                            description: |-
+                                              Write the credential bundle at this path in the projected volume.
+
+                                              The credential bundle is a single file that contains multiple PEM blocks.
+                                              The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                              key.
+
+                                              The remaining blocks are CERTIFICATE blocks, containing the issued
+                                              certificate chain from the signer (leaf and any intermediates).
+
+                                              Using credentialBundlePath lets your Pod's application code make a single
+                                              atomic read that retrieves a consistent key and certificate chain.  If you
+                                              project them to separate files, your application code will need to
+                                              additionally check that the leaf certificate was issued to the key.
+                                            type: string
+                                          keyPath:
+                                            description: |-
+                                              Write the key at this path in the projected volume.
+
+                                              Most applications should use credentialBundlePath.  When using keyPath
+                                              and certificateChainPath, your application needs to check that the key
+                                              and leaf certificate are consistent, because it is possible to read the
+                                              files mid-rotation.
+                                            type: string
+                                          keyType:
+                                            description: |-
+                                              The type of keypair Kubelet will generate for the pod.
+
+                                              Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                              "ECDSAP521", and "ED25519".
+                                            type: string
+                                          maxExpirationSeconds:
+                                            description: |-
+                                              maxExpirationSeconds is the maximum lifetime permitted for the
+                                              certificate.
+
+                                              Kubelet copies this value verbatim into the PodCertificateRequests it
+                                              generates for this projection.
+
+                                              If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                              will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                              value is 7862400 (91 days).
+
+                                              The signer implementation is then free to issue a certificate with any
+                                              lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                              seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                              `kubernetes.io` signers will never issue certificates with a lifetime
+                                              longer than 24 hours.
+                                            format: int32
+                                            type: integer
+                                          signerName:
+                                            description: Kubelet's generated CSRs
+                                              will be addressed to this signer.
+                                            type: string
+                                        required:
+                                        - keyType
+                                        - signerName
+                                        type: object
                                       secret:
                                         description: secret information about the
                                           secret data to project
@@ -3986,7 +4263,6 @@ spec:
                               description: |-
                                 rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                                 Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
-                                More info: https://examples.k8s.io/volumes/rbd/README.md
                               properties:
                                 fsType:
                                   description: |-
@@ -4342,8 +4618,9 @@ spec:
                             in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
+                              description: |-
+                                Name of the environment variable.
+                                May consist of any printable ASCII characters except '='.
                               type: string
                             value:
                               description: |-
@@ -4399,6 +4676,43 @@ spec:
                                       type: string
                                   required:
                                   - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  description: |-
+                                    FileKeyRef selects a key of the env file.
+                                    Requires the EnvFiles feature gate to be enabled.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        The key within the env file. An invalid key will prevent the pod from starting.
+                                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                                        During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                      type: string
+                                    optional:
+                                      default: false
+                                      description: |-
+                                        Specify whether the file or its key must be defined. If the file or key
+                                        does not exist, then the env var is not published.
+                                        If optional is set to true and the specified key does not exist,
+                                        the environment variable will not be set in the Pod's containers.
+
+                                        If optional is set to false and the specified key does not exist,
+                                        an error will be returned during Pod creation.
+                                      type: boolean
+                                    path:
+                                      description: |-
+                                        The path within the volume from which to select the file.
+                                        Must be relative and may not contain the '..' path or start with '..'.
+                                      type: string
+                                    volumeName:
+                                      description: The name of the volume mount containing
+                                        the env file.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  - volumeName
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
@@ -5233,15 +5547,13 @@ spec:
                                             volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                             If specified, the CSI driver will create or update the volume with the attributes defined
                                             in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                            it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                            will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                            If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                            will be set by the persistentvolume controller if it exists.
+                                            it can be changed after the claim is created. An empty string or nil value indicates that no
+                                            VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                            this field can be reset to its previous value (including nil) to cancel the modification.
                                             If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                             set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                             exists.
                                             More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                            (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                           type: string
                                         volumeMode:
                                           description: |-
@@ -5423,12 +5735,10 @@ spec:
                               description: |-
                                 glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                                 Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md
                               properties:
                                 endpoints:
-                                  description: |-
-                                    endpoints is the endpoint name that details Glusterfs topology.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                  description: endpoints is the endpoint name that
+                                    details Glusterfs topology.
                                   type: string
                                 path:
                                   description: |-
@@ -5507,7 +5817,7 @@ spec:
                               description: |-
                                 iscsi represents an ISCSI Disk resource that is attached to a
                                 kubelet's host machine and then exposed to the pod.
-                                More info: https://examples.k8s.io/volumes/iscsi/README.md
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                               properties:
                                 chapAuthDiscovery:
                                   description: chapAuthDiscovery defines whether support
@@ -5933,6 +6243,111 @@ spec:
                                             type: array
                                             x-kubernetes-list-type: atomic
                                         type: object
+                                      podCertificate:
+                                        description: |-
+                                          Projects an auto-rotating credential bundle (private key and certificate
+                                          chain) that the pod can use either as a TLS client or server.
+
+                                          Kubelet generates a private key and uses it to send a
+                                          PodCertificateRequest to the named signer.  Once the signer approves the
+                                          request and issues a certificate chain, Kubelet writes the key and
+                                          certificate chain to the pod filesystem.  The pod does not start until
+                                          certificates have been issued for each podCertificate projected volume
+                                          source in its spec.
+
+                                          Kubelet will begin trying to rotate the certificate at the time indicated
+                                          by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                          timestamp.
+
+                                          Kubelet can write a single file, indicated by the credentialBundlePath
+                                          field, or separate files, indicated by the keyPath and
+                                          certificateChainPath fields.
+
+                                          The credential bundle is a single file in PEM format.  The first PEM
+                                          entry is the private key (in PKCS#8 format), and the remaining PEM
+                                          entries are the certificate chain issued by the signer (typically,
+                                          signers will return their certificate chain in leaf-to-root order).
+
+                                          Prefer using the credential bundle format, since your application code
+                                          can read it atomically.  If you use keyPath and certificateChainPath,
+                                          your application must make two separate file reads. If these coincide
+                                          with a certificate rotation, it is possible that the private key and leaf
+                                          certificate you read may not correspond to each other.  Your application
+                                          will need to check for this condition, and re-read until they are
+                                          consistent.
+
+                                          The named signer controls chooses the format of the certificate it
+                                          issues; consult the signer implementation's documentation to learn how to
+                                          use the certificates it issues.
+                                        properties:
+                                          certificateChainPath:
+                                            description: |-
+                                              Write the certificate chain at this path in the projected volume.
+
+                                              Most applications should use credentialBundlePath.  When using keyPath
+                                              and certificateChainPath, your application needs to check that the key
+                                              and leaf certificate are consistent, because it is possible to read the
+                                              files mid-rotation.
+                                            type: string
+                                          credentialBundlePath:
+                                            description: |-
+                                              Write the credential bundle at this path in the projected volume.
+
+                                              The credential bundle is a single file that contains multiple PEM blocks.
+                                              The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                              key.
+
+                                              The remaining blocks are CERTIFICATE blocks, containing the issued
+                                              certificate chain from the signer (leaf and any intermediates).
+
+                                              Using credentialBundlePath lets your Pod's application code make a single
+                                              atomic read that retrieves a consistent key and certificate chain.  If you
+                                              project them to separate files, your application code will need to
+                                              additionally check that the leaf certificate was issued to the key.
+                                            type: string
+                                          keyPath:
+                                            description: |-
+                                              Write the key at this path in the projected volume.
+
+                                              Most applications should use credentialBundlePath.  When using keyPath
+                                              and certificateChainPath, your application needs to check that the key
+                                              and leaf certificate are consistent, because it is possible to read the
+                                              files mid-rotation.
+                                            type: string
+                                          keyType:
+                                            description: |-
+                                              The type of keypair Kubelet will generate for the pod.
+
+                                              Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                              "ECDSAP521", and "ED25519".
+                                            type: string
+                                          maxExpirationSeconds:
+                                            description: |-
+                                              maxExpirationSeconds is the maximum lifetime permitted for the
+                                              certificate.
+
+                                              Kubelet copies this value verbatim into the PodCertificateRequests it
+                                              generates for this projection.
+
+                                              If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                              will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                              value is 7862400 (91 days).
+
+                                              The signer implementation is then free to issue a certificate with any
+                                              lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                              seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                              `kubernetes.io` signers will never issue certificates with a lifetime
+                                              longer than 24 hours.
+                                            format: int32
+                                            type: integer
+                                          signerName:
+                                            description: Kubelet's generated CSRs
+                                              will be addressed to this signer.
+                                            type: string
+                                        required:
+                                        - keyType
+                                        - signerName
+                                        type: object
                                       secret:
                                         description: secret information about the
                                           secret data to project
@@ -6067,7 +6482,6 @@ spec:
                               description: |-
                                 rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                                 Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
-                                More info: https://examples.k8s.io/volumes/rbd/README.md
                               properties:
                                 fsType:
                                   description: |-


### PR DESCRIPTION
Diff results from updates to `k8s.io` modules in #864 - although I'm a little puzzled as to what that upgrade had to do with "add[ing] native openai impl to adk" :detective: 