### PR TITLE
chore(python): bump a2a-sdk to 0.3.23

### DIFF
--- a/python/packages/kagent-adk/pyproject.toml
+++ b/python/packages/kagent-adk/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "pydantic>=2.5.0",
   "typing-extensions>=4.8.0",
   "jsonref>=1.1.0",
-  "a2a-sdk>=0.3.22",
+  "a2a-sdk>=0.3.23",
   # Security: pin minimum versions for CVE fixes in transitive dependencies
   "urllib3>=2.6.3",  # CVE-2025-66418, CVE-2025-66471, CVE-2026-21441: unbounded decompression DoS
   "filelock>=3.20.3",  # CVE-2025-68146, CVE-2026-22701: TOCTOU symlink race condition

--- a/python/packages/kagent-core/pyproject.toml
+++ b/python/packages/kagent-core/pyproject.toml
@@ -9,7 +9,7 @@ description = "kagent common library for kagent python packages"
 readme = "README.md"
 requires-python = ">=3.11.0"
 dependencies = [
-  "a2a-sdk[http-server]>=0.3.9",
+  "a2a-sdk[http-server]>=0.3.23",
   "opentelemetry-api>=1.36.0",
   "opentelemetry-sdk>=1.36.0",
   "opentelemetry-exporter-otlp-proto-grpc>=1.36.0",

--- a/python/packages/kagent-crewai/pyproject.toml
+++ b/python/packages/kagent-crewai/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "pydantic>=2.0.0",
   "typing-extensions>=4.0.0",
   "uvicorn>=0.20.0",
-  "a2a-sdk[http-server]>=0.3.1",
+  "a2a-sdk[http-server]>=0.3.23",
   "kagent-core",
   "opentelemetry-instrumentation-crewai>=0.47.3",
   "google-genai>=1.21.1"

--- a/python/packages/kagent-langgraph/pyproject.toml
+++ b/python/packages/kagent-langgraph/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
   "pydantic>=2.0.0",
   "typing-extensions>=4.0.0",
   "uvicorn>=0.20.0",
-  "a2a-sdk>=0.2.16",
+  "a2a-sdk>=0.3.23",
   "kagent-core",
   "langsmith[otel]>=0.4.30",
 ]

--- a/python/packages/kagent-openai/pyproject.toml
+++ b/python/packages/kagent-openai/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.13"
 dependencies = [
   "openai>=1.72.0",
   "openai-agents>=0.4.0",
-  "a2a-sdk>=0.3.1",
+  "a2a-sdk>=0.3.23",
   "kagent-core",
   "kagent-skills",
   "httpx>=0.25.0",

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -32,7 +32,7 @@ dev = [
 
 [[package]]
 name = "a2a-sdk"
-version = "0.3.22"
+version = "0.3.23"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core" },
@@ -41,9 +41,9 @@ dependencies = [
     { name = "protobuf" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/a3/76f2d94a32a1b0dc760432d893a09ec5ed31de5ad51b1ef0f9d199ceb260/a2a_sdk-0.3.22.tar.gz", hash = "sha256:77a5694bfc4f26679c11b70c7f1062522206d430b34bc1215cfbb1eba67b7e7d", size = 231535, upload-time = "2025-12-16T18:39:21.19Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/6a/2fe24e0a85240a651006c12f79bdb37156adc760a96c44bc002ebda77916/a2a_sdk-0.3.23.tar.gz", hash = "sha256:7c46b8572c4633a2b41fced2833e11e62871e8539a5b3c782ba2ba1e33d213c2", size = 255265, upload-time = "2026-02-17T08:34:34.648Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/e8/f4e39fd1cf0b3c4537b974637143f3ebfe1158dad7232d9eef15666a81ba/a2a_sdk-0.3.22-py3-none-any.whl", hash = "sha256:b98701135bb90b0ff85d35f31533b6b7a299bf810658c1c65f3814a6c15ea385", size = 144347, upload-time = "2025-12-16T18:39:19.218Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/20/77d119f19ab03449d3e6bc0b1f11296d593dae99775c1d891ab1e290e416/a2a_sdk-0.3.23-py3-none-any.whl", hash = "sha256:8c2f01dffbfdd3509eafc15c4684743e6ae75e69a5df5d6f87be214c948e7530", size = 145689, upload-time = "2026-02-17T08:34:33.263Z" },
 ]
 
 [package.optional-dependencies]
@@ -2001,7 +2001,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "a2a-sdk", specifier = ">=0.3.22" },
+    { name = "a2a-sdk", specifier = ">=0.3.23" },
     { name = "agentsts-adk", specifier = ">=0.0.8" },
     { name = "agentsts-core", specifier = ">=0.0.8" },
     { name = "aiofiles", specifier = ">=24.1.0" },
@@ -2052,7 +2052,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "a2a-sdk", extras = ["http-server"], specifier = ">=0.3.9" },
+    { name = "a2a-sdk", extras = ["http-server"], specifier = ">=0.3.23" },
     { name = "opentelemetry-api", specifier = ">=1.36.0" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.36.0" },
     { name = "opentelemetry-instrumentation-anthropic", specifier = ">=0.44.0" },
@@ -2090,7 +2090,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "a2a-sdk", extras = ["http-server"], specifier = ">=0.3.1" },
+    { name = "a2a-sdk", extras = ["http-server"], specifier = ">=0.3.23" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
     { name = "crewai", extras = ["tools"], specifier = ">=1.2.0" },
     { name = "fastapi", specifier = ">=0.100.0" },
@@ -2134,7 +2134,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "a2a-sdk", specifier = ">=0.2.16" },
+    { name = "a2a-sdk", specifier = ">=0.3.23" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
     { name = "fastapi", specifier = ">=0.100.0" },
     { name = "httpx", specifier = ">=0.25.0" },
@@ -2178,7 +2178,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "a2a-sdk", specifier = ">=0.3.1" },
+    { name = "a2a-sdk", specifier = ">=0.3.23" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
     { name = "fastapi", specifier = ">=0.100.0" },
     { name = "httpx", specifier = ">=0.25.0" },


### PR DESCRIPTION
The main motivation is that it includes this fix:

- https://github.com/a2aproject/a2a-python/pull/614

It's described in more detail from a kagent perspective here:

- https://github.com/kagent-dev/kagent/pull/1268