### PR TITLE
fix overwriting of cfg.Namespace kagent-dev#1235

### DIFF
--- a/go/cli/cmd/kagent/main.go
+++ b/go/cli/cmd/kagent/main.go
@@ -334,7 +334,7 @@ Examples:
 	// Add flags for deploy command
 	deployCmd.Flags().StringVarP(&deployCfg.Image, "image", "i", "", "Image to use (defaults to localhost:5001/{agentName}:latest)")
 	deployCmd.Flags().StringVar(&deployCfg.EnvFile, "env-file", "", "Path to .env file containing environment variables (including API keys)")
-	deployCmd.Flags().StringVar(&deployCfg.Config.Namespace, "namespace", "", "Kubernetes namespace to deploy to")
+	deployCmd.Flags().StringVar(&deployCfg.Config.Namespace, "namespace", "kagent", "Kubernetes namespace to deploy to")
 	deployCmd.Flags().BoolVar(&deployCfg.DryRun, "dry-run", false, "Output YAML manifests without applying them to the cluster")
 	deployCmd.Flags().StringVar(&deployCfg.Platform, "platform", "", "Target platform for Docker build (e.g., linux/amd64, linux/arm64)")
 


### PR DESCRIPTION
kagent-dev#1235 points out that default namespace for installing kagent is `default`, rather than `kagent` as documented. This occurs due to overwriting of the default parameter in deployCfg loading. 