### PR TITLE
feat: sub-agent session viewing

### DIFF
--- a/go/internal/database/client.go
+++ b/go/internal/database/client.go
@@ -109,8 +109,7 @@ func (c *clientImpl) GetTaskMessages(taskID int) ([]*protocol.Message, error) {
 // GetSession retrieves a session by name and user ID
 func (c *clientImpl) GetSession(sessionName string, userID string) (*dbpkg.Session, error) {
 	return get[dbpkg.Session](c.db,
-		Clause{Key: "id", Value: sessionName},
-		Clause{Key: "user_id", Value: userID})
+		Clause{Key: "id", Value: sessionName})
 }
 
 // GetAgent retrieves an agent by name and user ID

--- a/go/internal/database/fake/client.go
+++ b/go/internal/database/fake/client.go
@@ -21,7 +21,7 @@ type InMemoryFakeClient struct {
 	mu                sync.RWMutex
 	feedback          map[string]*database.Feedback
 	tasks             map[string]*database.Task    // changed from runs, key: taskID
-	sessions          map[string]*database.Session // key: sessionID_userID
+	sessions          map[string]*database.Session // key: sessionID
 	agents            map[string]*database.Agent   // changed from teams
 	toolServers       map[string]*database.ToolServer
 	tools             map[string]*database.Tool
@@ -57,9 +57,6 @@ func NewClient() database.Client {
 	}
 }
 
-func (c *InMemoryFakeClient) sessionKey(sessionID, userID string) string {
-	return fmt.Sprintf("%s_%s", sessionID, userID)
-}
 
 func (c *InMemoryFakeClient) DeletePushNotification(taskID string) error {
 	c.mu.Lock()
@@ -133,8 +130,7 @@ func (c *InMemoryFakeClient) StoreSession(session *database.Session) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	key := c.sessionKey(session.ID, session.UserID)
-	c.sessions[key] = session
+	c.sessions[session.ID] = session
 	return nil
 }
 
@@ -195,8 +191,7 @@ func (c *InMemoryFakeClient) DeleteSession(sessionID string, userID string) erro
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	key := c.sessionKey(sessionID, userID)
-	delete(c.sessions, key)
+	delete(c.sessions, sessionID)
 	return nil
 }
 
@@ -243,8 +238,7 @@ func (c *InMemoryFakeClient) GetSession(sessionID string, userID string) (*datab
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	key := c.sessionKey(sessionID, userID)
-	session, exists := c.sessions[key]
+	session, exists := c.sessions[sessionID]
 	if !exists {
 		return nil, gorm.ErrRecordNotFound
 	}
@@ -486,8 +480,7 @@ func (c *InMemoryFakeClient) UpdateSession(session *database.Session) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	key := c.sessionKey(session.ID, session.UserID)
-	c.sessions[key] = session
+	c.sessions[session.ID] = session
 	return nil
 }
 

