### PR TITLE
fix(controller): use consistent ID format for agent deletion

### DIFF
--- a/go/internal/controller/reconciler/reconciler.go
+++ b/go/internal/controller/reconciler/reconciler.go
@@ -96,7 +96,8 @@ func (a *kagentReconciler) ReconcileKagentAgent(ctx context.Context, req ctrl.Re
 }
 
 func (a *kagentReconciler) handleAgentDeletion(req ctrl.Request) error {
-	if err := a.dbClient.DeleteAgent(req.String()); err != nil {
+	id := utils.ConvertToPythonIdentifier(req.String())
+	if err := a.dbClient.DeleteAgent(id); err != nil {
 		return fmt.Errorf("failed to delete agent %s: %w",
 			req.String(), err)
 	}

--- a/go/internal/controller/reconciler/reconciler_test.go
+++ b/go/internal/controller/reconciler/reconciler_test.go
@@ -3,9 +3,11 @@ package reconciler
 import (
 	"testing"
 
+	"github.com/kagent-dev/kagent/go/internal/utils"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 // TestComputeStatusSecretHash_Output verifies the output of the hash function
@@ -190,4 +192,18 @@ func TestComputeStatusSecretHash_Deterministic(t *testing.T) {
 			assert.Equal(t, tt.expectedEqual, got1 == got2)
 		})
 	}
+}
+
+func TestAgentIDConsistency(t *testing.T) {
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: "test-namespace",
+			Name:      "my-agent",
+		},
+	}
+
+	storeID := utils.ConvertToPythonIdentifier(utils.ResourceRefString(req.Namespace, req.Name))
+	deleteID := utils.ConvertToPythonIdentifier(req.String())
+
+	assert.Equal(t, storeID, deleteID)
 }


### PR DESCRIPTION
Agent deletion was failing to soft-delete database records because handleAgentDeletion used raw namespace/name format while upsertAgent stored agents with the Python-converted format (namespace__NS__name).

Fixes #1175