### PR TITLE
bump-golang-1.25.5

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/kagent-dev/kagent/go
 
-go 1.25.1
+go 1.25.5
 
 require (
 	github.com/abiosoft/ishell/v2 v2.0.2


### PR DESCRIPTION
Bump golang to latest, post CVE, release 1.25.5