### PR TITLE
fix(tracing): use a span processor to add custom span attributes

### DIFF
--- a/python/packages/kagent-core/src/kagent/core/tracing/_span_processor.py
+++ b/python/packages/kagent-core/src/kagent/core/tracing/_span_processor.py
@@ -1,0 +1,59 @@
+"""Custom span processor to add kagent attributes to all spans in a request context."""
+
+import logging
+from typing import Optional
+from contextvars import Token
+
+from opentelemetry import context as otel_context
+from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
+
+logger = logging.getLogger(__name__)
+
+KAGENT_ATTRIBUTES_KEY = "kagent_trace_span_attributes"
+
+
+class KagentAttributesSpanProcessor(SpanProcessor):
+    """A SpanProcessor that adds kagent-specific attributes to all spans."""
+
+    def on_start(self, span: Span, parent_context: Optional[otel_context.Context] = None) -> None:
+        """Called when a span is started. Adds kagent attributes if present in context."""
+        try:
+            ctx = parent_context if parent_context is not None else otel_context.get_current()
+            attributes = ctx.get(KAGENT_ATTRIBUTES_KEY)
+
+            if attributes and isinstance(attributes, dict):
+                for key, value in attributes.items():
+                    if value is not None:
+                        span.set_attribute(key, value)
+        except Exception as e:
+            logger.warning(f"Failed to add kagent attributes to span: {e}")
+
+    def on_end(self, span: ReadableSpan) -> None:
+        """Called when a span is ended. No action needed."""
+        pass
+
+    def shutdown(self) -> None:
+        """Called when the tracer provider is shutdown."""
+        pass
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        """Force flush any buffered spans. No buffering in this processor."""
+        return True
+
+
+def set_kagent_span_attributes(attributes: dict) -> Token[otel_context.Context]:
+    """Set kagent span attributes in the context.
+    Args:
+        attributes: Dictionary of kagent span attributes to store in context
+    Returns:
+        A context token that can be used to detach the context
+    """
+    return otel_context.attach(otel_context.set_value(KAGENT_ATTRIBUTES_KEY, attributes))
+
+
+def clear_kagent_span_attributes(token: Token[otel_context.Context]) -> None:
+    """Clear kagent span attributes from the OpenTelemetry context.
+    Args:
+        token: The context token returned by set_kagent_span_attributes
+    """
+    otel_context.detach(token)

--- a/python/packages/kagent-crewai/src/kagent/crewai/_executor.py
+++ b/python/packages/kagent-crewai/src/kagent/crewai/_executor.py
@@ -1,7 +1,7 @@
 import logging
 import uuid
 from datetime import datetime, timezone
-from typing import Union, override
+from typing import Any, Union, override
 
 import httpx
 from a2a.server.agent_execution import AgentExecutor
@@ -23,6 +23,11 @@ from pydantic import BaseModel
 
 from crewai import Crew, Flow
 from crewai.memory import LongTermMemory
+
+from kagent.core.tracing._span_processor import (
+    clear_kagent_span_attributes,
+    set_kagent_span_attributes,
+)
 
 from ._listeners import A2ACrewAIListener
 from ._memory import KagentMemoryStorage
@@ -63,120 +68,154 @@ class CrewAIAgentExecutor(AgentExecutor):
         if not context.message:
             raise ValueError("A2A request must have a message")
 
-        if not context.current_task:
+        # Convert the a2a request to kagent span attributes.
+        span_attributes = _convert_a2a_request_to_span_attributes(context)
+
+        # Set kagent span attributes for all spans in context.
+        context_token = set_kagent_span_attributes(span_attributes)
+        try:
+            if not context.current_task:
+                await event_queue.enqueue_event(
+                    TaskStatusUpdateEvent(
+                        task_id=context.task_id,
+                        status=TaskStatus(
+                            state=TaskState.submitted,
+                            message=context.message,
+                            timestamp=datetime.now(timezone.utc).isoformat(),
+                        ),
+                        context_id=context.context_id,
+                        final=False,
+                    )
+                )
+
             await event_queue.enqueue_event(
                 TaskStatusUpdateEvent(
                     task_id=context.task_id,
                     status=TaskStatus(
-                        state=TaskState.submitted,
-                        message=context.message,
+                        state=TaskState.working,
                         timestamp=datetime.now(timezone.utc).isoformat(),
                     ),
                     context_id=context.context_id,
                     final=False,
+                    metadata={
+                        "app_name": self.app_name,
+                        "session_id": context.context_id,
+                    },
                 )
             )
 
