### PR TITLE
 Dashboard namespace empty and backend connectivity issues

### DIFF
--- a/go/cli/cmd/kagent/main.go
+++ b/go/cli/cmd/kagent/main.go
@@ -31,7 +31,18 @@ func main() {
 
 		cancel()
 	}()
+	
+	// Initialize config first to load from file
+	if err := config.Init(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error initializing config: %v\n", err)
+		os.Exit(1)
+	}
+	
+	// Load config from file
 	cfg := &config.Config{}
+	if fileCfg, err := config.Get(); err == nil && fileCfg != nil {
+		cfg = fileCfg
+	}
 
 	rootCmd := &cobra.Command{
 		Use:   "kagent",
@@ -327,12 +338,6 @@ Examples:
 	deployCmd.Flags().StringVar(&deployCfg.Config.Namespace, "namespace", "", "Kubernetes namespace to deploy to")
 
 	rootCmd.AddCommand(installCmd, uninstallCmd, invokeCmd, bugReportCmd, versionCmd, dashboardCmd, getCmd, initCmd, buildCmd, deployCmd)
-
-	// Initialize config
-	if err := config.Init(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error initializing config: %v\n", err)
-		os.Exit(1)
-	}
 
 	if err := rootCmd.ExecuteContext(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)

--- a/helm/kagent/templates/ui-deployment.yaml
+++ b/helm/kagent/templates/ui-deployment.yaml
@@ -42,7 +42,7 @@ spec:
           imagePullPolicy: {{ .Values.ui.image.pullPolicy | default .Values.imagePullPolicy }}
           env:
             - name: NEXT_PUBLIC_BACKEND_URL
-              value: "http://{{ include "kagent.fullname" . }}-controller.{{ include "kagent.namespace" . }}.svc.cluster.local:{{ .Values.controller.service.ports.port }}/api"
+              value: "http://{{ include "kagent.fullname" . }}-controller:{{ .Values.controller.service.ports.port }}/api"
             {{- with .Values.ui.env }}
               {{- toYaml . | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
While using Kagent, I noticed that although Kagent was installed correctly in the kagent namespace and my CLI config had the correct namespace set, running kagent dashboard showed the namespace dropdown as empty and the dashboard failed to display agents and models.

Root Cause
After investigation, the issue boiled down to two key problems:

CLI Configuration Initialization
The CLI code was not loading the configuration file (~/.kagent/config.yaml) before parsing command-line flags. This caused it to ignore the configured namespace and other settings, leading to the dashboard commands querying the wrong or no namespace, resulting in empty namespace displays.

UI Backend Connectivity and DNS Resolution
The dashboard UI tried to talk to the backend controller using the controller’s full DNS name (e.g., kagent-controller.kagent.svc.cluster.local). However, DNS resolution for this full name failed inside the UI container due to cluster DNS issues, causing errors when fetching models and agents, and resulting in HTTP 500 errors on the UI side.

Changes Made
To fix these issues, I made the following changes:

Fix CLI Config Loading Order
Modified the CLI’s main function to initialize the config file before processing CLI flags. This ensures the CLI properly respects the namespace and all other user-configured settings.

Update Helm UI Deployment Template
Changed the UI’s backend URL environment variable in the Helm chart from using the full DNS name to using the short Kubernetes service name (kagent-controller).
This leverages Kubernetes’ built-in DNS search domains that reliably resolve short names within the same namespace, avoiding DNS resolution failures.

Impact
These fixes make sure the dashboard properly displays the configured namespace, and the UI correctly fetches and displays agents and models without errors or empty      

                                                                                                                 
<img width="1916" height="1074" alt="Screenshot from 2025-10-01 23-57-28" src="https://github.com/user-attachments/assets/0091b958-e58f-4445-8939-95aabdf99826" />

If the namespace were empty or not being read correctly, you would see a blank dashboard with no agents or models listed. 