### PR TITLE
Fix AnyUrl serialization issue in MCP tool calls

### DIFF
--- a/python/packages/kagent-adk/pyproject.toml
+++ b/python/packages/kagent-adk/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "pydantic>=2.5.0",
   "typing-extensions>=4.8.0",
   "jsonref>=1.1.0",
-  "a2a-sdk>=0.3.1",
+  "a2a-sdk>=0.3.7",
 ]
 
 [tool.uv.sources]

--- a/python/packages/kagent-adk/src/kagent/adk/_a2a.py
+++ b/python/packages/kagent-adk/src/kagent/adk/_a2a.py
@@ -132,5 +132,5 @@ class KAgentApp:
             # print(f"  [Event] Author: {event.author}, Type: {type(event).__name__}, Final: {event.is_final_response()}, Content: {event.content}")
 
             # Key Concept: is_final_response() marks the concluding message for the turn.
-            jsn = event.model_dump_json()
+            jsn = event.model_dump(mode="json")
             logger.info(f"  [Event] {jsn}")

--- a/python/packages/kagent-adk/src/kagent/adk/_session_service.py
+++ b/python/packages/kagent-adk/src/kagent/adk/_session_service.py
@@ -152,7 +152,7 @@ class KAgentSessionService(BaseSessionService):
         # Convert ADK Event to JSON format
         event_data = {
             "id": event.id,
-            "data": event.model_dump_json(),
+            "data": event.model_dump(mode="json"),
         }
 
         # Make API call to append event to session

--- a/python/packages/kagent-core/src/kagent/core/a2a/_task_store.py
+++ b/python/packages/kagent-core/src/kagent/core/a2a/_task_store.py
@@ -28,7 +28,7 @@ class KAgentTaskStore(TaskStore):
         Raises:
             httpx.HTTPStatusError: If the API request fails
         """
-        response = await self.client.post("/api/tasks", json=task.model_dump())
+        response = await self.client.post("/api/tasks", json=task.model_dump(mode="json"))
         response.raise_for_status()
 
     @override

--- a/python/packages/kagent-langgraph/src/kagent/langgraph/_checkpointer.py
+++ b/python/packages/kagent-langgraph/src/kagent/langgraph/_checkpointer.py
@@ -163,7 +163,7 @@ class KAgentCheckpointer(BaseCheckpointSaver[str]):
         # Call the Go service
         response = await self.client.post(
             "/api/langgraph/checkpoints",
-            json=request_data.model_dump(),
+            json=request_data.model_dump(mode="json"),
             headers={"X-User-ID": user_id},
         )
         response.raise_for_status()
@@ -216,7 +216,7 @@ class KAgentCheckpointer(BaseCheckpointSaver[str]):
 
         response = await self.client.post(
             "/api/langgraph/checkpoints/writes",
-            json=request_data.model_dump(),
+            json=request_data.model_dump(mode="json"),
             headers={"X-User-ID": user_id},
         )
         response.raise_for_status()

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -24,7 +24,7 @@ dev = [
 
 [[package]]
 name = "a2a-sdk"
-version = "0.3.3"
+version = "0.3.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core" },
@@ -33,9 +33,9 @@ dependencies = [
     { name = "protobuf" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f0/33/25ddb456829784575b5c693699162f7fa930d90a82e16fefaa53d8a02154/a2a_sdk-0.3.3.tar.gz", hash = "sha256:d32426a819d3305116d24e938787b0028c4240df862e7fc2c7bf039def0d60e2", size = 219695, upload-time = "2025-08-25T18:32:09.8Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/ad/b6ecb58f44459a24f1c260e91304e1ddbb7a8e213f1f82cc4c074f66e9bb/a2a_sdk-0.3.7.tar.gz", hash = "sha256:795aa2bd2cfb3c9e8654a1352bf5f75d6cf1205b262b1bf8f4003b5308267ea2", size = 223426, upload-time = "2025-09-23T16:27:29.585Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/cb/03315694ea2f9536c796767da0a1dd6d0b7c48df4badbab19c2c9c570741/a2a_sdk-0.3.3-py3-none-any.whl", hash = "sha256:d433c7f13a7a4b426e3aef798f9ef6eff0d3aea68c9a595634af865111b5c7c2", size = 135159, upload-time = "2025-08-25T18:32:08.18Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/27/9cf8c6de4ae71e9c98ec96b3304449d5d0cd36ec3b95e66b6e7f58a9e571/a2a_sdk-0.3.7-py3-none-any.whl", hash = "sha256:0813b8fd7add427b2b56895cf28cae705303cf6d671b305c0aac69987816e03e", size = 137957, upload-time = "2025-09-23T16:27:27.546Z" },
 ]
 
 [[package]]
@@ -1736,7 +1736,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "a2a-sdk", specifier = ">=0.3.1" },
+    { name = "a2a-sdk", specifier = ">=0.3.7" },
     { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "anthropic", extras = ["vertex"], specifier = ">=0.49.0" },
     { name = "anyio", specifier = ">=4.9.0" },


### PR DESCRIPTION
When using GitHub MCP tools like get_file_contents, the agent crashes with:
```

TypeError: Object of type AnyUrl is not JSON serializable

```
This happens because Pydantic's AnyUrl type needs special handling for JSON serialization.so i added mode="json" parameter to all model_dump() calls in the a2a framework and Updated a2a-sdk to v0.3.7 for compatibility

fixes #976 