### PR TITLE
chore: Unset OTel endpoints

### DIFF
--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -387,13 +387,13 @@ otel:
     enabled: false
     exporter:
       otlp:
-        endpoint: http://host.docker.internal:4317
+        endpoint: ""
         timeout: 15
         insecure: true
   logging:
     enabled: false
     exporter:
       otlp:
-        endpoint: http://host.docker.internal:4317
+        endpoint: ""
         timeout: 15
         insecure: true


### PR DESCRIPTION
Currently we set OTel endpoint by default, which will be picked up by the controller and will be propagated into any Agent created by the controller. 

This PR unsets these to avoid confusion and overriding what other projects might set during initialization.