### PR TITLE
chore: fix typo in module docstring

### DIFF
--- a/python/packages/kagent-adk/src/kagent/adk/converters/part_converter.py
+++ b/python/packages/kagent-adk/src/kagent/adk/converters/part_converter.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-module containing utilities for conversion betwen A2A Part and Google GenAI Part
+module containing utilities for conversion between A2A Part and Google GenAI Part
 """
 
 from __future__ import annotations


### PR DESCRIPTION
This pull request contains a minor documentation fix in the `part_converter.py` module. The change corrects a spelling error in the module docstring to improve clarity.