-        await event_queue.enqueue_event(
-            TaskStatusUpdateEvent(
-                task_id=context.task_id,
-                status=TaskStatus(
-                    state=TaskState.working,
-                    timestamp=datetime.now(timezone.utc).isoformat(),
-                ),
-                context_id=context.context_id,
-                final=False,
-                metadata={
-                    "app_name": self.app_name,
-                    "session_id": context.context_id,
-                },
-            )
-        )
+            # This listener will capture and convert CrewAI events and enqueue them to A2A event queue
+            A2ACrewAIListener(context, event_queue, self.app_name)
 
-        # This listener will capture and convert CrewAI events and enqueue them to A2A event queue
-        A2ACrewAIListener(context, event_queue, self.app_name)
+            try:
+                inputs = None
+                if context.message and context.message.parts:
+                    for part in context.message.parts:
+                        if isinstance(part, DataPart):
+                            inputs = part.root.data
+                            break
+                if inputs is None:
+                    user_input = context.get_user_input()
+                    inputs = {"input": user_input} if user_input else {}
 
-        try:
-            inputs = None
-            if context.message and context.message.parts:
-                for part in context.message.parts:
-                    if isinstance(part, DataPart):
-                        inputs = part.root.data
-                        break
-            if inputs is None:
-                user_input = context.get_user_input()
-                inputs = {"input": user_input} if user_input else {}
+                session_id = getattr(context, "session_id", context.context_id)
+                user_id = getattr(context, "user_id", "admin@kagent.dev")
 
