### PR TITLE
feat(fix): Allow transport adapter version to be overriden

### DIFF
--- a/go/cli/internal/cli/mcp/deploy.go
+++ b/go/cli/internal/cli/mcp/deploy.go
@@ -149,7 +149,7 @@ func init() {
 	packageDeployCmd.Flags().StringVar(&deployTransport, "transport", "", "Transport type (stdio, http)")
 	packageDeployCmd.Flags().IntVar(&deployPort, "port", 0, "Container port (default: 3000)")
 	packageDeployCmd.Flags().BoolVar(&deployNoInspector, "no-inspector", true, "Do not start the MCP inspector after deployment")
-	packageDeployCmd.Flags().StringVarP(&deployOutput, "output", "o", "", "Output file for the generated YAML")
+	packageDeployCmd.Flags().StringVarP(&deployOutput, "output", "", "", "Output file for the generated YAML")
 
 	// Mark required flags
 	_ = packageDeployCmd.MarkFlagRequired("deployment-name")

--- a/go/internal/controller/translator/mcp/translator_adapter.go
+++ b/go/internal/controller/translator/mcp/translator_adapter.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"os"
 	"sort"
 
 	"go.uber.org/multierr"
@@ -24,10 +25,10 @@ import (
 )
 
 const (
-	transportAdapterContainerImage = "ghcr.io/agentgateway/agentgateway:0.7.4-musl"
-	defaultDebianContainerImage    = "ghcr.io/astral-sh/uv:debian"
-	defaultNodeContainerImage      = "node:24-alpine3.21"
-	mcpServerConfigHashAnnotation  = "kagent.dev/mcpserver-config-hash"
+	defaultTransportAdapterContainerImage = "ghcr.io/agentgateway/agentgateway:0.9.0-musl"
+	defaultDebianContainerImage           = "ghcr.io/astral-sh/uv:debian"
+	defaultNodeContainerImage             = "node:24-alpine3.21"
+	mcpServerConfigHashAnnotation         = "kagent.dev/mcpserver-config-hash"
 )
 
 var mcpProtocol string = "kgateway.dev/mcp"
@@ -104,6 +105,12 @@ func (t *transportAdapterTranslator) translateTransportAdapterDeployment(
 
 	// Create volume mounts from the MCPServer spec
 	volumeMounts := t.createVolumeMounts(server.Spec.Deployment)
+
+	transportAdapterContainerImage := defaultTransportAdapterContainerImage
+	transportAdapterVersion := os.Getenv("TRANSPORT_ADAPTER_VERSION")
+	if transportAdapterVersion != "" {
+		transportAdapterContainerImage = fmt.Sprintf("ghcr.io/agentgateway/agentgateway:%s-musl", transportAdapterVersion)
+	}
 
 	var template corev1.PodSpec
 	switch server.Spec.TransportType {


### PR DESCRIPTION
**Overview**
- Allow transport adapter image's version tag to be overridden via the `controller.env` helm values.  
- Fixes a bug in the CLI where a conflicting shorthand causes the CLI to panic.

**Testing**
- Ran a local helm install of the provider by setting the `controller.env` values, and deploying a mcp server using the kmcp cli to verify the environment variable properly sets the init container image.