### PR TITLE
fix(version): print out version regardless of port-forwarding; pass through contexts 

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -13,6 +13,12 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+default: help
+
+.PHONY: help
+help: ## list makefile targets
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
 ##@ Development
 
 .PHONY: manifests

--- a/go/cli/internal/cli/agent/invoke.go
+++ b/go/cli/internal/cli/agent/invoke.go
@@ -24,10 +24,9 @@ type InvokeCfg struct {
 }
 
 func InvokeCmd(ctx context.Context, cfg *InvokeCfg) {
-
 	clientSet := cfg.Config.Client()
 
-	if err := CheckServerConnection(clientSet); err != nil {
+	if err := CheckServerConnection(ctx, clientSet); err != nil {
 		// If a connection does not exist, start a short-lived port-forward.
 		pf, err := NewPortForward(ctx, cfg.Config)
 		if err != nil {

--- a/go/cli/internal/cli/agent/utils.go
+++ b/go/cli/internal/cli/agent/utils.go
@@ -16,13 +16,13 @@ var (
 	ErrServerConnection = fmt.Errorf("error connecting to server. Please run 'install' command first")
 )
 
-func CheckServerConnection(client *client.ClientSet) error {
+func CheckServerConnection(ctx context.Context, client *client.ClientSet) error {
 	// Only check if we have a valid client
 	if client == nil {
 		return ErrServerConnection
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	ctx, cancel := context.WithTimeout(ctx, time.Second*5)
 	defer cancel()
 	_, err := client.Version.GetVersion(ctx)
 	if err != nil {
@@ -50,7 +50,7 @@ func NewPortForward(ctx context.Context, cfg *config.Config) (*PortForward, erro
 	client := cfg.Client()
 	var err error
 	for i := 0; i < 10; i++ {
-		err = CheckServerConnection(client)
+		err = CheckServerConnection(ctx, client)
 		if err == nil {
 			// Connection successful, port-forward is working
 			return &PortForward{


### PR DESCRIPTION
This PR prints out the `kagent` version even if a port-forwarding to the `kagent` server fails. In case the port-forwarding does not succeed, the unavailable versions will be marked as `<unknown>`:

Fixes: https://github.com/kagent-dev/kagent/issues/868
Related to: https://github.com/kagent-dev/kagent/pull/879
```sh
> go run cli/cmd/kagent/main.go version
Error starting port-forward: failed to establish connection to kagent-controller. error connecting to server. Please run 'install' command first
{"backend_version":"unknown","build_date":"unknown","git_commit":"none","kagent_version":"dev"}
```

~~**Note:** We might can consider removing the error message as it breaks the `json` output ...~~


Furthermore: 
- This PR uses `cmd.Context()` consistently throughout all `kagent` subcommands.
- It adds a `help` Makefile target for a neat list of available Makefile targets

```sh
> make
controller-gen                 Download controller-gen locally if necessary.
envtest                        Download setup-envtest locally if necessary.
fmt                            Run go fmt against code.
generate                       Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
golangci-lint                  Download golangci-lint locally if necessary.
help                           list makefile targets
lint-config                    Verify golangci-lint linter configuration
lint-fix                       Run golangci-lint linter and perform fixes
lint                           Run golangci-lint linter
manifests                      Generate ClusterRole and CustomResourceDefinition objects.
run                            Run a controller from your host.
setup-envtest                  Download the binaries required for ENVTEST in the local bin directory.
vet                            Run go vet against code.
```