### PR TITLE
fix(ui): refresh model dropdown after creating new model (#1148)

### DIFF
--- a/ui/src/app/models/new/page.tsx
+++ b/ui/src/app/models/new/page.tsx
@@ -6,6 +6,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { LoadingState } from "@/components/LoadingState";
 import { ErrorState } from "@/components/ErrorState";
 import { getModelConfig, createModelConfig, updateModelConfig } from "@/app/actions/modelConfigs";
+import { useAgents } from "@/components/AgentsProvider";
 import type {
     CreateModelConfigRequest,
     UpdateModelConfigPayload,
@@ -101,6 +102,7 @@ const processModelParams = (requiredParams: ModelParam[], optionalParams: ModelP
 function ModelPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { refreshModels } = useAgents();
 
   const isEditMode = searchParams.get("edit") === "true";
   const modelConfigName = searchParams.get("name");
@@ -478,6 +480,7 @@ function ModelPageContent() {
 
       if (!response.error) {
         toast.success(`Model configuration ${isEditMode ? 'updated' : 'created'} successfully!`);
+        await refreshModels();
         router.push("/models");
       } else {
         throw new Error(response.error || "Failed to save model configuration");

--- a/ui/src/components/AgentsProvider.tsx
+++ b/ui/src/components/AgentsProvider.tsx
@@ -53,6 +53,7 @@ interface AgentsContextType {
   error: string;
   tools: ToolsResponse[];
   refreshAgents: () => Promise<void>;
+  refreshModels: () => Promise<void>;
   createNewAgent: (agentData: AgentFormData) => Promise<BaseResponse<Agent>>;
   updateAgent: (agentData: AgentFormData) => Promise<BaseResponse<Agent>>;
   getAgent: (name: string, namespace: string) => Promise<AgentResponse | null>;
@@ -262,6 +263,7 @@ export function AgentsProvider({ children }: AgentsProviderProps) {
     error,
     tools,
     refreshAgents: fetchAgents,
+    refreshModels: fetchModels,
     createNewAgent,
     updateAgent,
     getAgent,


### PR DESCRIPTION
## Description
Fixes #1148

When a new model is created, it now immediately appears in the "Select Model" dropdown while configuring an agent, without requiring a manual page refresh.

## Changes
- Added `refreshModels` function to `AgentsProvider` context
- Call `refreshModels` after successful model creation/update in `/models/new` page

## Testing
1. Go to Models → Create New Model
2. Create a model successfully
3. Navigate to Agents → Add Agent
4. Open the Model dropdown
5. Newly created model appears immediately

## Before
- Newly created models only appeared after manual page refresh

## After
- Models list automatically refreshes and new model is immediately available in dropdown