### PR TITLE
agentsts: add use_issuer_host for token endpoint and fix MCP check

### DIFF
--- a/python/packages/agentsts-adk/src/agentsts/adk/_base.py
+++ b/python/packages/agentsts-adk/src/agentsts/adk/_base.py
@@ -22,7 +22,7 @@ from google.adk.sessions import BaseSessionService
 from google.adk.sessions.session import Session
 from google.adk.tools.base_tool import BaseTool
 from google.adk.tools.mcp_tool import MCPTool
-from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset
+from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset, McpToolset
 from google.adk.tools.tool_context import ToolContext
 from typing_extensions import override
 
@@ -43,6 +43,7 @@ class ADKSTSIntegration(STSIntegrationBase):
         fetch_actor_token: Optional[Union[Callable[[], str], Callable[[], Awaitable[str]]]] = None,
         timeout: int = 5,
         verify_ssl: bool = True,
+        use_issuer_host: bool = False,
         additional_config: Optional[Dict[str, Any]] = None,
     ):
         """Initialize the ADK STS integration.
@@ -53,6 +54,7 @@ class ADKSTSIntegration(STSIntegrationBase):
             fetch_actor_token: Optional callable (sync or async) that returns an actor token
             timeout: Request timeout in seconds
             verify_ssl: Whether to verify SSL certificates
+            use_issuer_host: Replace the host:port in token_endpoint with the host:port from well_known_uri
             additional_config: Additional configuration
         """
         super().__init__(
@@ -61,6 +63,7 @@ class ADKSTSIntegration(STSIntegrationBase):
             fetch_actor_token=fetch_actor_token,
             timeout=timeout,
             verify_ssl=verify_ssl,
+            use_issuer_host=use_issuer_host,
             additional_config=additional_config,
         )
 
@@ -105,7 +108,7 @@ class ADKTokenPropagationPlugin(BasePlugin):
             return
 
         for tool in agent.tools:
-            if isinstance(tool, MCPToolset):
+            if isinstance(tool, McpToolset):
                 mcp_toolset = tool
                 mcp_toolset._header_provider = self.header_provider
                 logger.debug("Updated tool connection params to include access token from STS server")

--- a/python/packages/agentsts-adk/tests/test_adk_integration.py
+++ b/python/packages/agentsts-adk/tests/test_adk_integration.py
@@ -972,6 +972,78 @@ class TestADKSTSIntegration:
             assert adk_integration._actor_token == "static-token-456"
             assert adk_integration.fetch_actor_token is None
 
+    def test_init_with_use_issuer_host(self):
+        """Test that ADKSTSIntegration passes use_issuer_host to STSConfig."""
+        with patch("agentsts.core._base.ActorTokenService"):
+            integration = ADKSTSIntegration(
+                well_known_uri="http://192.168.1.100:7777/.well-known/oauth-authorization-server",
+                use_issuer_host=True,
+            )
+            assert integration.sts_client.config.use_issuer_host is True
+
+    def test_init_without_use_issuer_host_defaults_to_false(self):
+        """Test that use_issuer_host defaults to False."""
+        with patch("agentsts.core._base.ActorTokenService"):
+            integration = ADKSTSIntegration(
+                well_known_uri="https://example.com/.well-known/oauth-authorization-server",
+            )
+            assert integration.sts_client.config.use_issuer_host is False
+
+    @pytest.mark.asyncio
+    async def test_use_issuer_host_replaces_token_endpoint_host(self):
+        """Test that use_issuer_host replaces host:port in token_endpoint with the issuer host."""
+        well_known_uri = "http://192.168.1.100:7777/.well-known/oauth-authorization-server"
+        well_known_response = {
+            "token_endpoint": "foo.bar:7777/oauth2/token",
+            "issuer": "http://192.168.1.100:7777",
+        }
+
+        with patch("agentsts.core._base.ActorTokenService"):
+            integration = ADKSTSIntegration(
+                well_known_uri=well_known_uri,
+                use_issuer_host=True,
+            )
+
+        with patch("agentsts.core.client._utils.httpx.AsyncClient") as mock_client_cls:
+            mock_response = Mock()
+            mock_response.json.return_value = well_known_response
+            mock_response.raise_for_status = Mock()
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client_cls.return_value)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value.get = AsyncMock(return_value=mock_response)
+
+            await integration.sts_client._initialize()
+
+        assert integration.sts_client._well_known_config.token_endpoint == "http://192.168.1.100:7777/oauth2/token"
+
+    @pytest.mark.asyncio
+    async def test_use_issuer_host_preserves_existing_scheme_in_token_endpoint(self):
+        """Test that use_issuer_host keeps the scheme from token_endpoint when it already has one."""
+        well_known_uri = "http://192.168.1.100:7777/.well-known/oauth-authorization-server"
+        well_known_response = {
+            "token_endpoint": "https://foo.bar:7777/oauth2/token",
+            "issuer": "http://192.168.1.100:7777",
+        }
+
+        with patch("agentsts.core._base.ActorTokenService"):
+            integration = ADKSTSIntegration(
+                well_known_uri=well_known_uri,
+                use_issuer_host=True,
+            )
+
+        with patch("agentsts.core.client._utils.httpx.AsyncClient") as mock_client_cls:
+            mock_response = Mock()
+            mock_response.json.return_value = well_known_response
+            mock_response.raise_for_status = Mock()
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client_cls.return_value)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value.get = AsyncMock(return_value=mock_response)
+
+            await integration.sts_client._initialize()
+
+        # https from token_endpoint is preserved; only host is replaced
+        assert integration.sts_client._well_known_config.token_endpoint == "https://192.168.1.100:7777/oauth2/token"
+
     @pytest.mark.asyncio
     async def test_get_auth_credential_without_actor_token(self):
         """Test that get_auth_credential calls exchange_token without actor token when none is set."""

