### PR TITLE
Add session tools to built-in kagent-agents MCP server

### DIFF
--- a/go/internal/mcp/mcp_handler.go
+++ b/go/internal/mcp/mcp_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -11,8 +12,10 @@ import (
 	"github.com/kagent-dev/kagent/go/api/v1alpha2"
 	"github.com/kagent-dev/kagent/go/internal/a2a"
 	authimpl "github.com/kagent-dev/kagent/go/internal/httpserver/auth"
+	"github.com/kagent-dev/kagent/go/internal/utils"
 	"github.com/kagent-dev/kagent/go/internal/version"
 	"github.com/kagent-dev/kagent/go/pkg/auth"
+	dbpkg "github.com/kagent-dev/kagent/go/pkg/database"
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -21,14 +24,19 @@ import (
 	"trpc.group/trpc-go/trpc-a2a-go/protocol"
 )
 
+const defaultUserID = "admin@kagent.dev"
+
 // MCPHandler handles MCP requests and bridges them to A2A endpoints
 type MCPHandler struct {
-	kubeClient    client.Client
-	a2aBaseURL    string
-	authenticator auth.AuthProvider
-	httpHandler   *mcpsdk.StreamableHTTPHandler
-	server        *mcpsdk.Server
-	a2aClients    sync.Map
+	kubeClient         client.Client
+	a2aBaseURL         string
+	authenticator      auth.AuthProvider
+	dbClient           dbpkg.Client
+	uiBaseURL          string
+	httpHandler        *mcpsdk.StreamableHTTPHandler
+	server             *mcpsdk.Server
+	a2aClients         sync.Map
+	sendA2AMessageFunc func(ctx context.Context, agentRef string, contextID *string, text string) error
 }
 
 // Input types for MCP tools
@@ -57,11 +65,13 @@ type InvokeAgentOutput struct {
 
 // NewMCPHandler creates a new MCP handler
 // Wraps the StreamableHTTPHandler and adds A2A bridging and context management.
-func NewMCPHandler(kubeClient client.Client, a2aBaseURL string, authenticator auth.AuthProvider) (*MCPHandler, error) {
+func NewMCPHandler(kubeClient client.Client, a2aBaseURL string, authenticator auth.AuthProvider, dbClient dbpkg.Client, uiBaseURL string) (*MCPHandler, error) {
 	handler := &MCPHandler{
 		kubeClient:    kubeClient,
 		a2aBaseURL:    a2aBaseURL,
 		authenticator: authenticator,
+		dbClient:      dbClient,
+		uiBaseURL:     uiBaseURL,
 	}
 
 	// Create MCP server
@@ -90,6 +100,36 @@ func NewMCPHandler(kubeClient client.Client, a2aBaseURL string, authenticator au
 			Description: "Invoke a kagent agent via A2A",
 		},
 		handler.handleInvokeAgent,
+	)
+
+	// Add create_session tool
+	mcpsdk.AddTool[CreateSessionInput, CreateSessionOutput](
+		server,
+		&mcpsdk.Tool{
+			Name:        "create_agent_session",
+			Description: "Create a new session (visible in the UI) for an agent with an initial task",
+		},
+		handler.handleCreateSession,
+	)
+
+	// Add get_session_events tool
+	mcpsdk.AddTool[GetSessionEventsInput, GetSessionEventsOutput](
+		server,
+		&mcpsdk.Tool{
+			Name:        "get_agent_session_events",
+			Description: "Retrieve the event history (conversation) of a session",
+		},
+		handler.handleGetSessionEvents,
+	)
+
+	// Add send_session_message tool
+	mcpsdk.AddTool[SendSessionMessageInput, SendSessionMessageOutput](
+		server,
+		&mcpsdk.Tool{
+			Name:        "send_agent_session_message",
+			Description: "Send a new message to an existing session (as the user)",
+		},
+		handler.handleSendSessionMessage,
 	)
 
 	// Create HTTP handler
@@ -170,6 +210,64 @@ func (h *MCPHandler) handleListAgents(ctx context.Context, req *mcpsdk.CallToolR
 	}, output, nil
 }
 
+func (h *MCPHandler) getOrCreateA2AClient(agentRef string) (*a2aclient.A2AClient, error) {
+	if cached, ok := h.a2aClients.Load(agentRef); ok {
+		if client, ok := cached.(*a2aclient.A2AClient); ok {
+			return client, nil
+		}
+	}
+
+	agentNS, agentName, _ := strings.Cut(agentRef, "/")
+	a2aURL := fmt.Sprintf("%s/%s/", h.a2aBaseURL, agentRef)
+	a2aOpts := []a2aclient.Option{
+		a2aclient.WithTimeout(30 * time.Second),
+		a2aclient.WithHTTPReqHandler(
+			authimpl.A2ARequestHandler(
+				h.authenticator,
+				types.NamespacedName{Namespace: agentNS, Name: agentName},
+			),
+		),
+	}
+
+	client, err := a2aclient.NewA2AClient(a2aURL, a2aOpts...)
+	if err != nil {
+		return nil, err
+	}
+	h.a2aClients.Store(agentRef, client)
+	return client, nil
+}
+
+// sendA2AMessage sends a non-blocking A2A message to the agent. The A2A protocol's
+// Blocking=false flag causes the server to return immediately with a Task in
+// "submitted" or "working" state while the agent continues processing in the background.
+func (h *MCPHandler) sendA2AMessage(ctx context.Context, agentRef string, contextID *string, text string) error {
+	if h.sendA2AMessageFunc != nil {
+		return h.sendA2AMessageFunc(ctx, agentRef, contextID, text)
+	}
+
+	a2aClient, err := h.getOrCreateA2AClient(agentRef)
+	if err != nil {
+		return fmt.Errorf("failed to create A2A client: %w", err)
+	}
+
+	blocking := false
+	_, err = a2aClient.SendMessage(ctx, protocol.SendMessageParams{
+		Message: protocol.Message{
+			Kind:      protocol.KindMessage,
+			Role:      protocol.MessageRoleUser,
+			ContextID: contextID,
+			Parts:     []protocol.Part{protocol.NewTextPart(text)},
+		},
+		Configuration: &protocol.SendMessageConfiguration{
+			Blocking: &blocking,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to send A2A message: %w", err)
+	}
+	return nil
+}
+
 // handleInvokeAgent handles the invoke_agent MCP tool
 func (h *MCPHandler) handleInvokeAgent(ctx context.Context, req *mcpsdk.CallToolRequest, input InvokeAgentInput) (*mcpsdk.CallToolResult, InvokeAgentOutput, error) {
 	log := ctrllog.FromContext(ctx).WithName("mcp-handler").WithValues("tool", "invoke_agent")
@@ -185,7 +283,6 @@ func (h *MCPHandler) handleInvokeAgent(ctx context.Context, req *mcpsdk.CallTool
 		}, InvokeAgentOutput{}, nil
 	}
 	agentRef := agentNS + "/" + agentName
-	agentNns := types.NamespacedName{Namespace: agentNS, Name: agentName}
 
 	// Get context ID from client request (stateless mode)
 	// If not provided, contextIDPtr will be nil and a new conversation will start
@@ -195,43 +292,15 @@ func (h *MCPHandler) handleInvokeAgent(ctx context.Context, req *mcpsdk.CallTool
 		log.V(1).Info("Using context_id from client request", "context_id", input.ContextID)
 	}
 
-	// Get or create cached A2A client for this agent
-	a2aURL := fmt.Sprintf("%s/%s/", h.a2aBaseURL, agentRef)
-	var a2aClient *a2aclient.A2AClient
-
-	if cached, ok := h.a2aClients.Load(agentRef); ok {
-		if client, ok := cached.(*a2aclient.A2AClient); ok {
-			a2aClient = client
-		}
-	}
-
-	// Create new client if not cached
-	if a2aClient == nil {
-		// Build A2A client options with authentication propagation
-		a2aOpts := []a2aclient.Option{
-			a2aclient.WithTimeout(30 * time.Second),
-			a2aclient.WithHTTPReqHandler(
-				authimpl.A2ARequestHandler(
-					h.authenticator,
-					agentNns,
-				),
-			),
-		}
-
-		newClient, err := a2aclient.NewA2AClient(a2aURL, a2aOpts...)
-		if err != nil {
-			log.Error(err, "Failed to create A2A client", "agent", agentRef)
-			return &mcpsdk.CallToolResult{
-				Content: []mcpsdk.Content{
-					&mcpsdk.TextContent{Text: fmt.Sprintf("Failed to create A2A client: %v", err)},
-				},
-				IsError: true,
-			}, InvokeAgentOutput{}, nil
-		}
-
-		// Cache the client
-		h.a2aClients.Store(agentRef, newClient)
-		a2aClient = newClient
+	a2aClient, err := h.getOrCreateA2AClient(agentRef)
+	if err != nil {
+		log.Error(err, "Failed to create A2A client", "agent", agentRef)
+		return &mcpsdk.CallToolResult{
+			Content: []mcpsdk.Content{
+				&mcpsdk.TextContent{Text: fmt.Sprintf("Failed to create A2A client: %v", err)},
+			},
+			IsError: true,
+		}, InvokeAgentOutput{}, nil
 	}
 
 	// Send message via A2A
@@ -301,6 +370,235 @@ func (h *MCPHandler) handleInvokeAgent(ctx context.Context, req *mcpsdk.CallTool
 			&mcpsdk.TextContent{Text: responseText},
 		},
 	}, output, nil
+}
+
+type CreateSessionInput struct {
+	Agent  string `json:"agent" jsonschema:"Agent reference in format namespace/name"`
+	Task   string `json:"task" jsonschema:"Initial task/message for the session"`
+	UserID string `json:"user_id,omitempty" jsonschema:"User ID to assign the session to (optional)"`
+	Name   string `json:"name,omitempty" jsonschema:"Optional name for the session"`
+}
+
+type CreateSessionOutput struct {
+	SessionID string `json:"session_id"`
+	Message   string `json:"message"`
+	URL       string `json:"url,omitempty"`
+}
+
+// handleCreateSession handles the create_session MCP tool
+func (h *MCPHandler) handleCreateSession(ctx context.Context, req *mcpsdk.CallToolRequest, input CreateSessionInput) (*mcpsdk.CallToolResult, CreateSessionOutput, error) {
+	log := ctrllog.FromContext(ctx).WithName("mcp-handler").WithValues("tool", "create_agent_session")
+
+	// Parse agent reference (namespace/name or just name)
+	_, agentName, ok := strings.Cut(input.Agent, "/")
+	if !ok {
+		return &mcpsdk.CallToolResult{
+			Content: []mcpsdk.Content{
+				&mcpsdk.TextContent{Text: "agent must be in format 'namespace/name'"},
+			},
+			IsError: true,
+		}, CreateSessionOutput{}, nil
+	}
+
+	if input.UserID == "" {
+		input.UserID = defaultUserID
+	}
+
+	// Verify agent exists
+	agent, err := h.dbClient.GetAgent(utils.ConvertToPythonIdentifier(input.Agent))
+	if err != nil {
+		return &mcpsdk.CallToolResult{
+			Content: []mcpsdk.Content{
+				&mcpsdk.TextContent{Text: fmt.Sprintf("Failed to find agent %s: %v", input.Agent, err)},
+			},
+			IsError: true,
+		}, CreateSessionOutput{}, nil
+	}
+
+	// Create session
+	sessionID := protocol.GenerateContextID()
+	sessionName := input.Name
+	if sessionName == "" {
+		sessionName = fmt.Sprintf("Session with %s", agentName)
+	}
+
+	session := &dbpkg.Session{
+		ID:      sessionID,
+		Name:    &sessionName,
+		UserID:  input.UserID,
+		AgentID: &agent.ID,
+	}
+
+	if err := h.dbClient.StoreSession(session); err != nil {
+		log.Error(err, "Failed to store session")
+		return &mcpsdk.CallToolResult{
+			Content: []mcpsdk.Content{
+				&mcpsdk.TextContent{Text: fmt.Sprintf("Failed to create session: %v", err)},
+			},
+			IsError: true,
+		}, CreateSessionOutput{}, nil
+	}
+
+	log.Info("Created session", "sessionID", sessionID, "agent", input.Agent, "userID", input.UserID)
+
+	if err := h.sendA2AMessage(ctx, input.Agent, &sessionID, input.Task); err != nil {
+		log.Error(err, "Failed to dispatch task to agent", "sessionID", sessionID, "agent", input.Agent)
+		url := fmt.Sprintf("%s/agents/%s/chat/%s", h.uiBaseURL, input.Agent, sessionID)
+		msg := fmt.Sprintf("Session created (ID: %s) but failed to dispatch the initial message to the agent: %v. You can retry by calling send_agent_session_message with session_id=%s.", sessionID, err, sessionID)
+		return &mcpsdk.CallToolResult{
+			Content: []mcpsdk.Content{
+				&mcpsdk.TextContent{Text: msg},
+			},
+			IsError: true,
+		}, CreateSessionOutput{SessionID: sessionID, Message: msg, URL: url}, nil
+	}
+
+	message := fmt.Sprintf("Session created successfully. Session ID: %s", sessionID)
+	url := fmt.Sprintf("%s/agents/%s/chat/%s", h.uiBaseURL, input.Agent, sessionID)
+
+	return &mcpsdk.CallToolResult{
+		Content: []mcpsdk.Content{
+			&mcpsdk.TextContent{Text: fmt.Sprintf("%s\nURL: %s", message, url)},
+		},
+	}, CreateSessionOutput{SessionID: sessionID, Message: message, URL: url}, nil
+}
+
+type GetSessionEventsInput struct {
+	SessionID string `json:"session_id" jsonschema:"ID of the session to retrieve events from"`
+	UserID    string `json:"user_id,omitempty" jsonschema:"User ID who owns the session (optional, defaults to admin@kagent.dev)"`
+	Limit     int    `json:"limit,omitempty" jsonschema:"Maximum number of events to retrieve (default: 50)"`
+}
+
+type GetSessionEventsOutput struct {
+	Events []SessionEvent `json:"events"`
+}
+
+type SessionEvent struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+	Type    string `json:"type"` // e.g. "message", "tool_call", "tool_result"
+}
+
+// handleGetSessionEvents handles the get_session_events MCP tool
+func (h *MCPHandler) handleGetSessionEvents(ctx context.Context, req *mcpsdk.CallToolRequest, input GetSessionEventsInput) (*mcpsdk.CallToolResult, GetSessionEventsOutput, error) {
+	log := ctrllog.FromContext(ctx).WithName("mcp-handler").WithValues("tool", "get_session_events")
+
+	if input.UserID == "" {
+		input.UserID = defaultUserID
+	}
+
+	limit := input.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+
+	// Fetch events from DB
+	dbEvents, err := h.dbClient.ListEventsForSession(input.SessionID, input.UserID, dbpkg.QueryOptions{
+		Limit:    limit,
+		OrderAsc: false, // Descending order to get most recent first
+	})
+	if err != nil {
+		log.Error(err, "Failed to list events for session", "sessionID", input.SessionID)
+		return &mcpsdk.CallToolResult{
+			Content: []mcpsdk.Content{
+				&mcpsdk.TextContent{Text: fmt.Sprintf("Failed to list events: %v", err)},
+			},
+			IsError: true,
+		}, GetSessionEventsOutput{}, nil
+	}
+
+	// Reverse events to be in chronological order for the transcript
+	slices.Reverse(dbEvents)
+
+	events := make([]SessionEvent, 0, len(dbEvents))
+	var sb strings.Builder
+
+	for _, dbEvent := range dbEvents {
+		msg, err := dbEvent.Parse()
+		if err != nil {
+			log.Error(err, "Failed to parse event data", "eventID", dbEvent.ID)
+			continue
+		}
+
+		// Convert protocol.Message to SessionEvent
+		content := a2a.ExtractText(msg)
+		role := string(msg.Role)
+
+		event := SessionEvent{
+			Role:    role,
+			Content: content,
+			Type:    string(msg.Kind),
+		}
+		events = append(events, event)
+
+		// Format for text output
+		sb.WriteString(fmt.Sprintf("[%s]: %s\n", strings.ToUpper(role), content))
+	}
+
+	if len(events) == 0 {
+		sb.WriteString("No events found for this session.")
+	}
+
+	return &mcpsdk.CallToolResult{
+		Content: []mcpsdk.Content{
+			&mcpsdk.TextContent{Text: sb.String()},
+		},
+	}, GetSessionEventsOutput{Events: events}, nil
+}
+
+type SendSessionMessageInput struct {
+	SessionID string `json:"session_id" jsonschema:"ID of the session to send message to"`
+	UserID    string `json:"user_id,omitempty" jsonschema:"User ID who owns the session (optional, defaults to admin@kagent.dev)"`
+	Content   string `json:"content" jsonschema:"Message content to send"`
+}
+
+type SendSessionMessageOutput struct {
+	Message string `json:"message"`
+}
+
+// handleSendSessionMessage handles the send_session_message MCP tool
+func (h *MCPHandler) handleSendSessionMessage(ctx context.Context, req *mcpsdk.CallToolRequest, input SendSessionMessageInput) (*mcpsdk.CallToolResult, SendSessionMessageOutput, error) {
+	log := ctrllog.FromContext(ctx).WithName("mcp-handler").WithValues("tool", "send_agent_session_message")
+
+	if input.UserID == "" {
+		input.UserID = defaultUserID
+	}
+
+	// Verify session exists
+	session, err := h.dbClient.GetSession(input.SessionID, input.UserID)
+	if err != nil {
+		log.Error(err, "Failed to find session", "sessionID", input.SessionID)
+		return &mcpsdk.CallToolResult{
+			Content: []mcpsdk.Content{
+				&mcpsdk.TextContent{Text: fmt.Sprintf("Failed to find session %s: %v", input.SessionID, err)},
+			},
+			IsError: true,
+		}, SendSessionMessageOutput{}, nil
+	}
+
+	if session.AgentID != nil {
+		agentRef := utils.ConvertToKubernetesIdentifier(*session.AgentID)
+		if err := h.sendA2AMessage(ctx, agentRef, &session.ID, input.Content); err != nil {
+			log.Error(err, "Failed to dispatch message to agent", "sessionID", session.ID, "agent", agentRef)
+			msg := fmt.Sprintf("Failed to dispatch message to agent: %v. WARNING: do NOT resend the same message — it may have been partially delivered. Check the session events first.", err)
+			return &mcpsdk.CallToolResult{
+				Content: []mcpsdk.Content{
+					&mcpsdk.TextContent{Text: msg},
+				},
+				IsError: true,
+			}, SendSessionMessageOutput{Message: msg}, nil
+		}
+	}
+
+	log.Info("Sent message to session", "sessionID", session.ID)
+
+	message := "Message sent successfully."
+
+	return &mcpsdk.CallToolResult{
+		Content: []mcpsdk.Content{
+			&mcpsdk.TextContent{Text: message},
+		},
+	}, SendSessionMessageOutput{Message: message}, nil
 }
 
 // ServeHTTP implements http.Handler interface

--- a/go/internal/mcp/mcp_handler_test.go
+++ b/go/internal/mcp/mcp_handler_test.go
@@ -1,0 +1,369 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	database_fake "github.com/kagent-dev/kagent/go/internal/database/fake"
+	"github.com/kagent-dev/kagent/go/internal/utils"
+	dbpkg "github.com/kagent-dev/kagent/go/pkg/database"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	"trpc.group/trpc-go/trpc-a2a-go/protocol"
+)
+
+func newTestHandler() (*MCPHandler, *database_fake.InMemoryFakeClient) {
+	dbClient := database_fake.NewClient()
+	fakeClient := dbClient.(*database_fake.InMemoryFakeClient)
+	handler := &MCPHandler{
+		dbClient:  dbClient,
+		uiBaseURL: "http://test-ui.example.com",
+		sendA2AMessageFunc: func(ctx context.Context, agentRef string, contextID *string, text string) error {
+			return nil
+		},
+	}
+	return handler, fakeClient
+}
+
+func storeTestAgent(t *testing.T, dbClient dbpkg.Client, agentRef string) *dbpkg.Agent {
+	t.Helper()
+	agent := &dbpkg.Agent{ID: utils.ConvertToPythonIdentifier(agentRef)}
+	require.NoError(t, dbClient.StoreAgent(agent))
+	return agent
+}
+
+func storeTestSession(t *testing.T, dbClient dbpkg.Client, sessionID, userID, agentID string) *dbpkg.Session {
+	t.Helper()
+	session := &dbpkg.Session{
+		ID:      sessionID,
+		UserID:  userID,
+		AgentID: &agentID,
+	}
+	require.NoError(t, dbClient.StoreSession(session))
+	return session
+}
+
+func makeEventData(t *testing.T, role protocol.MessageRole, text string) string {
+	t.Helper()
+	msg := protocol.Message{
+		Kind:  protocol.KindMessage,
+		Role:  role,
+		Parts: []protocol.Part{protocol.NewTextPart(text)},
+	}
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+	return string(data)
+}
+
+func TestHandleCreateSession(t *testing.T) {
+	tests := []struct {
+		name               string
+		input              CreateSessionInput
+		setupAgent         bool
+		a2aError           error
+		wantError          bool
+		wantSessionID      bool
+		wantURL            bool
+		errorContains      string
+		wantRetryHint      bool
+	}{
+		{
+			name: "success with custom name",
+			input: CreateSessionInput{
+				Agent:  "test-ns/test-agent",
+				Task:   "Do something",
+				UserID: "user-1",
+				Name:   "My Session",
+			},
+			setupAgent:    true,
+			wantSessionID: true,
+			wantURL:       true,
+		},
+		{
+			name: "success with default name",
+			input: CreateSessionInput{
+				Agent:  "test-ns/test-agent",
+				Task:   "Do something",
+				UserID: "user-1",
+			},
+			setupAgent:    true,
+			wantSessionID: true,
+			wantURL:       true,
+		},
+		{
+			name: "error invalid agent format",
+			input: CreateSessionInput{
+				Agent:  "no-slash",
+				Task:   "Do something",
+				UserID: "user-1",
+			},
+			wantError:     true,
+			errorContains: "namespace/name",
+		},
+		{
+			name: "defaults user_id when omitted",
+			input: CreateSessionInput{
+				Agent: "test-ns/test-agent",
+				Task:  "Do something",
+			},
+			setupAgent:    true,
+			wantSessionID: true,
+			wantURL:       true,
+		},
+		{
+			name: "error agent not found",
+			input: CreateSessionInput{
+				Agent:  "test-ns/missing-agent",
+				Task:   "Do something",
+				UserID: "user-1",
+			},
+			wantError:     true,
+			errorContains: "Failed to find agent",
+		},
+		{
+			name: "a2a dispatch failure returns error with retry hint",
+			input: CreateSessionInput{
+				Agent:  "test-ns/test-agent",
+				Task:   "Do something",
+				UserID: "user-1",
+			},
+			setupAgent:    true,
+			a2aError:      fmt.Errorf("connection refused"),
+			wantError:     true,
+			wantSessionID: true,
+			wantURL:       true,
+			errorContains: "failed to dispatch",
+			wantRetryHint: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler, _ := newTestHandler()
+
+			if tt.a2aError != nil {
+				handler.sendA2AMessageFunc = func(ctx context.Context, agentRef string, contextID *string, text string) error {
+					return tt.a2aError
+				}
+			}
+
+			if tt.setupAgent {
+				storeTestAgent(t, handler.dbClient, tt.input.Agent)
+			}
+
+			result, output, err := handler.handleCreateSession(context.Background(), &mcpsdk.CallToolRequest{}, tt.input)
+			require.NoError(t, err, "handler should not return Go error")
+			require.NotNil(t, result)
+
+			if tt.wantError {
+				assert.True(t, result.IsError)
+				require.NotEmpty(t, result.Content)
+				text := result.Content[0].(*mcpsdk.TextContent).Text
+				assert.Contains(t, text, tt.errorContains)
+				if tt.wantRetryHint {
+					assert.Contains(t, text, "send_agent_session_message")
+				}
+			} else {
+				assert.False(t, result.IsError)
+				assert.Contains(t, output.Message, "Session created successfully")
+			}
+
+			if tt.wantSessionID {
+				assert.NotEmpty(t, output.SessionID)
+			}
+			if tt.wantURL {
+				assert.Contains(t, output.URL, "http://test-ui.example.com/agents/"+tt.input.Agent+"/chat/")
+			}
+
+			if !tt.wantSessionID {
+				return
+			}
+
+			expectedUserID := tt.input.UserID
+			if expectedUserID == "" {
+				expectedUserID = defaultUserID
+			}
+
+			session, err := handler.dbClient.GetSession(output.SessionID, expectedUserID)
+			require.NoError(t, err)
+			assert.Equal(t, expectedUserID, session.UserID)
+			assert.NotNil(t, session.AgentID)
+
+			if tt.input.Name != "" {
+				assert.Equal(t, tt.input.Name, *session.Name)
+			} else {
+				assert.Contains(t, *session.Name, "Session with")
+			}
+		})
+	}
+}
+
+func TestHandleGetSessionEvents(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      GetSessionEventsInput
+		setupFunc  func(t *testing.T, dbClient dbpkg.Client)
+		wantEvents int
+		wantText   string
+	}{
+		{
+			name: "success with events",
+			input: GetSessionEventsInput{
+				SessionID: "session-1",
+				UserID:    "user-1",
+				Limit:     50,
+			},
+			setupFunc: func(t *testing.T, dbClient dbpkg.Client) {
+				require.NoError(t, dbClient.StoreEvents(
+					&dbpkg.Event{ID: "evt-1", SessionID: "session-1", UserID: "user-1", Data: makeEventData(t, protocol.MessageRoleUser, "hello")},
+					&dbpkg.Event{ID: "evt-2", SessionID: "session-1", UserID: "user-1", Data: makeEventData(t, protocol.MessageRoleAgent, "hi there")},
+				))
+			},
+			wantEvents: 2,
+			wantText:   "[USER]",
+		},
+		{
+			name: "success with no events",
+			input: GetSessionEventsInput{
+				SessionID: "empty-session",
+				UserID:    "user-1",
+			},
+			wantEvents: 0,
+			wantText:   "No events found",
+		},
+		{
+			name: "default limit applied",
+			input: GetSessionEventsInput{
+				SessionID: "session-1",
+				UserID:    "user-1",
+
+			},
+			setupFunc: func(t *testing.T, dbClient dbpkg.Client) {
+				require.NoError(t, dbClient.StoreEvents(
+					&dbpkg.Event{ID: "evt-1", SessionID: "session-1", UserID: "user-1", Data: makeEventData(t, protocol.MessageRoleUser, "msg")},
+				))
+			},
+			wantEvents: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler, _ := newTestHandler()
+
+			if tt.setupFunc != nil {
+				tt.setupFunc(t, handler.dbClient)
+			}
+
+			result, output, err := handler.handleGetSessionEvents(context.Background(), &mcpsdk.CallToolRequest{}, tt.input)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.False(t, result.IsError)
+
+			assert.Len(t, output.Events, tt.wantEvents)
+
+			require.NotEmpty(t, result.Content)
+			text := result.Content[0].(*mcpsdk.TextContent).Text
+			if tt.wantText != "" {
+				assert.Contains(t, text, tt.wantText)
+			}
+
+			if tt.wantEvents >= 2 {
+				assert.Equal(t, "user", output.Events[0].Role)
+				assert.Equal(t, "agent", output.Events[1].Role)
+			}
+		})
+	}
+}
+
+func TestHandleSendSessionMessage(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         SendSessionMessageInput
+		setupFunc     func(t *testing.T, dbClient dbpkg.Client)
+		a2aError      error
+		wantError     bool
+		errorContains string
+	}{
+		{
+			name: "success",
+			input: SendSessionMessageInput{
+				SessionID: "session-1",
+				UserID:    "user-1",
+				Content:   "hello agent",
+			},
+			setupFunc: func(t *testing.T, dbClient dbpkg.Client) {
+				storeTestSession(t, dbClient, "session-1", "user-1", "agent-1")
+			},
+		},
+		{
+			name: "defaults user_id when omitted",
+			input: SendSessionMessageInput{
+				SessionID: "session-default",
+				Content:   "hello with default user",
+			},
+			setupFunc: func(t *testing.T, dbClient dbpkg.Client) {
+				storeTestSession(t, dbClient, "session-default", defaultUserID, "agent-1")
+			},
+		},
+		{
+			name: "error session not found",
+			input: SendSessionMessageInput{
+				SessionID: "nonexistent",
+				UserID:    "user-1",
+				Content:   "hello",
+			},
+			wantError:     true,
+			errorContains: "Failed to find session",
+		},
+		{
+			name: "a2a dispatch failure returns error with no-resend warning",
+			input: SendSessionMessageInput{
+				SessionID: "session-1",
+				UserID:    "user-1",
+				Content:   "hello agent",
+			},
+			setupFunc: func(t *testing.T, dbClient dbpkg.Client) {
+				storeTestSession(t, dbClient, "session-1", "user-1", "agent-1")
+			},
+			a2aError:      fmt.Errorf("connection refused"),
+			wantError:     true,
+			errorContains: "do NOT resend",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler, _ := newTestHandler()
+
+			if tt.a2aError != nil {
+				handler.sendA2AMessageFunc = func(ctx context.Context, agentRef string, contextID *string, text string) error {
+					return tt.a2aError
+				}
+			}
+
+			if tt.setupFunc != nil {
+				tt.setupFunc(t, handler.dbClient)
+			}
+
+			result, output, err := handler.handleSendSessionMessage(context.Background(), &mcpsdk.CallToolRequest{}, tt.input)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			if tt.wantError {
+				assert.True(t, result.IsError)
+				require.NotEmpty(t, result.Content)
+				text := result.Content[0].(*mcpsdk.TextContent).Text
+				assert.Contains(t, text, tt.errorContains)
+				return
+			}
+
+			assert.False(t, result.IsError)
+			assert.Contains(t, output.Message, "Message sent successfully")
+		})
+	}
+}

