### PR TITLE
add an error message if model doesn't support function calling

### DIFF
--- a/python/packages/kagent-adk/src/kagent/adk/_agent_executor.py
+++ b/python/packages/kagent-adk/src/kagent/adk/_agent_executor.py
@@ -154,7 +154,7 @@ class A2aAgentExecutor(AgentExecutor):
                     or "APIConnectionError" in error_message
                 ):
                     # Check if it's related to function calling
-                    if "function_call" in error_message.lower() or "json.loads" in error_message: 
+                    if "function_call" in error_message.lower() or "json.loads" in error_message:
                         error_message = (
                             "The model does not support function calling properly. "
                             "This error typically occurs when using Ollama models with tools. "


### PR DESCRIPTION

This addresses #1112 , but it doesn't fix it since the fix is to use a model that supports function calling. However, we'll now show a message if the model doesn't support function calling.