### PR TITLE
Make mcp.TranslatorPlugin type public

### DIFF
--- a/go/internal/controller/translator/mcp/translator_adapter.go
+++ b/go/internal/controller/translator/mcp/translator_adapter.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/kagent-dev/kagent/go/api/v1alpha1"
 	"github.com/kagent-dev/kagent/go/internal/controller/translator/labels"
+	"github.com/kagent-dev/kagent/go/pkg/mcp_translator"
 )
 
 const (
@@ -39,11 +40,7 @@ type Translator interface {
 	) ([]client.Object, error)
 }
 
-type TranslatorPlugin func(
-	ctx context.Context,
-	server *v1alpha1.MCPServer,
-	objects []client.Object,
-) ([]client.Object, error)
+type TranslatorPlugin = mcp_translator.TranslatorPlugin
 
 type transportAdapterTranslator struct {
 	scheme  *runtime.Scheme

--- a/go/pkg/mcp_translator/mcp_translator_types.go
+++ b/go/pkg/mcp_translator/mcp_translator_types.go
@@ -1,0 +1,14 @@
+package mcp_translator
+
+import (
+	"context"
+
+	"github.com/kagent-dev/kagent/go/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type TranslatorPlugin func(
+	ctx context.Context,
+	server *v1alpha1.MCPServer,
+	objects []client.Object,
+) ([]client.Object, error)


### PR DESCRIPTION
A small fix to make mcp.TranslatorPlugin type public