### PR TITLE
fix(version): only stop port-forwarding when successfully connected

### DIFF
--- a/go/cli/cmd/kagent/main.go
+++ b/go/cli/cmd/kagent/main.go
@@ -121,9 +121,9 @@ func main() {
 			defer cli.VersionCmd(cfg)
 
 			if err := cli.CheckServerConnection(cmd.Context(), cfg.Client()); err != nil {
-				// silently error if kagent server is not reachable
-				pf, _ := cli.NewPortForward(cmd.Context(), cfg)
-				defer pf.Stop()
+				if pf, e := cli.NewPortForward(cmd.Context(), cfg); e == nil {
+					defer pf.Stop()
+				}
 			}
 		},
 	}


### PR DESCRIPTION
rel. https://github.com/kagent-dev/kagent/issues/868#issuecomment-3393734028

```bash
> go run cli/cmd/kagent/*.go version
{"backend_version":"unknown","build_date":"unknown","git_commit":"none","kagent_version":"dev"}
```

`kagent version`s portforwarding differs now to the other subcommands, perhaps we should just change `Stop()` to:

```go
func (p *PortForward) Stop() {
  if p == nil {
    return 
  }

	p.cancel()

	if p.cmd.Process != nil {
		p.cmd.Process.Kill() //nolint:errcheck
	}
}
```