### PR TITLE
skip building mcp servers on kagent deploy

### DIFF
--- a/go/cli/internal/cli/agent/build.go
+++ b/go/cli/internal/cli/agent/build.go
@@ -12,11 +12,12 @@ import (
 )
 
 type BuildCfg struct {
-	ProjectDir string
-	Image      string
-	Push       bool
-	Platform   string
-	Config     *config.Config
+	ProjectDir     string
+	Image          string
+	Push           bool
+	Platform       string
+	Config         *config.Config
+	SkipMCPServers bool
 }
 
 // BuildCmd builds a Docker image for an agent project
@@ -68,7 +69,8 @@ func BuildCmd(cfg *BuildCfg) error {
 	}
 
 	// Check if MCP servers exist and build images for each MCP server
-	if manifest != nil && len(manifest.McpServers) > 0 {
+	// Skip if SkipMCPServers flag is set
+	if !cfg.SkipMCPServers && manifest != nil && len(manifest.McpServers) > 0 {
 		if err := buildMcpServerImages(cfg, manifest); err != nil {
 			return fmt.Errorf("failed to build MCP server images: %v", err)
 		}

--- a/go/cli/internal/cli/agent/deploy.go
+++ b/go/cli/internal/cli/agent/deploy.go
@@ -153,11 +153,12 @@ func buildAndPushImage(cfg *DeployCfg) error {
 
 	fmt.Println("Building Docker image...")
 	buildCfg := &BuildCfg{
-		ProjectDir: cfg.ProjectDir,
-		Image:      cfg.Image,
-		Push:       true, // Always push when deploying
-		Platform:   cfg.Platform,
-		Config:     cfg.Config,
+		ProjectDir:     cfg.ProjectDir,
+		Image:          cfg.Image,
+		Push:           true, // Always push when deploying
+		Platform:       cfg.Platform,
+		Config:         cfg.Config,
+		SkipMCPServers: true, // Don't build MCP servers during deploy
 	}
 
 	if err := BuildCmd(buildCfg); err != nil {


### PR DESCRIPTION
building mcp servers when we run `kagent deploy` is redundant because those images aren't used anyway when deploying. we create the MCPServer/RemoteMCPServer resource instead.