### PR TITLE
feat(agent): default session name when auto-generating session

### DIFF
--- a/python/packages/kagent-adk/src/kagent/adk/_session_service.py
+++ b/python/packages/kagent-adk/src/kagent/adk/_session_service.py
@@ -32,6 +32,7 @@ class KAgentSessionService(BaseSessionService):
         user_id: str,
         state: Optional[dict[str, Any]] = None,
         session_id: Optional[str] = None,
+        session_name: Optional[str] = None,
     ) -> Session:
         # Prepare request data
         request_data = {
@@ -40,6 +41,8 @@ class KAgentSessionService(BaseSessionService):
         }
         if session_id:
             request_data["id"] = session_id
+        if session_name:
+            request_data["name"] = session_name
 
         # Make API call to create session
         response = await self.client.post(


### PR DESCRIPTION
Prior to this change, auto-generated sessions - created by invoking `message/send` via A2A - would be displayed in the UI as "Untitled". Now, they will have a default name as per sessions initiated via the UI.

Tested via command:

```bash
$ jq -n --arg id "$(cat /proc/sys/kernel/random/uuid)" --arg messageId "$(cat /proc/sys/kernel/random/uuid)" '{
  "jsonrpc": "2.0",
  "id": $id,
  "method": "message/send",
  "params": {
    "message": {
      "role": "user",
      "parts": [
        {
          "kind": "text",
          "text": "Hi there!"     
        }
      ],
      "messageId": $messageId
    },
    "metadata": {}
  }
}' \
  | curl -H "Content-Type: application/json" http://localhost:8083/api/a2a/kagent/k8s-agent/ -d @-
```

Current behaviour:
<img width="1815" height="607" alt="image" src="https://github.com/user-attachments/assets/fd5903a2-2770-4716-b193-8f1b4312bd88" />

After change:
<img width="1815" height="607" alt="image" src="https://github.com/user-attachments/assets/f9ccbba6-e9bf-4fe8-a247-a82bfd4b4ae9" />
