### PR TITLE
fix(helm): remove sqlite volume+mount if database is postgres

### DIFF
--- a/helm/kagent/templates/controller-deployment.yaml
+++ b/helm/kagent/templates/controller-deployment.yaml
@@ -26,13 +26,17 @@ spec:
       securityContext:
         {{- toYaml (.Values.controller.podSecurityContext | default .Values.podSecurityContext) | nindent 8 }}
       serviceAccountName: {{ include "kagent.fullname" . }}-controller
+      {{- if or (eq .Values.database.type "sqlite") (gt (len .Values.controller.volumes) 0) }}
       volumes:
+      {{- if eq .Values.database.type "sqlite" }}
       - name: sqlite-volume
         emptyDir:
           sizeLimit: 500Mi
           medium: Memory
+      {{- end }}
       {{- with .Values.controller.volumes }}
       {{- toYaml . | nindent 6 }}
+      {{- end }}
       {{- end }}
       {{- with .Values.controller.nodeSelector }}
       nodeSelector:
@@ -127,9 +131,13 @@ spec:
               path: /health
               port: http
             periodSeconds: 30
+          {{- if or (eq .Values.database.type "sqlite") (gt (len .Values.controller.volumeMounts) 0) }}
           volumeMounts:
+            {{- if eq .Values.database.type "sqlite" }}
             - name: sqlite-volume
               mountPath: /sqlite-volume
+            {{- end }}
             {{- with .Values.controller.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- end }}

--- a/helm/kagent/tests/controller-deployment_test.yaml
+++ b/helm/kagent/tests/controller-deployment_test.yaml
@@ -151,3 +151,50 @@ tests:
             value: AI
             effect: NoSchedule
             operator: Equal
+
+  - it: should not render sqlite volume and mount when using postgres with extra volumes
+    template: controller-deployment.yaml
+    set:
+      database:
+        type: postgres
+      controller:
+        volumes:
+          - name: extra-data
+            emptyDir: {}
+        volumeMounts:
+          - name: extra-data
+            mountPath: /extra
+    asserts:
+      # volumes block should exist due to provided extra volumes
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: extra-data
+            emptyDir: {}
+      # sqlite volume must not be present
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: sqlite-volume
+      # volumeMounts block should include our extra mount
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: extra-data
+            mountPath: /extra
+      # sqlite volume mount must not be present
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: sqlite-volume
+
+  - it: should not render volumes or volumeMounts sections when using postgres without extra volumes or mounts
+    template: controller-deployment.yaml
+    set:
+      database:
+        type: postgres
+    asserts:
+      - isNull:
+          path: spec.template.spec.volumes
+      - isNull:
+          path: spec.template.spec.containers[0].volumeMounts

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -105,18 +105,18 @@ controller:
       targetPort: 8083
   env: []
 
-# Additional volumes on the output Deployment definition.
+  # Additional volumes on the output Deployment definition.
   volumes: []
-#   - name: foo
-#     secret:
-#       secretName: mysecret
-#       optional: false
+  # - name: foo
+  #   secret:
+  #     secretName: mysecret
+  #     optional: false
 
-# Additional volumeMounts on the output Deployment definition.
+  # Additional volumeMounts on the output Deployment definition.
   volumeMounts: []
-#   - name: foo
-#     mountPath: "/etc/foo"
-#     readOnly: true
+  # - name: foo
+  #   mountPath: "/etc/foo"
+  #   readOnly: true
 
 # ==============================================================================
 # UI CONFIGURATION


### PR DESCRIPTION
Another artifact of #1133. No need for the sqlite volume+mount when database is set to postgres.