### PR TITLE
fix(openai): join all TextContent items from MCP tool results

### DIFF
--- a/python/packages/kagent-adk/src/kagent/adk/models/_openai.py
+++ b/python/packages/kagent-adk/src/kagent/adk/models/_openai.py
@@ -122,7 +122,7 @@ def _convert_content_to_openai_messages(
                     elif func_response.response and "content" in func_response.response:
                         content_list = func_response.response["content"]
                         if len(content_list) > 0:
-                            content = content_list[0]["text"]
+                            content = "\n".join(item["text"] for item in content_list if "text" in item)
                     elif func_response.response and "result" in func_response.response:
                         content = func_response.response["result"]
 


### PR DESCRIPTION
## Summary

Fix a regression in `_convert_content_to_openai_messages()` where MCP tool results
containing multiple `TextContent` items were silently truncated to only the first item
before being sent to the LLM.

## Problem

MCP tools can return a `CallToolResult` with a `content` array of multiple `TextContent`
items. For example, the AWS EKS MCP server's `list_k8s_resources` tool returns:

- `content[0]`: a short summary string (`"Successfully listed 18 Deployment resources..."`)
- `content[1]`: the full JSON payload with all resource data

Since PR #1131 (merged Dec 16, 2025 — commit `10304b9`), the handler for the `content`
format only consumed the first item:

```python
# Before fix (broken)
content_list = func_response.response["content"]
if len(content_list) > 0:
    content = content_list[0]["text"]  # drops everything after index 0
```

The LLM would therefore only receive the summary string and never see the actual
resource data, making it unable to answer questions about specific resource names,
labels, or any field present in the JSON.

This affects **all agents using `provider: OpenAI`** in their ModelConfig (which
includes agents behind a LiteLLM proxy with an OpenAI-compatible API).

## Root Cause

PR #1131 rewrote the tool result conversion to support three response formats
(`str`, `content[]`, `result`). The `content[]` branch was added to handle the MCP
`CallToolResult` format but incorrectly assumed a single content item. Returning
multiple `TextContent` items in a single `CallToolResult` is valid per the MCP spec
and widely used in practice.

## Fix

Join **all** `TextContent` items with newlines instead of taking only the first:

```python
# After fix
content_list = func_response.response["content"]
if len(content_list) > 0:
    content = "\n".join(
        item["text"]
        for item in content_list
        if "text" in item
    )
```

This matches the behavior of the LiteLLM adapter and correctly forwards the complete
tool result to the LLM.

## Testing

Manually verified against a live cluster with the AWS EKS MCP server:

- **Before fix**: agent calling `list_k8s_resources` on a namespace with 18 deployments
  could not identify any deployment by name — it only received the summary string
- **After fix**: agent correctly reads all 18 deployment names and their metadata from
  the full JSON payload

## Impact

- **Affected**: all agents with `provider: OpenAI` in `ModelConfig` (including
  OpenAI-compatible endpoints such as LiteLLM proxies)

## Checklist

- [x] Bug fix (non-breaking change)
- [x] Existing behavior is preserved for `str` and `result` response formats
- [x] Manually tested against a real MCP server with multi-item `content[]` response
