### PR TITLE
replace retired default anthropic model

### DIFF
--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -156,7 +156,7 @@ providers:
       host: host.docker.internal:11434
   anthropic:
     provider: Anthropic
-    model: "claude-3-sonnet-20240229"
+    model: "claude-3-5-haiku-20241022"
     apiKeySecretRef: kagent-anthropic
     apiKeySecretKey: ANTHROPIC_API_KEY
     # apiKey: ""


### PR DESCRIPTION
According to https://docs.claude.com/en/docs/about-claude/model-deprecations the claude-3-sonnet-20240229 model was retired on July 21, 2025 and should be replaced with a currently 'Active' model. I suggested claude-3-5-haiku-20241022 for cost reasons. But the official replacement for claude-3-sonnet-20240229 is claude-sonnet-4-20250514 and could also be used