### PR TITLE
feat(helm): add secretRef support for grafana-mcp

### DIFF
--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -349,7 +349,9 @@ tools:
 grafana-mcp:
   grafana:
     url: "grafana.kagent:3000/api"
-    apiKey: "-"
+    serviceAccountToken: ""
+    # apiKey: "" # Deprecated - use serviceAccountToken instead.
+    # secretRef: ""  # Name of Secret to reference (contains GRAFANA_SERVICE_ACCOUNT_TOKEN or GRAFANA_API_KEY)
   resources:
     requests:
       cpu: 100m

--- a/helm/tools/grafana-mcp/templates/deployment.yaml
+++ b/helm/tools/grafana-mcp/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
             - configMapRef:
                 name: {{ include "grafana-mcp.fullname" . }}
             - secretRef:
-                name: {{ include "grafana-mcp.fullname" . }}
+                name: {{ .Values.grafana.secretRef | default (include "grafana-mcp.fullname" .) | quote }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/helm/tools/grafana-mcp/templates/secret.yaml
+++ b/helm/tools/grafana-mcp/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.grafana.secretRef }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -13,3 +14,4 @@ data:
   {{- if and .Values.grafana.apiKey (not .Values.grafana.serviceAccountToken) }}
   GRAFANA_API_KEY: {{ .Values.grafana.apiKey | b64enc }}
   {{- end }}
+{{- end }}

--- a/helm/tools/grafana-mcp/values.yaml
+++ b/helm/tools/grafana-mcp/values.yaml
@@ -3,7 +3,8 @@ replicas: 1
 grafana:
   url: "grafana.kagent:3000/api"
   serviceAccountToken: ""
-  apiKey: "" # Deprecated - use serviceAccountToken instead.
+  # apiKey: "" # Deprecated - use serviceAccountToken instead.
+  # secretRef: ""  # Name of Secret to reference (contains GRAFANA_SERVICE_ACCOUNT_TOKEN or GRAFANA_API_KEY)
 
 image:
   registry: mcp


### PR DESCRIPTION
Hello. Thank you for all your mantaining this project.

## Overview

Add the ability to reference an existing Secret for grafana-mcp authentication instead of having the chart create new one.

This update improves security because it enables not to expose sensitive credentials in values file or `--set` option of helm cli or argocd application.

## Changes

### Add secretRef option to values.yaml

Added `secretRef` field to both `helm/kagent/values.yaml` and `helm/tools/grafana-mcp/values.yaml` to allow users to specify an existing Secret name containing `GRAFANA_SERVICE_ACCOUNT_TOKEN` or `GRAFANA_API_KEY`.

### Conditionally create Secret and refer it from deployment

Modified `helm/tools/grafana-mcp/templates/secret.yaml` to create a Secret only when `serviceAccountToken` or `apiKey` is provided. This prevents creating an empty Secret when using `secretRef`.

And also updated `helm/tools/grafana-mcp/templates/deployment.yaml` to reference the Secret specified by `secretRef` if provided, otherwise fall back to the chart-generated Secret name.

## Behavior change Matrix

| Parameter Combination | Before | After |
|----------------------|--------|-------|
| **1. Set only serviceAccountToken** | Secret created with `GRAFANA_SERVICE_ACCOUNT_TOKEN` | No change |
| **2. Set only apiKey** | Secret created with `GRAFANA_API_KEY` | No change |
| **3. Set only secretRef** | N/A | (recommended) Secret resource **not created**, existing Secret specified by value is used via `envFrom.secretRef` |
| **4. Set both of secretRef and serviceAccountToken (or apiKey)** | N/A | (unintended misuse) Secret specified by `secretRef` is referenced from Deployment |
| **5. Default values** | Empty Secret creaetd and referenced from Deployment | No change |

## Remarks

- Existing Secret reference method is carried out with respect for kagent `modelconfig-secret` pattern.