### PR TITLE
fix(helm): disable kmcp in minimal profile

### DIFF
--- a/go/core/cli/internal/profiles/minimal.yaml
+++ b/go/core/cli/internal/profiles/minimal.yaml
@@ -21,3 +21,6 @@ agents:
     enabled: false
   cilium-debug-agent:
     enabled: false
+
+kmcp:
+  enabled: false


### PR DESCRIPTION
## Summary
- Adds `kmcp.enabled: false` to the minimal profile values, preventing kmcp from being installed when using `kagent install --profile minimal`
- The minimal profile is intended as a bare minimum installation; kmcp should not be included

Fixes #1319

> Note: A previous PR (#1320) addressed this but was closed after the Go restructure (#1385) moved the file path from `go/cli/` to `go/core/cli/`. This PR applies the same fix at the correct path.

## Test plan
- [ ] Run `kagent install --profile minimal` and verify kmcp is not installed
- [ ] Run `kagent install --profile demo` and verify kmcp is still installed (default behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)