### PR TITLE
fix: suppress repeated experimental mode warnings for A2A agents

### DIFF
--- a/python/packages/kagent-adk/src/kagent/adk/__init__.py
+++ b/python/packages/kagent-adk/src/kagent/adk/__init__.py
@@ -1,9 +1,10 @@
 import importlib.metadata
 import warnings
 
-# Suppress repeated experimental mode warnings from google-adk's A2A decorators.
-# Without this filter, every RemoteA2aAgent/A2aAgentExecutor instantiation emits
-# a UserWarning, flooding logs during normal A2A operations.
+# Suppress repeated experimental-mode UserWarnings whose messages start with
+# "[EXPERIMENTAL]" and mention RemoteA2aAgent or A2aAgentExecutor.  This covers
+# warnings from google-adk's A2A decorators, where every instantiation would
+# otherwise emit a warning and flood logs during normal A2A operations.
 # See: https://github.com/kagent-dev/kagent/issues/1379
 warnings.filterwarnings(
     "once",


### PR DESCRIPTION
## Summary

Fixes #1379

The `google-adk` library's `@a2a_experimental` decorator emits a `UserWarning` on **every** `RemoteA2aAgent` and `A2aAgentExecutor` instantiation. During normal A2A operations with multiple agents, this floods logs with identical warning messages:

```
UserWarning: [EXPERIMENTAL] RemoteA2aAgent: ADK Implementation for A2A support...
```

### Changes

- **`kagent/adk/__init__.py`**: Added `warnings.filterwarnings("once", message=r"\[EXPERIMENTAL\]", category=UserWarning)` before any google-adk imports. This ensures the warning is emitted only once per unique message+location combination rather than on every instantiation.
- **`tests/unittests/test_experimental_warning_suppression.py`**: Added tests verifying the deduplication works and that non-experimental warnings remain unaffected.

### Why this approach

The warning originates in upstream `google-adk`'s `_make_feature_decorator` which wraps `__init__` with `warnings.warn()`. Rather than monkey-patching upstream code or suppressing warnings entirely, `filterwarnings("once", ...)` is the standard Python mechanism — the first warning still appears (preserving visibility) but subsequent duplicates are silenced.

## Test plan

- [x] New unit tests pass (`test_experimental_warning_emitted_once`, `test_non_experimental_warnings_unaffected`)
- [x] Ruff lint + format checks pass
- [ ] CI passes