### PR TITLE
bugfix: fix comparison of agent ids

### DIFF
--- a/go/internal/httpserver/handlers/sessions.go
+++ b/go/internal/httpserver/handlers/sessions.go
@@ -372,7 +372,7 @@ func (h *SessionsHandler) HandleAddEventToSession(w ErrorResponseWriter, r *http
 		return
 	}
 
-	if session.AgentID != nil && *session.AgentID != principal.Agent.ID {
+	if session.AgentID != nil && *session.AgentID != utils.ConvertToPythonIdentifier(principal.Agent.ID) {
 		w.RespondWithError(errors.NewForbiddenError("Session does not belong to this agent", nil))
 		return
 	}


### PR DESCRIPTION
Agent id `agent/ns` that is stored in a session is represented as `agent__NS__ns`. Whereas the same id is represented as `agent/ns` when it comes from the Principal. A check comparing expected agent id vs. current thus always fails.

This PR fixes the issue by normalizing the agent id format before the check to the one used when persisting the id in a db.  