--- a/python/packages/agentsts-core/src/agentsts/core/_base.py
+++ b/python/packages/agentsts-core/src/agentsts/core/_base.py
@@ -20,6 +20,7 @@ class STSIntegrationBase:
         fetch_actor_token: Optional[Union[Callable[[], str], Callable[[], Awaitable[str]]]] = None,
         timeout: int = 30,
         verify_ssl: bool = True,
+        use_issuer_host: bool = False,
         additional_config: Optional[Dict[str, Any]] = None,
     ):
         """Initialize the STS integration.
@@ -30,6 +31,7 @@ class STSIntegrationBase:
             fetch_actor_token: Optional callable (sync or async) that returns an actor token
             timeout: Request timeout in seconds
             verify_ssl: Whether to verify SSL certificates
+            use_issuer_host: Replace the host:port in token_endpoint with the host:port from well_known_uri
             additional_config: Additional configuration for the specific framework
         """
         self.well_known_uri = well_known_uri
@@ -43,6 +45,7 @@ class STSIntegrationBase:
             well_known_uri=well_known_uri,
             timeout=timeout,
             verify_ssl=verify_ssl,
+            use_issuer_host=use_issuer_host,
         )
         self.sts_client = STSClient(config)
         self.access_token = None  # cached access token

--- a/python/packages/agentsts-core/src/agentsts/core/client/_client.py
+++ b/python/packages/agentsts-core/src/agentsts/core/client/_client.py
@@ -41,7 +41,7 @@ class STSClient:
         """Initialize the client by fetching well-known configuration."""
         if not self._well_known_config:
             self._well_known_config = await fetch_well_known_configuration(
-                self.config.well_known_uri, self.config.timeout, self.config.verify_ssl
+                self.config.well_known_uri, self.config.timeout, self.config.verify_ssl, self.config.use_issuer_host
             )
 
         if not self._http_client:

--- a/python/packages/agentsts-core/src/agentsts/core/client/_config.py
+++ b/python/packages/agentsts-core/src/agentsts/core/client/_config.py
@@ -7,3 +7,7 @@ class STSConfig(BaseModel):
     well_known_uri: str = Field(..., description="The well-known configuration URI")
     timeout: int = Field(default=5, description="Request timeout in seconds")
     verify_ssl: bool = Field(default=True, description="Whether to verify SSL certificates")
+    use_issuer_host: bool = Field(
+        default=False,
+        description="Replace the host:port in token_endpoint with the host:port from well_known_uri",
+    )

--- a/python/packages/agentsts-core/src/agentsts/core/client/_utils.py
+++ b/python/packages/agentsts-core/src/agentsts/core/client/_utils.py
@@ -14,7 +14,7 @@ HTTPS_PROTOCOL = "https://"
 
 
 async def fetch_well_known_configuration(
-    well_known_uri: str, timeout: int = 5, verify_ssl: bool = True
+    well_known_uri: str, timeout: int = 5, verify_ssl: bool = True, use_issuer_host: bool = False
 ) -> WellKnownConfiguration:
     try:
         async with httpx.AsyncClient(timeout=timeout, verify=verify_ssl) as client:
@@ -31,6 +31,15 @@ async def fetch_well_known_configuration(
                 else:
                     protocol = HTTP_PROTOCOL
                 data["token_endpoint"] = protocol + data["token_endpoint"]
+
+            # replace host:port in token_endpoint with the host:port from well_known_uri
+            # protocol is already resolved above, so token_endpoint always has a scheme here
+            if use_issuer_host and "token_endpoint" in data:
+                from urllib.parse import urlparse, urlunparse
+
+                issuer = urlparse(well_known_uri)
+                endpoint = urlparse(data["token_endpoint"])
+                data["token_endpoint"] = urlunparse(endpoint._replace(netloc=issuer.netloc))
 
             config = WellKnownConfiguration.model_validate(data)
             return config


### PR DESCRIPTION
- Adds use_issuer_host to allow using the issuer's host for the token endpoint. This allows clients to call the STS service using an external IP/host to avoid using potentially private/internal hostnames for the token_endpoint returned by the well-known configuration endpoint.

- Fixes the check in add_to_agent to use McpToolset, as MCPToolSet is deprecated and fails the check against McpToolset which is a superclass. Using McpToolset is backward compatible as it is the superclass and will evaluate to true even against MCPToolSet.