### PR TITLE
fix(controller): apply RemoteMCPServer timeout to MCP client connections

### DIFF
--- a/go/internal/controller/reconciler/reconciler.go
+++ b/go/internal/controller/reconciler/reconciler.go
@@ -663,7 +663,15 @@ func (a *kagentReconciler) upsertToolServerForRemoteMCPServer(ctx context.Contex
 		return nil, fmt.Errorf("failed to create client for toolServer %s: %v", toolServer.Name, err)
 	}
 
-	tools, err := a.listTools(ctx, tsp, toolServer)
+	// Apply timeout from spec to context
+	timeoutCtx := ctx
+	if remoteMcpServer.Timeout != nil {
+		var cancel context.CancelFunc
+		timeoutCtx, cancel = context.WithTimeout(ctx, remoteMcpServer.Timeout.Duration)
+		defer cancel()
+	}
+
+	tools, err := a.listTools(timeoutCtx, tsp, toolServer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch tools for toolServer %s: %v", toolServer.Name, err)
 	}


### PR DESCRIPTION
The upsertToolServerForRemoteMCPServer function connects to MCP servers to discover tools but never applied the timeout from the RemoteMCPServer spec to the context. This caused indefinite hangs with broken MCP servers, blocking the single reconciler worker thread and preventing other RemoteMCPServers from being processed.  I observed this behavior locally while developing on a kind cluster

This fix applies the timeout from remoteMcpServer.Timeout to the context before calling listTools(), allowing graceful timeout and continued processing of other resources.