### PR TITLE
propagate headers from the agent to the mcp tools

### DIFF
--- a/python/packages/kagent-adk/src/kagent/adk/_agent_executor.py
+++ b/python/packages/kagent-adk/src/kagent/adk/_agent_executor.py
@@ -185,7 +185,7 @@ class A2aAgentExecutor(AgentExecutor):
                     logger.error("Failed to publish failure event: %s", enqueue_error, exc_info=True)
         finally:
             clear_kagent_span_attributes(context_token)
-            # close the runner which cleans up the mcptoolsets 
+            # close the runner which cleans up the mcptoolsets
             # since the runner is created for each a2a request
             # and the mcptoolsets are not shared between requests
             # this is necessary to gracefully handle mcp toolset connections

--- a/python/packages/kagent-core/src/kagent/core/a2a/__init__.py
+++ b/python/packages/kagent-core/src/kagent/core/a2a/__init__.py
@@ -15,6 +15,7 @@ from ._consts import (
     KAGENT_HITL_RESUME_KEYWORDS_DENY,
     get_kagent_metadata_key,
 )
+from ._context import clear_request_headers, get_request_headers, set_request_headers
 from ._hitl import (
     DecisionType,
     ToolApprovalRequest,
@@ -24,12 +25,13 @@ from ._hitl import (
     handle_tool_approval_interrupt,
     is_input_required_task,
 )
-from ._requests import KAgentRequestContextBuilder
+from ._requests import KAgentCallContextBuilder, KAgentRequestContextBuilder
 from ._task_result_aggregator import TaskResultAggregator
 from ._task_store import KAgentTaskStore
 
 __all__ = [
     "get_a2a_max_content_length",
+    "KAgentCallContextBuilder",
     "KAgentRequestContextBuilder",
     "KAgentTaskStore",
     "get_kagent_metadata_key",
@@ -40,6 +42,10 @@ __all__ = [
     "A2A_DATA_PART_METADATA_TYPE_CODE_EXECUTION_RESULT",
     "A2A_DATA_PART_METADATA_TYPE_EXECUTABLE_CODE",
     "TaskResultAggregator",
+    # Request context utilities
+    "get_request_headers",
+    "set_request_headers",
+    "clear_request_headers",
     # HITL constants
     "KAGENT_HITL_INTERRUPT_TYPE_TOOL_APPROVAL",
     "KAGENT_HITL_DECISION_TYPE_KEY",

--- a/python/packages/kagent-core/src/kagent/core/a2a/_context.py
+++ b/python/packages/kagent-core/src/kagent/core/a2a/_context.py
@@ -1,0 +1,30 @@
+"""Context variables for request-scoped data."""
+
+from contextvars import ContextVar
+from typing import Dict
+
+# Context variable to store HTTP request headers for the current request
+_request_headers_var: ContextVar[Dict[str, str]] = ContextVar("request_headers", default=None)
+
+
+def set_request_headers(headers: Dict[str, str]) -> None:
+    """Store request headers in the current context.
+
+    Args:
+        headers: Dictionary of HTTP request headers
+    """
+    _request_headers_var.set(headers)
+
+
+def get_request_headers() -> Dict[str, str]:
+    """Get request headers from the current context.
+
+    Returns:
+        Dictionary of HTTP request headers, or empty dict if not set
+    """
+    return _request_headers_var.get()
+
+
+def clear_request_headers() -> None:
+    """Clear request headers from the current context."""
+    _request_headers_var.set({})


### PR DESCRIPTION
HeaderCaptureMiddleware intercepts the incoming HTTP requests and copies headers into a context variable. The KAgentCallContextBuilder reads that and stores the headers in `ServerCallContext.state["headers"]`. 

Once the headers are in the context, the agent executor can read them and store them in the sessions state for any plugins to extract them/use them. 