### PR TITLE
fix: add cilium binary to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,3 +207,4 @@ go/bin/
 /contrib/memory/doc2vec/bun.lock
 
 .cursor/
+cilium-linux-amd64.tar.gz


### PR DESCRIPTION
This PR updates the local development documentation to include essential prerequisites for running agents, specifically the cilium-debug-agent. New contributors may encounter errors where agents fail to interact with their target services (e.g., Cilium pods) if the local environment is not fully configured.

This was discovered when troubleshooting issue #921, where cilium-debug-agent failed with a jsonpath: array index out of bounds error because the Cilium CNI was not installed.

Which issue(s) this PR fixes:

Fixes #921

Changes proposed in this PR:

Adds a section to DEVELOPMENT.md detailing the need to have a CNI like Cilium installed in the local cluster.

Includes a step to ensure required kagent Docker images are built and loaded into the local cluster's registry.

Adds a reminder to create necessary secrets, such as kagent-openai, before deploying agents.

By adding these steps, we can provide a smoother onboarding experience for new developers and prevent common environment-related errors.