### PR TITLE
feat: Add support for scheduling in agent Helm charts

### DIFF
--- a/helm/agents/argo-rollouts/templates/agent.yaml
+++ b/helm/agents/argo-rollouts/templates/agent.yaml
@@ -177,4 +177,15 @@ spec:
     deployment:
       resources:
         {{- toYaml .Values.resources | nindent 8 }}
-      
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/agents/argo-rollouts/values.yaml
+++ b/helm/agents/argo-rollouts/values.yaml
@@ -7,3 +7,7 @@ resources:
   limits:
     cpu: 1000m
     memory: 1Gi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/helm/agents/cilium-debug/templates/agent.yaml
+++ b/helm/agents/cilium-debug/templates/agent.yaml
@@ -195,3 +195,15 @@ spec:
     deployment:
       resources:
         {{- toYaml .Values.resources | nindent 8 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/agents/cilium-debug/values.yaml
+++ b/helm/agents/cilium-debug/values.yaml
@@ -7,3 +7,7 @@ resources:
   limits:
     cpu: 1000m
     memory: 1Gi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/helm/agents/cilium-manager/templates/agent.yaml
+++ b/helm/agents/cilium-manager/templates/agent.yaml
@@ -459,3 +459,15 @@ spec:
     deployment:
       resources:
         {{- toYaml .Values.resources | nindent 8 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/agents/cilium-manager/values.yaml
+++ b/helm/agents/cilium-manager/values.yaml
@@ -7,3 +7,7 @@ resources:
   limits:
     cpu: 1000m
     memory: 1Gi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/helm/agents/cilium-policy/templates/agent.yaml
+++ b/helm/agents/cilium-policy/templates/agent.yaml
@@ -514,3 +514,15 @@ spec:
     deployment:
       resources:
         {{- toYaml .Values.resources | nindent 8 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/agents/cilium-policy/values.yaml
+++ b/helm/agents/cilium-policy/values.yaml
@@ -7,3 +7,7 @@ resources:
   limits:
     cpu: 1000m
     memory: 1Gi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/helm/agents/helm/templates/agent.yaml
+++ b/helm/agents/helm/templates/agent.yaml
@@ -221,3 +221,15 @@ spec:
     deployment:
       resources:
         {{- toYaml .Values.resources | nindent 8 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/agents/helm/values.yaml
+++ b/helm/agents/helm/values.yaml
@@ -7,3 +7,7 @@ resources:
   limits:
     cpu: 1000m
     memory: 1Gi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/helm/agents/istio/templates/agent.yaml
+++ b/helm/agents/istio/templates/agent.yaml
@@ -259,3 +259,15 @@ spec:
     deployment:
       resources:
         {{- toYaml .Values.resources | nindent 8 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/agents/istio/values.yaml
+++ b/helm/agents/istio/values.yaml
@@ -7,3 +7,7 @@ resources:
   limits:
     cpu: 1000m
     memory: 1Gi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/helm/agents/k8s/templates/agent.yaml
+++ b/helm/agents/k8s/templates/agent.yaml
@@ -179,3 +179,15 @@ spec:
     deployment:
       resources:
         {{- toYaml .Values.resources | nindent 8 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/agents/k8s/values.yaml
+++ b/helm/agents/k8s/values.yaml
@@ -7,3 +7,7 @@ resources:
   limits:
     cpu: 1000m
     memory: 1Gi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/helm/agents/kgateway/templates/agent.yaml
+++ b/helm/agents/kgateway/templates/agent.yaml
@@ -305,3 +305,15 @@ spec:
     deployment:
       resources:
         {{- toYaml .Values.resources | nindent 8 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/agents/kgateway/values.yaml
+++ b/helm/agents/kgateway/values.yaml
@@ -7,3 +7,7 @@ resources:
   limits:
     cpu: 1000m
     memory: 1Gi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/helm/agents/observability/templates/agent.yaml
+++ b/helm/agents/observability/templates/agent.yaml
@@ -186,3 +186,15 @@ spec:
     deployment:
       resources:
         {{- toYaml .Values.resources | nindent 8 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/agents/observability/values.yaml
+++ b/helm/agents/observability/values.yaml
@@ -7,3 +7,7 @@ resources:
   limits:
     cpu: 1000m
     memory: 1Gi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/helm/agents/promql/templates/agent.yaml
+++ b/helm/agents/promql/templates/agent.yaml
@@ -203,4 +203,15 @@ spec:
     deployment:
       resources:
         {{- toYaml .Values.resources | nindent 8 }}
-      
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/agents/promql/values.yaml
+++ b/helm/agents/promql/values.yaml
@@ -7,3 +7,7 @@ resources:
   limits:
     cpu: 1000m
     memory: 1Gi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
Changes:
- Updated the Agent CRD in the kagent Helm chart with the changes from the base Agent CRD
- Added support for `nodeSelector`, `tolerations`, and `affinity` in each agent template in their respective Helm charts