### PR TITLE
fix(helm): add error when trying to scale controller with local SQLlite database

### DIFF
--- a/helm/kagent/templates/_helpers.tpl
+++ b/helm/kagent/templates/_helpers.tpl
@@ -106,3 +106,12 @@ Engine labels
 {{ include "kagent.labels" . }}
 app.kubernetes.io/component: engine
 {{- end }}
+
+{{/*
+Validate controller configuration
+*/}}
+{{- define "kagent.validateController" -}}
+{{- if and (gt (.Values.controller.replicas | int) 1) (eq .Values.database.type "sqlite") -}}
+{{- fail "ERROR: controller.replicas cannot be greater than 1 when database.type is 'sqlite' as the SQLite database is local to the pod. Please either set controller.replicas to 1 or change database.type to 'postgres'." }}
+{{- end -}}
+{{- end -}}

--- a/helm/kagent/templates/controller-deployment.yaml
+++ b/helm/kagent/templates/controller-deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "kagent.validateController" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/kagent/tests/controller-deployment_test.yaml
+++ b/helm/kagent/tests/controller-deployment_test.yaml
@@ -16,11 +16,24 @@ tests:
       - hasDocuments:
           count: 1
 
-  - it: should render controller deployment with custom replica count
+  - it: should fail when replicas > 1 and database type is sqlite
     template: controller-deployment.yaml
     set:
       controller:
         replicas: 3
+      database:
+        type: sqlite
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: controller.replicas cannot be greater than 1 when database.type is 'sqlite' as the SQLite database is local to the pod. Please either set controller.replicas to 1 or change database.type to 'postgres'."
+
+  - it: should render controller deployment with custom replica count if database type is postgres
+    template: controller-deployment.yaml
+    set:
+      controller:
+        replicas: 3
+      database:
+        type: postgres
     asserts:
       - equal:
           path: spec.replicas


### PR DESCRIPTION
Running multiple controller replicas when using a local SQLite database will lead to errors as API requests will inevitably end up being handled by a replicas that does not have the local state (e.g. A2A session). This check/error hopefully prevents users from making this mistake.

Split out from #1133