### PR TITLE
Fixes #1107  infinite re-render loop in model edit page

### DIFF
--- a/ui/src/app/models/new/page.tsx
+++ b/ui/src/app/models/new/page.tsx
@@ -175,7 +175,7 @@ function ModelPageContent() {
     const fetchModelData = async () => {
       if (isEditMode && modelConfigName && providers.length > 0 && providerModelsData) {
         try {
-          if (!isLoading) setIsLoading(true);
+          setIsLoading(true);
           const response = await getModelConfig(
             k8sRefUtils.toRef(modelConfigNamespace || '', modelConfigName)
           );
@@ -252,7 +252,7 @@ function ModelPageContent() {
     };
     fetchModelData();
     return () => { isMounted = false; };
-  }, [isEditMode, modelConfigName, providers, providerModelsData, modelConfigNamespace, isLoading]);
+  }, [isEditMode, modelConfigName, providers, providerModelsData, modelConfigNamespace]);
 
   useEffect(() => {
     if (selectedProvider) {


### PR DESCRIPTION
### Problem
When clicking the edit (pencil) icon on a model in the Models page, the UI enters an infinite loop causing:
• Continuous page refreshing
• Infinite API calls to /models/new?edit=true&name=...
• Unusable interface

### Root Cause
The useEffect hook in ui/src/app/models/new/page.tsx had isLoading in its dependency array. Since the effect calls setIsLoading(true), it triggers itself repeatedly.

### Solution
• Removed isLoading from the useEffect dependency array
• Simplified loading state logic by removing conditional check

### Changes
• Modified ui/src/app/models/new/page.tsx line 206
• Effect now only runs when actual dependencies change (edit mode, model name, providers, etc.)

### Testing
• Edit model functionality now loads once and remains stable
• No more infinite API calls or page refreshing
• Model data loads correctly for editing

Fixes #1107 described in the bug report where editing models caused infinite loops.

<img width="1721" height="965" alt="Screenshot 2025-11-18 at 9 41 14 AM" src="https://github.com/user-attachments/assets/8d4e5f2e-789f-4554-9831-76a8eae39d98" />
