### PR TITLE
fix: bump TOOLS_GO_VERSION arg for devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "build": {
     "dockerfile": "Dockerfile",
     "args": {
-      "TOOLS_GO_VERSION": "1.24.3",
+      "TOOLS_GO_VERSION": "1.25.5",
       "TOOLS_NODE_VERSION": "22.15.0",
       "TOOLS_UV_VERSION": "0.7.2",
       "TOOLS_K9S_VERSION": "0.50.4",


### PR DESCRIPTION
What: 
The devcontainer uses the argument TOOLS_GO_VERSION to download golang from the url "https://golang.org/dl/go${TOOLS_GO_VERSION}.linux-${ARCH}.tar.gz" in the [devcontainer.json file]( https://github.com/kagent-dev/kagent/blob/main/.devcontainer/devcontainer.json). The current version is set to "1.24.3" which does not correspond with [go.mod](https://github.com/kagent-dev/kagent/blob/main/go/go.mod) which is set to "1.25.5"

Why:
The current setup produces errors in VScode when building the devcontainer as it does not have the correct version of golang to use the golang packages. 

How:
Bumped from "1.24.3" to "1.25.5" in the devcontainer 

edit: typos