### PR TITLE
fix(helm): enable leader election unconditionally

### DIFF
--- a/helm/kagent/templates/_helpers.tpl
+++ b/helm/kagent/templates/_helpers.tpl
@@ -108,13 +108,6 @@ app.kubernetes.io/component: engine
 {{- end }}
 
 {{/*
-Check if leader election should be enabled (more than 1 replica)
-*/}}
-{{- define "kagent.leaderElectionEnabled" -}}
-{{- gt (.Values.controller.replicas | int) 1 -}}
-{{- end -}}
-
-{{/*
 Validate controller configuration
 */}}
 {{- define "kagent.validateController" -}}

--- a/helm/kagent/templates/controller-configmap.yaml
+++ b/helm/kagent/templates/controller-configmap.yaml
@@ -15,7 +15,7 @@ data:
   IMAGE_REGISTRY: {{ .Values.controller.agentImage.registry | default .Values.registry  | quote }}
   IMAGE_REPOSITORY: {{ .Values.controller.agentImage.repository | quote }}
   IMAGE_TAG: {{ coalesce .Values.controller.agentImage.tag .Values.tag .Chart.Version | quote }}
-  LEADER_ELECT: {{ include "kagent.leaderElectionEnabled" . | quote }}
+  LEADER_ELECT: "true"
   OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.otel.tracing.exporter.otlp.endpoint | quote }}
   OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: {{ .Values.otel.logging.exporter.otlp.endpoint | quote }}
   OTEL_EXPORTER_OTLP_LOGS_INSECURE: {{ .Values.otel.logging.exporter.otlp.insecure | quote }}

--- a/helm/kagent/templates/rbac/leader-election-role.yaml
+++ b/helm/kagent/templates/rbac/leader-election-role.yaml
@@ -1,4 +1,3 @@
-{{- if eq (include "kagent.leaderElectionEnabled" .) "true" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -25,4 +24,3 @@ rules:
   verbs:
   - create
   - patch
-{{- end }}

--- a/helm/kagent/templates/rbac/leader-election-rolebinding.yaml
+++ b/helm/kagent/templates/rbac/leader-election-rolebinding.yaml
@@ -1,4 +1,3 @@
-{{- if eq (include "kagent.leaderElectionEnabled" .) "true" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -14,4 +13,3 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "kagent.fullname" . }}-controller
   namespace: {{ include "kagent.namespace" . }}
-{{- end }}

--- a/helm/kagent/tests/controller-deployment_test.yaml
+++ b/helm/kagent/tests/controller-deployment_test.yaml
@@ -2,6 +2,8 @@ suite: test controller deployment
 templates:
   - controller-deployment.yaml
   - controller-configmap.yaml
+  - rbac/leader-election-role.yaml
+  - rbac/leader-election-rolebinding.yaml
 tests:
   - it: should render controller deployment with default values
     template: controller-deployment.yaml
@@ -207,3 +209,26 @@ tests:
           path: spec.template.spec.volumes
       - isNull:
           path: spec.template.spec.containers[0].volumeMounts
+
+  - it: should always enable leader election
+    template: controller-configmap.yaml
+    asserts:
+      - equal:
+          path: data.LEADER_ELECT
+          value: "true"
+
+  - it: should always create leader election Role
+    template: rbac/leader-election-role.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Role
+
+  - it: should always create leader election RoleBinding
+    template: rbac/leader-election-rolebinding.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: RoleBinding


### PR DESCRIPTION
All controllers (remote_mcp_server_controller, agent_controller, modelconfig_controller, mcp_server_tool_controller, and service_controller) explicitly require leader election (NeedLeaderElection: true):

However, PR #1146 made leader election conditional (enabled only when replicas > 1). When running with 1 replica, controllers wait for leader election that never happens, causing a reconciliation deadlock where no resources are processed. I observed this behavior locally while developing on a kind cluster.

This fix removes the conditional helper and always enables leader election:
- Deleted kagent.leaderElectionEnabled helper from _helpers.tpl
- Hardcoded LEADER_ELECT="true" in controller-configmap.yaml
- Removed conditional wrappers from leader-election RBAC resources

Leader election works correctly with 1 replica (pod immediately becomes leader), is required for controllers to function, and does not appear to incur any significant cost, so fixing the issue by just making leader election unconditional seems reasonable.