### PR TITLE
Built-in tool for agents to get session info

### DIFF
--- a/python/packages/kagent-adk/src/kagent/adk/cli.py
+++ b/python/packages/kagent-adk/src/kagent/adk/cli.py
@@ -15,7 +15,7 @@ from google.adk.cli.utils.agent_loader import AgentLoader
 from kagent.core import KAgentConfig, configure_logging, configure_tracing
 
 from . import AgentConfig, KAgentApp
-from .tools import add_skills_tool_to_agent
+from .tools import add_session_tool, add_skills_tool_to_agent
 
 logger = logging.getLogger(__name__)
 logging.getLogger("google_adk.google.adk.tools.base_authenticated_tool").setLevel(logging.ERROR)
@@ -74,7 +74,7 @@ def static(
 
     def root_agent_factory() -> BaseAgent:
         root_agent = agent_config.to_agent(app_cfg.name, sts_integration)
-
+        add_session_tool(root_agent)
         maybe_add_skills(root_agent)
 
         return root_agent
@@ -149,6 +149,7 @@ def run(
         if sts_integration:
             add_to_agent(sts_integration, root_agent)
 
+        add_session_tool(root_agent)
         maybe_add_skills(root_agent)
 
         return root_agent
@@ -213,6 +214,7 @@ async def test_agent(agent_config: AgentConfig, agent_card: AgentCard, task: str
 
     def root_agent_factory() -> BaseAgent:
         root_agent = agent_config.to_agent(app_cfg.name, sts_integration)
+        add_session_tool(root_agent)
         maybe_add_skills(root_agent)
         return root_agent
 

--- a/python/packages/kagent-adk/src/kagent/adk/tools/README.md
+++ b/python/packages/kagent-adk/src/kagent/adk/tools/README.md
@@ -29,7 +29,7 @@ app = App(
 
 ```python
 from kagent.adk.skills import SkillsTool
-from kagent.adk.tools import BashTool, ReadFileTool, WriteFileTool, EditFileTool
+from kagent.adk.tools import BashTool, ReadFileTool, WriteFileTool, EditFileTool, SessionInfoTool
 
 agent = Agent(
     tools=[
@@ -38,6 +38,7 @@ agent = Agent(
         ReadFileTool(),
         WriteFileTool(),
         EditFileTool(),
+        SessionInfoTool(),
     ]
 )
 ```
@@ -123,6 +124,7 @@ description: Analyze CSV/Excel files
 | **ReadFile**   | Read files with line numbers | `read_file("skills/data-analysis/config.json")`       |
 | **WriteFile**  | Create/overwrite files       | `write_file("outputs/report.pdf", data)`              |
 | **EditFile**   | Precise string replacements  | `edit_file("script.py", old="x", new="y")`            |
+| **SessionInfo**| Get session details          | `get_session_info()`                                  |
 
 ### Working Directory Structure
 

--- a/python/packages/kagent-adk/src/kagent/adk/tools/__init__.py
+++ b/python/packages/kagent-adk/src/kagent/adk/tools/__init__.py
@@ -1,5 +1,6 @@
 from .bash_tool import BashTool
 from .file_tools import EditFileTool, ReadFileTool, WriteFileTool
+from .session_tool import SessionInfoTool, add_session_tool
 from .skill_tool import SkillsTool
 from .skills_plugin import add_skills_tool_to_agent
 from .skills_toolset import SkillsToolset
@@ -8,8 +9,10 @@ __all__ = [
     "SkillsTool",
     "SkillsToolset",
     "BashTool",
+    "SessionInfoTool",
     "EditFileTool",
     "ReadFileTool",
     "WriteFileTool",
+    "add_session_tool",
     "add_skills_tool_to_agent",
 ]

--- a/python/packages/kagent-adk/src/kagent/adk/tools/session_tool.py
+++ b/python/packages/kagent-adk/src/kagent/adk/tools/session_tool.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict
+
+from google.adk.agents import BaseAgent, LlmAgent
+from google.adk.tools import BaseTool, ToolContext
+from google.genai import types
+
+logger = logging.getLogger("kagent_adk." + __name__)
+
+
+def add_session_tool(agent: BaseAgent) -> None:
+    if not isinstance(agent, LlmAgent):
+        return
+    existing_tool_names = {getattr(t, "name", None) for t in agent.tools}
+    if "get_session_info" not in existing_tool_names:
+        agent.tools.append(SessionInfoTool())
+        logger.debug(f"Added session info tool to agent: {agent.name}")
+
+
+class SessionInfoTool(BaseTool):
+    """Tool for retrieving information about the current agent session."""
+
+    def __init__(self):
+        super().__init__(
+            name="get_session_info",
+            description="Get information about the current agent session, including the session ID.",
+        )
+
+    def _get_declaration(self) -> types.FunctionDeclaration:
+        return types.FunctionDeclaration(
+            name=self.name,
+            description=self.description,
+            parameters=types.Schema(
+                type=types.Type.OBJECT,
+                properties={},
+            ),
+        )
+
+    async def run_async(self, *, args: Dict[str, Any], tool_context: ToolContext) -> str:
+        info = {
+            "session_id": tool_context.session.id,
+            "user_id": tool_context.session.user_id,
+            "app_name": tool_context.session.app_name,
+        }
+        return json.dumps(info)

--- a/python/packages/kagent-adk/src/kagent/adk/tools/skills_toolset.py
+++ b/python/packages/kagent-adk/src/kagent/adk/tools/skills_toolset.py
@@ -13,7 +13,7 @@ from google.adk.agents.readonly_context import ReadonlyContext
 from google.adk.tools import BaseTool
 from google.adk.tools.base_toolset import BaseToolset
 
-from ..tools import BashTool, EditFileTool, ReadFileTool, WriteFileTool
+from ..tools import BashTool, EditFileTool, ReadFileTool, SessionInfoTool, WriteFileTool
 from .skill_tool import SkillsTool
 
 logger = logging.getLogger("kagent_adk." + __name__)
@@ -28,6 +28,7 @@ class SkillsToolset(BaseToolset):
     3. WriteFileTool - Write/create files
     4. EditFileTool - Edit files with precise replacements
     5. BashTool - Execute shell commands
+    6. SessionInfoTool - Get session information
 
     Skills provide specialized domain knowledge and scripts that the agent can use
     to solve complex tasks. The toolset enables discovery of available skills,
@@ -51,13 +52,14 @@ class SkillsToolset(BaseToolset):
         self.write_file_tool = WriteFileTool()
         self.edit_file_tool = EditFileTool()
         self.bash_tool = BashTool(skills_directory)
+        self.session_info_tool = SessionInfoTool()
 
     @override
     async def get_tools(self, readonly_context: Optional[ReadonlyContext] = None) -> List[BaseTool]:
         """Get all skills tools.
 
         Returns:
-          List containing all skills tools: skills, read, write, edit, and bash.
+          List containing all skills tools: skills, read, write, edit, bash, and session info.
         """
         return [
             self.skills_tool,
@@ -65,4 +67,5 @@ class SkillsToolset(BaseToolset):
             self.write_file_tool,
             self.edit_file_tool,
             self.bash_tool,
+            self.session_info_tool,
         ]

--- a/python/packages/kagent-adk/tests/unittests/test_session_tool.py
+++ b/python/packages/kagent-adk/tests/unittests/test_session_tool.py
@@ -1,0 +1,38 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from unittest.mock import Mock
+
+import pytest
+from kagent.adk.tools.session_tool import SessionInfoTool
+
+
+class TestSessionInfoTool:
+    @pytest.mark.asyncio
+    async def test_session_info_tool(self):
+        tool = SessionInfoTool()
+
+        context = Mock()
+        context.session = Mock()
+        context.session.id = "session-123"
+        context.session.user_id = "user-456"
+        context.session.app_name = "test-app"
+
+        result = await tool.run_async(args={}, tool_context=context)
+
+        data = json.loads(result)
+        assert data["session_id"] == "session-123"
+        assert data["user_id"] == "user-456"
+        assert data["app_name"] == "test-app"


### PR DESCRIPTION
This tool is essential for my multi-agent development workflows.

It allows agents to generate a link to the kagent session for review when creating commits.

This also allows agents to register for automatic ping-backs from a tool I have that monitors to-do lists and periodically pings the agent session if it hasn't touched the to-do list in a while.

It probably has many other uses.

An alternative to this tool approach could be to auto-inject this information into the prompt somehow.  I wasn't sure if I should do it that way or not. The tool is working well enough for me.

I couldn't do this without modifying kagent itself because the agent name and session ID aren't available to MCP servers.

Signed-off-by: Dobes Vandermeer <dobes.vandermeer@newsela.com>
