### PR TITLE
feat: add read-only mode for GitOps-managed deployments

### DIFF
--- a/go/cmd/controller/main.go
+++ b/go/cmd/controller/main.go
@@ -17,7 +17,10 @@ limitations under the License.
 package main
 
 import (
+	"os"
+
 	"github.com/kagent-dev/kagent/go/internal/httpserver/auth"
+	pkgauth "github.com/kagent-dev/kagent/go/pkg/auth"
 	"github.com/kagent-dev/kagent/go/pkg/app"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -27,7 +30,12 @@ import (
 
 //nolint:gocyclo
 func main() {
-	authorizer := &auth.NoopAuthorizer{}
+	var authorizer pkgauth.Authorizer
+	if os.Getenv("KAGENT_READ_ONLY") == "true" {
+		authorizer = &auth.ReadOnlyAuthorizer{}
+	} else {
+		authorizer = &auth.NoopAuthorizer{}
+	}
 	authenticator := &auth.UnsecureAuthenticator{}
 	app.Start(func(bootstrap app.BootstrapConfig) (*app.ExtensionConfig, error) {
 		return &app.ExtensionConfig{

--- a/go/internal/httpserver/auth/authz.go
+++ b/go/internal/httpserver/auth/authz.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/kagent-dev/kagent/go/pkg/auth"
 )
@@ -13,3 +14,14 @@ func (a *NoopAuthorizer) Check(ctx context.Context, principal auth.Principal, ve
 }
 
 var _ auth.Authorizer = (*NoopAuthorizer)(nil)
+
+type ReadOnlyAuthorizer struct{}
+
+func (a *ReadOnlyAuthorizer) Check(ctx context.Context, principal auth.Principal, verb auth.Verb, resource auth.Resource) error {
+	if verb != auth.VerbGet {
+		return fmt.Errorf("read-only mode: %s operations are not permitted", verb)
+	}
+	return nil
+}
+
+var _ auth.Authorizer = (*ReadOnlyAuthorizer)(nil)

--- a/go/internal/httpserver/auth/authz_test.go
+++ b/go/internal/httpserver/auth/authz_test.go
@@ -1,0 +1,52 @@
+package auth_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kagent-dev/kagent/go/internal/httpserver/auth"
+	pkgauth "github.com/kagent-dev/kagent/go/pkg/auth"
+)
+
+func TestReadOnlyAuthorizer(t *testing.T) {
+	authorizer := &auth.ReadOnlyAuthorizer{}
+	ctx := context.Background()
+	principal := pkgauth.Principal{}
+	resource := pkgauth.Resource{Name: "test", Type: "agent"}
+
+	tests := []struct {
+		name    string
+		verb    pkgauth.Verb
+		wantErr bool
+	}{
+		{name: "allows get", verb: pkgauth.VerbGet, wantErr: false},
+		{name: "rejects create", verb: pkgauth.VerbCreate, wantErr: true},
+		{name: "rejects update", verb: pkgauth.VerbUpdate, wantErr: true},
+		{name: "rejects delete", verb: pkgauth.VerbDelete, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := authorizer.Check(ctx, principal, tt.verb, resource)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ReadOnlyAuthorizer.Check() verb=%s, error = %v, wantErr %v", tt.verb, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestNoopAuthorizer(t *testing.T) {
+	authorizer := &auth.NoopAuthorizer{}
+	ctx := context.Background()
+	principal := pkgauth.Principal{}
+	resource := pkgauth.Resource{Name: "test", Type: "agent"}
+
+	verbs := []pkgauth.Verb{pkgauth.VerbGet, pkgauth.VerbCreate, pkgauth.VerbUpdate, pkgauth.VerbDelete}
+	for _, verb := range verbs {
+		t.Run(string(verb), func(t *testing.T) {
+			if err := authorizer.Check(ctx, principal, verb, resource); err != nil {
+				t.Errorf("NoopAuthorizer.Check() verb=%s, unexpected error: %v", verb, err)
+			}
+		})
+	}
+}

--- a/ui/src/app/agents/new/page.tsx
+++ b/ui/src/app/agents/new/page.tsx
@@ -19,6 +19,7 @@ import { Tool, EnvVar } from "@/types";
 import { toast } from "sonner";
 import { NamespaceCombobox } from "@/components/NamespaceCombobox";
 import { Label } from "@/components/ui/label";
+import { useReadOnly } from "@/components/ReadOnlyProvider";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 
@@ -738,11 +739,23 @@ function AgentPageContent({ isEditMode, agentName, agentNamespace }: AgentPageCo
 
 // Main component that wraps the content in a Suspense boundary
 export default function AgentPage() {
+  const router = useRouter();
+  const readOnly = useReadOnly();
   // Determine if in edit mode
   const searchParams = useSearchParams();
   const isEditMode = searchParams.get("edit") === "true";
   const agentName = searchParams.get("name");
   const agentNamespace = searchParams.get("namespace");
+
+  useEffect(() => {
+    if (readOnly) {
+      router.replace("/");
+    }
+  }, [readOnly, router]);
+
+  if (readOnly) {
+    return <LoadingState />;
+  }
 
   // Create a key based on the edit mode and agent ID
   const formKey = isEditMode ? `edit-${agentName}-${agentNamespace}` : 'create';

--- a/ui/src/app/layout.tsx
+++ b/ui/src/app/layout.tsx
@@ -8,6 +8,9 @@ import { Footer } from "@/components/Footer";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import { Toaster } from "@/components/ui/sonner";
 import { AppInitializer } from "@/components/AppInitializer";
+import { ReadOnlyProvider } from "@/components/ReadOnlyProvider";
+
+export const dynamic = "force-dynamic";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -19,22 +22,26 @@ export const metadata: Metadata = {
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
+  const readOnly = process.env.NEXT_PUBLIC_READ_ONLY === "true";
+
   return (
-    <TooltipProvider>
-      <AgentsProvider>
-        <html lang="en" className="">
-          <body className={`${geistSans.className} flex flex-col h-screen overflow-hidden`}>
-            <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
-              <AppInitializer>
-                <Header />
-                <main className="flex-1 overflow-y-scroll w-full mx-auto">{children}</main>
-                <Footer />
-              </AppInitializer>
-              <Toaster richColors/>
-            </ThemeProvider>
-          </body>
-        </html>
-      </AgentsProvider>
-    </TooltipProvider>
+    <html lang="en" className="">
+      <body className={`${geistSans.className} flex flex-col h-screen overflow-hidden`}>
+        <ReadOnlyProvider readOnly={readOnly}>
+          <TooltipProvider>
+            <AgentsProvider>
+              <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+                <AppInitializer>
+                  <Header />
+                  <main className="flex-1 overflow-y-scroll w-full mx-auto">{children}</main>
+                  <Footer />
+                </AppInitializer>
+                <Toaster richColors/>
+              </ThemeProvider>
+            </AgentsProvider>
+          </TooltipProvider>
+        </ReadOnlyProvider>
+      </body>
+    </html>
   );
 }

--- a/ui/src/app/models/new/page.tsx
+++ b/ui/src/app/models/new/page.tsx
@@ -30,6 +30,7 @@ import { BasicInfoSection } from '@/components/models/new/BasicInfoSection';
 import { AuthSection } from '@/components/models/new/AuthSection';
 import { ParamsSection } from '@/components/models/new/ParamsSection';
 import { k8sRefUtils } from "@/lib/k8sUtils";
+import { useReadOnly } from "@/components/ReadOnlyProvider";
 
 interface ValidationErrors {
   name?: string;
@@ -759,6 +760,19 @@ function ModelPageContent() {
 }
 
 export default function ModelPage() {
+  const router = useRouter();
+  const readOnly = useReadOnly();
+
+  useEffect(() => {
+    if (readOnly) {
+      router.replace("/");
+    }
+  }, [readOnly, router]);
+
+  if (readOnly) {
+    return <LoadingState />;
+  }
+
   return (
     <React.Suspense fallback={<LoadingState />}>
       <ModelPageContent />

--- a/ui/src/app/models/page.tsx
+++ b/ui/src/app/models/page.tsx
@@ -17,6 +17,7 @@ import {
     DialogTitle,
 } from "@/components/ui/dialog";
 import { k8sRefUtils } from "@/lib/k8sUtils";
+import { useReadOnly } from "@/components/ReadOnlyProvider";
 
 export default function ModelsPage() {
     const router = useRouter();
@@ -25,6 +26,7 @@ export default function ModelsPage() {
     const [error, setError] = useState<string | null>(null);
     const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
     const [modelToDelete, setModelToDelete] = useState<ModelConfig | null>(null);
+    const readOnly = useReadOnly();
 
     useEffect(() => {
         fetchModels();
@@ -93,6 +95,7 @@ export default function ModelsPage() {
             <div className="max-w-6xl mx-auto">
                 <div className="flex justify-between items-center mb-8">
                     <h1 className="text-2xl font-bold">Models</h1>
+                    {!readOnly && (
                     <Button
                         variant="default"
                         onClick={() => router.push("/models/new")}
@@ -100,6 +103,7 @@ export default function ModelsPage() {
                         <Plus className="h-4 w-4 mr-2" />
                         New Model
                     </Button>
+                    )}
                 </div>
 
                 {loading ? (
@@ -120,6 +124,7 @@ export default function ModelsPage() {
                                         )}
                                         <span className="font-medium">{model.ref}</span>
                                     </div>
+                                    {!readOnly && (
                                     <div className="flex space-x-2">
                                         <Button
                                             data-test={`edit-model-${model.ref}`}
@@ -143,6 +148,7 @@ export default function ModelsPage() {
                                             <Trash2 className="h-4 w-4" />
                                         </Button>
                                     </div>
+                                    )}
                                 </div>
                                 {expandedRows.has(model.ref) && (
                                     <div className="p-4 border-t bg-secondary/10">

--- a/ui/src/app/servers/page.tsx
+++ b/ui/src/app/servers/page.tsx
@@ -10,8 +10,10 @@ import { AddServerDialog } from "@/components/AddServerDialog";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import Link from "next/link";
 import { toast } from "sonner";
+import { useReadOnly } from "@/components/ReadOnlyProvider";
 
 export default function ServersPage() {
+  const readOnly = useReadOnly();
   // State for servers and tools
   const [servers, setServers] = useState<ToolServerResponse[]>([]);
   const [toolServerTypes, setToolServerTypes] = useState<string[]>([]);
@@ -141,7 +143,7 @@ export default function ServersPage() {
             View Tools →
           </Link>
         </div>
-        {servers.length > 0 && (
+        {servers.length > 0 && !readOnly && (
           <Button onClick={() => setShowAddServer(true)} variant="default">
             <Plus className="h-4 w-4 mr-2" />
             Add MCP Server
@@ -181,9 +183,10 @@ export default function ServersPage() {
                       </div>
                     </div>
 
+                    {!readOnly && (
                     <div className="flex items-center gap-2">
-                      <DropdownMenu 
-                        open={openDropdownMenu === serverName} 
+                      <DropdownMenu
+                        open={openDropdownMenu === serverName}
                         onOpenChange={(isOpen) => setOpenDropdownMenu(isOpen ? serverName : null)}
                       >
                         <DropdownMenuTrigger asChild>
@@ -192,7 +195,7 @@ export default function ServersPage() {
                           </Button>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end">
-                           <DropdownMenuItem 
+                           <DropdownMenuItem
                              className="text-red-600 focus:text-red-700 focus:bg-red-50"
                              onSelect={(e) => {
                                e.preventDefault();
@@ -206,6 +209,7 @@ export default function ServersPage() {
                         </DropdownMenuContent>
                       </DropdownMenu>
                     </div>
+                    )}
                   </div>
                 </div>
 
@@ -245,11 +249,13 @@ export default function ServersPage() {
         <div className="flex flex-col items-center justify-center h-[300px] text-center p-4 border rounded-lg bg-secondary/5">
           <Server className="h-12 w-12 text-muted-foreground mb-4 opacity-20" />
           <h3 className="font-medium text-lg">No MCP servers connected</h3>
-          <p className="text-muted-foreground mt-1 mb-4">Add an MCP server to discover and use tools.</p>
+          <p className="text-muted-foreground mt-1 mb-4">{readOnly ? "No MCP servers configured yet. Servers are managed via GitOps." : "Add an MCP server to discover and use tools."}</p>
+          {!readOnly && (
           <Button onClick={() => setShowAddServer(true)} variant="default">
             <Plus className="h-4 w-4 mr-2" />
             Add MCP Server
           </Button>
+          )}
         </div>
       )}
 

--- a/ui/src/components/AgentCard.tsx
+++ b/ui/src/components/AgentCard.tsx
@@ -8,6 +8,7 @@ import { useRouter } from "next/navigation";
 import { Pencil } from "lucide-react";
 import { k8sRefUtils } from "@/lib/k8sUtils";
 import { cn } from "@/lib/utils";
+import { useReadOnly } from "./ReadOnlyProvider";
 
 interface AgentCardProps {
   agentResponse: AgentResponse;
@@ -15,6 +16,7 @@ interface AgentCardProps {
 
 export function AgentCard({ agentResponse: { agent, model, modelProvider, deploymentReady, accepted } }: AgentCardProps) {
   const router = useRouter();
+  const readOnly = useReadOnly();
   const agentRef = k8sRefUtils.toRef(
     agent.metadata.namespace || '',
     agent.metadata.name || ''
@@ -60,6 +62,7 @@ export function AgentCard({ agentResponse: { agent, model, modelProvider, deploy
           <KagentLogo className="h-5 w-5 flex-shrink-0" />
           <span className="truncate">{agentRef}</span>
         </CardTitle>
+        {!readOnly && (
         <div className="flex items-center space-x-2 relative z-30 opacity-0 group-hover:opacity-100 transition-opacity">
           <Button
             variant="ghost"
@@ -75,6 +78,7 @@ export function AgentCard({ agentResponse: { agent, model, modelProvider, deploy
             namespace={agent.metadata.namespace || ''}
           />
         </div>
+        )}
       </CardHeader>
       <CardContent className="flex flex-col justify-between h-32 relative z-10">
         <p className="text-sm text-muted-foreground line-clamp-3 overflow-hidden">

--- a/ui/src/components/AgentList.tsx
+++ b/ui/src/components/AgentList.tsx
@@ -7,9 +7,11 @@ import { ErrorState } from "./ErrorState";
 import { Button } from "./ui/button";
 import { LoadingState } from "./LoadingState";
 import { useAgents } from "./AgentsProvider";
+import { useReadOnly } from "./ReadOnlyProvider";
 
 export default function AgentList() {
   const { agents , loading, error } = useAgents();
+  const readOnly = useReadOnly();
 
   if (error) {
     return <ErrorState message={error} />;
@@ -31,13 +33,15 @@ export default function AgentList() {
         <div className="text-center py-12">
           <KagentLogo className="h-16 w-16 mx-auto mb-4" />
           <h3 className="text-lg font-medium  mb-2">No agents yet</h3>
-          <p className=" mb-6">Create your first agent to get started</p>
+          <p className=" mb-6">{readOnly ? "No agents configured yet. Agents are managed via GitOps." : "Create your first agent to get started"}</p>
+          {!readOnly && (
           <Button className="bg-violet-500 hover:bg-violet-600" asChild>
             <Link href={"/agents/new"}>
               <Plus className="h-4 w-4 mr-2" />
               Create New Agent
             </Link>
           </Button>
+          )}
         </div>
       ) : (
         <AgentGrid agentResponse={agents || []} />

--- a/ui/src/components/AppInitializer.tsx
+++ b/ui/src/components/AppInitializer.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react';
 import { OnboardingWizard } from './onboarding/OnboardingWizard';
+import { useReadOnly } from './ReadOnlyProvider';
 
 const LOCAL_STORAGE_KEY = 'kagent-onboarding';
 
@@ -14,6 +15,7 @@ const getInitialOnboardingState = (): boolean | null => {
 
 export function AppInitializer({ children }: { children: React.ReactNode }) {
   const [isOnboarding, setIsOnboarding] = useState<boolean | null>(getInitialOnboardingState);
+  const readOnly = useReadOnly();
 
   const handleOnboardingComplete = () => {
     localStorage.setItem(LOCAL_STORAGE_KEY, 'true');
@@ -30,7 +32,7 @@ export function AppInitializer({ children }: { children: React.ReactNode }) {
     return null; 
   }
 
-  if (isOnboarding) {
+  if (isOnboarding && !readOnly) {
     return <OnboardingWizard onOnboardingComplete={handleOnboardingComplete} onSkip={handleSkipWizard} />;
   }
 

--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -6,6 +6,7 @@ import KAgentLogoWithText from "./kagent-logo-text";
 import KagentLogo from "./kagent-logo";
 import { Plus, Menu, X, ChevronDown, Brain, Server, Eye, Hammer, HomeIcon } from "lucide-react";
 import { ThemeToggle } from "./ThemeToggle";
+import { useReadOnly } from "./ReadOnlyProvider";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -15,6 +16,7 @@ import {
 
 export function Header() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const readOnly = useReadOnly();
 
   const toggleMenu = () => {
     setIsMenuOpen(!isMenuOpen);
@@ -55,6 +57,7 @@ export function Header() {
 
 
             {/* Create Dropdown */}
+            {!readOnly && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button variant="link" className="text-secondary-foreground gap-1 px-2">
@@ -84,6 +87,7 @@ export function Header() {
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
+            )}
             
             {/* View Dropdown */}
             <DropdownMenu>
@@ -184,6 +188,7 @@ export function Header() {
               </DropdownMenu>
 
               {/* Mobile Create Dropdown */}
+              {!readOnly && (
                <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button variant="ghost" className="text-secondary-foreground justify-start px-1 gap-1 w-full">
@@ -213,6 +218,7 @@ export function Header() {
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
+              )}
               
               {/* Mobile Other Links */}
               <Button variant="ghost" className="text-secondary-foreground justify-start px-1" asChild>

--- a/ui/src/components/ReadOnlyProvider.tsx
+++ b/ui/src/components/ReadOnlyProvider.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { createContext, useContext, ReactNode } from "react";
+
+const ReadOnlyContext = createContext(false);
+
+export function ReadOnlyProvider({ readOnly, children }: { readOnly: boolean; children: ReactNode }) {
+  return <ReadOnlyContext.Provider value={readOnly}>{children}</ReadOnlyContext.Provider>;
+}
+
+export function useReadOnly() {
+  return useContext(ReadOnlyContext);
+}

--- a/ui/src/components/sidebars/AgentDetailsSidebar.tsx
+++ b/ui/src/components/sidebars/AgentDetailsSidebar.tsx
@@ -15,6 +15,7 @@ import { getAgents } from "@/app/actions/agents";
 import { k8sRefUtils } from "@/lib/k8sUtils";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Badge } from "@/components/ui/badge";
+import { useReadOnly } from "@/components/ReadOnlyProvider";
 
 interface AgentDetailsSidebarProps {
   selectedAgentName: string;
@@ -26,6 +27,7 @@ export function AgentDetailsSidebar({ selectedAgentName, currentAgent, allTools 
   const [toolDescriptions, setToolDescriptions] = useState<Record<string, string>>({});
   const [expandedTools, setExpandedTools] = useState<Record<string, boolean>>({});
   const [availableAgents, setAvailableAgents] = useState<AgentResponse[]>([]);
+  const readOnly = useReadOnly();
 
   const selectedTeam = currentAgent;
 
@@ -232,6 +234,7 @@ export function AgentDetailsSidebar({ selectedAgentName, currentAgent, allTools 
                 <SidebarGroupLabel className="font-bold mb-0 p-0">
                   {selectedTeam?.agent.metadata.namespace}/{selectedTeam?.agent.metadata.name} {selectedTeam?.model && `(${selectedTeam?.model})`}
                 </SidebarGroupLabel>
+                {!readOnly && (
                 <Button
                   variant="ghost"
                   size="icon"
@@ -243,6 +246,7 @@ export function AgentDetailsSidebar({ selectedAgentName, currentAgent, allTools 
                     <Edit className="h-3.5 w-3.5" />
                   </Link>
                 </Button>
+                )}
               </div>
               <p className="text-sm flex px-2 text-muted-foreground">{selectedTeam?.agent.spec.description}</p>
             </SidebarGroup>

--- a/ui/src/components/sidebars/ChatItem.tsx
+++ b/ui/src/components/sidebars/ChatItem.tsx
@@ -14,6 +14,7 @@ import { SidebarMenu, SidebarMenuAction, SidebarMenuButton, SidebarMenuItem } fr
 import Link from "next/link";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { Button } from "../ui/button";
+import { useReadOnly } from "../ReadOnlyProvider";
 
 interface ChatItemProps {
   sessionId: string;
@@ -27,6 +28,7 @@ interface ChatItemProps {
 
 const ChatItem = ({ sessionId, agentName, agentNamespace, onDelete, sessionName, onDownload, createdAt }: ChatItemProps) => {
   const title = sessionName || "Untitled";
+  const readOnly = useReadOnly();
   
   // Format timestamp based on how recent it is
   const formatTime = (dateString?: string) => {
@@ -81,6 +83,7 @@ const ChatItem = ({ sessionId, agentName, agentNamespace, onDelete, sessionName,
                   <span>Download</span>
                 </Button>
               </DropdownMenuItem>
+              {!readOnly && (
               <DropdownMenuItem onSelect={(e) => e.preventDefault()} className="p-0">
                 <AlertDialog>
                   <AlertDialogTrigger asChild>
@@ -104,6 +107,7 @@ const ChatItem = ({ sessionId, agentName, agentNamespace, onDelete, sessionName,
                   </AlertDialogContent>
                 </AlertDialog>
               </DropdownMenuItem>
+              )}
             </DropdownMenuContent>
           </DropdownMenu>
         </SidebarMenuItem>


### PR DESCRIPTION
## Summary

- Add `ReadOnlyAuthorizer` to the backend that only allows GET operations, activated via `KAGENT_READ_ONLY=true` env var
- Add `ReadOnlyProvider` React context for the frontend, reading `NEXT_PUBLIC_READ_ONLY` env var
- Conditionally hide all create/edit/delete UI controls when read-only mode is active
- Add route guards on `/agents/new` and `/models/new` pages
- Skip the onboarding wizard in read-only mode
- Show "managed via GitOps" messaging in empty states

This enables GitOps-managed deployments (FluxCD, ArgoCD) where agents, models, and MCP servers are defined declaratively as Kubernetes CRDs and the UI serves as a read-only dashboard.

## Environment Variables

| Variable | Component | Default | Description |
|----------|-----------|---------|-------------|
| `KAGENT_READ_ONLY` | Controller | `false` | Enables read-only mode on the API |
| `NEXT_PUBLIC_READ_ONLY` | UI | `false` | Enables read-only mode in the frontend |

## Files Changed

**Backend (Go):**
- `go/internal/httpserver/auth/authz.go` — new `ReadOnlyAuthorizer`
- `go/cmd/controller/main.go` — env var wiring

**Frontend (Next.js):**
- `ui/src/components/ReadOnlyProvider.tsx` — new React context
- `ui/src/app/layout.tsx` — wrap app in `ReadOnlyProvider`, add `force-dynamic`
- 10 component/page files — conditional rendering of write controls

## Test plan
- [ ] Set `KAGENT_READ_ONLY=true` + `NEXT_PUBLIC_READ_ONLY=true`, verify all write controls are hidden
- [ ] Verify API rejects POST/PUT/DELETE with clear error message
- [ ] Verify chat functionality still works (read-only hides management, not chat)
- [ ] Verify defaults: without env vars, everything works as before
- [ ] Run `make -C go test` and `make -C ui build`

Closes #1344
Related: #1270, #593