### PR TITLE
Fix: Update default Gemini model in Helm values to gemini-2.0-flash-lite for compatibility

### DIFF
--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -173,7 +173,7 @@ providers:
       azureEndpoint: ""
   gemini:
     provider: Gemini
-    model: "gemini-1.5-pro"
+    model: "gemini-2.0-flash-lite"
     apiKeySecretRef: kagent-gemini
     apiKeySecretKey: GOOGLE_API_KEY
     # apiKey: ""


### PR DESCRIPTION
The current default model `gemini-1.5-pro` in the Helm `values.yaml` file causes an error during deployment:

```
Model models/gemini-1.5-pro failed: 404 models/gemini-1.5-pro-002 is not found for API version v1beta, or is not supported for generateContent.
```
Issue which i faced:

<img width="1438" height="858" alt="Screenshot 2025-10-05 at 8 14 12 PM" src="https://github.com/user-attachments/assets/1a3b64e4-2a76-4ae4-8853-47c0774d33a9" />

To resolve this, the default model value has been updated to `gemini-2.0-flash-lite`, which is available and works correctly with the `generateContent` API.

**Changes made:**
* Updated the default value for `providers.openAI.model` (or equivalent key) in `values.yaml` to `gemini-2.0-flash-lite`.

<img width="1426" height="857" alt="Screenshot 2025-10-05 at 7 50 04 PM" src="https://github.com/user-attachments/assets/1b0db16a-19e6-432f-9039-9b7d1ea5defb" />
