### PR TITLE
fix outputs from agent calls

### DIFF
--- a/ui/src/app/actions/agents.ts
+++ b/ui/src/app/actions/agents.ts
@@ -9,40 +9,6 @@ import { isMcpTool, isAgentTool } from "@/lib/toolUtils";
 import { k8sRefUtils } from "@/lib/k8sUtils";
 
 /**
- * Converts a tool to AgentTool format
- * @param tool The tool to convert
- * @param allAgents List of all available agents to look up descriptions
- * @returns An AgentTool object, potentially augmented with description
- */
-function convertToolRepresentation(tool: unknown, allAgents: AgentResponse[]): Tool {
-  const typedTool = tool as Partial<Tool>;
-  if (isMcpTool(typedTool)) {
-    return tool as Tool;
-  } else if (isAgentTool(typedTool)) {
-    const foundAgent = allAgents.find(a => {
-      const aRef = k8sRefUtils.toRef(
-        a.agent.metadata.namespace || "",
-        a.agent.metadata.name,
-      )
-      return aRef === typedTool.agent.name
-    });
-    const description = foundAgent?.agent.spec.description;
-    return {
-      ...typedTool,
-      type: "Agent",
-      agent: {
-        ...typedTool.agent,
-        name: typedTool.agent.name,
-        description: description
-      }
-    } as Tool;
-  }
-
-  throw new Error(`Unknown tool type: ${tool}`);
-}
-
-
-/**
  * Converts AgentFormData to Agent format
  * @param agentFormData The form data to convert
  * @returns An Agent object

--- a/ui/src/components/AgentCard.tsx
+++ b/ui/src/components/AgentCard.tsx
@@ -10,10 +10,9 @@ import { k8sRefUtils } from "@/lib/k8sUtils";
 
 interface AgentCardProps {
   agentResponse: AgentResponse;
-  id: number;
 }
 
-export function AgentCard({ id, agentResponse: { agent, model, modelProvider, deploymentReady, accepted } }: AgentCardProps) {
+export function AgentCard({ agentResponse: { agent, model, modelProvider, deploymentReady, accepted } }: AgentCardProps) {
   const router = useRouter();
   const agentRef = k8sRefUtils.toRef(
     agent.metadata.namespace || '',

--- a/ui/src/components/AgentGrid.tsx
+++ b/ui/src/components/AgentGrid.tsx
@@ -15,7 +15,7 @@ export function AgentGrid({ agentResponse }: AgentGridProps) {
           item.agent.metadata.namespace || '',
           item.agent.metadata.name || '');
 
-        return <AgentCard key={agentRef} agentResponse={item} id={item.id} />
+        return <AgentCard key={agentRef} agentResponse={item} />
       })}
     </div>
   );

--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { Button } from "./ui/button";
 import KAgentLogoWithText from "./kagent-logo-text";
 import KagentLogo from "./kagent-logo";
-import { Plus, Menu, X, ChevronDown, Brain, Server, Eye, Hammer, HomeIcon, Wrench, Database } from "lucide-react";
+import { Plus, Menu, X, ChevronDown, Brain, Server, Eye, Hammer, HomeIcon, Wrench } from "lucide-react";
 import { ThemeToggle } from "./ThemeToggle";
 import {
   DropdownMenu,

--- a/ui/src/components/chat/AgentCallDisplay.tsx
+++ b/ui/src/components/chat/AgentCallDisplay.tsx
@@ -1,0 +1,130 @@
+import { useMemo, useState } from "react";
+import { FunctionCall } from "@/types";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { convertToUserFriendlyName } from "@/lib/utils";
+import { ChevronDown, ChevronUp, MessageSquare, Loader2, AlertCircle, CheckCircle } from "lucide-react";
+import KagentLogo from "../kagent-logo";
+
+export type AgentCallStatus = "requested" | "executing" | "completed";
+
+interface AgentCallDisplayProps {
+  call: FunctionCall;
+  result?: {
+    content: string;
+    is_error?: boolean;
+  };
+  status?: AgentCallStatus;
+  isError?: boolean;
+}
+
+const AgentCallDisplay = ({ call, result, status = "requested", isError = false }: AgentCallDisplayProps) => {
+  const [areInputsExpanded, setAreInputsExpanded] = useState(false);
+  const [areResultsExpanded, setAreResultsExpanded] = useState(false);
+
+  const agentDisplay = useMemo(() => convertToUserFriendlyName(call.name), [call.name]);
+  const hasResult = result !== undefined;
+
+  const getStatusDisplay = () => {
+    if (isError && status === "executing") {
+      return (
+        <>
+          <AlertCircle className="w-3 h-3 inline-block mr-2 text-red-500" />
+          Error
+        </>
+      );
+    }
+    switch (status) {
+      case "requested":
+        return (
+          <>
+            <KagentLogo className="w-3 h-3 inline-block mr-2 text-blue-500" />
+            Delegating
+          </>
+        );
+      case "executing":
+        return (
+          <>
+            <Loader2 className="w-3 h-3 inline-block mr-2 text-yellow-500 animate-spin" />
+            Awaiting response
+          </>
+        );
+      case "completed":
+        if (isError) {
+          return (
+            <>
+              <AlertCircle className="w-3 h-3 inline-block mr-2 text-red-500" />
+              Failed
+            </>
+          );
+        }
+        return (
+          <>
+            <CheckCircle className="w-3 h-3 inline-block mr-2 text-green-500" />
+            Completed
+          </>
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Card className={`w-full mx-auto my-1 min-w-full ${isError ? 'border-red-300' : ''}`}>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="text-xs flex space-x-5">
+          <div className="flex items-center font-medium">
+            <KagentLogo className="w-4 h-4 mr-2" />
+            {agentDisplay}
+          </div>
+          <div className="font-light">{call.id}</div>
+        </CardTitle>
+        <div className="flex justify-center items-center text-xs">
+          {getStatusDisplay()}
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-2 mt-2">
+          <button className="text-xs flex items-center gap-2" onClick={() => setAreInputsExpanded(!areInputsExpanded)}>
+            <MessageSquare className="w-4 h-4" />
+            <span>Input</span>
+            {areInputsExpanded ? <ChevronUp className="w-4 h-4 ml-1" /> : <ChevronDown className="w-4 h-4 ml-1" />}
+          </button>
+          {areInputsExpanded && (
+            <div className="mt-2 bg-muted/50 p-3 rounded">
+              <pre className="text-sm whitespace-pre-wrap break-words">{JSON.stringify(call.args, null, 2)}</pre>
+            </div>
+          )}
+        </div>
+
+        <div className="mt-4 w-full">
+          {status === "executing" && !hasResult && (
+            <div className="flex items-center gap-2 py-2">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              <span className="text-sm">{agentDisplay} is responding...</span>
+            </div>
+          )}
+          {hasResult && result?.content && (
+            <div className="space-y-2">
+              <button className="text-xs flex items-center gap-2" onClick={() => setAreResultsExpanded(!areResultsExpanded)}>
+                <MessageSquare className="w-4 h-4" />
+                <span>Output</span>
+                {areResultsExpanded ? <ChevronUp className="w-4 h-4 ml-1" /> : <ChevronDown className="w-4 h-4 ml-1" />}
+              </button>
+              {areResultsExpanded && (
+                <div className={`mt-2 ${isError ? 'bg-red-50 dark:bg-red-950/10' : 'bg-muted/50'} p-3 rounded`}>
+                  <pre className={`text-sm whitespace-pre-wrap break-words ${isError ? 'text-red-600 dark:text-red-400' : ''}`}>
+                    {result?.content}
+                  </pre>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default AgentCallDisplay;
+
+

--- a/ui/src/components/create/ModelSelectionSection.tsx
+++ b/ui/src/components/create/ModelSelectionSection.tsx
@@ -78,7 +78,7 @@ export const ModelSelectionSection = ({
                   <span>{model.model} ({model.ref})</span>
                   {isDifferentNamespace && (
                     <span className="text-xs text-muted-foreground">
-                      Change agent namespace to "{modelNamespace}" to use this model
+                      Change agent namespace to &quot;{modelNamespace}&quot; to use this model
                     </span>
                   )}
                 </div>

--- a/ui/src/lib/__tests__/messageHandlers.test.ts
+++ b/ui/src/lib/__tests__/messageHandlers.test.ts
@@ -1,0 +1,255 @@
+import { describe, test, expect } from '@jest/globals';
+import { v4 as uuidv4 } from 'uuid';
+import { Message } from '@a2a-js/sdk';
+import {
+  extractMessagesFromTasks,
+  extractTokenStatsFromTasks,
+  createMessage,
+  normalizeToolResultToText,
+  type ToolResponseData,
+  type ADKMetadata,
+  createMessageHandlers,
+} from '@/lib/messageHandlers';
+
+describe('messageHandlers helpers', () => {
+  test('normalizeToolResultToText handles string result', () => {
+    const data: ToolResponseData = { id: '1', name: 'tool', response: { result: 'hello' } };
+    expect(normalizeToolResultToText(data)).toBe('hello');
+  });
+
+  test('normalizeToolResultToText handles content array', () => {
+    const data: ToolResponseData = { id: '1', name: 'tool', response: { result: { content: [{ text: 'a' }, { text: 'b' }] } } } as any;
+    expect(normalizeToolResultToText(data)).toBe('ab');
+  });
+
+  test('normalizeToolResultToText handles object fallback', () => {
+    const data: ToolResponseData = { id: '1', name: 'tool', response: { result: { foo: 'bar' } } } as any;
+    expect(normalizeToolResultToText(data)).toContain('foo');
+  });
+
+  test('createMessage builds a message with metadata', () => {
+    const msg = createMessage('hi', 'assistant', { originalType: 'TextMessage', contextId: 'ctx', taskId: 'task' });
+    expect(msg.kind).toBe('message');
+    expect(msg.parts[0]).toEqual({ kind: 'text', text: 'hi' });
+    expect((msg.metadata as any).originalType).toBe('TextMessage');
+    expect(msg.contextId).toBe('ctx');
+    expect(msg.taskId).toBe('task');
+  });
+
+  test('extractMessagesFromTasks deduplicates messageIds', () => {
+    const mId = uuidv4();
+    const tasks: any = [
+      { history: [{ kind: 'message', messageId: mId }, { kind: 'message', messageId: mId }] },
+    ];
+    const out = extractMessagesFromTasks(tasks);
+    expect(out.length).toBe(1);
+    expect(out[0].messageId).toBe(mId);
+  });
+
+  test('extractTokenStatsFromTasks picks max token counts', () => {
+    const tasks: any = [
+      { metadata: { kagent_usage_metadata: { totalTokenCount: 10, promptTokenCount: 3, candidatesTokenCount: 7 } } as ADKMetadata },
+      { metadata: { kagent_usage_metadata: { totalTokenCount: 12, promptTokenCount: 1, candidatesTokenCount: 9 } } as ADKMetadata },
+    ];
+    const stats = extractTokenStatsFromTasks(tasks);
+    expect(stats.total).toBe(12);
+    expect(stats.input).toBe(3);
+    expect(stats.output).toBe(9);
+  });
+});
+
+describe('createMessageHandlers smoke test (function_call and delegated response)', () => {
+  test('emits ToolCallRequestEvent and delegated TextMessage + execution event', () => {
+    const emitted: Message[] = [];
+    const handlers = createMessageHandlers({
+      setMessages: (updater) => {
+        const next = updater(emitted);
+        emitted.length = 0;
+        emitted.push(...next);
+      },
+      setIsStreaming: () => {},
+      setStreamingContent: () => {},
+      setTokenStats: () => {},
+      setChatStatus: () => {},
+      agentContext: { namespace: 'kagent', agentName: 'testagent' },
+    });
+
+    // Simulate status-update with function_call to an agent tool
+    const statusUpdateCall: any = {
+      kind: 'status-update',
+      contextId: 'ctx',
+      taskId: 'task',
+      final: false,
+      status: {
+        state: 'working',
+        message: {
+          role: 'agent',
+          parts: [
+            {
+              kind: 'data',
+              data: { id: 'call_1', name: 'kagent__NS__k8s_agent', args: { request: 'list' } },
+              metadata: { kagent_type: 'function_call' },
+            },
+          ],
+        },
+      },
+    };
+
+    // @ts-expect-error - private access in tests
+    handlers.handleMessageEvent(statusUpdateCall);
+
+    // Simulate status-update with function_response from agent
+    const statusUpdateResp: any = {
+      kind: 'status-update',
+      contextId: 'ctx',
+      taskId: 'task',
+      final: false,
+      status: {
+        state: 'working',
+        message: {
+          role: 'agent',
+          parts: [
+            {
+              kind: 'data',
+              data: { id: 'call_1', name: 'kagent__NS__k8s_agent', response: { result: 'ok' } },
+              metadata: { kagent_type: 'function_response' },
+            },
+          ],
+        },
+      },
+    };
+
+    // @ts-expect-error
+    handlers.handleMessageEvent(statusUpdateResp);
+
+    // Expect: ToolCallRequestEvent + delegated TextMessage + ToolCallExecutionEvent
+    expect(emitted.length).toBe(3);
+    const [req, plain, exec] = emitted;
+    expect((req.metadata as any).originalType).toBe('ToolCallRequestEvent');
+    expect((plain.metadata as any).originalType).toBe('TextMessage');
+    expect((plain.metadata as any).displaySource).toBe('kagent/k8s-agent');
+    expect((exec.metadata as any).originalType).toBe('ToolCallExecutionEvent');
+  });
+
+  test('emits ToolCallRequestEvent + ToolCallExecutionEvent for non-agent tool', () => {
+    const emitted: Message[] = [];
+    const handlers = createMessageHandlers({
+      setMessages: (updater) => {
+        const next = updater(emitted);
+        emitted.length = 0;
+        emitted.push(...next);
+      },
+      setIsStreaming: () => {},
+      setStreamingContent: () => {},
+      setTokenStats: () => {},
+      agentContext: { namespace: 'kagent', agentName: 'testagent' },
+    });
+
+    const statusUpdateCall: any = {
+      kind: 'status-update', contextId: 'ctx', taskId: 'task', final: false,
+      status: { state: 'working', message: { role: 'agent', parts: [{ kind: 'data', data: { id: 'call_2', name: 'some_tool', args: { a: 1 } }, metadata: { kagent_type: 'function_call' } }] } }
+    };
+    // @ts-expect-error
+    handlers.handleMessageEvent(statusUpdateCall);
+
+    const statusUpdateResp: any = {
+      kind: 'status-update', contextId: 'ctx', taskId: 'task', final: false,
+      status: { state: 'working', message: { role: 'agent', parts: [{ kind: 'data', data: { id: 'call_2', name: 'some_tool', response: { result: 'tool ok' } }, metadata: { kagent_type: 'function_response' } }] } }
+    };
+    // @ts-expect-error
+    handlers.handleMessageEvent(statusUpdateResp);
+
+    expect(emitted.length).toBe(2);
+    expect((emitted[0].metadata as any).originalType).toBe('ToolCallRequestEvent');
+    expect((emitted[1].metadata as any).originalType).toBe('ToolCallExecutionEvent');
+  });
+
+  test('final text message on status-update with text part', () => {
+    const emitted: Message[] = [];
+    const handlers = createMessageHandlers({
+      setMessages: (updater) => {
+        const next = updater(emitted);
+        emitted.length = 0;
+        emitted.push(...next);
+      },
+      setIsStreaming: () => {},
+      setStreamingContent: () => {},
+      setTokenStats: () => {},
+      agentContext: { namespace: 'kagent', agentName: 'testagent' },
+    });
+
+    const statusWithText: any = {
+      kind: 'status-update', contextId: 'ctx', taskId: 'task', final: true,
+      status: { state: 'working', message: { role: 'agent', parts: [{ kind: 'text', text: 'hello' }] } }
+    };
+    // @ts-expect-error
+    handlers.handleMessageEvent(statusWithText);
+
+    expect(emitted.length).toBe(1);
+    expect((emitted[0].metadata as any).originalType).toBe('TextMessage');
+    expect((emitted[0].parts[0] as any).text).toBe('hello');
+  });
+
+  test('artifact-update converts tool parts and appends summary', () => {
+    const emitted: Message[] = [];
+    const handlers = createMessageHandlers({
+      setMessages: (updater) => {
+        const next = updater(emitted);
+        emitted.length = 0;
+        emitted.push(...next);
+      },
+      setIsStreaming: () => {},
+      setStreamingContent: () => {},
+      setTokenStats: () => {},
+      agentContext: { namespace: 'kagent', agentName: 'testagent' },
+    });
+
+    const artifactEvent: any = {
+      kind: 'artifact-update', contextId: 'ctx', taskId: 'task', lastChunk: true,
+      artifact: {
+        parts: [
+          { kind: 'data', data: { id: 'call_3', name: 'some_tool', args: { q: 1 } }, metadata: { kagent_type: 'function_call' } },
+          { kind: 'data', data: { id: 'call_3', name: 'some_tool', response: { result: 'out' } }, metadata: { kagent_type: 'function_response' } },
+        ]
+      }
+    };
+    // @ts-expect-error
+    handlers.handleMessageEvent(artifactEvent);
+
+    // Expect: request, execution, summary (no text message since no text part)
+    expect(emitted.length).toBe(3);
+    expect((emitted[0].metadata as any).originalType).toBe('ToolCallRequestEvent');
+    expect((emitted[1].metadata as any).originalType).toBe('ToolCallExecutionEvent');
+    expect((emitted[2].metadata as any).originalType).toBe('ToolCallSummaryMessage');
+  });
+
+  test('token usage updates on status-update metadata', () => {
+    let capturedStats: any = { total: 0, input: 0, output: 0 };
+    const emitted: Message[] = [];
+    const handlers = createMessageHandlers({
+      setMessages: (updater) => {
+        const next = updater(emitted);
+        emitted.length = 0;
+        emitted.push(...next);
+      },
+      setIsStreaming: () => {},
+      setStreamingContent: () => {},
+      setTokenStats: (updater: any) => {
+        capturedStats = updater(capturedStats);
+      },
+      agentContext: { namespace: 'kagent', agentName: 'testagent' },
+    });
+
+    const statusWithUsage: any = {
+      kind: 'status-update', contextId: 'ctx', taskId: 'task', final: false,
+      metadata: { kagent_usage_metadata: { totalTokenCount: 5, promptTokenCount: 2, candidatesTokenCount: 3 } },
+      status: { state: 'working' }
+    };
+    // @ts-expect-error
+    handlers.handleMessageEvent(statusWithUsage);
+
+    expect(capturedStats).toEqual({ total: 5, input: 2, output: 3 });
+  });
+});
+
+

--- a/ui/src/lib/messageHandlers.ts
+++ b/ui/src/lib/messageHandlers.ts
@@ -1,6 +1,6 @@
 import { Message, Task, TaskStatusUpdateEvent, TaskArtifactUpdateEvent, TextPart, Part, DataPart } from "@a2a-js/sdk";
 import { v4 as uuidv4 } from "uuid";
-import { convertToUserFriendlyName, messageUtils } from "@/lib/utils";
+import { convertToUserFriendlyName, messageUtils, isAgentToolName } from "@/lib/utils";
 import { TokenStats, ChatStatus } from "@/types";
 import { mapA2AStateToStatus } from "@/lib/statusUtils";
 
@@ -87,9 +87,7 @@ export interface ToolResponseData {
   name: string;
   response?: {
     isError?: boolean;
-    result?: {
-      content?: Array<{ text?: string } | unknown>;
-    };
+    result?: unknown;
   };
 }
 
@@ -107,6 +105,45 @@ export interface ProcessedToolResultData {
   is_error: boolean;
 }
 
+// Normalize various tool response result shapes into plain text
+export function normalizeToolResultToText(toolData: ToolResponseData): string {
+  const result = toolData.response?.result;
+
+  if (typeof result === "string") {
+    return result;
+  }
+
+  if (result && typeof result === "object") {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const anyResult: any = result;
+    const content = anyResult?.content;
+    if (Array.isArray(content)) {
+      return content.map((c: unknown) => {
+        if (typeof c === "object" && c !== null && "text" in (c as Record<string, unknown>)) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          return ((c as any).text as string) || "";
+        }
+        try {
+          return typeof c === "string" ? c : JSON.stringify(c);
+        } catch {
+          return String(c);
+        }
+      }).join("");
+    }
+
+    if ("text" in anyResult && typeof anyResult.text === "string") {
+      return anyResult.text;
+    }
+
+    try {
+      return JSON.stringify(result);
+    } catch {
+      return String(result);
+    }
+  }
+
+  return "";
+}
 
 function isTextPart(part: Part): part is TextPart {
   return part.kind === "text";
@@ -179,6 +216,122 @@ export type MessageHandlers = {
 };
 
 export const createMessageHandlers = (handlers: MessageHandlers) => {
+  const appendMessage = (message: Message) => {
+    handlers.setMessages(prev => [...prev, message]);
+  };
+
+  const updateTokenStatsFromMetadata = (adkMetadata: ADKMetadata | undefined) => {
+    if (!adkMetadata?.kagent_usage_metadata) return;
+    const usage = adkMetadata.kagent_usage_metadata;
+    const tokenStats = {
+      total: usage.totalTokenCount || 0,
+      input: usage.promptTokenCount || 0,
+      output: usage.candidatesTokenCount || 0,
+    };
+    handlers.setTokenStats(prev => ({
+      total: Math.max(prev.total, tokenStats.total),
+      input: Math.max(prev.input, tokenStats.input),
+      output: Math.max(prev.output, tokenStats.output),
+    }));
+  };
+
+  const aggregatePartsToText = (parts: Part[]): string => {
+    return parts.map((part: Part) => {
+      if (isTextPart(part)) {
+        return part.text || "";
+      } else if (isDataPart(part)) {
+        try {
+          return JSON.stringify(part.data || "");
+        } catch {
+          return String(part.data);
+        }
+      } else if (part.kind === "file") {
+        return `[File: ${(part as { file?: { name?: string } }).file?.name || "unknown"}]`;
+      }
+      return String(part);
+    }).join("");
+  };
+
+  const finalizeStreaming = () => {
+    handlers.setIsStreaming(false);
+    handlers.setStreamingContent(() => "");
+    if (handlers.setChatStatus) {
+      handlers.setChatStatus("ready");
+    }
+  };
+
+  const processFunctionCallPart = (
+    toolData: ToolCallData,
+    contextId: string | undefined,
+    taskId: string | undefined,
+    source: string,
+    options?: { setProcessingStatus?: boolean }
+  ) => {
+    if (options?.setProcessingStatus && handlers.setChatStatus) {
+      handlers.setChatStatus("processing_tools");
+    }
+    const toolCallContent: ProcessedToolCallData[] = [{
+      id: toolData.id,
+      name: toolData.name,
+      args: toolData.args || {}
+    }];
+    const convertedMessage = createMessage(
+      "",
+      source,
+      {
+        originalType: "ToolCallRequestEvent",
+        contextId,
+        taskId,
+        additionalMetadata: { toolCallData: toolCallContent }
+      }
+    );
+    appendMessage(convertedMessage);
+  };
+
+  const processFunctionResponsePart = (
+    toolData: ToolResponseData,
+    contextId: string | undefined,
+    taskId: string | undefined,
+    defaultSource: string,
+    includeDelegatedPlainMessage: boolean
+  ) => {
+    const textContent = normalizeToolResultToText(toolData);
+
+    if (isAgentToolName(toolData.name) && includeDelegatedPlainMessage) {
+      const delegatedSource = convertToUserFriendlyName(toolData.name);
+      const plainMessage = createMessage(
+        textContent,
+        delegatedSource,
+        {
+          originalType: "TextMessage",
+          contextId,
+          taskId
+        }
+      );
+      appendMessage(plainMessage);
+    }
+
+    const toolResultContent: ProcessedToolResultData[] = [{
+      call_id: toolData.id,
+      name: toolData.name,
+      content: textContent,
+      is_error: toolData.response?.isError || false
+    }];
+    const execEvent = createMessage(
+      "",
+      defaultSource,
+      {
+        originalType: "ToolCallExecutionEvent",
+        contextId,
+        taskId,
+        additionalMetadata: { toolResultData: toolResultContent }
+      }
+    );
+    appendMessage(execEvent);
+  };
+
+  const isUserMessage = (message: Message): boolean => message.role === "user";
+
   // Simple fallback source when metadata is not available
   const defaultAgentSource = handlers.agentContext 
     ? `${handlers.agentContext.namespace}/${handlers.agentContext.agentName.replace(/_/g, "-")}`
@@ -194,28 +347,14 @@ export const createMessageHandlers = (handlers: MessageHandlers) => {
     try {
       const adkMetadata = getADKMetadata(statusUpdate);
 
-      if (adkMetadata?.kagent_usage_metadata) {
-        const usage = adkMetadata.kagent_usage_metadata;
-
-        const tokenStats = {
-          total: usage.totalTokenCount || 0,
-          input: usage.promptTokenCount || 0,
-          output: usage.candidatesTokenCount || 0,
-        };
-        // Update token stats cumulatively - each A2A event might have incremental usage
-        handlers.setTokenStats(prev => ({
-          total: Math.max(prev.total, tokenStats.total),
-          input: Math.max(prev.input, tokenStats.input),
-          output: Math.max(prev.output, tokenStats.output),
-        }));
-      }
+      updateTokenStatsFromMetadata(adkMetadata);
 
       // If the status update has a message, process it
       if (statusUpdate.status.message) {
         const message = statusUpdate.status.message;
 
         // Skip user messages to avoid duplicates (they're already shown immediately)
-        if (message.role === "user") {
+        if (isUserMessage(message)) {
           return;
         }
 
@@ -252,58 +391,14 @@ export const createMessageHandlers = (handlers: MessageHandlers) => {
             const partMetadata = part.metadata as ADKMetadata | undefined;
 
             if (partMetadata?.kagent_type === "function_call") {
-              if (handlers.setChatStatus) {
-                handlers.setChatStatus("processing_tools");
-              }
-
               const toolData = data as unknown as ToolCallData;
-              const toolCallContent: ProcessedToolCallData[] = [{
-                id: toolData.id,
-                name: toolData.name,
-                args: toolData.args || {}
-              }];
               const source = getSourceFromMetadata(adkMetadata, defaultAgentSource);
-              const convertedMessage = createMessage(
-                "",
-                source,
-                {
-                  originalType: "ToolCallRequestEvent",
-                  contextId: statusUpdate.contextId,
-                  taskId: statusUpdate.taskId,
-                  additionalMetadata: { toolCallData: toolCallContent }
-                }
-              );
-              handlers.setMessages(prevMessages => [...prevMessages, convertedMessage]);
+              processFunctionCallPart(toolData, statusUpdate.contextId, statusUpdate.taskId, source, { setProcessingStatus: true });
 
             } else if (partMetadata?.kagent_type === "function_response") {
               const toolData = data as unknown as ToolResponseData;
-              const content = toolData.response?.result?.content || [];
-              const textContent = content.map((c: unknown) => {
-                if (typeof c === 'object' && c !== null && 'text' in c) {
-                  return (c as { text?: string }).text || '';
-                }
-                return String(c);
-              }).join("");
-
-              const toolResultContent: ProcessedToolResultData[] = [{
-                call_id: toolData.id,
-                name: toolData.name,
-                content: textContent,
-                is_error: toolData.response?.isError || false
-              }];
               const source = getSourceFromMetadata(adkMetadata, defaultAgentSource);
-              
-              const convertedMessage = createMessage(
-                "",
-                source,
-                {
-                  originalType: "ToolCallExecutionEvent",
-                  contextId: statusUpdate.contextId,
-                  taskId: statusUpdate.taskId,
-                  additionalMetadata: { toolResultData: toolResultContent }
-                }
-              );
-              handlers.setMessages(prevMessages => [...prevMessages, convertedMessage]);
+              processFunctionResponsePart(toolData, statusUpdate.contextId, statusUpdate.taskId, source, true);
             }
           }
         }
@@ -315,11 +410,7 @@ export const createMessageHandlers = (handlers: MessageHandlers) => {
       }
 
       if (statusUpdate.final) {
-        handlers.setIsStreaming(false);
-        handlers.setStreamingContent(() => "");
-        if (handlers.setChatStatus) {
-          handlers.setChatStatus("ready");
-        }
+        finalizeStreaming();
       }
     } catch (error) {
       console.error("❌ Error in handleA2ATaskStatusUpdate:", error);
@@ -332,50 +423,73 @@ export const createMessageHandlers = (handlers: MessageHandlers) => {
       adkMetadata = getADKMetadata(artifactUpdate.artifact);
     }
 
-    if (adkMetadata?.kagent_usage_metadata) {
-      const usage = adkMetadata.kagent_usage_metadata;
+    updateTokenStatsFromMetadata(adkMetadata);
 
-      const tokenStats = {
-        total: usage.totalTokenCount || 0,
-        input: usage.promptTokenCount || 0,
-        output: usage.candidatesTokenCount || 0,
-      };
-      // Update token stats cumulatively for final counts
-      handlers.setTokenStats(prev => ({
-        total: Math.max(prev.total, tokenStats.total),
-        input: Math.max(prev.input, tokenStats.input),
-        output: Math.max(prev.output, tokenStats.output),
-      }));
-    }
-
-    // Add artifact content as final message (artifacts are typically final responses)
-    const artifactText = artifactUpdate.artifact.parts.map((part: Part) => {
-      // Handle different part types from A2A SDK
+    // Add artifact content and convert tool parts to messages
+    let artifactText = "";
+    const convertedMessages: Message[] = [];
+    for (const part of artifactUpdate.artifact.parts) {
       if (isTextPart(part)) {
-        return part.text || "";
-      } else if (isDataPart(part)) {
-        return JSON.stringify(part.data || "");
-      } else if (part.kind === "file") {
-        return `[File: ${(part as { file?: { name?: string } }).file?.name || "unknown"}]`;
+        artifactText += part.text || "";
+        continue;
       }
-      return String(part);
-    }).join("");
+      if (isDataPart(part)) {
+        const partMetadata = part.metadata as ADKMetadata | undefined;
+        const data = part.data;
+        const source = getSourceFromMetadata(adkMetadata, defaultAgentSource);
+
+        if (partMetadata?.kagent_type === "function_call") {
+          const toolData = data as unknown as ToolCallData;
+          const toolCallContent: ProcessedToolCallData[] = [{ id: toolData.id, name: toolData.name, args: toolData.args || {} }];
+          const convertedMessage = createMessage("", source, { originalType: "ToolCallRequestEvent", contextId: artifactUpdate.contextId, taskId: artifactUpdate.taskId, additionalMetadata: { toolCallData: toolCallContent } });
+          convertedMessages.push(convertedMessage);
+          continue;
+        }
+
+        if (partMetadata?.kagent_type === "function_response") {
+          const toolData = data as unknown as ToolResponseData;
+          const textContent = normalizeToolResultToText(toolData);
+          const toolResultContent: ProcessedToolResultData[] = [{ call_id: toolData.id, name: toolData.name, content: textContent, is_error: toolData.response?.isError || false }];
+          const convertedMessage = createMessage("", source, { originalType: "ToolCallExecutionEvent", contextId: artifactUpdate.contextId, taskId: artifactUpdate.taskId, additionalMetadata: { toolResultData: toolResultContent } });
+          convertedMessages.push(convertedMessage);
+          continue;
+        }
+
+        try {
+          artifactText += JSON.stringify(data || "");
+        } catch {
+          artifactText += String(data);
+        }
+        continue;
+      }
+      if (part.kind === "file") {
+        artifactText += `[File: ${(part as { file?: { name?: string } }).file?.name || "unknown"}]`;
+        continue;
+      }
+      artifactText += String(part);
+    }
 
     if (artifactUpdate.lastChunk) {
       handlers.setIsStreaming(false);
       handlers.setStreamingContent(() => "");
 
       const source = getSourceFromMetadata(adkMetadata, defaultAgentSource);
-      const displayMessage = createMessage(
-        artifactText,
-        source,
-        {
-          originalType: "TextMessage",
-          contextId: artifactUpdate.contextId,
-          taskId: artifactUpdate.taskId
-        }
-      );
-      handlers.setMessages(prevMessages => [...prevMessages, displayMessage]);
+      if (artifactText) {
+        const displayMessage = createMessage(
+          artifactText,
+          source,
+          {
+            originalType: "TextMessage",
+            contextId: artifactUpdate.contextId,
+            taskId: artifactUpdate.taskId
+          }
+        );
+        handlers.setMessages(prevMessages => [...prevMessages, displayMessage]);
+      }
+
+      if (convertedMessages.length > 0) {
+        handlers.setMessages(prevMessages => [...prevMessages, ...convertedMessages]);
+      }
       
       // Add a tool call summary message to mark any pending tool calls as completed
       const summarySource = getSourceFromMetadata(adkMetadata, defaultAgentSource);
@@ -397,16 +511,7 @@ export const createMessageHandlers = (handlers: MessageHandlers) => {
   };
 
   const handleA2AMessage = (message: Message) => {
-    const content = message.parts.map(part => {
-      if (isTextPart(part)) {
-        return part.text || "";
-      } else if (isDataPart(part)) {
-        return JSON.stringify(part.data || "");
-      } else if (part.kind === "file") {
-        return `[File: ${(part as { file?: { name?: string } }).file?.name || "unknown"}]`;
-      }
-      return "";
-    }).join("");
+    const content = aggregatePartsToText(message.parts);
 
     if (message.role !== "user") {
       const source = getSourceFromMetadata(message.metadata as ADKMetadata, defaultAgentSource);
@@ -424,12 +529,12 @@ export const createMessageHandlers = (handlers: MessageHandlers) => {
   };
 
   const handleOtherMessage = (message: Message) => {
-    handlers.setIsStreaming(false);
-    handlers.setStreamingContent(() => "");
-    handlers.setMessages(prevMessages => [...prevMessages, message]);
+    finalizeStreaming();
+    appendMessage(message);
   };
 
   const handleMessageEvent = (message: Message) => {
+    console.log(message);
     if (messageUtils.isA2ATask(message)) {
       handleA2ATask(message);
       return;

--- a/ui/src/lib/messageHandlers.ts
+++ b/ui/src/lib/messageHandlers.ts
@@ -534,7 +534,6 @@ export const createMessageHandlers = (handlers: MessageHandlers) => {
   };
 
   const handleMessageEvent = (message: Message) => {
-    console.log(message);
     if (messageUtils.isA2ATask(message)) {
       handleA2ATask(message);
       return;

--- a/ui/src/lib/toolUtils.ts
+++ b/ui/src/lib/toolUtils.ts
@@ -11,12 +11,15 @@ const MCP_SERVER_TYPE = "McpServer" as const;
 
 export const isAgentTool = (value: unknown): value is { type: "Agent"; agent: TypedLocalReference } => {
   if (!value || typeof value !== "object") return false;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const obj = value as any;
   return obj.type === "Agent" && obj.agent && typeof obj.agent === "object" && typeof obj.agent.name === "string";
 };
 
 export const isAgentResponse = (value: unknown): value is AgentResponse => {
   if (!value || typeof value !== "object") return false;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const obj = value as any;
   return !!obj.agent && typeof obj.agent === "object" && !!obj.agent.metadata && typeof obj.agent.metadata?.name === "string";
 };

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -143,8 +143,13 @@ export const messageUtils = {
   },
 };
 
+const NAMESPACE_SEPARATOR = "__NS__";
 export function convertToUserFriendlyName(name: string): string {
   if (!name) return "Unknown Source";
-  name = name.replace(/__NS__/g, "/");
+  name = name.replace(NAMESPACE_SEPARATOR, "/");
   return name.replace(/_/g, "-");
+}
+
+export function isAgentToolName(name: string | undefined): boolean {
+  return typeof name === "string" && name.includes(NAMESPACE_SEPARATOR);
 }


### PR DESCRIPTION
Fixes #898 .

Adds a dedicated component that shows calls made to the (sub) agents similarly to when we call functions. 

<img width="1208" height="625" alt="Screenshot 2025-09-16 at 12 15 07 PM" src="https://github.com/user-attachments/assets/d327caf4-0dae-4db0-ba89-ce6ef15815dd" />
