### PR TITLE
fix: avoid 500s when a2a cleanup is cancelled

### DIFF
--- a/python/packages/kagent-adk/src/kagent/adk/_a2a.py
+++ b/python/packages/kagent-adk/src/kagent/adk/_a2a.py
@@ -6,7 +6,6 @@ from typing import Any, Callable, List, Optional
 
 import httpx
 from a2a.server.apps import A2AFastAPIApplication
-from a2a.server.request_handlers import DefaultRequestHandler
 from a2a.server.tasks import InMemoryTaskStore
 from a2a.types import AgentCard
 from agentsts.adk import ADKSTSIntegration, ADKTokenPropagationPlugin
@@ -28,6 +27,7 @@ from kagent.core.a2a import (
 
 from ._agent_executor import A2aAgentExecutor, A2aAgentExecutorConfig
 from ._lifespan import LifespanManager
+from ._safe_request_handler import SafeRequestHandler
 from ._session_service import KAgentSessionService
 from ._token import KAgentTokenService
 
@@ -112,7 +112,7 @@ class KAgentApp:
             task_store = KAgentTaskStore(http_client)
 
         request_context_builder = KAgentRequestContextBuilder(task_store=task_store)
-        request_handler = DefaultRequestHandler(
+        request_handler = SafeRequestHandler(
             agent_executor=agent_executor,
             task_store=task_store,
             request_context_builder=request_context_builder,

--- a/python/packages/kagent-adk/src/kagent/adk/_safe_request_handler.py
+++ b/python/packages/kagent-adk/src/kagent/adk/_safe_request_handler.py
@@ -1,0 +1,24 @@
+import asyncio
+import logging
+
+from a2a.server.request_handlers import DefaultRequestHandler
+
+logger = logging.getLogger(__name__)
+
+
+class SafeRequestHandler(DefaultRequestHandler):
+    """Request handler that avoids turning cleanup cancellation into 500s."""
+
+    async def _cleanup_producer(self, producer_task, task_id):
+        try:
+            await super()._cleanup_producer(producer_task, task_id)
+        except asyncio.CancelledError:
+            logger.debug(
+                "A2A cleanup cancelled",
+                extra={"task_id": task_id},
+                exc_info=True,
+            )
+            # Make a best-effort attempt to clean up resources.
+            await self._queue_manager.close(task_id)
+            async with self._running_agents_lock:
+                self._running_agents.pop(task_id, None)

--- a/python/packages/kagent-adk/tests/unittests/test_safe_request_handler.py
+++ b/python/packages/kagent-adk/tests/unittests/test_safe_request_handler.py
@@ -1,0 +1,57 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kagent.adk._safe_request_handler import SafeRequestHandler
+
+
+@pytest.mark.asyncio
+async def test_cleanup_producer_swallows_cancelled_error():
+    mock_queue_manager = AsyncMock()
+    handler = SafeRequestHandler(
+        agent_executor=AsyncMock(),
+        task_store=AsyncMock(),
+        request_context_builder=AsyncMock(),
+    )
+    handler._queue_manager = mock_queue_manager
+    handler._running_agents = {"task-123": MagicMock()}
+    handler._running_agents_lock = asyncio.Lock()
+
+    async def cancelled_task():
+        raise asyncio.CancelledError()
+
+    producer_task = asyncio.create_task(cancelled_task())
+    try:
+        await handler._cleanup_producer(producer_task, task_id="task-123")
+    finally:
+        if not producer_task.done():
+            producer_task.cancel()
+
+    # Verify cleanup was still performed despite cancellation
+    mock_queue_manager.close.assert_called_once_with("task-123")
+    assert "task-123" not in handler._running_agents
+
+
+@pytest.mark.asyncio
+async def test_cleanup_producer_normal_completion():
+    """Verify normal cleanup calls parent correctly."""
+    mock_queue_manager = AsyncMock()
+    handler = SafeRequestHandler(
+        agent_executor=AsyncMock(),
+        task_store=AsyncMock(),
+        request_context_builder=AsyncMock(),
+    )
+    handler._queue_manager = mock_queue_manager
+    handler._running_agents = {"task-456": MagicMock()}
+    handler._running_agents_lock = asyncio.Lock()
+
+    async def successful_task():
+        return "done"
+
+    producer_task = asyncio.create_task(successful_task())
+    await handler._cleanup_producer(producer_task, task_id="task-456")
+
+    # Verify cleanup was performed
+    mock_queue_manager.close.assert_called_once_with("task-456")
+    assert "task-456" not in handler._running_agents


### PR DESCRIPTION
We hit a case where a client retried on `5xx` responses, and the agent's Slack tool had already executed before the server returned `500`. The request itself was effectively successful, but cleanup raised `CancelledError`, which bubbled into a `500` and triggered the retry. That led to duplicate Slack messages.

This change treats `CancelledError` during `_cleanup_producer` as non‑fatal so a completed request doesn't get turned into a `500` during cleanup. The result is that clients don't retry after work has already been done, avoiding duplicate side effects.