### PR TITLE
fix: show nested agent tool calls with visual hierarchy

### DIFF
--- a/ui/src/components/chat/AgentCallDisplay.tsx
+++ b/ui/src/components/chat/AgentCallDisplay.tsx
@@ -1,11 +1,27 @@
 import { useMemo, useState } from "react";
 import { FunctionCall } from "@/types";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
-import { convertToUserFriendlyName } from "@/lib/utils";
+import { convertToUserFriendlyName, isAgentToolName } from "@/lib/utils";
 import { ChevronDown, ChevronUp, MessageSquare, Loader2, AlertCircle, CheckCircle } from "lucide-react";
 import KagentLogo from "../kagent-logo";
+import ToolDisplay, { ToolCallStatus } from "@/components/ToolDisplay";
 
 export type AgentCallStatus = "requested" | "executing" | "completed";
+
+// Constants
+const MAX_NESTING_DEPTH = 10;
+const NESTING_INDENT_REM = 1.5;
+
+interface NestedToolCall {
+  id: string;
+  call: FunctionCall;
+  result?: {
+    content: string;
+    is_error?: boolean;
+  };
+  status: ToolCallStatus;
+  nestedCalls?: NestedToolCall[];
+}
 
 interface AgentCallDisplayProps {
   call: FunctionCall;
@@ -15,14 +31,31 @@ interface AgentCallDisplayProps {
   };
   status?: AgentCallStatus;
   isError?: boolean;
+  nestedCalls?: NestedToolCall[]; // Support for nested agent/tool calls
+  depth?: number; // Track nesting depth for visual indentation
 }
 