--- a/go/internal/mcp/mcp_handler.go
+++ b/go/internal/mcp/mcp_handler.go
@@ -187,13 +187,13 @@ func (h *MCPHandler) handleInvokeAgent(ctx context.Context, req *mcpsdk.CallTool
 	agentRef := agentNS + "/" + agentName
 	agentNns := types.NamespacedName{Namespace: agentNS, Name: agentName}
 
-	// Get context ID from client request (stateless mode)
-	// If not provided, contextIDPtr will be nil and a new conversation will start
-	var contextIDPtr *string
-	if input.ContextID != "" {
-		contextIDPtr = &input.ContextID
-		log.V(1).Info("Using context_id from client request", "context_id", input.ContextID)
+	// Always ensure a context_id is set so the child session ID is deterministic
+	// and can be stored in the parent's event data for immediate UI linkability.
+	if input.ContextID == "" {
+		input.ContextID = protocol.GenerateContextID()
 	}
+	contextIDPtr := &input.ContextID
+	log.V(1).Info("Using context_id", "context_id", input.ContextID)
 
 	// Get or create cached A2A client for this agent
 	a2aURL := fmt.Sprintf("%s/%s/", h.a2aBaseURL, agentRef)

--- a/python/packages/kagent-adk/src/kagent/adk/converters/part_converter.py
+++ b/python/packages/kagent-adk/src/kagent/adk/converters/part_converter.py
@@ -164,14 +164,23 @@ def convert_genai_part_to_a2a_part(
         )
 
     if part.function_response:
+        data = part.function_response.model_dump(by_alias=True, exclude_none=True)
+        metadata = {
+            get_kagent_metadata_key(A2A_DATA_PART_METADATA_TYPE_KEY): A2A_DATA_PART_METADATA_TYPE_FUNCTION_RESPONSE
+        }
+        # Extract embedded sub-agent A2A metadata from the function response; this is used in the UI to link to the sub-agent session
+        response = data.get("response", {})
+        if isinstance(response, dict):
+            sub_ctx_id = response.pop("a2a:context_id", None)
+            sub_task_id = response.pop("a2a:task_id", None)
+            if sub_ctx_id:
+                metadata["a2a:context_id"] = sub_ctx_id
+            if sub_task_id:
+                metadata["a2a:task_id"] = sub_task_id
         return a2a_types.Part(
             root=a2a_types.DataPart(
-                data=part.function_response.model_dump(by_alias=True, exclude_none=True),
-                metadata={
-                    get_kagent_metadata_key(
-                        A2A_DATA_PART_METADATA_TYPE_KEY
-                    ): A2A_DATA_PART_METADATA_TYPE_FUNCTION_RESPONSE
-                },
+                data=data,
+                metadata=metadata,
             )
         )
 

--- a/python/packages/kagent-adk/tests/unittests/test_agent_tool.py
+++ b/python/packages/kagent-adk/tests/unittests/test_agent_tool.py
@@ -1,0 +1,190 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from google.genai import types as genai_types
+
+from kagent.adk.converters.part_converter import convert_genai_part_to_a2a_part
+from kagent.core.a2a import (
+    A2A_DATA_PART_METADATA_TYPE_FUNCTION_RESPONSE,
+    A2A_DATA_PART_METADATA_TYPE_KEY,
+    get_kagent_metadata_key,
+)
+
+
+class TestPartConverterMetadataExtraction:
+    """Test cases for convert_genai_part_to_a2a_part() metadata extraction."""
+
+    def test_metadata_extracted_from_function_response(self):
+        function_response = genai_types.FunctionResponse(
+            name="test_tool",
+            id="call-1",
+            response={
+                "result": "ok",
+                "a2a:context_id": "ctx-123",
+                "a2a:task_id": "task-456",
+            },
+        )
+        part = genai_types.Part(function_response=function_response)
+
+        a2a_part = convert_genai_part_to_a2a_part(part)
+
+        assert a2a_part is not None
+        assert a2a_part.root.metadata is not None
+        assert a2a_part.root.metadata["a2a:context_id"] == "ctx-123"
+        assert a2a_part.root.metadata["a2a:task_id"] == "task-456"
+
+        assert "a2a:context_id" not in a2a_part.root.data["response"]
+        assert "a2a:task_id" not in a2a_part.root.data["response"]
+        assert a2a_part.root.data["response"]["result"] == "ok"
+
+    def test_metadata_only_context_id_extracted(self):
+        function_response = genai_types.FunctionResponse(
+            name="test_tool",
+            id="call-1",
+            response={
+                "result": "ok",
+                "a2a:context_id": "ctx-only",
+            },
+        )
+        part = genai_types.Part(function_response=function_response)
+
+        a2a_part = convert_genai_part_to_a2a_part(part)
+
+        assert a2a_part is not None
+        assert a2a_part.root.metadata["a2a:context_id"] == "ctx-only"
+        assert "a2a:task_id" not in a2a_part.root.metadata
+        assert "a2a:context_id" not in a2a_part.root.data["response"]
+
+    def test_metadata_only_task_id_extracted(self):
+        function_response = genai_types.FunctionResponse(
+            name="test_tool",
+            id="call-1",
+            response={
+                "result": "ok",
+                "a2a:task_id": "task-only",
+            },
+        )
+        part = genai_types.Part(function_response=function_response)
+
+        a2a_part = convert_genai_part_to_a2a_part(part)
+
+        assert a2a_part is not None
+        assert a2a_part.root.metadata["a2a:task_id"] == "task-only"
+        assert "a2a:context_id" not in a2a_part.root.metadata
+        assert "a2a:task_id" not in a2a_part.root.data["response"]
+
+    def test_no_metadata_when_not_present(self):
+        """Test that DataPart metadata only has type key when no embedded metadata."""
+        function_response = genai_types.FunctionResponse(
+            name="test_tool",
+            id="call-1",
+            response={"result": "ok"},
+        )
+        part = genai_types.Part(function_response=function_response)
+
+        a2a_part = convert_genai_part_to_a2a_part(part)
+
+        assert a2a_part is not None
+        assert a2a_part.root.metadata is not None
+        # Should only have the type key
+        assert get_kagent_metadata_key(A2A_DATA_PART_METADATA_TYPE_KEY) in a2a_part.root.metadata
+        assert (
+            a2a_part.root.metadata[get_kagent_metadata_key(A2A_DATA_PART_METADATA_TYPE_KEY)]
+            == A2A_DATA_PART_METADATA_TYPE_FUNCTION_RESPONSE
+        )
+        assert "a2a:context_id" not in a2a_part.root.metadata
+        assert "a2a:task_id" not in a2a_part.root.metadata
+
+    def test_metadata_keys_cleaned_from_response_dict(self):
+        function_response = genai_types.FunctionResponse(
+            name="test_tool",
+            id="call-1",
+            response={
+                "result": "ok",
+                "other_key": "other_value",
+                "a2a:context_id": "ctx-123",
+                "a2a:task_id": "task-456",
+            },
+        )
+        part = genai_types.Part(function_response=function_response)
+
+        a2a_part = convert_genai_part_to_a2a_part(part)
+
+        assert a2a_part is not None
+        response_data = a2a_part.root.data["response"]
+
+        assert "a2a:context_id" not in response_data
+        assert "a2a:task_id" not in response_data
+        assert response_data["result"] == "ok"
+        assert response_data["other_key"] == "other_value"
+
+    def test_metadata_extraction_with_nested_response_dict(self):
+        function_response = genai_types.FunctionResponse(
+            name="test_tool",
+            id="call-1",
+            response={
+                "nested": {
+                    "result": "ok",
+                },
+                "a2a:context_id": "ctx-nested",
+            },
+        )
+        part = genai_types.Part(function_response=function_response)
+
+        a2a_part = convert_genai_part_to_a2a_part(part)
+
+        assert a2a_part is not None
+        assert a2a_part.root.data["response"]["nested"]["result"] == "ok"
+        assert "a2a:context_id" not in a2a_part.root.data["response"]
+        assert a2a_part.root.metadata["a2a:context_id"] == "ctx-nested"
+
+    def test_metadata_extraction_with_empty_response_dict(self):
+        """Test that extraction handles empty response dict."""
+        function_response = genai_types.FunctionResponse(
+            name="test_tool",
+            id="call-1",
+            response={},
+        )
+        part = genai_types.Part(function_response=function_response)
+
+        a2a_part = convert_genai_part_to_a2a_part(part)
+
+        assert a2a_part is not None
+        assert a2a_part.root.data["response"] == {}
+        assert get_kagent_metadata_key(A2A_DATA_PART_METADATA_TYPE_KEY) in a2a_part.root.metadata
+        assert "a2a:context_id" not in a2a_part.root.metadata
+        assert "a2a:task_id" not in a2a_part.root.metadata
+
+    def test_metadata_extraction_preserves_other_metadata(self):
+        function_response = genai_types.FunctionResponse(
+            name="test_tool",
+            id="call-1",
+            response={
+                "result": "ok",
+                "a2a:context_id": "ctx-123",
+            },
+        )
+        part = genai_types.Part(function_response=function_response)
+
+        a2a_part = convert_genai_part_to_a2a_part(part)
+
+        assert a2a_part is not None
+        metadata = a2a_part.root.metadata
+
+        assert get_kagent_metadata_key(A2A_DATA_PART_METADATA_TYPE_KEY) in metadata
+        assert (
+            metadata[get_kagent_metadata_key(A2A_DATA_PART_METADATA_TYPE_KEY)]
+            == A2A_DATA_PART_METADATA_TYPE_FUNCTION_RESPONSE
+        )
+        assert metadata["a2a:context_id"] == "ctx-123"

--- a/ui/src/components/chat/AgentCallDisplay.tsx
+++ b/ui/src/components/chat/AgentCallDisplay.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import Link from "next/link";
 import { FunctionCall } from "@/types";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { convertToUserFriendlyName } from "@/lib/utils";
@@ -15,14 +16,24 @@ interface AgentCallDisplayProps {
   };
   status?: AgentCallStatus;
   isError?: boolean;
+  sessionId?: string; // Child session ID from A2A delegation
 }
 
-const AgentCallDisplay = ({ call, result, status = "requested", isError = false }: AgentCallDisplayProps) => {
+const AGENT_TOOL_NAME_RE = /^(.+)__NS__(.+)$/;
+
+const AgentCallDisplay = ({ call, result, status = "requested", isError = false, sessionId }: AgentCallDisplayProps) => {
   const [areInputsExpanded, setAreInputsExpanded] = useState(false);
   const [areResultsExpanded, setAreResultsExpanded] = useState(false);
 
   const agentDisplay = useMemo(() => convertToUserFriendlyName(call.name), [call.name]);
   const hasResult = result !== undefined;
+
+  const agentMatch = call.name.match(AGENT_TOOL_NAME_RE);
+  // Link to the child session directly if we have a contextId (child session ID)
+  // https://kagent.staging.kops.goformative.com/agents/kagent/atlas/chat/ctx-067bd63f-999b-44b7-83e6-d21a58fa1c10
+  const sessionLink = agentMatch && sessionId
+    ? `/agents/${agentMatch[1].replace(/_/g, "-")}/${agentMatch[2].replace(/_/g, "-")}/chat/${sessionId}`
+    : null;
 
   const getStatusDisplay = () => {
     if (isError && status === "executing") {
@@ -76,7 +87,15 @@ const AgentCallDisplay = ({ call, result, status = "requested", isError = false 
             <KagentLogo className="w-4 h-4 mr-2" />
             {agentDisplay}
           </div>
-          <div className="font-light">{call.id}</div>
+          <div className="font-light">
+            {sessionLink ? (
+              <Link href={sessionLink} className="text-blue-500 hover:underline">
+                {call.id}
+              </Link>
+            ) : (
+              call.id
+            )}
+          </div>
         </CardTitle>
         <div className="flex justify-center items-center text-xs">
           {getStatusDisplay()}

--- a/ui/src/components/chat/ToolCallDisplay.tsx
+++ b/ui/src/components/chat/ToolCallDisplay.tsx
@@ -19,6 +19,7 @@ interface ToolCallState {
     is_error?: boolean;
   };
   status: ToolCallStatus;
+  contextId?: string; // Child session ID from A2A delegation
 }
 
 // Create a global cache to track tool calls across components
@@ -33,13 +34,13 @@ const isToolCallRequestMessage = (message: Message): boolean => {
     }
     return false;
   }) || false;
-  
+
   // Fallback to streaming format check
   if (!hasDataParts) {
     const metadata = message.metadata as ADKMetadata;
     return metadata?.originalType === "ToolCallRequestEvent";
   }
-  
+
   return hasDataParts;
 };
 
@@ -50,13 +51,13 @@ const isToolCallExecutionMessage = (message: Message): boolean => {
     }
     return false;
   }) || false;
-  
+
   // Fallback to streaming format check
   if (!hasDataParts) {
     const metadata = message.metadata as ADKMetadata;
     return metadata?.originalType === "ToolCallExecutionEvent";
   }
-  
+
   return hasDataParts;
 };
 
