### PR TITLE
allow rbac rolebindings to be disabled

### DIFF
--- a/helm/kagent/templates/rbac/clusterrole.yaml
+++ b/helm/kagent/templates/rbac/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.clusterRoleEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -169,3 +170,4 @@ rules:
   - update
   - patch
   - delete
+{{- end }}

--- a/helm/kagent/templates/rbac/clusterrolebinding.yaml
+++ b/helm/kagent/templates/rbac/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.clusterRoleEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -27,3 +28,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "kagent.fullname" . }}-controller
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm/kagent/tests/rbac_test.yaml
+++ b/helm/kagent/tests/rbac_test.yaml
@@ -145,4 +145,45 @@ tests:
           value: RELEASE-NAME
       - equal:
           path: metadata.labels["app.kubernetes.io/managed-by"]
-          value: Helm 
+          value: Helm
+
+  # Tests for rbac.clusterRoleEnabled switch
+  - it: should render clusterroles when rbac.clusterRoleEnabled is true (default)
+    template: rbac/clusterrole.yaml
+    set:
+      rbac:
+        clusterRoleEnabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: ClusterRole
+
+  - it: should not render clusterroles when rbac.clusterRoleEnabled is false
+    template: rbac/clusterrole.yaml
+    set:
+      rbac:
+        clusterRoleEnabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render clusterrolebindings when rbac.clusterRoleEnabled is true (default)
+    template: rbac/clusterrolebinding.yaml
+    set:
+      rbac:
+        clusterRoleEnabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: ClusterRoleBinding
+
+  - it: should not render clusterrolebindings when rbac.clusterRoleEnabled is false
+    template: rbac/clusterrolebinding.yaml
+    set:
+      rbac:
+        clusterRoleEnabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -37,6 +37,15 @@ securityContext: {}
   # runAsUser: 1000
 
 # ==============================================================================
+# RBAC CONFIGURATION
+# ==============================================================================
+
+rbac:
+  # -- Whether to create ClusterRole and ClusterRoleBinding resources.
+  # Set to false if you want to manage RBAC externally or use pre-existing roles.
+  clusterRoleEnabled: true
+
+# ==============================================================================
 # CORE KAGENT COMPONENTS
 # ==============================================================================
 


### PR DESCRIPTION
allow rbac rolebindings to be disabled
- this allows for external configuration of these, for instance for more locked-down permissioning