### PR TITLE
feat(helm): add service account token support for grafana-mcp

### DIFF
--- a/helm/tools/grafana-mcp/templates/secret.yaml
+++ b/helm/tools/grafana-mcp/templates/secret.yaml
@@ -7,4 +7,9 @@ metadata:
     {{- include "grafana-mcp.labels" . | nindent 4 }}
 type: Opaque
 data:
+  {{- if .Values.grafana.serviceAccountToken }}
+  GRAFANA_SERVICE_ACCOUNT_TOKEN: {{ .Values.grafana.serviceAccountToken | b64enc }}
+  {{- end }}
+  {{- if and .Values.grafana.apiKey (not .Values.grafana.serviceAccountToken) }}
   GRAFANA_API_KEY: {{ .Values.grafana.apiKey | b64enc }}
+  {{- end }}

--- a/helm/tools/grafana-mcp/values.yaml
+++ b/helm/tools/grafana-mcp/values.yaml
@@ -2,7 +2,8 @@ replicas: 1
 
 grafana:
   url: "grafana.kagent:3000/api"
-  apiKey: "-"
+  serviceAccountToken: ""
+  apiKey: "" # Deprecated - use serviceAccountToken instead.
 
 image:
   registry: mcp


### PR DESCRIPTION
## Overview

Add support for Grafana service account token authentication in the grafana-mcp Helm chart.

API keys are deprecated in Grafana and will be removed in a future release. Service account tokens are the recommended authentication method.

- [Migrate from API keys to service account tokens](https://grafana.com/docs/grafana/latest/administration/service-accounts/migrate-api-keys/)
- [mcp-grafana Usage](https://github.com/grafana/mcp-grafana?tab=readme-ov-file#usage)

## Changes

- Add `serviceAccountToken` option to values.yaml
- Mark `apiKey` as deprecated in values.yaml
- Update secret.yaml template

## About Backward Compatibility

This change modifies the behavior of `GRAFANA_API_KEY` environment variable rendering:

| Condition | Before | After |
|-----------|--------|-------|
| `grafana.apiKey` is not set | `GRAFANA_API_KEY: "-"` | Not rendered |
| `grafana.apiKey` is set | `GRAFANA_API_KEY: <value>` | `GRAFANA_API_KEY: <value>` |

I think this is functionally equivalent because the placeholder value `"-"` is not a valid API key and would not work for authentication.
