### PR TITLE
fix(ui): prevent duplicate ask_user card on session load

### DIFF
--- a/ui/src/lib/messageHandlers.ts
+++ b/ui/src/lib/messageHandlers.ts
@@ -28,6 +28,13 @@ export function extractMessagesFromTasks(tasks: Task[]): Message[] {
               i
             );
 
+            // Skip unresolved confirmations — extractApprovalMessagesFromTasks
+            // handles pending ones via task.status.message to avoid duplicates.
+            if (!decision) {
+              seenMessageIds.add(historyItem.messageId);
+              continue;
+            }
+
             for (const confPart of confirmationParts) {
               const approvalMsg = buildApprovalMessage(confPart, task.contextId, task.id, decision);
               messages.push(approvalMsg);


### PR DESCRIPTION
## Summary

- When loading a session with a pending `ask_user` request, the \"Questions for you\" card was rendered twice
- Two code paths both generated an `AskUserRequest` message for the same pending confirmation:
  1. `extractMessagesFromTasks()` found it in task history (no decision yet → pending card)
  2. `extractApprovalMessagesFromTasks()` found the same confirmation in `task.status.message`
- Both were concatenated into `storedMessages`, causing the duplicate

**Fix:** `extractMessagesFromTasks()` now skips unresolved confirmations (where no subsequent user decision exists in history). Pending confirmations are exclusively owned by `extractApprovalMessagesFromTasks()` via `task.status.message`; resolved ones continue to render inline from history as before.

## Test plan

- [ ] Start a session with an agent that uses `ask_user` (e.g. an agent configured to ask before merging a PR)
- [ ] Trigger the `ask_user` prompt, then reload/revisit the session
- [ ] Change/Swap to another conversation - then return
- [ ] Verify only one \"Questions for you\" card is shown (previously two appeared)
- [ ] Verify that answering the question still works correctly
- [ ] Verify resolved `ask_user` sessions show the answered card correctly (read-only)