### PR TITLE
fix: suppress RemoteA2aAgent experimental warning log spam

### DIFF
--- a/python/packages/kagent-adk/src/kagent/adk/types.py
+++ b/python/packages/kagent-adk/src/kagent/adk/types.py
@@ -359,7 +359,7 @@ class AgentConfig(BaseModel):
                     )
 
                 with warnings.catch_warnings():
-                    warnings.filterwarnings("ignore", message=r".*\[EXPERIMENTAL\] RemoteA2aAgent.*")
+                    warnings.filterwarnings("ignore", message=r"^\[EXPERIMENTAL\] RemoteA2aAgent:")
                     remote_a2a_agent = RemoteA2aAgent(
                         name=remote_agent.name,
                         agent_card=f"{remote_agent.url}{AGENT_CARD_WELL_KNOWN_PATH}",


### PR DESCRIPTION
## Summary
- Wraps `RemoteA2aAgent` instantiation in `warnings.catch_warnings()` to suppress the upstream `google-adk` experimental mode `UserWarning` that floods logs during A2A agent interactions
- The suppression is scoped to only the `RemoteA2aAgent` constructor call site, not applied globally

Closes #1379

## Test plan
- [x] Existing proxy/A2A tests pass (17 passed)
- [ ] Deploy agents with A2A tools and verify experimental warnings no longer flood logs