### PR TITLE
fix: remove unrecognized int format from CRD schemas

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -24,6 +24,11 @@ help: ## list makefile targets
 .PHONY: manifests
 manifests: controller-gen generate ## Generate ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd paths="./..." output:crd:artifacts:config=config/crd/bases
+	@# Remove format: int32/int64 from CRD schemas to avoid Kubernetes API server warnings
+	@# See https://github.com/kagent-dev/kagent/issues/1318
+	@for f in config/crd/bases/*.yaml; do \
+		sed -i '/^[[:space:]]*format: int\(32\|64\)$$/d' "$$f"; \
+	done
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/go/config/crd/bases/kagent.dev_agents.yaml
+++ b/go/config/crd/bases/kagent.dev_agents.yaml
@@ -293,7 +293,6 @@ spec:
                     type: object
                   replicas:
                     description: If not specified, the default value is 1.
-                    format: int32
                     minimum: 1
                     type: integer
                   volumes:
@@ -322,7 +321,6 @@ spec:
                                 If omitted, the default is to mount by volume name.
                                 Examples: For volume /dev/sda1, you specify the partition as "1".
                                 Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                              format: int32
                               type: integer
                             readOnly:
                               description: |-
@@ -510,7 +508,6 @@ spec:
                                 Directories within the path are not affected by this setting.
                                 This might be in conflict with other options that affect the file
                                 mode, like fsGroup, and the result can be other mode bits set.
-                              format: int32
                               type: integer
                             items:
                               description: |-
@@ -536,7 +533,6 @@ spec:
                                       If not specified, the volume defaultMode will be used.
                                       This might be in conflict with other options that affect the file
                                       mode, like fsGroup, and the result can be other mode bits set.
-                                    format: int32
                                     type: integer
                                   path:
                                     description: |-
@@ -630,7 +626,6 @@ spec:
                                 Directories within the path are not affected by this setting.
                                 This might be in conflict with other options that affect the file
                                 mode, like fsGroup, and the result can be other mode bits set.
-                              format: int32
                               type: integer
                             items:
                               description: Items is a list of downward API volume
@@ -664,7 +659,6 @@ spec:
                                       If not specified, the volume defaultMode will be used.
                                       This might be in conflict with other options that affect the file
                                       mode, like fsGroup, and the result can be other mode bits set.
-                                    format: int32
                                     type: integer
                                   path:
                                     description: 'Required: Path is  the relative
@@ -1007,7 +1001,6 @@ spec:
                               type: string
                             lun:
                               description: 'lun is Optional: FC target lun number'
-                              format: int32
                               type: integer
                             readOnly:
                               description: |-
@@ -1116,7 +1109,6 @@ spec:
                                 Examples: For volume /dev/sda1, you specify the partition as "1".
                                 Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                 More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                              format: int32
                               type: integer
                             pdName:
                               description: |-
@@ -1276,7 +1268,6 @@ spec:
                               type: string
                             lun:
                               description: lun represents iSCSI Target Lun number.
-                              format: int32
                               type: integer
                             portals:
                               description: |-
@@ -1421,7 +1412,6 @@ spec:
                                 Directories within the path are not affected by this setting.
                                 This might be in conflict with other options that affect the file
                                 mode, like fsGroup, and the result can be other mode bits set.
-                              format: int32
                               type: integer
                             sources:
                               description: |-
@@ -1553,7 +1543,6 @@ spec:
                                                 If not specified, the volume defaultMode will be used.
                                                 This might be in conflict with other options that affect the file
                                                 mode, like fsGroup, and the result can be other mode bits set.
-                                              format: int32
                                               type: integer
                                             path:
                                               description: |-
@@ -1621,7 +1610,6 @@ spec:
                                                 If not specified, the volume defaultMode will be used.
                                                 This might be in conflict with other options that affect the file
                                                 mode, like fsGroup, and the result can be other mode bits set.
-                                              format: int32
                                               type: integer
                                             path:
                                               description: 'Required: Path is  the
@@ -1759,7 +1747,6 @@ spec:
                                           seconds (1 hour).  This constraint is enforced by kube-apiserver.
                                           `kubernetes.io` signers will never issue certificates with a lifetime
                                           longer than 24 hours.
-                                        format: int32
                                         type: integer
                                       signerName:
                                         description: Kubelet's generated CSRs will
@@ -1815,7 +1802,6 @@ spec:
                                                 If not specified, the volume defaultMode will be used.
                                                 This might be in conflict with other options that affect the file
                                                 mode, like fsGroup, and the result can be other mode bits set.
-                                              format: int32
                                               type: integer
                                             path:
                                               description: |-
@@ -1864,7 +1850,6 @@ spec:
                                           start trying to rotate the token if the token is older than 80 percent of
                                           its time to live or if the token is older than 24 hours.Defaults to 1 hour
                                           and must be at least 10 minutes.
-                                        format: int64
                                         type: integer
                                       path:
                                         description: |-
@@ -2075,7 +2060,6 @@ spec:
                                 Directories within the path are not affected by this setting.
                                 This might be in conflict with other options that affect the file
                                 mode, like fsGroup, and the result can be other mode bits set.
-                              format: int32
                               type: integer
                             items:
                               description: |-
@@ -2101,7 +2085,6 @@ spec:
                                       If not specified, the volume defaultMode will be used.
                                       This might be in conflict with other options that affect the file
                                       mode, like fsGroup, and the result can be other mode bits set.
-                                    format: int32
                                     type: integer
                                   path:
                                     description: |-
@@ -2305,7 +2288,6 @@ spec:
                         observedGeneration represents the .metadata.generation that the condition was set based upon.
                         For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
                         with respect to the current state of the instance.
-                      format: int64
                       minimum: 0
                       type: integer
                     reason:
@@ -2346,7 +2328,6 @@ spec:
                 format: byte
                 type: string
               observedGeneration:
-                format: int64
                 type: integer
             required:
             - configHash
@@ -2574,7 +2555,6 @@ spec:
                                       description: Weight associated with matching
                                         the corresponding nodeSelectorTerm, in the
                                         range 1-100.
-                                      format: int32
                                       type: integer
                                   required:
                                   - preference
@@ -2857,7 +2837,6 @@ spec:
                                       description: |-
                                         weight associated with matching the corresponding podAffinityTerm,
                                         in the range 1-100.
-                                      format: int32
                                       type: integer
                                   required:
                                   - podAffinityTerm
@@ -3217,7 +3196,6 @@ spec:
                                       description: |-
                                         weight associated with matching the corresponding podAffinityTerm,
                                         in the range 1-100.
-                                      format: int32
                                       type: integer
                                   required:
                                   - podAffinityTerm
@@ -3638,7 +3616,6 @@ spec:
 
                               If unset, the Kubelet will not modify the ownership and permissions of any volume.
                               Note that this field cannot be set when spec.os.name is windows.
-                            format: int64
                             type: integer
                           fsGroupChangePolicy:
                             description: |-
@@ -3658,7 +3635,6 @@ spec:
                               PodSecurityContext, the value specified in SecurityContext takes precedence
                               for that container.
                               Note that this field cannot be set when spec.os.name is windows.
-                            format: int64
                             type: integer
                           runAsNonRoot:
                             description: |-
@@ -3677,7 +3653,6 @@ spec:
                               PodSecurityContext, the value specified in SecurityContext takes precedence
                               for that container.
                               Note that this field cannot be set when spec.os.name is windows.
-                            format: int64
                             type: integer
                           seLinuxChangePolicy:
                             description: |-
@@ -3767,7 +3742,6 @@ spec:
                               supplementalGroupsPolicy field.
                               Note that this field cannot be set when spec.os.name is windows.
                             items:
-                              format: int64
                               type: integer
                             type: array
                             x-kubernetes-list-type: atomic
@@ -3834,7 +3808,6 @@ spec:
                             type: object
                         type: object
                       replicas:
-                        format: int32
                         type: integer
                       resources:
                         description: ResourceRequirements describes the compute resource
@@ -3987,7 +3960,6 @@ spec:
                               May also be set in PodSecurityContext.  If set in both SecurityContext and
                               PodSecurityContext, the value specified in SecurityContext takes precedence.
                               Note that this field cannot be set when spec.os.name is windows.
-                            format: int64
                             type: integer
                           runAsNonRoot:
                             description: |-
@@ -4005,7 +3977,6 @@ spec:
                               May also be set in PodSecurityContext.  If set in both SecurityContext and
                               PodSecurityContext, the value specified in SecurityContext takes precedence.
                               Note that this field cannot be set when spec.os.name is windows.
-                            format: int64
                             type: integer
                           seLinuxOptions:
                             description: |-
@@ -4143,7 +4114,6 @@ spec:
                                 of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
                                 it is not set, which means tolerate the taint forever (do not evict). Zero and
                                 negative values will be treated as 0 (evict immediately) by the system.
-                              format: int64
                               type: integer
                             value:
                               description: |-
@@ -4241,7 +4211,6 @@ spec:
                                     If omitted, the default is to mount by volume name.
                                     Examples: For volume /dev/sda1, you specify the partition as "1".
                                     Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                                  format: int32
                                   type: integer
                                 readOnly:
                                   description: |-
@@ -4430,7 +4399,6 @@ spec:
                                     Directories within the path are not affected by this setting.
                                     This might be in conflict with other options that affect the file
                                     mode, like fsGroup, and the result can be other mode bits set.
-                                  format: int32
                                   type: integer
                                 items:
                                   description: |-
@@ -4456,7 +4424,6 @@ spec:
                                           If not specified, the volume defaultMode will be used.
                                           This might be in conflict with other options that affect the file
                                           mode, like fsGroup, and the result can be other mode bits set.
-                                        format: int32
                                         type: integer
                                       path:
                                         description: |-
@@ -4550,7 +4517,6 @@ spec:
                                     Directories within the path are not affected by this setting.
                                     This might be in conflict with other options that affect the file
                                     mode, like fsGroup, and the result can be other mode bits set.
-                                  format: int32
                                   type: integer
                                 items:
                                   description: Items is a list of downward API volume
@@ -4586,7 +4552,6 @@ spec:
                                           If not specified, the volume defaultMode will be used.
                                           This might be in conflict with other options that affect the file
                                           mode, like fsGroup, and the result can be other mode bits set.
-                                        format: int32
                                         type: integer
                                       path:
                                         description: 'Required: Path is  the relative
@@ -4931,7 +4896,6 @@ spec:
                                   type: string
                                 lun:
                                   description: 'lun is Optional: FC target lun number'
-                                  format: int32
                                   type: integer
                                 readOnly:
                                   description: |-
@@ -5040,7 +5004,6 @@ spec:
                                     Examples: For volume /dev/sda1, you specify the partition as "1".
                                     Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                     More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                  format: int32
                                   type: integer
                                 pdName:
                                   description: |-
@@ -5200,7 +5163,6 @@ spec:
                                   type: string
                                 lun:
                                   description: lun represents iSCSI Target Lun number.
-                                  format: int32
                                   type: integer
                                 portals:
                                   description: |-
@@ -5345,7 +5307,6 @@ spec:
                                     Directories within the path are not affected by this setting.
                                     This might be in conflict with other options that affect the file
                                     mode, like fsGroup, and the result can be other mode bits set.
-                                  format: int32
                                   type: integer
                                 sources:
                                   description: |-
@@ -5478,7 +5439,6 @@ spec:
                                                     If not specified, the volume defaultMode will be used.
                                                     This might be in conflict with other options that affect the file
                                                     mode, like fsGroup, and the result can be other mode bits set.
-                                                  format: int32
                                                   type: integer
                                                 path:
                                                   description: |-
@@ -5548,7 +5508,6 @@ spec:
                                                     If not specified, the volume defaultMode will be used.
                                                     This might be in conflict with other options that affect the file
                                                     mode, like fsGroup, and the result can be other mode bits set.
-                                                  format: int32
                                                   type: integer
                                                 path:
                                                   description: 'Required: Path is  the
@@ -5687,7 +5646,6 @@ spec:
                                               seconds (1 hour).  This constraint is enforced by kube-apiserver.
                                               `kubernetes.io` signers will never issue certificates with a lifetime
                                               longer than 24 hours.
-                                            format: int32
                                             type: integer
                                           signerName:
                                             description: Kubelet's generated CSRs
@@ -5743,7 +5701,6 @@ spec:
                                                     If not specified, the volume defaultMode will be used.
                                                     This might be in conflict with other options that affect the file
                                                     mode, like fsGroup, and the result can be other mode bits set.
-                                                  format: int32
                                                   type: integer
                                                 path:
                                                   description: |-
@@ -5792,7 +5749,6 @@ spec:
                                               start trying to rotate the token if the token is older than 80 percent of
                                               its time to live or if the token is older than 24 hours.Defaults to 1 hour
                                               and must be at least 10 minutes.
-                                            format: int64
                                             type: integer
                                           path:
                                             description: |-
@@ -6003,7 +5959,6 @@ spec:
                                     Directories within the path are not affected by this setting.
                                     This might be in conflict with other options that affect the file
                                     mode, like fsGroup, and the result can be other mode bits set.
-                                  format: int32
                                   type: integer
                                 items:
                                   description: |-
@@ -6029,7 +5984,6 @@ spec:
                                           If not specified, the volume defaultMode will be used.
                                           This might be in conflict with other options that affect the file
                                           mode, like fsGroup, and the result can be other mode bits set.
-                                        format: int32
                                         type: integer
                                       path:
                                         description: |-
@@ -6354,7 +6308,6 @@ spec:
                                       description: Weight associated with matching
                                         the corresponding nodeSelectorTerm, in the
                                         range 1-100.
-                                      format: int32
                                       type: integer
                                   required:
                                   - preference
@@ -6637,7 +6590,6 @@ spec:
                                       description: |-
                                         weight associated with matching the corresponding podAffinityTerm,
                                         in the range 1-100.
-                                      format: int32
                                       type: integer
                                   required:
                                   - podAffinityTerm
@@ -6997,7 +6949,6 @@ spec:
                                       description: |-
                                         weight associated with matching the corresponding podAffinityTerm,
                                         in the range 1-100.
-                                      format: int32
                                       type: integer
                                   required:
                                   - podAffinityTerm
@@ -7411,7 +7362,6 @@ spec:
 
                               If unset, the Kubelet will not modify the ownership and permissions of any volume.
                               Note that this field cannot be set when spec.os.name is windows.
-                            format: int64
                             type: integer
                           fsGroupChangePolicy:
                             description: |-
@@ -7431,7 +7381,6 @@ spec:
                               PodSecurityContext, the value specified in SecurityContext takes precedence
                               for that container.
                               Note that this field cannot be set when spec.os.name is windows.
-                            format: int64
                             type: integer
                           runAsNonRoot:
                             description: |-
@@ -7450,7 +7399,6 @@ spec:
                               PodSecurityContext, the value specified in SecurityContext takes precedence
                               for that container.
                               Note that this field cannot be set when spec.os.name is windows.
-                            format: int64
                             type: integer
                           seLinuxChangePolicy:
                             description: |-
@@ -7540,7 +7488,6 @@ spec:
                               supplementalGroupsPolicy field.
                               Note that this field cannot be set when spec.os.name is windows.
                             items:
-                              format: int64
                               type: integer
                             type: array
                             x-kubernetes-list-type: atomic
@@ -7607,7 +7554,6 @@ spec:
                             type: object
                         type: object
                       replicas:
-                        format: int32
                         type: integer
                       resources:
                         description: ResourceRequirements describes the compute resource
@@ -7760,7 +7706,6 @@ spec:
                               May also be set in PodSecurityContext.  If set in both SecurityContext and
                               PodSecurityContext, the value specified in SecurityContext takes precedence.
                               Note that this field cannot be set when spec.os.name is windows.
-                            format: int64
                             type: integer
                           runAsNonRoot:
                             description: |-
@@ -7778,7 +7723,6 @@ spec:
                               May also be set in PodSecurityContext.  If set in both SecurityContext and
                               PodSecurityContext, the value specified in SecurityContext takes precedence.
                               Note that this field cannot be set when spec.os.name is windows.
-                            format: int64
                             type: integer
                           seLinuxOptions:
                             description: |-
@@ -7916,7 +7860,6 @@ spec:
                                 of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
                                 it is not set, which means tolerate the taint forever (do not evict). Zero and
                                 negative values will be treated as 0 (evict immediately) by the system.
-                              format: int64
                               type: integer
                             value:
                               description: |-
@@ -8014,7 +7957,6 @@ spec:
                                     If omitted, the default is to mount by volume name.
                                     Examples: For volume /dev/sda1, you specify the partition as "1".
                                     Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                                  format: int32
                                   type: integer
                                 readOnly:
                                   description: |-
@@ -8203,7 +8145,6 @@ spec:
                                     Directories within the path are not affected by this setting.
                                     This might be in conflict with other options that affect the file
                                     mode, like fsGroup, and the result can be other mode bits set.
-                                  format: int32
                                   type: integer
                                 items:
                                   description: |-
@@ -8229,7 +8170,6 @@ spec:
                                           If not specified, the volume defaultMode will be used.
                                           This might be in conflict with other options that affect the file
                                           mode, like fsGroup, and the result can be other mode bits set.
-                                        format: int32
                                         type: integer
                                       path:
                                         description: |-
@@ -8323,7 +8263,6 @@ spec:
                                     Directories within the path are not affected by this setting.
                                     This might be in conflict with other options that affect the file
                                     mode, like fsGroup, and the result can be other mode bits set.
-                                  format: int32
                                   type: integer
                                 items:
                                   description: Items is a list of downward API volume
@@ -8359,7 +8298,6 @@ spec:
                                           If not specified, the volume defaultMode will be used.
                                           This might be in conflict with other options that affect the file
                                           mode, like fsGroup, and the result can be other mode bits set.
-                                        format: int32
                                         type: integer
                                       path:
                                         description: 'Required: Path is  the relative
@@ -8704,7 +8642,6 @@ spec:
                                   type: string
                                 lun:
                                   description: 'lun is Optional: FC target lun number'
-                                  format: int32
                                   type: integer
                                 readOnly:
                                   description: |-
@@ -8813,7 +8750,6 @@ spec:
                                     Examples: For volume /dev/sda1, you specify the partition as "1".
                                     Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                     More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                  format: int32
                                   type: integer
                                 pdName:
                                   description: |-
@@ -8973,7 +8909,6 @@ spec:
                                   type: string
                                 lun:
                                   description: lun represents iSCSI Target Lun number.
-                                  format: int32
                                   type: integer
                                 portals:
                                   description: |-
@@ -9118,7 +9053,6 @@ spec:
                                     Directories within the path are not affected by this setting.
                                     This might be in conflict with other options that affect the file
                                     mode, like fsGroup, and the result can be other mode bits set.
-                                  format: int32
                                   type: integer
                                 sources:
                                   description: |-
@@ -9251,7 +9185,6 @@ spec:
                                                     If not specified, the volume defaultMode will be used.
                                                     This might be in conflict with other options that affect the file
                                                     mode, like fsGroup, and the result can be other mode bits set.
-                                                  format: int32
                                                   type: integer
                                                 path:
                                                   description: |-
@@ -9321,7 +9254,6 @@ spec:
                                                     If not specified, the volume defaultMode will be used.
                                                     This might be in conflict with other options that affect the file
                                                     mode, like fsGroup, and the result can be other mode bits set.
-                                                  format: int32
                                                   type: integer
                                                 path:
                                                   description: 'Required: Path is  the
@@ -9460,7 +9392,6 @@ spec:
                                               seconds (1 hour).  This constraint is enforced by kube-apiserver.
                                               `kubernetes.io` signers will never issue certificates with a lifetime
                                               longer than 24 hours.
-                                            format: int32
                                             type: integer
                                           signerName:
                                             description: Kubelet's generated CSRs
@@ -9516,7 +9447,6 @@ spec:
                                                     If not specified, the volume defaultMode will be used.
                                                     This might be in conflict with other options that affect the file
                                                     mode, like fsGroup, and the result can be other mode bits set.
-                                                  format: int32
                                                   type: integer
                                                 path:
                                                   description: |-
@@ -9565,7 +9495,6 @@ spec:
                                               start trying to rotate the token if the token is older than 80 percent of
                                               its time to live or if the token is older than 24 hours.Defaults to 1 hour
                                               and must be at least 10 minutes.
-                                            format: int64
                                             type: integer
                                           path:
                                             description: |-
@@ -9776,7 +9705,6 @@ spec:
                                     Directories within the path are not affected by this setting.
                                     This might be in conflict with other options that affect the file
                                     mode, like fsGroup, and the result can be other mode bits set.
-                                  format: int32
                                   type: integer
                                 items:
                                   description: |-
@@ -9802,7 +9730,6 @@ spec:
                                           If not specified, the volume defaultMode will be used.
                                           This might be in conflict with other options that affect the file
                                           mode, like fsGroup, and the result can be other mode bits set.
-                                        format: int32
                                         type: integer
                                       path:
                                         description: |-
@@ -10206,7 +10133,6 @@ spec:
                         observedGeneration represents the .metadata.generation that the condition was set based upon.
                         For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
                         with respect to the current state of the instance.
-                      format: int64
                       minimum: 0
                       type: integer
                     reason:
@@ -10241,7 +10167,6 @@ spec:
                   type: object
                 type: array
               observedGeneration:
-                format: int64
                 type: integer
             required:
             - observedGeneration

--- a/go/config/crd/bases/kagent.dev_memories.yaml
+++ b/go/config/crd/bases/kagent.dev_memories.yaml
@@ -114,7 +114,6 @@ spec:
                         observedGeneration represents the .metadata.generation that the condition was set based upon.
                         For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
                         with respect to the current state of the instance.
-                      format: int64
                       minimum: 0
                       type: integer
                     reason:
@@ -149,7 +148,6 @@ spec:
                   type: object
                 type: array
               observedGeneration:
-                format: int64
                 type: integer
             required:
             - conditions

--- a/go/config/crd/bases/kagent.dev_modelconfigs.yaml
+++ b/go/config/crd/bases/kagent.dev_modelconfigs.yaml
@@ -303,7 +303,6 @@ spec:
                         observedGeneration represents the .metadata.generation that the condition was set based upon.
                         For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
                         with respect to the current state of the instance.
-                      format: int64
                       minimum: 0
                       type: integer
                     reason:
@@ -338,7 +337,6 @@ spec:
                   type: object
                 type: array
               observedGeneration:
-                format: int64
                 type: integer
             required:
             - conditions
@@ -710,7 +708,6 @@ spec:
                         observedGeneration represents the .metadata.generation that the condition was set based upon.
                         For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
                         with respect to the current state of the instance.
-                      format: int64
                       minimum: 0
                       type: integer
                     reason:
@@ -745,7 +742,6 @@ spec:
                   type: object
                 type: array
               observedGeneration:
-                format: int64
                 type: integer
               secretHash:
                 description: The secret hash stores a hash of any secrets required

--- a/go/config/crd/bases/kagent.dev_modelproviderconfigs.yaml
+++ b/go/config/crd/bases/kagent.dev_modelproviderconfigs.yaml
@@ -129,7 +129,6 @@ spec:
                         observedGeneration represents the .metadata.generation that the condition was set based upon.
                         For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
                         with respect to the current state of the instance.
-                      format: int64
                       minimum: 0
                       type: integer
                     reason:
@@ -184,7 +183,6 @@ spec:
               observedGeneration:
                 description: ObservedGeneration reflects the generation of the most
                   recently observed ModelProviderConfig spec
-                format: int64
                 type: integer
               secretHash:
                 description: SecretHash is a hash of the referenced secret data, used

--- a/go/config/crd/bases/kagent.dev_remotemcpservers.yaml
+++ b/go/config/crd/bases/kagent.dev_remotemcpservers.yaml
@@ -208,7 +208,6 @@ spec:
                         observedGeneration represents the .metadata.generation that the condition was set based upon.
                         For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
                         with respect to the current state of the instance.
-                      format: int64
                       minimum: 0
                       type: integer
                     reason:
@@ -258,7 +257,6 @@ spec:
                 description: |-
                   INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
                   Important: Run "make" to regenerate code after modifying this file
-                format: int64
                 type: integer
             required:
             - conditions

--- a/go/config/crd/bases/kagent.dev_toolservers.yaml
+++ b/go/config/crd/bases/kagent.dev_toolservers.yaml
@@ -243,7 +243,6 @@ spec:
                         observedGeneration represents the .metadata.generation that the condition was set based upon.
                         For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
                         with respect to the current state of the instance.
-                      format: int64
                       minimum: 0
                       type: integer
                     reason:
@@ -319,7 +318,6 @@ spec:
                 description: |-
                   INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
                   Important: Run "make" to regenerate code after modifying this file
-                format: int64
                 type: integer
             required:
             - conditions

--- a/helm/kagent-crds/templates/kagent.dev_agents.yaml
+++ b/helm/kagent-crds/templates/kagent.dev_agents.yaml
@@ -293,7 +293,6 @@ spec:
                     type: object
                   replicas:
                     description: If not specified, the default value is 1.
-                    format: int32
                     minimum: 1
                     type: integer
                   volumes:
@@ -322,7 +321,6 @@ spec:
                                 If omitted, the default is to mount by volume name.
                                 Examples: For volume /dev/sda1, you specify the partition as "1".
                                 Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                              format: int32
                               type: integer
                             readOnly:
                               description: |-
@@ -510,7 +508,6 @@ spec:
                                 Directories within the path are not affected by this setting.
                                 This might be in conflict with other options that affect the file
                                 mode, like fsGroup, and the result can be other mode bits set.
-                              format: int32
                               type: integer
                             items:
                               description: |-
@@ -536,7 +533,6 @@ spec:
                                       If not specified, the volume defaultMode will be used.
                                       This might be in conflict with other options that affect the file
                                       mode, like fsGroup, and the result can be other mode bits set.
-                                    format: int32
                                     type: integer
                                   path:
                                     description: |-
@@ -630,7 +626,6 @@ spec:
                                 Directories within the path are not affected by this setting.
                                 This might be in conflict with other options that affect the file
                                 mode, like fsGroup, and the result can be other mode bits set.
-                              format: int32
                               type: integer
                             items:
                               description: Items is a list of downward API volume
@@ -664,7 +659,6 @@ spec:
                                       If not specified, the volume defaultMode will be used.
                                       This might be in conflict with other options that affect the file
                                       mode, like fsGroup, and the result can be other mode bits set.
-                                    format: int32
                                     type: integer
                                   path:
                                     description: 'Required: Path is  the relative
@@ -1007,7 +1001,6 @@ spec:
                               type: string
                             lun:
                               description: 'lun is Optional: FC target lun number'
-                              format: int32
                               type: integer
                             readOnly:
                               description: |-
@@ -1116,7 +1109,6 @@ spec:
                                 Examples: For volume /dev/sda1, you specify the partition as "1".
                                 Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                 More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                              format: int32
                               type: integer
                             pdName:
                               description: |-
@@ -1276,7 +1268,6 @@ spec:
                               type: string
                             lun:
                               description: lun represents iSCSI Target Lun number.
-                              format: int32
                               type: integer
                             portals:
                               description: |-
@@ -1421,7 +1412,6 @@ spec:
                                 Directories within the path are not affected by this setting.
                                 This might be in conflict with other options that affect the file
                                 mode, like fsGroup, and the result can be other mode bits set.
-                              format: int32
                               type: integer
                             sources:
                               description: |-
@@ -1553,7 +1543,6 @@ spec:
                                                 If not specified, the volume defaultMode will be used.
                                                 This might be in conflict with other options that affect the file
                                                 mode, like fsGroup, and the result can be other mode bits set.
-                                              format: int32
                                               type: integer
                                             path:
                                               description: |-
@@ -1621,7 +1610,6 @@ spec:
                                                 If not specified, the volume defaultMode will be used.
                                                 This might be in conflict with other options that affect the file
                                                 mode, like fsGroup, and the result can be other mode bits set.
-                                              format: int32
                                               type: integer
                                             path:
                                               description: 'Required: Path is  the
@@ -1759,7 +1747,6 @@ spec:
                                           seconds (1 hour).  This constraint is enforced by kube-apiserver.
                                           `kubernetes.io` signers will never issue certificates with a lifetime
                                           longer than 24 hours.
-                                        format: int32
                                         type: integer
                                       signerName:
                                         description: Kubelet's generated CSRs will
@@ -1815,7 +1802,6 @@ spec:
                                                 If not specified, the volume defaultMode will be used.
                                                 This might be in conflict with other options that affect the file
                                                 mode, like fsGroup, and the result can be other mode bits set.
-                                              format: int32
                                               type: integer
                                             path:
                                               description: |-
@@ -1864,7 +1850,6 @@ spec:
                                           start trying to rotate the token if the token is older than 80 percent of
                                           its time to live or if the token is older than 24 hours.Defaults to 1 hour
                                           and must be at least 10 minutes.
-                                        format: int64
                                         type: integer
                                       path:
                                         description: |-
@@ -2075,7 +2060,6 @@ spec:
                                 Directories within the path are not affected by this setting.
                                 This might be in conflict with other options that affect the file
                                 mode, like fsGroup, and the result can be other mode bits set.
-                              format: int32
                               type: integer
                             items:
                               description: |-
@@ -2101,7 +2085,6 @@ spec:
                                       If not specified, the volume defaultMode will be used.
                                       This might be in conflict with other options that affect the file
                                       mode, like fsGroup, and the result can be other mode bits set.
-                                    format: int32
                                     type: integer
                                   path:
                                     description: |-
@@ -2305,7 +2288,6 @@ spec:
                         observedGeneration represents the .metadata.generation that the condition was set based upon.
                         For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
                         with respect to the current state of the instance.
-                      format: int64
                       minimum: 0
                       type: integer
                     reason:
@@ -2346,7 +2328,6 @@ spec:
                 format: byte
                 type: string
               observedGeneration:
-                format: int64
                 type: integer
             required:
             - configHash
@@ -2574,7 +2555,6 @@ spec:
                                       description: Weight associated with matching
                                         the corresponding nodeSelectorTerm, in the
                                         range 1-100.
-                                      format: int32
                                       type: integer
                                   required:
                                   - preference
@@ -2857,7 +2837,6 @@ spec:
                                       description: |-
                                         weight associated with matching the corresponding podAffinityTerm,
                                         in the range 1-100.
-                                      format: int32
                                       type: integer
                                   required:
                                   - podAffinityTerm
@@ -3217,7 +3196,6 @@ spec:
                                       description: |-
                                         weight associated with matching the corresponding podAffinityTerm,
                                         in the range 1-100.
-                                      format: int32
                                       type: integer
                                   required:
                                   - podAffinityTerm
@@ -3638,7 +3616,6 @@ spec:
 
                               If unset, the Kubelet will not modify the ownership and permissions of any volume.
                               Note that this field cannot be set when spec.os.name is windows.
-                            format: int64
                             type: integer
                           fsGroupChangePolicy:
                             description: |-
@@ -3658,7 +3635,6 @@ spec:
                               PodSecurityContext, the value specified in SecurityContext takes precedence
                               for that container.
                               Note that this field cannot be set when spec.os.name is windows.
-                            format: int64
                             type: integer
                           runAsNonRoot:
                             description: |-
@@ -3677,7 +3653,6 @@ spec:
                               PodSecurityContext, the value specified in SecurityContext takes precedence
                               for that container.
                               Note that this field cannot be set when spec.os.name is windows.
-                            format: int64
                             type: integer
                           seLinuxChangePolicy:
                             description: |-
@@ -3767,7 +3742,6 @@ spec:
                               supplementalGroupsPolicy field.
                               Note that this field cannot be set when spec.os.name is windows.
                             items:
-                              format: int64
                               type: integer
                             type: array
                             x-kubernetes-list-type: atomic
@@ -3834,7 +3808,6 @@ spec:
                             type: object
                         type: object
                       replicas:
-                        format: int32
                         type: integer
                       resources:
                         description: ResourceRequirements describes the compute resource
@@ -3987,7 +3960,6 @@ spec:
                               May also be set in PodSecurityContext.  If set in both SecurityContext and
                               PodSecurityContext, the value specified in SecurityContext takes precedence.
                               Note that this field cannot be set when spec.os.name is windows.
-                            format: int64
                             type: integer
                           runAsNonRoot:
                             description: |-
@@ -4005,7 +3977,6 @@ spec:
                               May also be set in PodSecurityContext.  If set in both SecurityContext and
                               PodSecurityContext, the value specified in SecurityContext takes precedence.
                               Note that this field cannot be set when spec.os.name is windows.
-                            format: int64
                             type: integer
                           seLinuxOptions:
                             description: |-
@@ -4143,7 +4114,6 @@ spec:
                                 of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
                                 it is not set, which means tolerate the taint forever (do not evict). Zero and
                                 negative values will be treated as 0 (evict immediately) by the system.
-                              format: int64
                               type: integer
                             value:
                               description: |-
@@ -4241,7 +4211,6 @@ spec:
                                     If omitted, the default is to mount by volume name.
                                     Examples: For volume /dev/sda1, you specify the partition as "1".
                                     Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                                  format: int32
                                   type: integer
                                 readOnly:
                                   description: |-
@@ -4430,7 +4399,6 @@ spec:
                                     Directories within the path are not affected by this setting.
                                     This might be in conflict with other options that affect the file
                                     mode, like fsGroup, and the result can be other mode bits set.
-                                  format: int32
                                   type: integer
                                 items:
                                   description: |-
@@ -4456,7 +4424,6 @@ spec:
                                           If not specified, the volume defaultMode will be used.
                                           This might be in conflict with other options that affect the file
                                           mode, like fsGroup, and the result can be other mode bits set.
-                                        format: int32
                                         type: integer
                                       path:
                                         description: |-
@@ -4550,7 +4517,6 @@ spec:
                                     Directories within the path are not affected by this setting.
                                     This might be in conflict with other options that affect the file
                                     mode, like fsGroup, and the result can be other mode bits set.
-                                  format: int32
                                   type: integer
                                 items:
                                   description: Items is a list of downward API volume
@@ -4586,7 +4552,6 @@ spec:
                                           If not specified, the volume defaultMode will be used.
                                           This might be in conflict with other options that affect the file
                                           mode, like fsGroup, and the result can be other mode bits set.
-                                        format: int32
                                         type: integer
                                       path:
                                         description: 'Required: Path is  the relative
@@ -4931,7 +4896,6 @@ spec:
                                   type: string
                                 lun:
                                   description: 'lun is Optional: FC target lun number'
-                                  format: int32
                                   type: integer
                                 readOnly:
                                   description: |-
@@ -5040,7 +5004,6 @@ spec:
                                     Examples: For volume /dev/sda1, you specify the partition as "1".
                                     Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                     More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                  format: int32
                                   type: integer
                                 pdName:
                                   description: |-
@@ -5200,7 +5163,6 @@ spec:
                                   type: string
                                 lun:
                                   description: lun represents iSCSI Target Lun number.
-                                  format: int32
                                   type: integer
                                 portals:
                                   description: |-
@@ -5345,7 +5307,6 @@ spec:
                                     Directories within the path are not affected by this setting.
                                     This might be in conflict with other options that affect the file
                                     mode, like fsGroup, and the result can be other mode bits set.
-                                  format: int32
                                   type: integer
                                 sources:
                                   description: |-
@@ -5478,7 +5439,6 @@ spec:
                                                     If not specified, the volume defaultMode will be used.
                                                     This might be in conflict with other options that affect the file
                                                     mode, like fsGroup, and the result can be other mode bits set.
-                                                  format: int32
                                                   type: integer
                                                 path:
                                                   description: |-
@@ -5548,7 +5508,6 @@ spec:
                                                     If not specified, the volume defaultMode will be used.
                                                     This might be in conflict with other options that affect the file
                                                     mode, like fsGroup, and the result can be other mode bits set.
-                                                  format: int32
                                                   type: integer
                                                 path:
                                                   description: 'Required: Path is  the
@@ -5687,7 +5646,6 @@ spec:
                                               seconds (1 hour).  This constraint is enforced by kube-apiserver.
                                               `kubernetes.io` signers will never issue certificates with a lifetime
                                               longer than 24 hours.
-                                            format: int32
                                             type: integer
                                           signerName:
                                             description: Kubelet's generated CSRs
@@ -5743,7 +5701,6 @@ spec:
                                                     If not specified, the volume defaultMode will be used.
                                                     This might be in conflict with other options that affect the file
                                                     mode, like fsGroup, and the result can be other mode bits set.
-                                                  format: int32
                                                   type: integer
                                                 path:
                                                   description: |-
@@ -5792,7 +5749,6 @@ spec:
                                               start trying to rotate the token if the token is older than 80 percent of
                                               its time to live or if the token is older than 24 hours.Defaults to 1 hour
                                               and must be at least 10 minutes.
-                                            format: int64
                                             type: integer
                                           path:
                                             description: |-
@@ -6003,7 +5959,6 @@ spec:
                                     Directories within the path are not affected by this setting.
                                     This might be in conflict with other options that affect the file
                                     mode, like fsGroup, and the result can be other mode bits set.
-                                  format: int32
                                   type: integer
                                 items:
                                   description: |-
@@ -6029,7 +5984,6 @@ spec:
                                           If not specified, the volume defaultMode will be used.
                                           This might be in conflict with other options that affect the file
                                           mode, like fsGroup, and the result can be other mode bits set.
-                                        format: int32
                                         type: integer
                                       path:
                                         description: |-
@@ -6354,7 +6308,6 @@ spec:
                                       description: Weight associated with matching
                                         the corresponding nodeSelectorTerm, in the
                                         range 1-100.
-                                      format: int32
                                       type: integer
                                   required:
                                   - preference
@@ -6637,7 +6590,6 @@ spec:
                                       description: |-
                                         weight associated with matching the corresponding podAffinityTerm,
                                         in the range 1-100.
-                                      format: int32
                                       type: integer
                                   required:
                                   - podAffinityTerm
@@ -6997,7 +6949,6 @@ spec:
                                       description: |-
                                         weight associated with matching the corresponding podAffinityTerm,
                                         in the range 1-100.
-                                      format: int32
                                       type: integer
                                   required:
                                   - podAffinityTerm
@@ -7411,7 +7362,6 @@ spec:
 
                               If unset, the Kubelet will not modify the ownership and permissions of any volume.
                               Note that this field cannot be set when spec.os.name is windows.
-                            format: int64
                             type: integer
                           fsGroupChangePolicy:
                             description: |-
@@ -7431,7 +7381,6 @@ spec:
                               PodSecurityContext, the value specified in SecurityContext takes precedence
                               for that container.
                               Note that this field cannot be set when spec.os.name is windows.
-                            format: int64
                             type: integer
                           runAsNonRoot:
                             description: |-
@@ -7450,7 +7399,6 @@ spec:
                               PodSecurityContext, the value specified in SecurityContext takes precedence
                               for that container.
                               Note that this field cannot be set when spec.os.name is windows.
-                            format: int64
                             type: integer
                           seLinuxChangePolicy:
                             description: |-
@@ -7540,7 +7488,6 @@ spec:
                               supplementalGroupsPolicy field.
                               Note that this field cannot be set when spec.os.name is windows.
                             items:
-                              format: int64
                               type: integer
                             type: array
                             x-kubernetes-list-type: atomic
@@ -7607,7 +7554,6 @@ spec:
                             type: object
                         type: object
                       replicas:
-                        format: int32
                         type: integer
                       resources:
                         description: ResourceRequirements describes the compute resource
@@ -7760,7 +7706,6 @@ spec:
                               May also be set in PodSecurityContext.  If set in both SecurityContext and
                               PodSecurityContext, the value specified in SecurityContext takes precedence.
                               Note that this field cannot be set when spec.os.name is windows.
-                            format: int64
                             type: integer
                           runAsNonRoot:
                             description: |-
@@ -7778,7 +7723,6 @@ spec:
                               May also be set in PodSecurityContext.  If set in both SecurityContext and
                               PodSecurityContext, the value specified in SecurityContext takes precedence.
                               Note that this field cannot be set when spec.os.name is windows.
-                            format: int64
                             type: integer
                           seLinuxOptions:
                             description: |-
@@ -7916,7 +7860,6 @@ spec:
                                 of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
                                 it is not set, which means tolerate the taint forever (do not evict). Zero and
                                 negative values will be treated as 0 (evict immediately) by the system.
-                              format: int64
                               type: integer
                             value:
                               description: |-
@@ -8014,7 +7957,6 @@ spec:
                                     If omitted, the default is to mount by volume name.
                                     Examples: For volume /dev/sda1, you specify the partition as "1".
                                     Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                                  format: int32
                                   type: integer
                                 readOnly:
                                   description: |-
@@ -8203,7 +8145,6 @@ spec:
                                     Directories within the path are not affected by this setting.
                                     This might be in conflict with other options that affect the file
                                     mode, like fsGroup, and the result can be other mode bits set.
-                                  format: int32
                                   type: integer
                                 items:
                                   description: |-
@@ -8229,7 +8170,6 @@ spec:
                                           If not specified, the volume defaultMode will be used.
                                           This might be in conflict with other options that affect the file
                                           mode, like fsGroup, and the result can be other mode bits set.
-                                        format: int32
                                         type: integer
                                       path:
                                         description: |-
@@ -8323,7 +8263,6 @@ spec:
                                     Directories within the path are not affected by this setting.
                                     This might be in conflict with other options that affect the file
                                     mode, like fsGroup, and the result can be other mode bits set.
-                                  format: int32
                                   type: integer
                                 items:
                                   description: Items is a list of downward API volume
@@ -8359,7 +8298,6 @@ spec:
                                           If not specified, the volume defaultMode will be used.
                                           This might be in conflict with other options that affect the file
                                           mode, like fsGroup, and the result can be other mode bits set.
-                                        format: int32
                                         type: integer
                                       path:
                                         description: 'Required: Path is  the relative
@@ -8704,7 +8642,6 @@ spec:
                                   type: string
                                 lun:
                                   description: 'lun is Optional: FC target lun number'
-                                  format: int32
                                   type: integer
                                 readOnly:
                                   description: |-
@@ -8813,7 +8750,6 @@ spec:
                                     Examples: For volume /dev/sda1, you specify the partition as "1".
                                     Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                     More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                  format: int32
                                   type: integer
                                 pdName:
                                   description: |-
@@ -8973,7 +8909,6 @@ spec:
                                   type: string
                                 lun:
                                   description: lun represents iSCSI Target Lun number.
-                                  format: int32
                                   type: integer
                                 portals:
                                   description: |-
@@ -9118,7 +9053,6 @@ spec:
                                     Directories within the path are not affected by this setting.
                                     This might be in conflict with other options that affect the file
                                     mode, like fsGroup, and the result can be other mode bits set.
-                                  format: int32
                                   type: integer
                                 sources:
                                   description: |-
@@ -9251,7 +9185,6 @@ spec:
                                                     If not specified, the volume defaultMode will be used.
                                                     This might be in conflict with other options that affect the file
                                                     mode, like fsGroup, and the result can be other mode bits set.
-                                                  format: int32
                                                   type: integer
                                                 path:
                                                   description: |-
@@ -9321,7 +9254,6 @@ spec:
                                                     If not specified, the volume defaultMode will be used.
                                                     This might be in conflict with other options that affect the file
                                                     mode, like fsGroup, and the result can be other mode bits set.
-                                                  format: int32
                                                   type: integer
                                                 path:
                                                   description: 'Required: Path is  the
@@ -9460,7 +9392,6 @@ spec:
                                               seconds (1 hour).  This constraint is enforced by kube-apiserver.
                                               `kubernetes.io` signers will never issue certificates with a lifetime
                                               longer than 24 hours.
-                                            format: int32
                                             type: integer
                                           signerName:
                                             description: Kubelet's generated CSRs
@@ -9516,7 +9447,6 @@ spec:
                                                     If not specified, the volume defaultMode will be used.
                                                     This might be in conflict with other options that affect the file
                                                     mode, like fsGroup, and the result can be other mode bits set.
-                                                  format: int32
                                                   type: integer
                                                 path:
                                                   description: |-
@@ -9565,7 +9495,6 @@ spec:
                                               start trying to rotate the token if the token is older than 80 percent of
                                               its time to live or if the token is older than 24 hours.Defaults to 1 hour
                                               and must be at least 10 minutes.
-                                            format: int64
                                             type: integer
                                           path:
                                             description: |-
@@ -9776,7 +9705,6 @@ spec:
                                     Directories within the path are not affected by this setting.
                                     This might be in conflict with other options that affect the file
                                     mode, like fsGroup, and the result can be other mode bits set.
-                                  format: int32
                                   type: integer
                                 items:
                                   description: |-
@@ -9802,7 +9730,6 @@ spec:
                                           If not specified, the volume defaultMode will be used.
                                           This might be in conflict with other options that affect the file
                                           mode, like fsGroup, and the result can be other mode bits set.
-                                        format: int32
                                         type: integer
                                       path:
                                         description: |-
@@ -10206,7 +10133,6 @@ spec:
                         observedGeneration represents the .metadata.generation that the condition was set based upon.
                         For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
                         with respect to the current state of the instance.
-                      format: int64
                       minimum: 0
                       type: integer
                     reason:
@@ -10241,7 +10167,6 @@ spec:
                   type: object
                 type: array
               observedGeneration:
-                format: int64
                 type: integer
             required:
             - observedGeneration

--- a/helm/kagent-crds/templates/kagent.dev_memories.yaml
+++ b/helm/kagent-crds/templates/kagent.dev_memories.yaml
@@ -114,7 +114,6 @@ spec:
                         observedGeneration represents the .metadata.generation that the condition was set based upon.
                         For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
                         with respect to the current state of the instance.
-                      format: int64
                       minimum: 0
                       type: integer
                     reason:
@@ -149,7 +148,6 @@ spec:
                   type: object
                 type: array
               observedGeneration:
-                format: int64
                 type: integer
             required:
             - conditions

--- a/helm/kagent-crds/templates/kagent.dev_modelconfigs.yaml
+++ b/helm/kagent-crds/templates/kagent.dev_modelconfigs.yaml
@@ -303,7 +303,6 @@ spec:
                         observedGeneration represents the .metadata.generation that the condition was set based upon.
                         For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
                         with respect to the current state of the instance.
-                      format: int64
                       minimum: 0
                       type: integer
                     reason:
@@ -338,7 +337,6 @@ spec:
                   type: object
                 type: array
               observedGeneration:
-                format: int64
                 type: integer
             required:
             - conditions
@@ -710,7 +708,6 @@ spec:
                         observedGeneration represents the .metadata.generation that the condition was set based upon.
                         For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
                         with respect to the current state of the instance.
-                      format: int64
                       minimum: 0
                       type: integer
                     reason:
@@ -745,7 +742,6 @@ spec:
                   type: object
                 type: array
               observedGeneration:
-                format: int64
                 type: integer
               secretHash:
                 description: The secret hash stores a hash of any secrets required

--- a/helm/kagent-crds/templates/kagent.dev_modelproviderconfigs.yaml
+++ b/helm/kagent-crds/templates/kagent.dev_modelproviderconfigs.yaml
@@ -129,7 +129,6 @@ spec:
                         observedGeneration represents the .metadata.generation that the condition was set based upon.
                         For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
                         with respect to the current state of the instance.
-                      format: int64
                       minimum: 0
                       type: integer
                     reason:
@@ -184,7 +183,6 @@ spec:
               observedGeneration:
                 description: ObservedGeneration reflects the generation of the most
                   recently observed ModelProviderConfig spec
-                format: int64
                 type: integer
               secretHash:
                 description: SecretHash is a hash of the referenced secret data, used

--- a/helm/kagent-crds/templates/kagent.dev_remotemcpservers.yaml
+++ b/helm/kagent-crds/templates/kagent.dev_remotemcpservers.yaml
@@ -208,7 +208,6 @@ spec:
                         observedGeneration represents the .metadata.generation that the condition was set based upon.
                         For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
                         with respect to the current state of the instance.
-                      format: int64
                       minimum: 0
                       type: integer
                     reason:
@@ -258,7 +257,6 @@ spec:
                 description: |-
                   INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
                   Important: Run "make" to regenerate code after modifying this file
-                format: int64
                 type: integer
             required:
             - conditions

--- a/helm/kagent-crds/templates/kagent.dev_toolservers.yaml
+++ b/helm/kagent-crds/templates/kagent.dev_toolservers.yaml
@@ -243,7 +243,6 @@ spec:
                         observedGeneration represents the .metadata.generation that the condition was set based upon.
                         For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
                         with respect to the current state of the instance.
-                      format: int64
                       minimum: 0
                       type: integer
                     reason:
@@ -319,7 +318,6 @@ spec:
                 description: |-
                   INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
                   Important: Run "make" to regenerate code after modifying this file
-                format: int64
                 type: integer
             required:
             - conditions


### PR DESCRIPTION
## Summary

Fixes #1318

When running `helm install kagent-crds oci://ghcr.io/kagent-dev/kagent/helm/kagent-crds`, warnings are emitted:

```
Warning: unrecognized format "int64"
Warning: unrecognized format "int32"
```

These warnings come from `format: int32` and `format: int64` annotations in the CRD OpenAPI schemas. While controller-gen adds these annotations from Go types (`int32`/`int64`), the Kubernetes API server does not recognize them as valid OpenAPI format values.

## Changes

1. **`go/Makefile`**: Added a post-processing step to `make manifests` that strips `format: int32` and `format: int64` lines from generated CRD YAML files after controller-gen runs
2. **CRD files**: Removed the format annotations from all CRD files in both `go/config/crd/bases/` and `helm/kagent-crds/templates/`

This is a standard approach used by many Kubernetes operators to suppress these warnings. The integer type information (`type: integer`) is preserved — only the unrecognized `format` annotation is removed.

## Test plan

- [x] All CRD YAML files parse correctly after removal
- [x] CRD files in `go/config/crd/bases/` and `helm/kagent-crds/templates/` are in sync
- [ ] `helm install kagent-crds` no longer produces int format warnings