### PR TITLE
Fix UI/streaming timeouts for long running LLM requests

### DIFF
--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -72,7 +72,7 @@ controller:
   streaming: # Streaming buffer size for A2A communication
     maxBufSize: 1Mi # 1024 * 1024
     initialBufSize: 4Ki # 4 * 1024
-    timeout: 60s # 60 seconds
+    timeout: 600s # 600 seconds
   # -- Namespaces the controller should watch.
   # If empty, the controller will watch ALL available namespaces.
   # @default -- [] (watches all available namespaces)

--- a/ui/src/components/chat/ChatInterface.tsx
+++ b/ui/src/components/chat/ChatInterface.tsx
@@ -247,7 +247,7 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
           }
         };
 
-        // Start timeout timer 
+        // Start timeout timer
         const startTimeout = () => {
           if (timeoutTimer) clearTimeout(timeoutTimer);
           timeoutTimer = setTimeout(handleTimeout, streamTimeout);

--- a/ui/src/components/chat/ChatInterface.tsx
+++ b/ui/src/components/chat/ChatInterface.tsx
@@ -225,32 +225,57 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
           message: a2aMessage,
           metadata: {}
         };
-        const stream = await kagentA2AClient.sendMessageStream(selectedNamespace, selectedAgentName, sendParams);
+        const stream = await kagentA2AClient.sendMessageStream(
+          selectedNamespace,
+          selectedAgentName,
+          sendParams,
+          abortControllerRef.current?.signal
+        );
 
         let lastEventTime = Date.now();
-        const streamTimeout = 60000;
-
-        for await (const event of stream) {
-          lastEventTime = Date.now();
-
-          try {
-            handleMessageEvent(event);
-          } catch (error) {
-            console.error("❌ Event that caused error:", event);
+        let timeoutTimer: NodeJS.Timeout | null = null;
+        let streamActive = true;
+        const streamTimeout = 600000; // 10 minutes
+        
+        // Timeout handler
+        const handleTimeout = () => {
+          if (streamActive) {
+            console.error("⏰ Stream timeout - no events received for 10 minutes");
+            toast.error("⏰ Stream timed out - no events received for 10 minutes");
+            streamActive = false;
+            if (abortControllerRef.current) abortControllerRef.current.abort();
           }
+        };
 
-          // Check if we should stop streaming due to cancellation
-          if (abortControllerRef.current?.signal.aborted) {
-            break;
-          }
+        // Start timeout timer 
+        const startTimeout = () => {
+          if (timeoutTimer) clearTimeout(timeoutTimer);
+          timeoutTimer = setTimeout(handleTimeout, streamTimeout);
+        };
+        startTimeout();
 
-          // Timeout check (in case stream hangs)
-          if (Date.now() - lastEventTime > streamTimeout) {
-            console.warn("⏰ Stream timeout - no events received for 30 seconds");
-            break;
+        try {
+          for await (const event of stream) {
+            lastEventTime = Date.now();
+            startTimeout(); // Reset timeout after every event
+
+            try {
+              handleMessageEvent(event);
+            } catch (error) {
+              console.error("❌ Event that caused error:", event);
+            }
+
+            // Check if we should stop streaming due to cancellation
+            if (abortControllerRef.current?.signal.aborted) {
+              console.info("Stream aborted");
+              streamActive = false;
+              break;
+            }
           }
+        } finally {
+          streamActive = false;
+          if (timeoutTimer) clearTimeout(timeoutTimer);
         }
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } catch (error: any) {
         if (error.name === "AbortError") {
           toast.info("Request cancelled");

--- a/ui/src/lib/a2aClient.ts
+++ b/ui/src/lib/a2aClient.ts
@@ -38,15 +38,17 @@ export class KagentA2AClient {
 
   /**
    * Send a streaming message using the A2A protocol via Next.js API route
+   * Accepts an optional AbortSignal for cancellation support
    */
   async sendMessageStream(
-    namespace: string, 
-    agentName: string, 
-    params: MessageSendParams
+    namespace: string,
+    agentName: string,
+    params: MessageSendParams,
+    signal?: AbortSignal
   ): Promise<AsyncIterable<any>> {
     const request = this.createStreamingRequest(params);
-    // This redirects to the Next.js API route 
-    // Note that this route CAN'T be the same 
+    // This redirects to the Next.js API route
+    // Note that this route CAN'T be the same
     // as the routes on the backend.
     const proxyUrl = `/a2a/${namespace}/${agentName}`;
 
@@ -57,6 +59,7 @@ export class KagentA2AClient {
         'Accept': 'text/event-stream',
       },
       body: JSON.stringify(request),
+      signal,
     });
 
     if (!response.ok) {
@@ -102,11 +105,11 @@ export class KagentA2AClient {
             for (const line of lines) {
               if (line.startsWith('data: ')) {
                 const dataString = line.substring(6);
-                
+
                 if (dataString === '[DONE]') {
                   return;
                 }
-                
+
                 try {
                   const eventData = JSON.parse(dataString);
                   yield eventData.result || eventData;


### PR DESCRIPTION
Whilst API interaction with Agents may use a streaming connection the agents themselves [do not use streaming](https://github.com/kagent-dev/kagent/blob/5c99583b505cbc205bcf1503ffdb1b241abf08c9/python/packages/kagent-adk/src/kagent/adk/converters/request_converter.py#L32) when communicating with the model .Thus, if a model takes longer than 60s to run (looking at you `gpt-5`) then things start timing out. 

This PR:
- increases the default timeout on the A2A streaming connections in the controller to 10mins (this is a thumbsuck number and was chosen to match the [default timeout](https://github.com/google/adk-python/blame/main/src/google/adk/agents/remote_a2a_agent.py#L86) used by Google on non-streaming `RemoteA2AAgent` calls)
- adds a keep-alive implementation to the UI A2A proxy to prevent the streaming connection from being closed prematurely
- fixes the streaming timeout in the UI client-side code (again using 10 minutes before timing out)

Closes #869

Potentially also related to/resolves #892?