### PR TITLE
Don't always run uv sync

### DIFF
--- a/go/cli/internal/agent/frameworks/adk/python/templates/Dockerfile.tmpl
+++ b/go/cli/internal/agent/frameworks/adk/python/templates/Dockerfile.tmpl
@@ -8,11 +8,13 @@ FROM $DOCKER_REGISTRY/kagent-dev/kagent/kagent-adk:$VERSION
 
 WORKDIR /app
 
-COPY {{.Name}}/ {{.Name}}/
 COPY pyproject.toml pyproject.toml
-COPY README.md README.md
 COPY .python-version .python-version
 
 RUN uv sync
+
+COPY {{.Name}}/ {{.Name}}/
+COPY README.md README.md
+
 
 CMD ["{{.Name}}"]


### PR DESCRIPTION
Makes projects created by kagent init not always run uv sync when any file is changed. Still keeps the pyproject.toml and .python-version before the uv sync so we do rebuild this layer if needed.