-            session_id = getattr(context, "session_id", context.context_id)
-            user_id = getattr(context, "user_id", "admin@kagent.dev")
-
-            if isinstance(self._crew, Flow):
-                flow_class = type(self._crew)
-                persistence = KagentFlowPersistence(
-                    thread_id=session_id,
-                    user_id=user_id,
-                    base_url=str(self._http_client.base_url),
-                )
-                flow_instance = flow_class()
-                flow_instance.persistence = persistence
-
-                # setting "id" in flow input will enable reusing persisted flow state
-                # if no flow state is persisted or if persistence is not enabled, this works like a normal kickoff
-                inputs["id"] = session_id
-
-                # output_text will be None if the last method in the flow does not return anything but updates the state instead
-                output_text = await flow_instance.kickoff_async(inputs=inputs)
-                result_text = output_text or flow_instance.state.model_dump_json()
-            else:
-                if self._crew.memory:
-                    self._crew.long_term_memory = LongTermMemory(
-                        KagentMemoryStorage(
-                            thread_id=session_id,
-                            user_id=user_id,
-                            base_url=str(self._http_client.base_url),
-                        )
+                if isinstance(self._crew, Flow):
+                    flow_class = type(self._crew)
+                    persistence = KagentFlowPersistence(
+                        thread_id=session_id,
+                        user_id=user_id,
+                        base_url=str(self._http_client.base_url),
                     )
-                result = await self._crew.kickoff_async(inputs=inputs)
-                result_text = str(result.raw or "No response was generated.")
+                    flow_instance = flow_class()
+                    flow_instance.persistence = persistence
 
-            await event_queue.enqueue_event(
-                TaskArtifactUpdateEvent(
-                    task_id=context.task_id,
-                    last_chunk=True,
-                    context_id=context.context_id,
-                    artifact=Artifact(
-                        artifact_id=str(uuid.uuid4()),
-                        parts=[Part(TextPart(text=result_text))],
-                    ),
-                )
-            )
-            await event_queue.enqueue_event(
-                TaskStatusUpdateEvent(
-                    task_id=context.task_id,
-                    status=TaskStatus(
-                        state=TaskState.completed,
-                        timestamp=datetime.now(timezone.utc).isoformat(),
-                    ),
-                    context_id=context.context_id,
-                    final=True,
-                )
-            )
+                    # setting "id" in flow input will enable reusing persisted flow state
+                    # if no flow state is persisted or if persistence is not enabled, this works like a normal kickoff
+                    inputs["id"] = session_id
 
-        except Exception as e:
-            logger.error(f"Error during CrewAI execution: {e}", exc_info=True)
-            await event_queue.enqueue_event(
-                TaskStatusUpdateEvent(
-                    task_id=context.task_id,
-                    status=TaskStatus(
-                        state=TaskState.failed,
-                        timestamp=datetime.now(timezone.utc).isoformat(),
-                        message=Message(
-                            message_id=str(uuid.uuid4()),
-                            role=Role.agent,
-                            parts=[Part(TextPart(text=str(e)))],
+                    # output_text will be None if the last method in the flow does not return anything but updates the state instead
+                    output_text = await flow_instance.kickoff_async(inputs=inputs)
+                    result_text = output_text or flow_instance.state.model_dump_json()
+                else:
+                    if self._crew.memory:
+                        self._crew.long_term_memory = LongTermMemory(
+                            KagentMemoryStorage(
+                                thread_id=session_id,
+                                user_id=user_id,
+                                base_url=str(self._http_client.base_url),
+                            )
+                        )
+                    result = await self._crew.kickoff_async(inputs=inputs)
+                    result_text = str(result.raw or "No response was generated.")
+
+                await event_queue.enqueue_event(
+                    TaskArtifactUpdateEvent(
+                        task_id=context.task_id,
+                        last_chunk=True,
+                        context_id=context.context_id,
+                        artifact=Artifact(
+                            artifact_id=str(uuid.uuid4()),
+                            parts=[Part(TextPart(text=result_text))],
                         ),
-                    ),
-                    context_id=context.context_id,
-                    final=True,
+                    )
                 )
-            )
+                await event_queue.enqueue_event(
+                    TaskStatusUpdateEvent(
+                        task_id=context.task_id,
+                        status=TaskStatus(
+                            state=TaskState.completed,
+                            timestamp=datetime.now(timezone.utc).isoformat(),
+                        ),
+                        context_id=context.context_id,
+                        final=True,
+                    )
+                )
+
+            except Exception as e:
+                logger.error(f"Error during CrewAI execution: {e}", exc_info=True)
+                await event_queue.enqueue_event(
+                    TaskStatusUpdateEvent(
+                        task_id=context.task_id,
+                        status=TaskStatus(
+                            state=TaskState.failed,
+                            timestamp=datetime.now(timezone.utc).isoformat(),
+                            message=Message(
+                                message_id=str(uuid.uuid4()),
+                                role=Role.agent,
+                                parts=[Part(TextPart(text=str(e)))],
+                            ),
+                        ),
+                        context_id=context.context_id,
+                        final=True,
+                    )
+                )
+        finally:
+            clear_kagent_span_attributes(context_token)
+
+
+def _get_user_id(request: RequestContext) -> str:
+    # Get user from call context if available (auth is enabled on a2a server)
+    if request.call_context and request.call_context.user and request.call_context.user.user_name:
+        return request.call_context.user.user_name
+
+    # Get user from context id
+    return f"A2A_USER_{request.context_id}"
+
+
+def _convert_a2a_request_to_span_attributes(
+    request: RequestContext,
+) -> dict[str, Any]:
+    if not request.message:
+        raise ValueError("Request message cannot be None")
+
+    span_attributes = {
+        "kagent.user_id": _get_user_id(request),
+        "gen_ai.conversation.id": request.context_id,
+    }
+
+    if request.task_id:
+        span_attributes["gen_ai.task.id"] = request.task_id
+
+    return span_attributes


### PR DESCRIPTION
- Fix custom tracing span attributes for the kagent-adk, kagent-langgraph, kagent-crewai packages.
- Add a custom span processor which can be used to include custom kagent span metrics for all spans created within a particular OTel trace context.
- Use the custom span processor, and update the execute method of each agent framework package to set the custom span attributes in context.