### PR TITLE
fix(helm): set KAGENT_CONTROLLER_NAME to support custom release names

### DIFF
--- a/helm/kagent/templates/controller-configmap.yaml
+++ b/helm/kagent/templates/controller-configmap.yaml
@@ -9,6 +9,7 @@ data:
   A2A_BASE_URL: {{ include "kagent.a2aBaseUrl" . | quote }}
   DATABASE_TYPE: {{ .Values.database.type | quote }}
   DEFAULT_MODEL_CONFIG_NAME: {{ include "kagent.defaultModelConfigName" . | quote }}
+  KAGENT_CONTROLLER_NAME: {{ include "kagent.fullname" . }}-controller
   IMAGE_PULL_POLICY: {{ .Values.controller.agentImage.pullPolicy | default .Values.imagePullPolicy | quote }}
   {{- if and .Values.controller.agentImage.pullSecret (not (eq .Values.controller.agentImage.pullSecret "")) }}
   IMAGE_PULL_SECRET: {{ .Values.controller.agentImage.pullSecret | quote }}


### PR DESCRIPTION
## Summary

When installing kagent with a custom Helm release name (e.g., `helm install my-kagent ...`), agents failed to connect to the controller because `KAGENT_URL` was hardcoded to `kagent-controller`.

**Root cause:** The `GetControllerName()` function in `go/internal/utils/common.go` looks for the `KAGENT_CONTROLLER_NAME` environment variable, but it was never set in the Helm chart, causing it to fall back to the hardcoded default `kagent-controller`.

**Fix:** Add `KAGENT_CONTROLLER_NAME` to the controller ConfigMap using the Helm fullname template to match the actual service name.

## Test Plan

- [x] Reproduced the issue by installing with custom release name (`my-kagent`)
- [x] Verified `KAGENT_CONTROLLER_NAME` was missing from ConfigMap before fix
- [x] Applied fix and verified `KAGENT_CONTROLLER_NAME=my-kagent-controller` in ConfigMap after upgrade

Fixes #1193