-const AgentCallDisplay = ({ call, result, status = "requested", isError = false }: AgentCallDisplayProps) => {
+const AgentCallDisplay = ({ call, result, status = "requested", isError = false, nestedCalls = [], depth = 0 }: AgentCallDisplayProps) => {
   const [areInputsExpanded, setAreInputsExpanded] = useState(false);
   const [areResultsExpanded, setAreResultsExpanded] = useState(false);
+  const [areNestedCallsExpanded, setAreNestedCallsExpanded] = useState(true); // Expanded by default for better visibility
 
   const agentDisplay = useMemo(() => convertToUserFriendlyName(call.name), [call.name]);
   const hasResult = result !== undefined;
+  const hasNestedCalls = nestedCalls && nestedCalls.length > 0;
+
+  // Protection against infinite recursion
+  if (depth > MAX_NESTING_DEPTH) {
+    console.warn(`Maximum nesting depth (${MAX_NESTING_DEPTH}) reached for agent call:`, call.name);
+    return (
+      <div className="p-2 text-xs text-muted-foreground border border-yellow-500 rounded">
+        ⚠️ Maximum nesting depth reached
+      </div>
+    );
+  }
+
+  // Calculate left margin based on nesting depth
+  const marginLeft = depth > 0 ? `${depth * NESTING_INDENT_REM}rem` : '0';
 
   const getStatusDisplay = () => {
     if (isError && status === "executing") {
@@ -69,59 +102,100 @@ const AgentCallDisplay = ({ call, result, status = "requested", isError = false 
   };
 
   return (
-    <Card className={`w-full mx-auto my-1 min-w-full ${isError ? 'border-red-300' : ''}`}>
-      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-xs flex space-x-5">
-          <div className="flex items-center font-medium">
-            <KagentLogo className="w-4 h-4 mr-2" />
-            {agentDisplay}
+    <div style={{ marginLeft }}>
+      <Card className={`w-full mx-auto my-1 min-w-full ${isError ? 'border-red-300' : ''} ${depth > 0 ? 'border-l-4 border-l-blue-400' : ''}`}>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-xs flex space-x-5">
+            <div className="flex items-center font-medium">
+              <KagentLogo className="w-4 h-4 mr-2" />
+              {agentDisplay}
+              {depth > 0 && <span className="ml-2 text-xs text-muted-foreground">(nested level {depth})</span>}
+            </div>
+            <div className="font-light">{call.id}</div>
+          </CardTitle>
+          <div className="flex justify-center items-center text-xs">
+            {getStatusDisplay()}
           </div>
-          <div className="font-light">{call.id}</div>
-        </CardTitle>
-        <div className="flex justify-center items-center text-xs">
-          {getStatusDisplay()}
-        </div>
-      </CardHeader>
-      <CardContent>
-        <div className="space-y-2 mt-2">
-          <button className="text-xs flex items-center gap-2" onClick={() => setAreInputsExpanded(!areInputsExpanded)}>
-            <MessageSquare className="w-4 h-4" />
-            <span>Input</span>
-            {areInputsExpanded ? <ChevronUp className="w-4 h-4 ml-1" /> : <ChevronDown className="w-4 h-4 ml-1" />}
-          </button>
-          {areInputsExpanded && (
-            <div className="mt-2 bg-muted/50 p-3 rounded">
-              <pre className="text-sm whitespace-pre-wrap break-words">{JSON.stringify(call.args, null, 2)}</pre>
-            </div>
-          )}
-        </div>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2 mt-2">
+            <button className="text-xs flex items-center gap-2" onClick={() => setAreInputsExpanded(!areInputsExpanded)}>
+              <MessageSquare className="w-4 h-4" />
+              <span>Input</span>
+              {areInputsExpanded ? <ChevronUp className="w-4 h-4 ml-1" /> : <ChevronDown className="w-4 h-4 ml-1" />}
+            </button>
+            {areInputsExpanded && (
+              <div className="mt-2 bg-muted/50 p-3 rounded">
+                <pre className="text-sm whitespace-pre-wrap break-words">{JSON.stringify(call.args, null, 2)}</pre>
+              </div>
+            )}
+          </div>
 
-        <div className="mt-4 w-full">
-          {status === "executing" && !hasResult && (
-            <div className="flex items-center gap-2 py-2">
-              <Loader2 className="h-4 w-4 animate-spin" />
-              <span className="text-sm">{agentDisplay} is responding...</span>
-            </div>
-          )}
-          {hasResult && result?.content && (
-            <div className="space-y-2">
-              <button className="text-xs flex items-center gap-2" onClick={() => setAreResultsExpanded(!areResultsExpanded)}>
-                <MessageSquare className="w-4 h-4" />
-                <span>Output</span>
-                {areResultsExpanded ? <ChevronUp className="w-4 h-4 ml-1" /> : <ChevronDown className="w-4 h-4 ml-1" />}
+          <div className="mt-4 w-full">
+            {status === "executing" && !hasResult && (
+              <div className="flex items-center gap-2 py-2">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                <span className="text-sm">{agentDisplay} is responding...</span>
+              </div>
+            )}
+            {hasResult && result?.content && (
+              <div className="space-y-2">
+                <button className="text-xs flex items-center gap-2" onClick={() => setAreResultsExpanded(!areResultsExpanded)}>
+                  <MessageSquare className="w-4 h-4" />
+                  <span>Output</span>
+                  {areResultsExpanded ? <ChevronUp className="w-4 h-4 ml-1" /> : <ChevronDown className="w-4 h-4 ml-1" />}
+                </button>
+                {areResultsExpanded && (
+                  <div className={`mt-2 ${isError ? 'bg-red-50 dark:bg-red-950/10' : 'bg-muted/50'} p-3 rounded`}>
+                    <pre className={`text-sm whitespace-pre-wrap break-words ${isError ? 'text-red-600 dark:text-red-400' : ''}`}>
+                      {result?.content}
+                    </pre>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+
+          {/* Nested agent/tool calls section */}
+          {hasNestedCalls && (
+            <div className="mt-4 border-t pt-4">
+              <button
+                className="text-xs flex items-center gap-2 font-semibold mb-2"
+                onClick={() => setAreNestedCallsExpanded(!areNestedCallsExpanded)}
+              >
+                <span>Delegated Calls ({nestedCalls.length})</span>
+                {areNestedCallsExpanded ? <ChevronUp className="w-4 h-4 ml-1" /> : <ChevronDown className="w-4 h-4 ml-1" />}
               </button>
-              {areResultsExpanded && (
-                <div className={`mt-2 ${isError ? 'bg-red-50 dark:bg-red-950/10' : 'bg-muted/50'} p-3 rounded`}>
-                  <pre className={`text-sm whitespace-pre-wrap break-words ${isError ? 'text-red-600 dark:text-red-400' : ''}`}>
-                    {result?.content}
-                  </pre>
+              {areNestedCallsExpanded && (
+                <div className="space-y-2 mt-2">
+                  {nestedCalls.map((nestedCall) => (
+                    isAgentToolName(nestedCall.call.name) ? (
+                      <AgentCallDisplay
+                        key={nestedCall.id}
+                        call={nestedCall.call}
+                        result={nestedCall.result}
+                        status={nestedCall.status}
+                        isError={nestedCall.result?.is_error}
+                        nestedCalls={nestedCall.nestedCalls}
+                        depth={depth + 1}
+                      />
+                    ) : (
+                      <ToolDisplay
+                        key={nestedCall.id}
+                        call={nestedCall.call}
+                        result={nestedCall.result}
+                        status={nestedCall.status}
+                        isError={nestedCall.result?.is_error}
+                      />
+                    )
+                  ))}
                 </div>
               )}
             </div>
           )}
-        </div>
-      </CardContent>
-    </Card>
+        </CardContent>
+      </Card>
+    </div>
   );
 };
 

--- a/ui/src/components/chat/ToolCallDisplay.tsx
+++ b/ui/src/components/chat/ToolCallDisplay.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import { Message, TextPart } from "@a2a-js/sdk";
 import ToolDisplay, { ToolCallStatus } from "@/components/ToolDisplay";
 import AgentCallDisplay from "@/components/chat/AgentCallDisplay";
@@ -19,6 +19,7 @@ interface ToolCallState {
     is_error?: boolean;
   };
   status: ToolCallStatus;
+  nestedCalls?: ToolCallState[]; // Track nested agent calls
 }
 
 // Create a global cache to track tool calls across components
@@ -163,28 +164,34 @@ const ToolCallDisplay = ({ currentMessage, allMessages }: ToolCallDisplayProps) 
     };
   }, [currentMessage]);
 
-  useEffect(() => {
+  // Memoize the expensive nested call building operation
+  const processedToolCalls = useMemo(() => {
     if (ownedCallIds.size === 0) {
-      // If the component doesn't own any call IDs, ensure toolCalls is empty and return.
-      if (toolCalls.size > 0) {
-        setToolCalls(new Map());
-      }
-      return;
+      return new Map<string, ToolCallState>();
     }
 
-    const newToolCalls = new Map<string, ToolCallState>();
+    try {
+      const newToolCalls = new Map<string, ToolCallState>();
+      const allToolCallsMap = new Map<string, ToolCallState>(); // Track ALL tool calls for nesting
 
-    // First pass: collect all tool call requests that this component owns
+    // First pass: collect all tool call requests (both owned and nested)
     for (const message of allMessages) {
       if (isToolCallRequestMessage(message)) {
         const requests = extractToolCallRequests(message);
         for (const request of requests) {
-          if (request.id && ownedCallIds.has(request.id)) {
-            newToolCalls.set(request.id, {
+          if (request.id) {
+            const toolCallState: ToolCallState = {
               id: request.id,
               call: request,
-              status: "requested"
-            });
+              status: "requested",
+              nestedCalls: []
+            };
+
+            allToolCallsMap.set(request.id, toolCallState);
+
+            if (ownedCallIds.has(request.id)) {
+              newToolCalls.set(request.id, toolCallState);
+            }
           }
         }
       }
@@ -195,8 +202,8 @@ const ToolCallDisplay = ({ currentMessage, allMessages }: ToolCallDisplayProps) 
       if (isToolCallExecutionMessage(message)) {
         const results = extractToolCallResults(message);
         for (const result of results) {
-          if (result.call_id && newToolCalls.has(result.call_id)) {
-            const existingCall = newToolCalls.get(result.call_id)!;
+          if (result.call_id && allToolCallsMap.has(result.call_id)) {
+            const existingCall = allToolCallsMap.get(result.call_id)!;
             existingCall.result = {
               content: result.content,
               is_error: result.is_error
@@ -217,26 +224,94 @@ const ToolCallDisplay = ({ currentMessage, allMessages }: ToolCallDisplayProps) 
     }
 
     if (summaryMessageEncountered) {
-      newToolCalls.forEach((call, id) => {
-        // Only update owned calls that are in 'executing' state and have a result
-        if (call.status === "executing" && call.result && ownedCallIds.has(id)) {
+      allToolCallsMap.forEach((call) => {
+        // Only update calls that are in 'executing' state and have a result
+        if (call.status === "executing" && call.result) {
           call.status = "completed";
         }
       });
     } else {
       // For stored tasks without summary messages, auto-complete tool calls that have results
-      newToolCalls.forEach((call, id) => {
-        if (call.status === "executing" && call.result && ownedCallIds.has(id)) {
+      allToolCallsMap.forEach((call) => {
+        if (call.status === "executing" && call.result) {
           call.status = "completed";
         }
       });
     }
-    
+
+    // Fourth pass: Build nested call hierarchy
+    // Map to track which message created which call (callId -> message that created it)
+    const callIdToMessage = new Map<string, typeof allMessages[0]>();
+
+    for (const message of allMessages) {
+      if (isToolCallRequestMessage(message)) {
+        const requests = extractToolCallRequests(message);
+        for (const request of requests) {
+          if (request.id) {
+            callIdToMessage.set(request.id, message);
+          }
+        }
+      }
+    }
+
+    // Build parent-child relationships
+    // A call B is nested under call A if:
+    // - Both A and B are agent calls
+    // - B's message appeared after A's message but before A completed
+    // - B is not in ownedCallIds (not a top-level call)
+    allToolCallsMap.forEach((parentCall) => {
+      if (!isAgentToolName(parentCall.call.name)) return;
+
+      const nestedCallsList: ToolCallState[] = [];
+      const parentMessage = callIdToMessage.get(parentCall.id);
+      if (!parentMessage) return;
+
+      const parentIndex = allMessages.indexOf(parentMessage);
+
+      // Find where parent completed (if it did)
+      let parentCompletionIndex = allMessages.length;
+      for (let i = parentIndex + 1; i < allMessages.length; i++) {
+        if (isToolCallExecutionMessage(allMessages[i])) {
+          const results = extractToolCallResults(allMessages[i]);
+          if (results.some(r => r.call_id === parentCall.id)) {
+            parentCompletionIndex = i;
+            break;
+          }
+        }
+      }
+
+      // Look for child calls between parent start and completion
+      allToolCallsMap.forEach((potentialChild, childId) => {
+        // Skip if it's the parent itself or if it's a top-level owned call
+        if (childId === parentCall.id || ownedCallIds.has(childId)) return;
+
+        const childMessage = callIdToMessage.get(childId);
+        if (!childMessage) return;
+
+        const childIndex = allMessages.indexOf(childMessage);
+
+        // Child must appear after parent but before parent completes
+        if (childIndex > parentIndex && childIndex < parentCompletionIndex) {
+          nestedCallsList.push(potentialChild);
+        }
+      });
+
+      parentCall.nestedCalls = nestedCallsList;
+    });
+
+      return newToolCalls;
+    } catch (error) {
+      console.error("Error building nested call hierarchy:", error);
+      return new Map<string, ToolCallState>(); // Return empty map on error
+    }
+  }, [allMessages, ownedCallIds]);
+
+  // Update state when processed calls change
+  useEffect(() => {
     // Only update state if there's a change, to prevent unnecessary re-renders.
-    // This is a shallow comparison, but sufficient for this case.
-    let changed = newToolCalls.size !== toolCalls.size;
+    let changed = processedToolCalls.size !== toolCalls.size;
     if (!changed) {
-      for (const [key, value] of newToolCalls) {
+      for (const [key, value] of processedToolCalls) {
         const oldVal = toolCalls.get(key);
         if (!oldVal || oldVal.status !== value.status || oldVal.result?.content !== value.result?.content) {
           changed = true;
@@ -246,10 +321,9 @@ const ToolCallDisplay = ({ currentMessage, allMessages }: ToolCallDisplayProps) 
     }
 
     if (changed) {
-        setToolCalls(newToolCalls);
+        setToolCalls(processedToolCalls);
     }
-
-  }, [allMessages, ownedCallIds, toolCalls]);
+  }, [processedToolCalls, toolCalls]);
 
   // If no tool calls to display for this message, return null
   const currentDisplayableCalls = Array.from(toolCalls.values()).filter(call => ownedCallIds.has(call.id));
@@ -265,6 +339,7 @@ const ToolCallDisplay = ({ currentMessage, allMessages }: ToolCallDisplayProps) 
             result={toolCall.result}
             status={toolCall.status}
             isError={toolCall.result?.is_error}
+            nestedCalls={toolCall.nestedCalls}
           />
         ) : (
           <ToolDisplay

--- a/ui/src/components/chat/__tests__/AgentCallDisplay.test.tsx
+++ b/ui/src/components/chat/__tests__/AgentCallDisplay.test.tsx
@@ -1,0 +1,221 @@
+import { describe, test, expect } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import AgentCallDisplay from '../AgentCallDisplay';
+import { FunctionCall } from '@/types';
+
+// Mock the ToolDisplay component
+jest.mock('@/components/ToolDisplay', () => ({
+  __esModule: true,
+  default: ({ call }: any) => <div data-testid={`tool-${call.id}`}>Tool: {call.name}</div>,
+}));
+
+describe('AgentCallDisplay - Nested Rendering', () => {
+  const basicCall: FunctionCall = {
+    id: 'test-1',
+    name: 'kagent__NS__test-agent',
+    args: { query: 'test' },
+  };
+
+  test('renders agent call without nesting at depth 0', () => {
+    render(<AgentCallDisplay call={basicCall} status="requested" />);
+
+    expect(screen.getByText(/kagent\/test-agent/)).toBeInTheDocument();
+    expect(screen.queryByText(/nested level/)).not.toBeInTheDocument();
+  });
+
+  test('renders agent call with nested level indicator at depth 1', () => {
+    render(<AgentCallDisplay call={basicCall} status="requested" depth={1} />);
+
+    expect(screen.getByText(/nested level 1/)).toBeInTheDocument();
+  });
+
+  test('renders agent call with nested level indicator at depth 2', () => {
+    render(<AgentCallDisplay call={basicCall} status="requested" depth={2} />);
+
+    expect(screen.getByText(/nested level 2/)).toBeInTheDocument();
+  });
+
+  test('displays "Delegated Calls" section when nestedCalls provided', () => {
+    const nestedCalls = [
+      {
+        id: 'nested-1',
+        call: {
+          id: 'nested-1',
+          name: 'kagent__NS__sub-agent',
+          args: {},
+        },
+        status: 'completed' as const,
+      },
+    ];
+
+    render(<AgentCallDisplay call={basicCall} status="completed" nestedCalls={nestedCalls} />);
+
+    expect(screen.getByText(/Delegated Calls \(1\)/)).toBeInTheDocument();
+  });
+
+  test('displays correct count for multiple nested calls', () => {
+    const nestedCalls = [
+      {
+        id: 'nested-1',
+        call: {
+          id: 'nested-1',
+          name: 'kagent__NS__sub-agent-1',
+          args: {},
+        },
+        status: 'completed' as const,
+      },
+      {
+        id: 'nested-2',
+        call: {
+          id: 'nested-2',
+          name: 'kagent__NS__sub-agent-2',
+          args: {},
+        },
+        status: 'completed' as const,
+      },
+      {
+        id: 'nested-3',
+        call: {
+          id: 'nested-3',
+          name: 'read_file', // Tool call
+          args: {},
+        },
+        status: 'completed' as const,
+      },
+    ];
+
+    render(<AgentCallDisplay call={basicCall} status="completed" nestedCalls={nestedCalls} />);
+
+    expect(screen.getByText(/Delegated Calls \(3\)/)).toBeInTheDocument();
+  });
+
+  test('does not display "Delegated Calls" section when no nested calls', () => {
+    render(<AgentCallDisplay call={basicCall} status="completed" nestedCalls={[]} />);
+
+    expect(screen.queryByText(/Delegated Calls/)).not.toBeInTheDocument();
+  });
+
+  test('renders nested tool calls within delegated section', () => {
+    const nestedCalls = [
+      {
+        id: 'tool-1',
+        call: {
+          id: 'tool-1',
+          name: 'read_file',
+          args: { path: '/test' },
+        },
+        status: 'completed' as const,
+      },
+    ];
+
+    render(<AgentCallDisplay call={basicCall} status="completed" nestedCalls={nestedCalls} />);
+
+    // Should render ToolDisplay component for non-agent calls
+    expect(screen.getByTestId('tool-tool-1')).toBeInTheDocument();
+  });
+
+  test('displays different status indicators correctly', () => {
+    const { rerender } = render(<AgentCallDisplay call={basicCall} status="requested" />);
+    expect(screen.getByText(/Delegating/)).toBeInTheDocument();
+
+    rerender(<AgentCallDisplay call={basicCall} status="executing" />);
+    expect(screen.getByText(/Awaiting response/)).toBeInTheDocument();
+
+    rerender(<AgentCallDisplay call={basicCall} status="completed" />);
+    expect(screen.getByText(/Completed/)).toBeInTheDocument();
+  });
+
+  test('displays error status correctly', () => {
+    const result = {
+      content: 'Error occurred',
+      is_error: true,
+    };
+
+    render(<AgentCallDisplay call={basicCall} status="completed" result={result} isError={true} />);
+
+    expect(screen.getByText(/Failed/)).toBeInTheDocument();
+  });
+
+  test('applies correct styling for nested depth', () => {
+    const { container } = render(
+      <AgentCallDisplay call={basicCall} status="requested" depth={1} />
+    );
+
+    // Check for border styling on nested calls
+    const card = container.querySelector('.border-l-4');
+    expect(card).toBeInTheDocument();
+  });
+
+  test('recursive nesting - nested call can have its own nested calls', () => {
+    const deeplyNestedCalls = [
+      {
+        id: 'level2',
+        call: {
+          id: 'level2',
+          name: 'kagent__NS__level2-agent',
+          args: {},
+        },
+        status: 'completed' as const,
+        nestedCalls: [
+          {
+            id: 'level3',
+            call: {
+              id: 'level3',
+              name: 'kagent__NS__level3-agent',
+              args: {},
+            },
+            status: 'completed' as const,
+          },
+        ],
+      },
+    ];
+
+    render(
+      <AgentCallDisplay call={basicCall} status="completed" nestedCalls={deeplyNestedCalls} />
+    );
+
+    // Should have delegated calls sections (multiple due to recursion)
+    const delegatedSections = screen.getAllByText(/Delegated Calls \(1\)/);
+    expect(delegatedSections.length).toBeGreaterThan(0);
+  });
+
+  test('displays input/output sections', () => {
+    const callWithArgs: FunctionCall = {
+      id: 'test-1',
+      name: 'kagent__NS__test-agent',
+      args: { query: 'search term', limit: 10 },
+    };
+
+    const result = {
+      content: 'Search completed successfully',
+      is_error: false,
+    };
+
+    render(<AgentCallDisplay call={callWithArgs} status="completed" result={result} />);
+
+    // Input and Output sections should be present
+    expect(screen.getByText(/Input/)).toBeInTheDocument();
+    expect(screen.getByText(/Output/)).toBeInTheDocument();
+  });
+
+  test('enforces maximum nesting depth limit', () => {
+    const MAX_DEPTH = 10;
+
+    render(<AgentCallDisplay call={basicCall} status="requested" depth={MAX_DEPTH + 1} />);
+
+    // Should display warning instead of rendering normally
+    expect(screen.getByText(/Maximum nesting depth reached/)).toBeInTheDocument();
+    expect(screen.queryByText(/kagent\/test-agent/)).not.toBeInTheDocument();
+  });
+
+  test('renders normally at maximum allowed depth', () => {
+    const MAX_DEPTH = 10;
+
+    render(<AgentCallDisplay call={basicCall} status="requested" depth={MAX_DEPTH} />);
+
+    // Should render normally at exactly max depth
+    expect(screen.getByText(/kagent\/test-agent/)).toBeInTheDocument();
+    expect(screen.queryByText(/Maximum nesting depth reached/)).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/components/chat/__tests__/ToolCallDisplay.test.tsx
+++ b/ui/src/components/chat/__tests__/ToolCallDisplay.test.tsx
@@ -1,0 +1,330 @@
+import { describe, test, expect } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Message } from '@a2a-js/sdk';
+import ToolCallDisplay from '../ToolCallDisplay';
+
+// Mock the child components
+jest.mock('../AgentCallDisplay', () => ({
+  __esModule: true,
+  default: ({ call, nestedCalls, depth }: any) => (
+    <div data-testid={`agent-call-${call.id}`} data-depth={depth}>
+      Agent: {call.name}
+      {nestedCalls && nestedCalls.length > 0 && (
+        <div data-testid={`nested-calls-${call.id}`}>
+          Nested: {nestedCalls.length}
+        </div>
+      )}
+    </div>
+  ),
+}));
+
+jest.mock('@/components/ToolDisplay', () => ({
+  __esModule: true,
+  default: ({ call }: any) => <div data-testid={`tool-call-${call.id}`}>Tool: {call.name}</div>,
+}));
+
+describe('ToolCallDisplay - Nested Agent Calls', () => {
+  test('displays simple agent call without nesting', () => {
+    const currentMessage: Message = {
+      kind: 'message',
+      role: 'assistant',
+      parts: [
+        {
+          kind: 'data',
+          data: {
+            id: 'call-1',
+            name: 'kagent__NS__test-agent',
+            args: { query: 'test' },
+          },
+          metadata: {
+            kagent_type: 'function_call',
+          },
+        },
+      ],
+    };
+
+    const allMessages = [currentMessage];
+
+    render(<ToolCallDisplay currentMessage={currentMessage} allMessages={allMessages} />);
+
+    expect(screen.getByTestId('agent-call-call-1')).toBeInTheDocument();
+    expect(screen.getByText(/Agent: kagent__NS__test-agent/)).toBeInTheDocument();
+  });
+
+  test('builds nested call hierarchy for agent->subagent calls', () => {
+    const parentCall: Message = {
+      kind: 'message',
+      role: 'assistant',
+      parts: [
+        {
+          kind: 'data',
+          data: {
+            id: 'parent-1',
+            name: 'kagent__NS__main-agent',
+            args: {},
+          },
+          metadata: {
+            kagent_type: 'function_call',
+          },
+        },
+      ],
+    };
+
+    const nestedCall: Message = {
+      kind: 'message',
+      role: 'assistant',
+      parts: [
+        {
+          kind: 'data',
+          data: {
+            id: 'nested-1',
+            name: 'kagent__NS__sub-agent',
+            args: {},
+          },
+          metadata: {
+            kagent_type: 'function_call',
+          },
+        },
+      ],
+    };
+
+    const parentResult: Message = {
+      kind: 'message',
+      role: 'assistant',
+      parts: [
+        {
+          kind: 'data',
+          data: {
+            id: 'parent-1',
+            name: 'kagent__NS__main-agent',
+            response: { result: 'done' },
+          },
+          metadata: {
+            kagent_type: 'function_response',
+          },
+        },
+      ],
+    };
+
+    const allMessages = [parentCall, nestedCall, parentResult];
+
+    render(<ToolCallDisplay currentMessage={parentCall} allMessages={allMessages} />);
+
+    // Parent call should be displayed
+    expect(screen.getByTestId('agent-call-parent-1')).toBeInTheDocument();
+
+    // Should have nested calls indicator
+    expect(screen.getByTestId('nested-calls-parent-1')).toBeInTheDocument();
+    expect(screen.getByText(/Nested: 1/)).toBeInTheDocument();
+  });
+
+  test('handles multi-level nesting (agent->subagent->subagent)', () => {
+    const level1Call: Message = {
+      kind: 'message',
+      role: 'assistant',
+      parts: [
+        {
+          kind: 'data',
+          data: {
+            id: 'level1',
+            name: 'kagent__NS__main',
+            args: {},
+          },
+          metadata: {
+            kagent_type: 'function_call',
+          },
+        },
+      ],
+    };
+
+    const level2Call: Message = {
+      kind: 'message',
+      role: 'assistant',
+      parts: [
+        {
+          kind: 'data',
+          data: {
+            id: 'level2',
+            name: 'kagent__NS__research',
+            args: {},
+          },
+          metadata: {
+            kagent_type: 'function_call',
+          },
+        },
+      ],
+    };
+
+    const level3Call: Message = {
+      kind: 'message',
+      role: 'assistant',
+      parts: [
+        {
+          kind: 'data',
+          data: {
+            id: 'level3',
+            name: 'kagent__NS__data',
+            args: {},
+          },
+          metadata: {
+            kagent_type: 'function_call',
+          },
+        },
+      ],
+    };
+
+    const level1Result: Message = {
+      kind: 'message',
+      role: 'assistant',
+      parts: [
+        {
+          kind: 'data',
+          data: {
+            id: 'level1',
+            name: 'kagent__NS__main',
+            response: { result: 'complete' },
+          },
+          metadata: {
+            kagent_type: 'function_response',
+          },
+        },
+      ],
+    };
+
+    const allMessages = [level1Call, level2Call, level3Call, level1Result];
+
+    render(<ToolCallDisplay currentMessage={level1Call} allMessages={allMessages} />);
+
+    // Level 1 should be displayed with nested calls
+    expect(screen.getByTestId('agent-call-level1')).toBeInTheDocument();
+    expect(screen.getByTestId('nested-calls-level1')).toBeInTheDocument();
+  });
+
+  test('handles regular tool calls within agent calls', () => {
+    const agentCall: Message = {
+      kind: 'message',
+      role: 'assistant',
+      parts: [
+        {
+          kind: 'data',
+          data: {
+            id: 'agent-1',
+            name: 'kagent__NS__agent',
+            args: {},
+          },
+          metadata: {
+            kagent_type: 'function_call',
+          },
+        },
+      ],
+    };
+
+    const toolCall: Message = {
+      kind: 'message',
+      role: 'assistant',
+      parts: [
+        {
+          kind: 'data',
+          data: {
+            id: 'tool-1',
+            name: 'read_file', // No __NS__ = regular tool
+            args: { path: '/test' },
+          },
+          metadata: {
+            kagent_type: 'function_call',
+          },
+        },
+      ],
+    };
+
+    const agentResult: Message = {
+      kind: 'message',
+      role: 'assistant',
+      parts: [
+        {
+          kind: 'data',
+          data: {
+            id: 'agent-1',
+            name: 'kagent__NS__agent',
+            response: { result: 'done' },
+          },
+          metadata: {
+            kagent_type: 'function_response',
+          },
+        },
+      ],
+    };
+
+    const allMessages = [agentCall, toolCall, agentResult];
+
+    render(<ToolCallDisplay currentMessage={agentCall} allMessages={allMessages} />);
+
+    // Should display agent call with nested tool
+    expect(screen.getByTestId('agent-call-agent-1')).toBeInTheDocument();
+  });
+
+  test('does not nest calls that appear after parent completion', () => {
+    const parentCall: Message = {
+      kind: 'message',
+      role: 'assistant',
+      parts: [
+        {
+          kind: 'data',
+          data: {
+            id: 'parent',
+            name: 'kagent__NS__parent',
+            args: {},
+          },
+          metadata: {
+            kagent_type: 'function_call',
+          },
+        },
+      ],
+    };
+
+    const parentResult: Message = {
+      kind: 'message',
+      role: 'assistant',
+      parts: [
+        {
+          kind: 'data',
+          data: {
+            id: 'parent',
+            name: 'kagent__NS__parent',
+            response: { result: 'done' },
+          },
+          metadata: {
+            kagent_type: 'function_response',
+          },
+        },
+      ],
+    };
+
+    const afterCall: Message = {
+      kind: 'message',
+      role: 'assistant',
+      parts: [
+        {
+          kind: 'data',
+          data: {
+            id: 'after',
+            name: 'kagent__NS__after',
+            args: {},
+          },
+          metadata: {
+            kagent_type: 'function_call',
+          },
+        },
+      ],
+    };
+
+    const allMessages = [parentCall, parentResult, afterCall];
+
+    render(<ToolCallDisplay currentMessage={parentCall} allMessages={allMessages} />);
+
+    // Parent should not have nested calls (call came after completion)
+    expect(screen.getByTestId('agent-call-parent')).toBeInTheDocument();
+    expect(screen.queryByTestId('nested-calls-parent')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Add support for displaying nested agent calls (agent -> subagent -> subagent) with proper indentation and visual indicators.

The UI now shows delegated calls in a collapsible section with:
- Indented display for each nesting level
- Level indicators showing nesting depth
- Protection against excessive nesting (max 10 levels)

Includes test coverage for nested call scenarios.

Screenshot: 

<img width="1293" height="574" alt="image" src="https://github.com/user-attachments/assets/fbced72b-c225-4ced-8bf3-c33da6773544" />



Fixes #972