### PR TITLE
feat(ui): add keyboard shortcut hint to chat input

### DIFF
--- a/ui/src/components/chat/ChatInterface.tsx
+++ b/ui/src/components/chat/ChatInterface.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type React from "react";
-import { useState, useRef, useEffect, useMemo } from "react";
+import { useState, useRef, useEffect } from "react";
 import { ArrowBigUp, X, Loader2, Mic, Square } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -74,11 +74,11 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
     },
   });
 
-  const shortcutKey = useMemo(() => {
-    if (typeof navigator !== "undefined") {
-      return /Mac|iPhone|iPad|iPod/.test(navigator.userAgent) ? "⌘" : "Ctrl";
+  const [shortcutKey, setShortcutKey] = useState("Ctrl");
+  useEffect(() => {
+    if (/Mac|iPhone|iPad|iPod/.test(navigator.userAgent)) {
+      setShortcutKey("⌘");
     }
-    return "Ctrl";
   }, []);
 
   const { handleMessageEvent } = createMessageHandlers({


### PR DESCRIPTION
## Summary

Adds a subtle text hint next to the Send button showing the keyboard shortcut to submit a message:

- **macOS**: `⌘+Enter to send`
- **Windows/Linux**: `Ctrl+Enter to send`

The hint uses `text-xs text-muted-foreground` styling to stay unobtrusive, and is positioned to the left of the action buttons using `mr-auto`.

### Implementation

- Added `useMemo` hook with `navigator.userAgent` detection to determine OS
- Single `<span>` element in the existing button row — no layout changes
- Falls back to "Ctrl" for SSR (server-side rendering) compatibility

Closes #824

Signed-off-by: Sean Florez <sean@opspawn.com>