### PR TITLE
feat: allow configuring uvicorn log level via environment variable

### DIFF
--- a/python/packages/kagent-adk/src/kagent/adk/cli.py
+++ b/python/packages/kagent-adk/src/kagent/adk/cli.py
@@ -90,6 +90,7 @@ def static(
         port=port,
         workers=workers,
         reload=reload,
+        log_level=os.getenv("UVICORN_LOG_LEVEL", "info"),
     )
 
 
@@ -204,6 +205,7 @@ def run(
         host=host,
         port=port,
         workers=workers,
+        log_level=os.getenv("UVICORN_LOG_LEVEL", "info"),
     )
 
 


### PR DESCRIPTION
## Summary

- Add `UVICORN_LOG_LEVEL` environment variable support to control uvicorn server log verbosity
- Defaults to `"info"` for backward compatibility
- Applied to both `static` and `run` commands in the ADK CLI

## Motivation

Currently the uvicorn log level is not configurable at deployment time, resulting in excessive logs (health checks, startup messages) in production environments. This change allows operators to set the desired verbosity via an environment variable.

## Usage

```bash
# Reduce log noise in production
export UVICORN_LOG_LEVEL=warning
```

Closes #1269