### PR TITLE
fix: add non-empty status messages for Accepted condition

### DIFF
--- a/go/internal/controller/reconciler/reconciler.go
+++ b/go/internal/controller/reconciler/reconciler.go
@@ -123,7 +123,7 @@ func (a *kagentReconciler) reconcileAgentStatus(ctx context.Context, agent *v1al
 	} else {
 		status = metav1.ConditionTrue
 		reason = "Reconciled"
-		message = "Agent has been accepted for processing"
+		message = "Agent configuration accepted"
 	}
 
 	conditionChanged := meta.SetStatusCondition(&agent.Status.Conditions, metav1.Condition{
@@ -321,7 +321,7 @@ func (a *kagentReconciler) reconcileModelConfigStatus(ctx context.Context, model
 	} else {
 		status = metav1.ConditionTrue
 		reason = "ModelConfigReconciled"
-		message = "ModelConfig has been accepted for processing"
+		message = "Model configuration accepted"
 	}
 
 	conditionChanged := meta.SetStatusCondition(&modelConfig.Status.Conditions, metav1.Condition{
@@ -470,7 +470,7 @@ func (a *kagentReconciler) reconcileRemoteMCPServerStatus(
 	} else {
 		status = metav1.ConditionTrue
 		reason = "Reconciled"
-		message = "RemoteMCPServer has been accepted for processing"
+		message = "Remote MCP server configuration accepted"
 	}
 	conditionChanged := meta.SetStatusCondition(&server.Status.Conditions, metav1.Condition{
 		Type:               v1alpha2.AgentConditionTypeAccepted,

--- a/go/internal/controller/reconciler/status/mcp_server.go
+++ b/go/internal/controller/reconciler/status/mcp_server.go
@@ -33,7 +33,7 @@ func ReconcileMCPServerStatus(ctx context.Context, kube client.Client, mcpServer
 func setAcceptedCondition(mcpServer *v1alpha1.MCPServer, err error) {
 	status := metav1.ConditionTrue
 	reason := v1alpha1.MCPServerReasonAccepted
-	message := "MCPServer has been accepted for processing"
+	message := "MCP server configuration accepted"
 
 	if err != nil {
 		status = metav1.ConditionFalse


### PR DESCRIPTION
Fixes #1390

Adds descriptive status messages to the Accepted condition in `reconcileAgentStatus`, `reconcileModelConfigStatus`, and `reconcileRemoteMCPServerStatus`. Previously these conditions had empty messages, which could cause confusion in status output.

Changes:
- `reconcileAgentStatus`: Added "Agent configuration accepted" message
- `reconcileModelConfigStatus`: Added "Model configuration accepted" message  
- `reconcileRemoteMCPServerStatus`: Added "Remote MCP server configuration accepted" message

Signed-off-by: fl-sean03 <sean.florez@colorado.edu>