### PR TITLE
chore: bump query doc image tag 

### DIFF
--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -235,7 +235,7 @@ querydoc:
   image:
     registry: ghcr.io
     repository: kagent-dev/doc2vec/mcp
-    tag: 1.1.12
+    tag: 1.1.13
     pullPolicy: IfNotPresent
   resources:
     requests:


### PR DESCRIPTION
Bumps query doc image tag to `1.1.13` which includes a fix to properly handle multiple concurrent sessions. Tested locally in my kind cluster.