### PR TITLE
feat(run): add --build flag to rebuild image before running

### DIFF
--- a/go/cli/cmd/kagent/main.go
+++ b/go/cli/cmd/kagent/main.go
@@ -389,8 +389,21 @@ Examples:
 				runCfg.ProjectDir = "."
 			}
 
+			if runCfg.Build {
+				fmt.Fprintf(os.Stderr, "Building image before running...\n")
+
+				buildCfg := &cli.BuildCfg{
+					Config:     runCfg.Config,
+					ProjectDir: runCfg.ProjectDir,
+				}
+
+				if err := cli.BuildCmd(buildCfg); err != nil {
+					fmt.Fprintf(os.Stderr, "Build failed: %v\n", err)
+					os.Exit(1)
+				}
+			}
 			if err := cli.RunCmd(cmd.Context(), runCfg); err != nil {
-				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				fmt.Fprintf(os.Stderr, "Error running agent: %v\n", err)
 				os.Exit(1)
 			}
 		},
@@ -398,6 +411,7 @@ Examples:
 	}
 
 	runCmd.Flags().StringVar(&runCfg.ProjectDir, "project-dir", "", "Project directory (default: current directory)")
+	runCmd.Flags().BoolVar(&runCfg.Build, "build", false, "Rebuild the Docker image before running")
 
 	rootCmd.AddCommand(installCmd, uninstallCmd, invokeCmd, bugReportCmd, versionCmd, dashboardCmd, getCmd, initCmd, buildCmd, deployCmd, addMcpCmd, runCmd, mcp.NewMCPCmd())
 

--- a/go/cli/internal/cli/agent/run.go
+++ b/go/cli/internal/cli/agent/run.go
@@ -19,6 +19,7 @@ import (
 type RunCfg struct {
 	ProjectDir string
 	Config     *config.Config
+	Build	   bool	
 }
 
 // RunCmd starts docker-compose in the background and launches a chat session with the local agent


### PR DESCRIPTION
fixes #1096 

This PR adds a `--build` flag to the kagent run command. When passed, it rebuilds the Docker image (via BuildCmd).