@@ -67,11 +68,11 @@ const isToolCallSummaryMessage = (message: Message): boolean => {
 
 const extractToolCallRequests = (message: Message): FunctionCall[] => {
   if (!isToolCallRequestMessage(message)) return [];
-  
+
   // Check for stored task format first (data parts)
   const dataParts = message.parts?.filter(part => part.kind === "data") || [];
   const functionCalls: FunctionCall[] = [];
-  
+
   for (const part of dataParts) {
     if (part.metadata) {
       if (getMetadataValue<string>(part.metadata as Record<string, unknown>, "type") === "function_call") {
@@ -84,16 +85,16 @@ const extractToolCallRequests = (message: Message): FunctionCall[] => {
       }
     }
   }
-  
+
   // If we found function calls in data parts, return them
   if (functionCalls.length > 0) {
     return functionCalls;
   }
-  
+
   // Try streaming format (metadata or text content)
   const textParts = message.parts?.filter(part => part.kind === "text") || [];
   const content = textParts.map(part => (part as TextPart).text).join("");
-  
+
   try {
     // Tool call data might be stored as JSON in content or metadata
     const metadata = message.metadata as ADKMetadata;
@@ -106,11 +107,11 @@ const extractToolCallRequests = (message: Message): FunctionCall[] => {
 
 const extractToolCallResults = (message: Message): ProcessedToolResultData[] => {
   if (!isToolCallExecutionMessage(message)) return [];
-  
+
   // Check for stored task format first (data parts)
   const dataParts = message.parts?.filter(part => part.kind === "data") || [];
   const toolResults: ProcessedToolResultData[] = [];
-  
+
   for (const part of dataParts) {
     if (part.metadata) {
       if (getMetadataValue<string>(part.metadata as Record<string, unknown>, "type") === "function_response") {
@@ -118,26 +119,31 @@ const extractToolCallResults = (message: Message): ProcessedToolResultData[] => 
         // Extract normalized content from the result (supports string/object/array)
         const textContent = normalizeToolResultToText(data);
 
+        // Extract child session ID from A2A metadata if present
+        const metadata = part.metadata as Record<string, unknown> | undefined;
+        const contextId = metadata?.["a2a:context_id"] as string | undefined;
+
         toolResults.push({
           call_id: data.id,
           name: data.name,
           content: textContent,
-          is_error: data.response?.isError || false
+          contextId: contextId || undefined,
+          is_error: data.response?.isError || false,
         });
       }
     }
   }
-  
+
   // If we found tool results in data parts, return them
   if (toolResults.length > 0) {
     return toolResults;
   }
-  
+
   // Try streaming format (metadata or text content)
   const textParts = message.parts?.filter(part => part.kind === "text") || [];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const content = textParts.map(part => (part as any).text).join("");
-  
+
   try {
     const metadata = message.metadata as ADKMetadata;
     const resultData = metadata?.toolResultData || JSON.parse(content || "[]");
@@ -213,6 +219,7 @@ const ToolCallDisplay = ({ currentMessage, allMessages }: ToolCallDisplayProps) 
               content: result.content,
               is_error: result.is_error
             };
+            existingCall.contextId = result.contextId;
             existingCall.status = "executing";
           }
         }
@@ -224,7 +231,7 @@ const ToolCallDisplay = ({ currentMessage, allMessages }: ToolCallDisplayProps) 
     for (const message of allMessages) {
       if (isToolCallSummaryMessage(message)) {
         summaryMessageEncountered = true;
-        break; 
+        break;
       }
     }
 
@@ -251,6 +258,7 @@ const ToolCallDisplay = ({ currentMessage, allMessages }: ToolCallDisplayProps) 
   const currentDisplayableCalls = Array.from(toolCalls.values()).filter(call => ownedCallIds.has(call.id));
   if (currentDisplayableCalls.length === 0) return null;
 
+  const sessionId = currentMessage.metadata?.kagent_session_id;
   return (
     <div className="space-y-2">
       {currentDisplayableCalls.map(toolCall => (
@@ -261,6 +269,7 @@ const ToolCallDisplay = ({ currentMessage, allMessages }: ToolCallDisplayProps) 
             result={toolCall.result}
             status={toolCall.status}
             isError={toolCall.result?.is_error}
+            sessionId={typeof sessionId === 'string' ? sessionId :  undefined}
           />
         ) : (
           <ToolDisplay

--- a/ui/src/lib/messageHandlers.ts
+++ b/ui/src/lib/messageHandlers.ts
@@ -8,7 +8,7 @@ import { mapA2AStateToStatus } from "@/lib/statusUtils";
 export function extractMessagesFromTasks(tasks: Task[]): Message[] {
   const messages: Message[] = [];
   const seenMessageIds = new Set<string>();
-  
+
   for (const task of tasks) {
     if (task.history) {
       for (const historyItem of task.history) {
@@ -22,7 +22,7 @@ export function extractMessagesFromTasks(tasks: Task[]): Message[] {
       }
     }
   }
-  
+
   return messages;
 }
 
@@ -30,11 +30,11 @@ export function extractTokenStatsFromTasks(tasks: Task[]): TokenStats {
   let maxTotal = 0;
   let maxInput = 0;
   let maxOutput = 0;
-  
+
   for (const task of tasks) {
     if (task.metadata) {
       const usage = getMetadataValue<ADKMetadata["kagent_usage_metadata"]>(task.metadata as Record<string, unknown>, "usage_metadata");
-      
+
       if (usage) {
         maxTotal = Math.max(maxTotal, usage.totalTokenCount || 0);
         maxInput = Math.max(maxInput, usage.promptTokenCount || 0);
@@ -42,7 +42,7 @@ export function extractTokenStatsFromTasks(tasks: Task[]): TokenStats {
       }
     }
   }
-  
+
   return {
     total: maxTotal,
     input: maxInput,
@@ -50,9 +50,9 @@ export function extractTokenStatsFromTasks(tasks: Task[]): TokenStats {
   };
 }
 
-export type OriginalMessageType = 
+export type OriginalMessageType =
   | "TextMessage"
-  | "ToolCallRequestEvent" 
+  | "ToolCallRequestEvent"
   | "ToolCallExecutionEvent"
   | "ToolCallSummaryMessage";
 
@@ -118,6 +118,7 @@ export interface ProcessedToolResultData {
   call_id: string;
   name: string;
   content: string;
+  contextId?: string; // Child session ID from A2A context_id
   is_error: boolean;
 }
 
@@ -333,7 +334,7 @@ export const createMessageHandlers = (handlers: MessageHandlers) => {
   const isUserMessage = (message: Message): boolean => message.role === "user";
 
   // Simple fallback source when metadata is not available
-  const defaultAgentSource = handlers.agentContext 
+  const defaultAgentSource = handlers.agentContext
     ? `${handlers.agentContext.namespace}/${handlers.agentContext.agentName.replace(/_/g, "-")}`
     : "assistant";
 
@@ -485,7 +486,7 @@ export const createMessageHandlers = (handlers: MessageHandlers) => {
       if (convertedMessages.length > 0) {
         handlers.setMessages(prevMessages => [...prevMessages, ...convertedMessages]);
       }
-      
+
       // Add a tool call summary message to mark any pending tool calls as completed
       const summarySource = getSourceFromMetadata(adkMetadata, defaultAgentSource);
       const toolSummaryMessage = createMessage(
@@ -557,4 +558,4 @@ export const createMessageHandlers = (handlers: MessageHandlers) => {
   return {
     handleMessageEvent
   };
-}; 
+};


### PR DESCRIPTION
- Parent agent assigns session IDs and stores in the event, for linking.  
- UI can see child contextId stored in the event and show a link to it.
- Allow anyone who knows the ID of a session to access it

Note that this does kind of remove a permission check.  This seems OK to me because in its current state kagent does not have multi-user support anyway.  Later if multi-user becomes a thing, the permission check could be adjusted somehow.


