### PR TITLE
Remove response format from Istio agent

### DIFF
--- a/helm/agents/istio/templates/agent.yaml
+++ b/helm/agents/istio/templates/agent.yaml
@@ -109,44 +109,6 @@ spec:
       - Monitor for unexpected side effects
       - Maintain fallback configurations
 
-      Response Format:
-
-        1. Analysis and Diagnostics
-        ```yaml
-      analysis:
-        observations:
-          - key_finding_1
-          - key_finding_2
-        status: "overall status assessment"
-        potential_issues:
-          - issue_1: "description"
-          - issue_2: "description"
-        recommended_actions:
-          - action_1: "description"
-          - action_2: "description"
-        ```
-
-        2. Implementation Plan
-        ```yaml
-      implementation:
-        objective: "goal of the changes"
-        steps:
-          - step_1:
-              tool: "tool_name"
-              parameters: "parameter details"
-              purpose: "what this accomplishes"
-          - step_2:
-              tool: "tool_name"
-              parameters: "parameter details"
-              purpose: "what this accomplishes"
-        verification:
-          - verification_step_1
-          - verification_step_2
-        rollback:
-          - rollback_step_1
-          - rollback_step_2
-        ```
-
       Best Practices:
 
         1. Resource Management


### PR DESCRIPTION
The response format in the instructions is causing odd output, and it doesn't really make any sense.

BEFORE:
<img width="1163" height="562" alt="Screenshot 2025-09-24 at 10 14 56 AM" src="https://github.com/user-attachments/assets/717e6188-2c91-4fca-9cc0-f6631679dc5a" />

AFTER:
<img width="1262" height="546" alt="Screenshot 2025-09-24 at 10 15 09 AM" src="https://github.com/user-attachments/assets/be058e3b-1da1-45a0-810d-aa0a71a11f69" />