--- a/go/pkg/app/app.go
+++ b/go/pkg/app/app.go
@@ -127,6 +127,9 @@ type Config struct {
 		Path string
 		Url  string
 	}
+	UI struct {
+		BaseURL string
+	}
 }
 
 func (cfg *Config) SetFlags(commandLine *flag.FlagSet) {
@@ -156,6 +159,8 @@ func (cfg *Config) SetFlags(commandLine *flag.FlagSet) {
 	commandLine.StringVar(&cfg.Database.Type, "database-type", "sqlite", "The type of the database to use. Supported values: sqlite, postgres.")
 	commandLine.StringVar(&cfg.Database.Path, "sqlite-database-path", "./kagent.db", "The path to the SQLite database file.")
 	commandLine.StringVar(&cfg.Database.Url, "postgres-database-url", "postgres://postgres:kagent@db.kagent.svc.cluster.local:5432/crud", "The URL of the PostgreSQL database.")
+
+	commandLine.StringVar(&cfg.UI.BaseURL, "ui-base-url", "http://localhost:3000", "The base URL of the UI.")
 
 	commandLine.StringVar(&cfg.WatchNamespaces, "watch-namespaces", "", "The namespaces to watch for .")
 
@@ -460,6 +465,8 @@ func Start(getExtensionConfig GetExtensionConfig) {
 		mgr.GetClient(),
 		cfg.A2ABaseUrl+httpserver.APIPathA2A,
 		extensionCfg.Authenticator,
+		dbClient,
+		cfg.UI.BaseURL,
 	)
 	if err != nil {
 		setupLog.Error(err, "unable to create MCP handler")

--- a/helm/kagent/templates/toolserver-controller.yaml
+++ b/helm/kagent/templates/toolserver-controller.yaml
@@ -1,0 +1,10 @@
+apiVersion: kagent.dev/v1alpha2
+kind: RemoteMCPServer
+metadata:
+  name: {{ include "kagent.fullname" . }}-controller
+  namespace: {{ include "kagent.namespace" . }}
+  labels:
+    {{- include "kagent.labels" . | nindent 4 }}
+spec:
+  url: "http://{{ include "kagent.fullname" . }}-controller.{{ include "kagent.namespace" . }}:{{ .Values.controller.service.ports.port }}/mcp"
+  description: "Kagent Controller Built-in Tools (Session Management, Agent Invocation)"


### PR DESCRIPTION
This allows an agent to create an kagent session to run a task instead of simple delegation.  This can be used to "hand off" a task to a different agent.

For example you can have an interactive session with a planning agent, it can hand that off to the implementation agent, and you can have an interactive session with the implementation agent.

The interactive session is desirable so the agent can ask questions or get corrections.  Doing it via multiple agents is desirable so that you can pick your model parameters and system prompt separately for the task.

This combines the two together - you can setup a RemoteMCPServer that points to the kagent-controller and give the planning agent the power to create a session and give you a link to it to continue the work.

In principle this might move in the direction of having multi-agent coordination where you can interact with the agents and they interact with each other if you give them each others' session IDs or have a coordinating agent that starts multiple agents and then gives them each others' session IDs.
