### PR TITLE
fix: suppress repeated A2A experimental mode warnings

### DIFF
--- a/python/packages/kagent-adk/src/kagent/adk/types.py
+++ b/python/packages/kagent-adk/src/kagent/adk/types.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from typing import Any, Callable, Literal, Optional, Union
 
 import httpx
@@ -24,6 +25,11 @@ from .models import AzureOpenAI as OpenAIAzure
 from .models import OpenAI as OpenAINative
 
 logger = logging.getLogger(__name__)
+
+# Suppress repeated experimental mode warnings from google-adk's RemoteA2aAgent.
+# The warning is useful on first occurrence but floods logs when creating
+# multiple remote agent instances.  See: https://github.com/kagent-dev/kagent/issues/1379
+warnings.filterwarnings("once", message=r"\[EXPERIMENTAL\].*A2A support", category=UserWarning)
 
 # Proxy host header used for Gateway API routing when using a proxy
 PROXY_HOST_HEADER = "x-kagent-host"


### PR DESCRIPTION
Fixes #1379

## Problem
When using A2A tools, the upstream `google-adk` `RemoteA2aAgent` class is decorated with `@a2a_experimental`, which emits a `UserWarning` on **every instantiation**. Since kagent creates multiple `RemoteA2aAgent` instances (one per `remote_agent`), this floods logs with repeated `[EXPERIMENTAL] RemoteA2aAgent: ADK Implementation for A2A support...` warnings.

## Fix
Add `warnings.filterwarnings("once", ...)` at module level in `types.py` to show the upstream experimental warning exactly **once** instead of on every `RemoteA2aAgent` construction. The filter matches the specific `[EXPERIMENTAL]...A2A support` message pattern.

This is idiomatic Python — `warnings.filterwarnings("once")` is the standard mechanism for deduplicating repeated warnings. The warning still appears on first occurrence so users know A2A support is experimental.

## Changes
- `python/packages/kagent-adk/src/kagent/adk/types.py`: Added `import warnings` and a `filterwarnings("once")` call targeting the A2A experimental warning.

Signed-off-by: Sean Florez <sean@opspawn.com>