### PR TITLE
Front-end session type/function fixup

### DIFF
--- a/ui/src/app/actions/sessions.ts
+++ b/ui/src/app/actions/sessions.ts
@@ -108,31 +108,3 @@ export async function checkSessionExists(sessionId: string): Promise<BaseRespons
     return createErrorResponse<boolean>(error, "Error checking session");
   }
 }
-
-/**
- * Updates a session
- * @param session The session to update
- * @returns A promise with the updated session
- */
-export async function updateSession(session: Session): Promise<BaseResponse<Session>> {
-  try {
-    const sessionToUpdate = {
-      ...session,
-      agent_id: Number(session.agent_id)
-    };
-
-    const response = await fetchApi<BaseResponse<Session>>(`/sessions/${session.id}`, {
-      method: "PUT",
-      body: JSON.stringify(sessionToUpdate),
-    });
-
-    if (!response) {
-      throw new Error("Failed to update session");
-    }
-
-    revalidatePath("/");
-    return { message: "Session updated successfully", data: response.data };
-  } catch (error) {
-    return createErrorResponse<Session>(error, "Error updating session");
-  }
-}

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -187,7 +187,7 @@ export interface FunctionCall {
 export interface Session {
   id: string;
   name: string;
-  agent_id: number;
+  agent_id: string;
   user_id: string;
   created_at: string;
   updated_at: string;


### PR DESCRIPTION
- Use `agent_id: string` to match API as implemented
- Remove unused / broken `updateSession` function

`updateSession` would not have worked as the server is expecting `agent_ref`, `name`, `id` and this was providing something completely different and probably would have errored or given `NaN` for `agent_id` anyway as `session.agent_id` should be something like `kagent__NS__k8s`

I wasn't quite sure if this is the only usage of `PUT /sessions/{id}`.  It would be nice to also remove that endpoint as it doesn't seem to do anything useful currently and takes `agent_ref` instead of `agent_id` which is inconsistent with the field naming in `GET /sessions/{id}`