### PR TITLE
fix: get userid from parameters when agent calls us

### DIFF
--- a/go/internal/httpserver/handlers/sessions.go
+++ b/go/internal/httpserver/handlers/sessions.go
@@ -414,7 +414,6 @@ func getUserID(r *http.Request) (string, error) {
 }
 
 func getUserIDOrAgentUser(r *http.Request) (string, error) {
-
 	principal, err := GetPrincipal(r)
 	if err != nil {
 		return "", err
@@ -425,7 +424,6 @@ func getUserIDOrAgentUser(r *http.Request) (string, error) {
 	} else if principal.Agent.ID != "" {
 		// grab the user id from the query param
 		return getUserID(r)
-
 	}
 	return "", fmt.Errorf("no user or agent in principal")
 }

--- a/go/internal/httpserver/handlers/sessions.go
+++ b/go/internal/httpserver/handlers/sessions.go
@@ -46,7 +46,7 @@ func (h *SessionsHandler) HandleGetSessionsForAgent(w ErrorResponseWriter, r *ht
 	}
 	log = log.WithValues("agentName", agentName)
 
-	userID, err := GetUserID(r)
+	userID, err := getUserIDOrAgentUser(r)
 	if err != nil {
 		w.RespondWithError(errors.NewBadRequestError("Failed to get user ID", err))
 		return
@@ -104,7 +104,7 @@ func (h *SessionsHandler) HandleCreateSession(w ErrorResponseWriter, r *http.Req
 		return
 	}
 
-	userID, err := GetUserID(r)
+	userID, err := getUserIDOrAgentUser(r)
 	if err != nil {
 		w.RespondWithError(errors.NewBadRequestError("Failed to get user ID", err))
 		return
@@ -168,7 +168,7 @@ func (h *SessionsHandler) HandleGetSession(w ErrorResponseWriter, r *http.Reques
 	}
 	log = log.WithValues("session_id", sessionID)
 
-	userID, err := GetUserID(r)
+	userID, err := getUserIDOrAgentUser(r)
 	if err != nil {
 		w.RespondWithError(errors.NewBadRequestError("Failed to get user ID", err))
 		return
@@ -398,9 +398,34 @@ func getUserID(r *http.Request) (string, error) {
 	userID := r.URL.Query().Get("user_id")
 	if userID == "" {
 		log.Info("Missing user_id parameter in request")
+	}
+
+	// if not in query param, check header
+	if userID == "" {
+		userID = r.Header.Get("X-User-ID")
+	}
+	if userID == "" {
+		log.Info("Missing X-User-ID header in request")
 		return "", fmt.Errorf("user_id is required")
 	}
 
 	log.V(2).Info("Retrieved user_id from request", "userID", userID)
 	return userID, nil
+}
+
+func getUserIDOrAgentUser(r *http.Request) (string, error) {
+
+	principal, err := GetPrincipal(r)
+	if err != nil {
+		return "", err
+	}
+
+	if principal.User.ID != "" {
+		return principal.User.ID, nil
+	} else if principal.Agent.ID != "" {
+		// grab the user id from the query param
+		return getUserID(r)
+
+	}
+	return "", fmt.Errorf("no user or agent in principal")
 }

--- a/python/packages/kagent-adk/src/kagent/adk/_session_service.py
+++ b/python/packages/kagent-adk/src/kagent/adk/_session_service.py
@@ -24,10 +24,6 @@ class KAgentSessionService(BaseSessionService):
         super().__init__()
         self.client = client
 
-    async def _get_user_id(self) -> str:
-        """Get the default user ID. Override this method to implement custom user ID logic."""
-        return "admin@kagent.dev"
-
     @override
     async def create_session(
         self,


### PR DESCRIPTION
get userid from query param if agent creates a session.

note - in the future we may want to create the session for the agent internally instead of having the agent call create_session.