### PR TITLE
fix(ui): use empty apiGroup for core K8s resources in parseGroupKind

### DIFF
--- a/ui/src/app/actions/agents.ts
+++ b/ui/src/app/actions/agents.ts
@@ -43,19 +43,12 @@ function fromAgentFormDataToAgent(agentFormData: AgentFormData): Agent {
           namespace = agentNamespace;
         }
 
-        let kind = mcpServer.kind;
-        // Special handling for kagent-querydoc - always ensure correct apiGroup
-        if (mcpServer.name.toLocaleLowerCase().includes("kagent-querydoc")) {
-          mcpServer.apiGroup = "";
-          kind = "Service";
-        }
-
         return {
           type: "McpServer",
           mcpServer: {
             name,
             namespace,
-            kind,
+            kind: mcpServer.kind,
             apiGroup: mcpServer.apiGroup,
             toolNames: mcpServer.toolNames,
           },

--- a/ui/src/lib/__tests__/toolUtils.test.ts
+++ b/ui/src/lib/__tests__/toolUtils.test.ts
@@ -699,9 +699,9 @@ describe('Tool Utility Functions', () => {
       });
     });
 
-    it('should parse groupKind with only kind', () => {
+    it('should parse groupKind with only kind (core resource, empty apiGroup)', () => {
       expect(parseGroupKind('MCPServer')).toEqual({
-        apiGroup: 'kagent.dev',
+        apiGroup: '',
         kind: 'MCPServer'
       });
     });
@@ -713,9 +713,9 @@ describe('Tool Utility Functions', () => {
       });
     });
 
-    it('should handle Service without apiGroup', () => {
+    it('should handle Service without apiGroup (core K8s resource)', () => {
       expect(parseGroupKind('Service')).toEqual({
-        apiGroup: 'kagent.dev',
+        apiGroup: '',
         kind: 'Service'
       });
     });
@@ -761,7 +761,7 @@ describe('Tool Utility Functions', () => {
       });
     });
 
-    it('should handle special case for kagent-querydoc with empty apiGroup and extract namespace', () => {
+    it('should handle Service groupKind with empty apiGroup and extract namespace', () => {
       const tool: ToolsResponse = {
         id: "query_documentation",
         server_name: "kagent/kagent-querydoc",
@@ -829,7 +829,7 @@ describe('Tool Utility Functions', () => {
         mcpServer: {
           name: "some-server",
           namespace: "default",
-          apiGroup: "kagent.dev",
+          apiGroup: "",
           kind: "MCPServer",
           toolNames: ["some_tool"]
         }
@@ -854,7 +854,7 @@ describe('Tool Utility Functions', () => {
         mcpServer: {
           name: "some-server",
           namespace: undefined,
-          apiGroup: "kagent.dev",
+          apiGroup: "",
           kind: "MCPServer",
           toolNames: ["some_tool"]
         }


### PR DESCRIPTION
The UI's parseGroupKind function incorrectly assigned apiGroup "kagent.dev" to single-part groupKind strings like "Service". Core Kubernetes resources have an empty API group, so this caused the Go translator to fail with "unknown tool server type: Service.kagent.dev" when creating agents with Service-type MCP tool servers via the UI.

Fixes #1364