### PR TITLE
fix(kagent-adk/cli/test): fix "NotADirectoryError: [Errno 20] Not a directory: 'xxx/agent-card.json'"

### DIFF
--- a/python/packages/kagent-adk/src/kagent/adk/cli.py
+++ b/python/packages/kagent-adk/src/kagent/adk/cli.py
@@ -98,14 +98,12 @@ async def test_agent(agent_config: AgentConfig, agent_card: AgentCard, task: str
 @app.command()
 def test(
     task: Annotated[str, typer.Option("--task", help="The task to test the agent with")],
-    config_file: Annotated[str, typer.Option("--agent-config", help="The path to the agent config file")],
-    card_file: Annotated[str, typer.Option("--agent-card", help="The path to the agent card file")],
+    filepath: Annotated[str, typer.Option("--filepath", help="The path to the directory of config files")],
 ):
-    with open(config_file, "r") as f:
-        content = f.read()
-        config = json.loads(content)
+    with open(os.path.join(filepath, "config.json"), "r") as f:
+        config = json.load(f)
 
-    with open(card_file, "r") as f:
+    with open(os.path.join(filepath, "agent-card.json"), "r") as f:
         agent_card = json.load(f)
     agent_card = AgentCard.model_validate(agent_card)
     agent_config = AgentConfig.model_validate(config)


### PR DESCRIPTION

## Before

```
$ uv run cli.py test --task 'who are you' --filepath config.json 
...
NotADirectoryError: [Errno 20] Not a directory: 'config.json/agent-card.json'
```

## After

```
$ uv run cli.py test --task 'who are you' --filepath ./
...
INFO:root:Starting KAgent
INFO:kagent.adk._a2a:
>>> User Query: who are you
...
```