### PR TITLE
fix: add timestamps to agent log output (#739)

### DIFF
--- a/python/packages/kagent-core/src/kagent/core/_logging.py
+++ b/python/packages/kagent-core/src/kagent/core/_logging.py
@@ -3,24 +3,29 @@ import os
 
 _logging_configured = False
 
+LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+
 
 def configure_logging() -> None:
     """Configure logging based on LOG_LEVEL environment variable."""
     global _logging_configured
 
     log_level = os.getenv("LOG_LEVEL", "INFO").upper()
+    formatter = logging.Formatter(LOG_FORMAT)
 
     # Only configure if not already configured (avoid duplicate handlers)
     if not logging.root.handlers:
         logging.basicConfig(
             level=log_level,
-            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+            format=LOG_FORMAT,
         )
         _logging_configured = True
         logging.info(f"Logging configured with level: {log_level}")
     elif not _logging_configured:
-        # Update level if already configured but we haven't logged yet
+        # Update level and ensure timestamp format on existing handlers
         logging.root.setLevel(log_level)
+        for handler in logging.root.handlers:
+            handler.setFormatter(formatter)
         _logging_configured = True
         logging.info(f"Logging level updated to: {log_level}")
     else:

--- a/python/packages/kagent-openai/src/kagent/openai/_a2a.py
+++ b/python/packages/kagent-openai/src/kagent/openai/_a2a.py
@@ -32,19 +32,9 @@ from openai import AsyncOpenAI
 from ._agent_executor import OpenAIAgentExecutor, OpenAIAgentExecutorConfig
 from ._session_service import KAgentSessionFactory
 
-# Configure logging
+# Logging is configured by kagent.core (imported above) which sets
+# timestamp format via configure_logging() at import time.
 logger = logging.getLogger(__name__)
-
-
-def configure_logging() -> None:
-    """Configure logging based on LOG_LEVEL environment variable."""
-    log_level = os.getenv("LOG_LEVEL", "INFO").upper()
-    numeric_level = getattr(logging, log_level, logging.INFO)
-    logging.basicConfig(level=numeric_level)
-    logging.info(f"Logging configured with level: {log_level}")
-
-
-configure_logging()
 
 
 def health_check(request: Request) -> PlainTextResponse:


### PR DESCRIPTION
## Summary
Fixes #739 — agent logs were missing timestamps, making it difficult to correlate events.

**Root cause**: `kagent-openai`'s `configure_logging()` called `logging.basicConfig()` without a format string, and `kagent-core`'s `configure_logging()` didn't apply the formatter to pre-existing handlers.

**Fix**:
- Removed redundant `configure_logging()` from `kagent-openai/_a2a.py` (relies on kagent-core's version called at import time)
- Updated `kagent-core/_logging.py` to apply the timestamp formatter to existing handlers in the `elif` branch

All 155 tests pass.

Signed-off-by: fl-sean03 <sean@opspawn.com>