### PR TITLE
Fix kmcp image tag in values.yaml

### DIFF
--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -188,7 +188,7 @@ kmcp:
   fullnameOverride: "" # Override if desired
   namespaceOverride: "" # Override if desired (in conjunction with fullnameOverride to drop the `kagent-` prefix if you want)
   image:
-    tag: "v0.1.9" # Required until https://github.com/kagent-dev/kmcp/issues/74 is resolved
+    tag: "0.1.9" # Required until https://github.com/kagent-dev/kmcp/issues/74 is resolved
   # See https://github.com/kagent-dev/kmcp/blob/main/helm/kmcp/values.yaml for chart values
 
 # ==============================================================================


### PR DESCRIPTION
without this fix helm installation leads to a faiing kmco controller pod: 
  Warning  Failed     4m51s (x5 over 8m28s)   kubelet            Failed to pull image "ghcr.io/kagent-dev/kmcp/controller:v0.1.9": rpc error: code = NotFound desc = failed to pull and unpack image "ghcr.io/kagent-dev/kmcp/controller:v0.1.9": failed to resolve reference "ghcr.io/kagent-dev/kmcp/controller:v0.1.9": ghcr.io/kagent-dev/kmcp/controller:v0.1.9: not found