### PR TITLE
feature(helm): Add support for affinities for main deployments

### DIFF
--- a/helm/kagent/templates/controller-deployment.yaml
+++ b/helm/kagent/templates/controller-deployment.yaml
@@ -39,6 +39,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.controller.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: controller
           args:

--- a/helm/kagent/templates/ui-deployment.yaml
+++ b/helm/kagent/templates/ui-deployment.yaml
@@ -34,6 +34,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.ui.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: ui
           securityContext:

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -46,6 +46,9 @@ tolerations: []
 # -- Node labels to match for `Pod` [scheduling](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).
 nodeSelector: {}
 
+# Affinities for `Pod` https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/
+affinity: {}
+
 # ==============================================================================
 # DATABASE CONFIGURATION
 # ==============================================================================
@@ -85,6 +88,9 @@ controller:
 
   # -- Node labels to match for `Pod` [scheduling](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).
   nodeSelector: {}
+  
+  # Affintities for `Pod` https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/
+  affinity: {}
 
   image:
     registry: ""
@@ -135,6 +141,9 @@ ui:
 
   # -- Node labels to match for `Pod` [scheduling](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).
   nodeSelector: {}
+
+  # Affintities for `Pod` https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/
+  affinity: {}
 
 # ==============================================================================
 # LLM PROVIDERS CONFIGURATION
@@ -208,6 +217,15 @@ kagent-tools:
       memory: 1Gi
   tools:
     loglevel: "debug"
+  
+  # -- Node taints which will be tolerated for `Pod` [scheduling](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).
+  tolerations: []
+
+  # -- Node labels to match for `Pod` [scheduling](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).
+  nodeSelector: {}
+  
+  # Affintities for `Pod` https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/
+  affinity: {}
 
 # ==============================================================================
 # AGENTS

--- a/helm/tools/grafana-mcp/templates/deployment.yaml
+++ b/helm/tools/grafana-mcp/templates/deployment.yaml
@@ -27,6 +27,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: grafana-mcp
           securityContext:

--- a/helm/tools/grafana-mcp/values.yaml
+++ b/helm/tools/grafana-mcp/values.yaml
@@ -24,6 +24,8 @@ tolerations: []
 
 nodeSelector: {}
 
+affinity: {}
+
 service:
   type: ClusterIP
   port: 8000

--- a/helm/tools/querydoc/templates/deployment.yaml
+++ b/helm/tools/querydoc/templates/deployment.yaml
@@ -29,6 +29,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: querydoc
           securityContext:

--- a/helm/tools/querydoc/values.yaml
+++ b/helm/tools/querydoc/values.yaml
@@ -20,6 +20,8 @@ tolerations: []
 
 nodeSelector: {}
 
+affinity: {}
+
 service:
   type: ClusterIP
   port: 8080


### PR DESCRIPTION
Helm charts do not currently support `affinity`.  
This PR adds basic support for scheduling the main workloads with affinities.
This is sometimes an ideal choice over `nodeSelector`.

Ideally these would also be added to the `tools` and `kmcp` charts.