### PR TITLE
Restore chat status/subscription when loading a chat

### DIFF
--- a/ui/src/lib/messageHandlers.ts
+++ b/ui/src/lib/messageHandlers.ts
@@ -1,4 +1,7 @@
 import { Message, Task, TaskStatusUpdateEvent, TaskArtifactUpdateEvent, TextPart, Part, DataPart } from "@a2a-js/sdk";
+
+/** Union of all event types that can arrive from an A2A SSE stream. */
+export type StreamEvent = Message | Task | TaskStatusUpdateEvent | TaskArtifactUpdateEvent;
 import { v4 as uuidv4 } from "uuid";
 import { convertToUserFriendlyName, messageUtils } from "@/lib/utils";
 import { TokenStats, ChatStatus } from "@/types";
@@ -528,7 +531,7 @@ export const createMessageHandlers = (handlers: MessageHandlers) => {
     appendMessage(message);
   };
 
-  const handleMessageEvent = (message: Message) => {
+  const handleMessageEvent = (message: StreamEvent) => {
     if (messageUtils.isA2ATask(message)) {
       handlers.setIsStreaming(true);
       return;


### PR DESCRIPTION
Previously the UI would just assume a chat was idle when loading it.  This fetches the chat status and displays an appropriate state.  It will resubscribe for live updates in some cases as well.

This makes the experience a lot nicer when switching between chats or reloading the page while looking at a chat.
