### PR TITLE
docs: add prerequisites section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,27 @@
 - [Quick Start](https://kagent.dev/docs/kagent/getting-started/quickstart)
 - [Installation guide](https://kagent.dev/docs/kagent/introduction/installation)
 
+### Prerequisites
+
+To get started with kagent, you'll need:
+
+**Required Tools:**
+- **[kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)** - For creating a local Kubernetes cluster
+- **[kubectl](https://kubernetes.io/docs/tasks/tools/)** - For interacting with your cluster  
+- **[Helm](https://helm.sh/docs/intro/install/)** - For installing the kagent chart
+- **[OpenAI API key](https://platform.openai.com/api-keys)** - For running AI agents (or use [Anthropic](https://console.anthropic.com/), [Ollama](https://ollama.ai/), etc.)
+
+**Quick verification:**
+```bash
+kind version
+kubectl version --client
+helm version
+```
+
+> **💡 Tip:** If you're planning to contribute code, see [DEVELOPMENT.md](DEVELOPMENT.md) for additional development tools.
+
+**Ready to start?** Follow our [Quick Start guide](https://kagent.dev/docs/kagent/getting-started/quickstart) to deploy your first agent in minutes!  
+
 ## Technical Details
 
 ### Core Concepts


### PR DESCRIPTION
## Description
Adds a prerequisites section to the main README that aligns with the Quick Start documentation, making it easier for new users to understand what they need before getting started.

## Motivation
As a new contributor, Currently, users must navigate to the documentation site to learn what tools they need. This change surfaces those requirements directly in the README, reducing friction for new users while keeping the content focused and aligned with our Quick Start guide.

## Changes
- Added "Prerequisites" section after "Getting started"
- Listed required tools (kind, kubectl, Helm, API key)
- Included direct links to installation guides
- Added quick verification commands
- Separated basic usage from development requirements

## Related Documentation
This aligns with our [Quick Start guide](https://kagent.dev/docs/kagent/getting-started/quickstart#prerequisites)

## Type of Change
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/kagent-dev/kagent/blob/main/CONTRIBUTING.md) guide
- [x] My commits are signed off (DCO)
- [x] This aligns with existing documentation
- [x] This improves the user experience for new users

Signed-off-by: Paul Olukayode <paulkayode2018@gmail.com>