### PR TITLE
fix(openai): enable usage metadata in streaming responses

### DIFF
--- a/python/packages/kagent-adk/src/kagent/adk/models/_openai.py
+++ b/python/packages/kagent-adk/src/kagent/adk/models/_openai.py
@@ -434,7 +434,11 @@ class BaseOpenAI(BaseLlm):
                 # Accumulate tool calls - keyed by index since they arrive in chunks
                 tool_calls_acc: dict[int, dict[str, Any]] = {}
 
-                async for chunk in await self._client.chat.completions.create(stream=True, **kwargs):
+                # Request usage metadata in streaming mode (OpenAI API feature since Nov 2023)
+                # Without this option, chunk.usage is always None in streaming responses
+                async for chunk in await self._client.chat.completions.create(
+                    stream=True, stream_options={"include_usage": True}, **kwargs
+                ):
                     if chunk.choices and chunk.choices[0].delta:
                         delta = chunk.choices[0].delta
 


### PR DESCRIPTION
## What this PR does

Adds `stream_options={"include_usage": True}` to OpenAI streaming API calls to enable token usage metadata in streaming responses.

## Problem

Without this parameter, the OpenAI API does not return token usage statistics (`prompt_tokens`, `completion_tokens`, `total_tokens`) in streaming mode, causing `usage_metadata` to always be `None`. This breaks token counting and usage tracking features.

## Solution

Pass `stream_options` with `include_usage=True` when calling the OpenAI chat completions API in streaming mode. This feature is available in the OpenAI API since November 2023.

## Testing

Added unit tests to verify:
- `stream_options` is passed correctly in streaming calls
- Usage metadata is properly propagated from streaming responses

## Related Issue

Fixes token counting not working in streaming mode (usage_metadata is always None).