### PR TITLE
fix: bubble up subagent HITL approval to parent agent

### DIFF
--- a/python/packages/kagent-adk/src/kagent/adk/_agent_executor.py
+++ b/python/packages/kagent-adk/src/kagent/adk/_agent_executor.py
@@ -14,7 +14,6 @@ from a2a.types import (
     Artifact,
     Message,
     Part,
-    Role,
     TaskArtifactUpdateEvent,
     TaskState,
     TaskStatus,
@@ -316,33 +315,61 @@ class A2aAgentExecutor(UpstreamA2aAgentExecutor):
                 continue
             raise result
 
-    async def _publish_failed_status_event(
+    async def _publish_final_task_result(
         self,
         context: RequestContext,
         event_queue: EventQueue,
-        error_message: str,
+        task_result_aggregator: TaskResultAggregator,
+        run_metadata: dict[str, str],
     ) -> None:
-        try:
+        """Publish the final task result event based on the aggregated state.
+
+        If the task is still in working state with message parts, publishes an
+        artifact update followed by a completed status. Otherwise publishes
+        the aggregator's current state as the final status.
+        """
+        if (
+            task_result_aggregator.task_state == TaskState.working
+            and task_result_aggregator.task_status_message is not None
+            and task_result_aggregator.task_status_message.parts
+        ):
+            await event_queue.enqueue_event(
+                TaskArtifactUpdateEvent(
+                    task_id=context.task_id,
+                    last_chunk=True,
+                    context_id=context.context_id,
+                    artifact=Artifact(
+                        artifact_id=str(uuid.uuid4()),
+                        parts=task_result_aggregator.task_status_message.parts,
+                    ),
+                )
+            )
             await event_queue.enqueue_event(
                 TaskStatusUpdateEvent(
                     task_id=context.task_id,
                     status=TaskStatus(
-                        state=TaskState.failed,
+                        state=TaskState.completed,
                         timestamp=datetime.now(timezone.utc).isoformat(),
-                        message=Message(
-                            message_id=str(uuid.uuid4()),
-                            role=Role.agent,
-                            parts=[Part(TextPart(text=error_message))],
-                        ),
                     ),
                     context_id=context.context_id,
                     final=True,
+                    metadata=run_metadata,
                 )
             )
-        except BaseException as enqueue_error:
-            if isinstance(enqueue_error, (KeyboardInterrupt, SystemExit)):
-                raise
-            logger.error("Failed to publish failure event: %s", enqueue_error, exc_info=True)
+        else:
+            await event_queue.enqueue_event(
+                TaskStatusUpdateEvent(
+                    task_id=context.task_id,
+                    status=TaskStatus(
+                        state=task_result_aggregator.task_state,
+                        timestamp=datetime.now(timezone.utc).isoformat(),
+                        message=task_result_aggregator.task_status_message,
+                    ),
+                    context_id=context.context_id,
+                    final=True,
+                    metadata=run_metadata,
+                )
+            )
 
     @staticmethod
     def _find_pending_confirmations(session: Session) -> dict[str, str | None]:
@@ -557,51 +584,7 @@ class A2aAgentExecutor(UpstreamA2aAgentExecutor):
                     break
 
         # publish the task result event - this is final
-        if (
-            task_result_aggregator.task_state == TaskState.working
-            and task_result_aggregator.task_status_message is not None
-            and task_result_aggregator.task_status_message.parts
-        ):
-            # if task is still working properly, publish the artifact update event as
-            # the final result according to a2a protocol.
-            await event_queue.enqueue_event(
-                TaskArtifactUpdateEvent(
-                    task_id=context.task_id,
-                    last_chunk=True,
-                    context_id=context.context_id,
-                    artifact=Artifact(
-                        artifact_id=str(uuid.uuid4()),
-                        parts=task_result_aggregator.task_status_message.parts,
-                    ),
-                )
-            )
-            # publish the final status update event
-            await event_queue.enqueue_event(
-                TaskStatusUpdateEvent(
-                    task_id=context.task_id,
-                    status=TaskStatus(
-                        state=TaskState.completed,
-                        timestamp=datetime.now(timezone.utc).isoformat(),
-                    ),
-                    context_id=context.context_id,
-                    final=True,
-                    metadata=run_metadata,
-                )
-            )
-        else:
-            await event_queue.enqueue_event(
-                TaskStatusUpdateEvent(
-                    task_id=context.task_id,
-                    status=TaskStatus(
-                        state=task_result_aggregator.task_state,
-                        timestamp=datetime.now(timezone.utc).isoformat(),
-                        message=task_result_aggregator.task_status_message,
-                    ),
-                    context_id=context.context_id,
-                    final=True,
-                    metadata=run_metadata,
-                )
-            )
+        await self._publish_final_task_result(context, event_queue, task_result_aggregator, run_metadata)
 
     async def _prepare_session(self, context: RequestContext, run_args: dict[str, Any], runner: Runner):
         session_id = run_args["session_id"]

--- a/python/packages/kagent-adk/src/kagent/adk/_hitl_agent_tool.py
+++ b/python/packages/kagent-adk/src/kagent/adk/_hitl_agent_tool.py
@@ -1,0 +1,380 @@
+"""AgentTool subclass that propagates sub-agent HITL via ToolContext.request_confirmation().
+
+When the wrapped RemoteA2aAgent enters input_required (e.g., from a tool requiring
+human approval or an ask_user call), this tool pauses execution using the ADK's native
+ToolContext HITL mechanism. On resume, the user's decision is forwarded to the
+sub-agent via its A2A client.
+
+This keeps HITL logic in the tool layer (not the executor) and uses ADK's native
+confirmation mechanism, consistent with the design established in PR #1398.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from typing import Any
+
+from a2a.client.middleware import ClientCallContext
+from a2a.types import (
+    DataPart as A2ADataPart,
+    Message as A2AMessage,
+    Part as A2APart,
+    Role,
+    TaskState,
+    TextPart as A2ATextPart,
+)
+from google.adk.tools.agent_tool import AgentTool, _get_input_schema, _get_output_schema
+from google.adk.tools.tool_context import ToolContext
+from google.adk.utils.context_utils import Aclosing
+from google.genai import types as genai_types
+from typing_extensions import override
+
+from kagent.core.a2a import (
+    KAGENT_HITL_DECISION_TYPE_APPROVE,
+    KAGENT_HITL_DECISION_TYPE_KEY,
+    KAGENT_HITL_DECISION_TYPE_REJECT,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class HitlAwareAgentTool(AgentTool):
+    """AgentTool that uses ToolContext.request_confirmation() for sub-agent HITL.
+
+    When the wrapped agent enters input_required, this tool:
+    1. Saves the sub-agent's task/context IDs in tool_context.state
+    2. Calls tool_context.request_confirmation() to pause execution
+    3. On resume, forwards the user's decision to the sub-agent via A2A
+
+    This keeps HITL logic in the tool layer (not the executor) and uses
+    ADK's native confirmation mechanism, consistent with the design
+    established in PR #1398.
+    """
+
+    # State key for persisting sub-agent HITL context across tool replays
+    _SUBAGENT_HITL_STATE_KEY = "_subagent_hitl"
+
+    # Timeout for forwarding decisions to sub-agents
+    _FORWARD_TIMEOUT_SECONDS = 300
+
+    @override
+    async def run_async(
+        self,
+        *,
+        args: dict[str, Any],
+        tool_context: ToolContext,
+    ) -> Any:
+        # Resume path: user has responded to a HITL confirmation
+        if tool_context.tool_confirmation is not None:
+            if not tool_context.tool_confirmation.confirmed:
+                return self._handle_rejection(tool_context)
+            return await self._forward_and_continue(tool_context)
+
+        # First invocation: run the sub-agent with HITL detection
+        return await self._run_with_hitl_detection(args, tool_context)
+
+    # ------------------------------------------------------------------
+    # First invocation — run sub-agent and detect input_required
+    # ------------------------------------------------------------------
+
+    async def _run_with_hitl_detection(
+        self,
+        args: dict[str, Any],
+        tool_context: ToolContext,
+    ) -> Any:
+        """Run the sub-agent, pausing via request_confirmation if it enters input_required.
+
+        Mirrors AgentTool.run_async() but adds input_required detection in the
+        event loop so we can surface the sub-agent's HITL request to the parent.
+        """
+        from google.adk.memory.in_memory_memory_service import InMemoryMemoryService
+        from google.adk.runners import Runner
+        from google.adk.sessions.in_memory_session_service import InMemorySessionService
+        from google.adk.tools._forwarding_artifact_service import ForwardingArtifactService
+
+        if self.skip_summarization:
+            tool_context.actions.skip_summarization = True
+
+        content = self._build_input_content(args)
+
+        invocation_context = tool_context._invocation_context
+        parent_app_name = invocation_context.app_name if invocation_context else None
+        child_app_name = parent_app_name or self.agent.name
+        plugins = invocation_context.plugin_manager.plugins if self.include_plugins else None
+
+        runner = Runner(
+            app_name=child_app_name,
+            agent=self.agent,
+            artifact_service=ForwardingArtifactService(tool_context),
+            session_service=InMemorySessionService(),
+            memory_service=InMemoryMemoryService(),
+            credential_service=invocation_context.credential_service,
+            plugins=plugins,
+        )
+
+        state_dict = {k: v for k, v in tool_context.state.to_dict().items() if not k.startswith("_adk")}
+        session = await runner.session_service.create_session(
+            app_name=child_app_name,
+            user_id=invocation_context.user_id,
+            state=state_dict,
+        )
+
+        last_content = None
+        try:
+            async with Aclosing(
+                runner.run_async(
+                    user_id=session.user_id,
+                    session_id=session.id,
+                    new_message=content,
+                )
+            ) as event_stream:
+                async for event in event_stream:
+                    if event.actions.state_delta:
+                        tool_context.state.update(event.actions.state_delta)
+                    if event.content:
+                        last_content = event.content
+
+                    # Detect sub-agent entering input_required
+                    a2a_response = _extract_input_required(event)
+                    if a2a_response is not None:
+                        _save_hitl_state(tool_context, a2a_response)
+                        hint = _extract_hitl_hint(a2a_response)
+                        tool_context.request_confirmation(hint=hint)
+                        return {"status": "confirmation_requested", "subagent_hitl": True}
+        finally:
+            await runner.close()
+
+        return self._format_result(last_content)
+
+    # ------------------------------------------------------------------
+    # Resume path — forward decision and collect result
+    # ------------------------------------------------------------------
+
+    def _handle_rejection(self, tool_context: ToolContext) -> str:
+        """Handle a rejected HITL confirmation."""
+        tool_context.state.pop(self._SUBAGENT_HITL_STATE_KEY, None)
+        payload = tool_context.tool_confirmation.payload or {}
+        reason = payload.get("rejection_reason", "") if isinstance(payload, dict) else ""
+        if reason:
+            return f"Sub-agent action was rejected by user. Reason: {reason}"
+        return "Sub-agent action was rejected by user."
+
+    async def _forward_and_continue(self, tool_context: ToolContext) -> Any:
+        """Forward the user's approval to the sub-agent and return the result."""
+        hitl_state = tool_context.state.get(self._SUBAGENT_HITL_STATE_KEY)
+        if not hitl_state:
+            logger.error("No sub-agent HITL state found for resume")
+            return {"error": "No sub-agent HITL state found for resume"}
+
+        task_id = hitl_state.get("task_id")
+        context_id = hitl_state.get("context_id")
+
+        # Ensure the remote agent is resolved (prefer public API, fall back to private)
+        ensure_resolved = getattr(self.agent, "ensure_resolved", None) or getattr(self.agent, "_ensure_resolved", None)
+        if ensure_resolved is None:
+            logger.error("RemoteA2aAgent has no ensure_resolved method")
+            tool_context.state.pop(self._SUBAGENT_HITL_STATE_KEY, None)
+            return {"error": "Cannot connect to sub-agent: missing ensure_resolved method"}
+
+        try:
+            await ensure_resolved()
+        except Exception as exception:
+            logger.error("Failed to resolve RemoteA2aAgent: %s", exception)
+            tool_context.state.pop(self._SUBAGENT_HITL_STATE_KEY, None)
+            return {"error": f"Failed to connect to sub-agent: {exception}"}
+
+        # Get the A2A client (private API — no public send/resume API exists yet)
+        a2a_client = getattr(self.agent, "_a2a_client", None)
+        send_message = getattr(a2a_client, "send_message", None) if a2a_client else None
+        if send_message is None:
+            logger.error("RemoteA2aAgent does not expose A2A send_message")
+            tool_context.state.pop(self._SUBAGENT_HITL_STATE_KEY, None)
+            return {
+                "error": "Cannot communicate with sub-agent: "
+                "RemoteA2aAgent does not expose '_a2a_client.send_message'. "
+                "Upgrade google-adk to a version with a public send/resume API."
+            }
+
+        # Build the decision message to forward
+        decision_message = A2AMessage(
+            message_id=str(uuid.uuid4()),
+            role=Role.user,
+            parts=[A2APart(A2ADataPart(data={KAGENT_HITL_DECISION_TYPE_KEY: KAGENT_HITL_DECISION_TYPE_APPROVE}))],
+            task_id=task_id,
+            context_id=context_id,
+        )
+
+        # Forward with timeout
+        try:
+            result_text, needs_more_input, new_a2a_response = await asyncio.wait_for(
+                _send_and_collect(send_message, decision_message, tool_context),
+                timeout=self._FORWARD_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            logger.error(
+                "Timed out forwarding decision to sub-agent after %ds",
+                self._FORWARD_TIMEOUT_SECONDS,
+            )
+            tool_context.state.pop(self._SUBAGENT_HITL_STATE_KEY, None)
+            return {"error": f"Timed out waiting for sub-agent to respond (>{self._FORWARD_TIMEOUT_SECONDS}s)"}
+        except Exception as exception:
+            logger.error("Failed to forward decision to sub-agent: %s", exception, exc_info=True)
+            tool_context.state.pop(self._SUBAGENT_HITL_STATE_KEY, None)
+            return {"error": f"Failed to communicate with sub-agent: {exception}"}
+
+        # If the sub-agent needs another round of input, re-request confirmation
+        if needs_more_input and new_a2a_response is not None:
+            _save_hitl_state(tool_context, new_a2a_response)
+            hint = _extract_hitl_hint(new_a2a_response)
+            tool_context.request_confirmation(hint=hint)
+            return {"status": "confirmation_requested", "subagent_hitl": True}
+
+        # Clear HITL state after successful completion
+        tool_context.state.pop(self._SUBAGENT_HITL_STATE_KEY, None)
+        return result_text or ""
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _build_input_content(self, args: dict[str, Any]) -> genai_types.Content:
+        """Build the genai Content to send to the sub-agent (mirrors AgentTool logic)."""
+        input_schema = _get_input_schema(self.agent)
+        if input_schema:
+            input_value = input_schema.model_validate(args)
+            return genai_types.Content(
+                role="user",
+                parts=[genai_types.Part.from_text(text=input_value.model_dump_json(exclude_none=True))],
+            )
+        return genai_types.Content(
+            role="user",
+            parts=[genai_types.Part.from_text(text=args["request"])],
+        )
+
+    def _format_result(self, last_content: genai_types.Content | None) -> Any:
+        """Format the sub-agent's last content into a return value (mirrors AgentTool logic)."""
+        if last_content is None or last_content.parts is None:
+            return ""
+        merged_text = "\n".join(p.text for p in last_content.parts if p.text and not p.thought)
+        output_schema = _get_output_schema(self.agent)
+        if output_schema:
+            return output_schema.model_validate_json(merged_text).model_dump(exclude_none=True)
+        return merged_text
+
+
+# ------------------------------------------------------------------
+# Module-level helpers (stateless, testable independently)
+# ------------------------------------------------------------------
+
+
+def _extract_input_required(event: Any) -> dict | None:
+    """Check if an ADK event indicates the remote agent entered input_required.
+
+    Returns the A2A response dict if input_required was detected, None otherwise.
+    """
+    custom_metadata = getattr(event, "custom_metadata", None)
+    if not custom_metadata:
+        return None
+
+    a2a_response = custom_metadata.get("a2a:response")
+    if not isinstance(a2a_response, dict):
+        return None
+
+    status = a2a_response.get("status", {})
+    if status.get("state") == "input-required":
+        return a2a_response
+
+    return None
+
+
+def _extract_hitl_hint(a2a_response: dict) -> str:
+    """Extract a human-readable HITL hint from the A2A response's status message."""
+    status = a2a_response.get("status", {})
+    message = status.get("message", {})
+    parts = message.get("parts", [])
+    for part in parts:
+        if isinstance(part, dict):
+            text = part.get("text")
+            if text:
+                return text
+    return "Sub-agent requires user input."
+
+
+def _save_hitl_state(tool_context: ToolContext, a2a_response: dict) -> None:
+    """Persist sub-agent HITL context in tool_context.state for resume."""
+    tool_context.state[HitlAwareAgentTool._SUBAGENT_HITL_STATE_KEY] = {
+        "task_id": a2a_response.get("id"),
+        "context_id": a2a_response.get("contextId") or a2a_response.get("context_id"),
+    }
+
+
+async def _send_and_collect(
+    send_message: Any,
+    message: A2AMessage,
+    tool_context: ToolContext,
+) -> tuple[str, bool, dict | None]:
+    """Send a message to the sub-agent and collect the response.
+
+    Returns (result_text, needs_more_input, a2a_response_dict_for_next_hitl).
+    """
+    result_parts: list[str] = []
+    needs_input = False
+    a2a_response_dict: dict | None = None
+
+    state_dict = tool_context.state.to_dict() if hasattr(tool_context.state, "to_dict") else dict(tool_context.state)
+
+    async for a2a_response in send_message(
+        request=message,
+        context=ClientCallContext(state=state_dict),
+    ):
+        if isinstance(a2a_response, tuple):
+            task, update = a2a_response
+
+            if update is None and task and task.status:
+                # Initial task response (non-streaming or first response)
+                if task.status.state == TaskState.completed:
+                    _collect_text_parts(task.status.message, result_parts)
+                elif task.status.state == TaskState.failed:
+                    return _extract_error_text(task.status.message), False, None
+                elif task.status.state == TaskState.input_required:
+                    needs_input = True
+                    a2a_response_dict = task.model_dump(exclude_none=True, by_alias=True)
+
+            elif update is not None and hasattr(update, "status") and update.status:
+                # Streaming status update
+                if update.status.state == TaskState.completed:
+                    _collect_text_parts(update.status.message, result_parts)
+                elif update.status.state == TaskState.failed:
+                    return _extract_error_text(update.status.message), False, None
+                elif update.status.state == TaskState.input_required:
+                    needs_input = True
+                    if task:
+                        a2a_response_dict = task.model_dump(exclude_none=True, by_alias=True)
+        else:
+            # Non-streaming message response
+            if hasattr(a2a_response, "parts") and a2a_response.parts:
+                _collect_text_parts(a2a_response, result_parts)
+
+    return "\n".join(result_parts), needs_input, a2a_response_dict
+
+
+def _collect_text_parts(message: Any, result_parts: list[str]) -> None:
+    """Extract text from an A2A message's parts and append to result_parts."""
+    if not message or not getattr(message, "parts", None):
+        return
+    for part in message.parts:
+        root = part.root if hasattr(part, "root") else part
+        if isinstance(root, A2ATextPart):
+            result_parts.append(root.text)
+
+
+def _extract_error_text(message: Any) -> str:
+    """Extract error text from a failed A2A message."""
+    if message and getattr(message, "parts", None):
+        for part in message.parts:
+            root = part.root if hasattr(part, "root") else part
+            if isinstance(root, A2ATextPart):
+                return root.text
+    return "Sub-agent execution failed"

--- a/python/packages/kagent-adk/src/kagent/adk/types.py
+++ b/python/packages/kagent-adk/src/kagent/adk/types.py
@@ -10,11 +10,11 @@ from google.adk.agents.readonly_context import ReadonlyContext
 from google.adk.agents.remote_a2a_agent import AGENT_CARD_WELL_KNOWN_PATH, DEFAULT_TIMEOUT, RemoteA2aAgent
 from google.adk.models.anthropic_llm import Claude as ClaudeLLM
 from google.adk.models.google_llm import Gemini as GeminiLLM
-from google.adk.tools.agent_tool import AgentTool
 from google.adk.tools.mcp_tool import SseConnectionParams, StreamableHTTPConnectionParams
 from pydantic import BaseModel, Field
 
 from kagent.adk._approval import make_approval_callback
+from kagent.adk._hitl_agent_tool import HitlAwareAgentTool
 from kagent.adk._mcp_toolset import KAgentMcpToolset
 from kagent.adk.models._litellm import KAgentLiteLlm
 from kagent.adk.sandbox_code_executer import SandboxedLocalCodeExecutor
@@ -373,7 +373,7 @@ class AgentConfig(BaseModel):
                     httpx_client=client,
                 )
 
-                tools.append(AgentTool(agent=remote_a2a_agent))
+                tools.append(HitlAwareAgentTool(agent=remote_a2a_agent))
 
         code_executor = SandboxedLocalCodeExecutor() if self.execute_code else None
         model = _create_llm_from_model_config(self.model)

--- a/python/packages/kagent-adk/tests/unittests/test_hitl.py
+++ b/python/packages/kagent-adk/tests/unittests/test_hitl.py
@@ -1,9 +1,10 @@
-"""Tests for the HITL approval callback and agent executor's HITL handling logic."""
+"""Tests for the HITL approval callback, agent executor's HITL handling, and HitlAwareAgentTool."""
 
+import asyncio
 import json
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
 
-from a2a.types import DataPart, Message, Part, Role
+from a2a.types import DataPart, Message, Part, Role, TaskState, TaskStatus, TextPart
 from google.adk.flows.llm_flows.functions import REQUEST_CONFIRMATION_FUNCTION_CALL_NAME
 from google.adk.sessions import Session
 from google.adk.tools.tool_confirmation import ToolConfirmation
@@ -11,6 +12,15 @@ from google.genai import types as genai_types
 
 from kagent.adk._agent_executor import A2aAgentExecutor
 from kagent.adk._approval import make_approval_callback
+from kagent.adk._hitl_agent_tool import (
+    HitlAwareAgentTool,
+    _collect_text_parts,
+    _extract_error_text,
+    _extract_hitl_hint,
+    _extract_input_required,
+    _save_hitl_state,
+    _send_and_collect,
+)
 from kagent.core.a2a import (
     KAGENT_ASK_USER_ANSWERS_KEY,
     KAGENT_HITL_DECISION_TYPE_APPROVE,
@@ -25,7 +35,8 @@ from kagent.core.a2a import (
 class MockState(dict):
     """Dict subclass that mimics ToolContext.state behavior."""
 
-    pass
+    def to_dict(self):
+        return dict(self)
 
 
 class MockEventActions:
@@ -33,6 +44,7 @@ class MockEventActions:
 
     def __init__(self):
         self.requested_tool_confirmations: dict[str, ToolConfirmation] = {}
+        self.skip_summarization = False
 
 
 class MockToolContext:
@@ -42,6 +54,7 @@ class MockToolContext:
         self.state = MockState()
         self.function_call_id = "test_fc_id"
         self._event_actions = MockEventActions()
+        self.actions = self._event_actions
         self.tool_confirmation = tool_confirmation
 
     def request_confirmation(self, *, hint=None, payload=None):
@@ -79,7 +92,6 @@ class TestMakeApprovalCallback:
         result = callback(tool, {"path": "/tmp"}, ctx)
         assert result is not None
         assert result["status"] == "confirmation_requested"
-        assert result["tool"] == "delete_file"
         # Confirmation should be stored in event_actions
         assert "test_fc_id" in ctx._event_actions.requested_tool_confirmations
 
@@ -545,3 +557,394 @@ def test_process_hitl_decision_ask_user_answers():
     resp = json.loads(fr.response["response"])
     assert resp["confirmed"] is True
     assert resp["payload"]["answers"] == answers
+
+
+# ---------------------------------------------------------------------------
+# HitlAwareAgentTool helper tests
+# ---------------------------------------------------------------------------
+
+
+class MockADKEvent:
+    """Minimal mock for an ADK Event with custom_metadata."""
+
+    def __init__(self, custom_metadata=None, author=None, partial=False):
+        self.custom_metadata = custom_metadata
+        self.author = author
+        self.partial = partial
+
+
+class TestExtractInputRequired:
+    """Tests for _extract_input_required."""
+
+    def test_returns_none_for_no_metadata(self):
+        event = MockADKEvent(custom_metadata=None)
+        assert _extract_input_required(event) is None
+
+    def test_returns_none_for_no_a2a_response(self):
+        event = MockADKEvent(custom_metadata={"some_key": "value"})
+        assert _extract_input_required(event) is None
+
+    def test_returns_none_for_non_dict_response(self):
+        event = MockADKEvent(custom_metadata={"a2a:response": "not a dict"})
+        assert _extract_input_required(event) is None
+
+    def test_returns_none_for_working_state(self):
+        response = {"status": {"state": "working"}}
+        event = MockADKEvent(custom_metadata={"a2a:response": response})
+        assert _extract_input_required(event) is None
+
+    def test_returns_none_for_completed_state(self):
+        response = {"status": {"state": "completed"}}
+        event = MockADKEvent(custom_metadata={"a2a:response": response})
+        assert _extract_input_required(event) is None
+
+    def test_returns_response_for_input_required(self):
+        response = {
+            "id": "task-123",
+            "contextId": "ctx-456",
+            "status": {
+                "state": "input-required",
+                "message": {
+                    "messageId": "msg-1",
+                    "role": "agent",
+                    "parts": [{"kind": "text", "text": "Approval needed"}],
+                },
+            },
+        }
+        event = MockADKEvent(custom_metadata={"a2a:response": response})
+        result = _extract_input_required(event)
+        assert result is not None
+        assert result["id"] == "task-123"
+        assert result["status"]["state"] == "input-required"
+
+
+class TestExtractHitlHint:
+    """Tests for _extract_hitl_hint."""
+
+    def test_extracts_text_from_parts(self):
+        response = {
+            "status": {
+                "state": "input-required",
+                "message": {
+                    "parts": [{"text": "Approve this tool?"}],
+                },
+            },
+        }
+        assert _extract_hitl_hint(response) == "Approve this tool?"
+
+    def test_returns_fallback_for_no_message(self):
+        response = {"status": {"state": "input-required"}}
+        assert _extract_hitl_hint(response) == "Sub-agent requires user input."
+
+    def test_returns_fallback_for_empty_parts(self):
+        response = {"status": {"state": "input-required", "message": {"parts": []}}}
+        assert _extract_hitl_hint(response) == "Sub-agent requires user input."
+
+
+class TestSaveHitlState:
+    """Tests for _save_hitl_state."""
+
+    def test_saves_task_and_context_ids(self):
+        tool_context = MockToolContext()
+        a2a_response = {"id": "task-42", "contextId": "ctx-99"}
+        _save_hitl_state(tool_context, a2a_response)
+        state = tool_context.state[HitlAwareAgentTool._SUBAGENT_HITL_STATE_KEY]
+        assert state["task_id"] == "task-42"
+        assert state["context_id"] == "ctx-99"
+
+    def test_handles_snake_case_context_id(self):
+        tool_context = MockToolContext()
+        a2a_response = {"id": "task-1", "context_id": "ctx-2"}
+        _save_hitl_state(tool_context, a2a_response)
+        state = tool_context.state[HitlAwareAgentTool._SUBAGENT_HITL_STATE_KEY]
+        assert state["context_id"] == "ctx-2"
+
+
+class TestCollectTextParts:
+    """Tests for _collect_text_parts."""
+
+    def test_collects_text_from_message(self):
+        message = MagicMock()
+        text_part = MagicMock()
+        text_part.root = TextPart(text="hello")
+        message.parts = [text_part]
+        result = []
+        _collect_text_parts(message, result)
+        assert result == ["hello"]
+
+    def test_handles_none_message(self):
+        result = []
+        _collect_text_parts(None, result)
+        assert result == []
+
+
+class TestExtractErrorText:
+    """Tests for _extract_error_text."""
+
+    def test_extracts_error_from_message(self):
+        message = MagicMock()
+        text_part = MagicMock()
+        text_part.root = TextPart(text="Something failed")
+        message.parts = [text_part]
+        assert _extract_error_text(message) == "Something failed"
+
+    def test_returns_default_for_no_message(self):
+        assert _extract_error_text(None) == "Sub-agent execution failed"
+
+
+class TestHitlAwareAgentToolRejection:
+    """Tests for HitlAwareAgentTool._handle_rejection."""
+
+    def test_rejection_clears_state_and_returns_message(self):
+        from google.adk.agents.remote_a2a_agent import RemoteA2aAgent
+
+        agent = create_autospec(RemoteA2aAgent, instance=True)
+        agent.name = "test_agent"
+        agent.description = "test"
+        tool = HitlAwareAgentTool(agent=agent)
+
+        ctx = MockToolContext(tool_confirmation=ToolConfirmation(confirmed=False))
+        ctx.state[HitlAwareAgentTool._SUBAGENT_HITL_STATE_KEY] = {"task_id": "t1", "context_id": "c1"}
+
+        result = tool._handle_rejection(ctx)
+        assert "rejected" in result
+        assert HitlAwareAgentTool._SUBAGENT_HITL_STATE_KEY not in ctx.state
+
+    def test_rejection_includes_reason(self):
+        from google.adk.agents.remote_a2a_agent import RemoteA2aAgent
+
+        agent = create_autospec(RemoteA2aAgent, instance=True)
+        agent.name = "test_agent"
+        agent.description = "test"
+        tool = HitlAwareAgentTool(agent=agent)
+
+        ctx = MockToolContext(
+            tool_confirmation=ToolConfirmation(
+                confirmed=False,
+                payload={"rejection_reason": "Too dangerous"},
+            )
+        )
+        ctx.state[HitlAwareAgentTool._SUBAGENT_HITL_STATE_KEY] = {"task_id": "t1", "context_id": "c1"}
+
+        result = tool._handle_rejection(ctx)
+        assert "Too dangerous" in result
+
+
+class TestHitlAwareAgentToolForwardAndContinue:
+    """Tests for HitlAwareAgentTool._forward_and_continue."""
+
+    def test_missing_hitl_state_returns_error(self):
+        from google.adk.agents.remote_a2a_agent import RemoteA2aAgent
+
+        agent = create_autospec(RemoteA2aAgent, instance=True)
+        agent.name = "test_agent"
+        agent.description = "test"
+        tool = HitlAwareAgentTool(agent=agent)
+
+        ctx = MockToolContext(tool_confirmation=ToolConfirmation(confirmed=True))
+        # No HITL state saved
+
+        result = asyncio.get_event_loop().run_until_complete(tool._forward_and_continue(ctx))
+        assert "error" in result
+
+    def test_missing_ensure_resolved_returns_error(self):
+        from google.adk.agents.remote_a2a_agent import RemoteA2aAgent
+
+        agent = create_autospec(RemoteA2aAgent, instance=True)
+        agent.name = "test_agent"
+        agent.description = "test"
+        # Remove both resolve methods
+        del agent.ensure_resolved
+        del agent._ensure_resolved
+        tool = HitlAwareAgentTool(agent=agent)
+
+        ctx = MockToolContext(tool_confirmation=ToolConfirmation(confirmed=True))
+        ctx.state[HitlAwareAgentTool._SUBAGENT_HITL_STATE_KEY] = {"task_id": "t1", "context_id": "c1"}
+
+        result = asyncio.get_event_loop().run_until_complete(tool._forward_and_continue(ctx))
+        assert "error" in result
+        # State should be cleared
+        assert HitlAwareAgentTool._SUBAGENT_HITL_STATE_KEY not in ctx.state
+
+    def test_successful_forward_returns_text(self):
+        from google.adk.agents.remote_a2a_agent import RemoteA2aAgent
+
+        agent = create_autospec(RemoteA2aAgent, instance=True)
+        agent.name = "test_agent"
+        agent.description = "test"
+        agent._ensure_resolved = AsyncMock()
+
+        # Mock A2A client with a completed response
+        mock_task = MagicMock()
+        mock_task.status = TaskStatus(
+            state=TaskState.completed,
+            message=Message(
+                message_id="m1",
+                role=Role.agent,
+                parts=[Part(TextPart(text="Task completed successfully"))],
+            ),
+        )
+
+        async def mock_send_message(**kwargs):
+            yield (mock_task, None)
+
+        agent._a2a_client = MagicMock()
+        agent._a2a_client.send_message = mock_send_message
+
+        tool = HitlAwareAgentTool(agent=agent)
+
+        ctx = MockToolContext(tool_confirmation=ToolConfirmation(confirmed=True))
+        ctx.state[HitlAwareAgentTool._SUBAGENT_HITL_STATE_KEY] = {"task_id": "t1", "context_id": "c1"}
+
+        result = asyncio.get_event_loop().run_until_complete(tool._forward_and_continue(ctx))
+        assert result == "Task completed successfully"
+        # State should be cleared after success
+        assert HitlAwareAgentTool._SUBAGENT_HITL_STATE_KEY not in ctx.state
+
+    def test_timeout_returns_error_and_clears_state(self):
+        from google.adk.agents.remote_a2a_agent import RemoteA2aAgent
+
+        agent = create_autospec(RemoteA2aAgent, instance=True)
+        agent.name = "test_agent"
+        agent.description = "test"
+        agent._ensure_resolved = AsyncMock()
+
+        async def slow_send_message(**kwargs):
+            await asyncio.sleep(10)
+            yield  # pragma: no cover
+
+        agent._a2a_client = MagicMock()
+        agent._a2a_client.send_message = slow_send_message
+
+        tool = HitlAwareAgentTool(agent=agent)
+        tool._FORWARD_TIMEOUT_SECONDS = 0.01  # Very short for testing
+
+        ctx = MockToolContext(tool_confirmation=ToolConfirmation(confirmed=True))
+        ctx.state[HitlAwareAgentTool._SUBAGENT_HITL_STATE_KEY] = {"task_id": "t1", "context_id": "c1"}
+
+        result = asyncio.get_event_loop().run_until_complete(tool._forward_and_continue(ctx))
+        assert "error" in result
+        assert "Timed out" in result["error"]
+        assert HitlAwareAgentTool._SUBAGENT_HITL_STATE_KEY not in ctx.state
+
+    def test_multi_round_hitl_re_requests_confirmation(self):
+        """When subagent enters input_required again, tool re-requests confirmation."""
+        from google.adk.agents.remote_a2a_agent import RemoteA2aAgent
+
+        agent = create_autospec(RemoteA2aAgent, instance=True)
+        agent.name = "test_agent"
+        agent.description = "test"
+        agent._ensure_resolved = AsyncMock()
+
+        # Sub-agent enters input_required again
+        mock_task = MagicMock()
+        mock_task.status = TaskStatus(
+            state=TaskState.input_required,
+            message=Message(
+                message_id="m2",
+                role=Role.agent,
+                parts=[Part(TextPart(text="Need more approval"))],
+            ),
+        )
+        mock_task.model_dump = MagicMock(
+            return_value={
+                "id": "task-2",
+                "contextId": "ctx-2",
+                "status": {
+                    "state": "input-required",
+                    "message": {
+                        "parts": [{"text": "Need more approval"}],
+                    },
+                },
+            }
+        )
+
+        async def mock_send_message(**kwargs):
+            yield (mock_task, None)
+
+        agent._a2a_client = MagicMock()
+        agent._a2a_client.send_message = mock_send_message
+
+        tool = HitlAwareAgentTool(agent=agent)
+
+        ctx = MockToolContext(tool_confirmation=ToolConfirmation(confirmed=True))
+        ctx.state[HitlAwareAgentTool._SUBAGENT_HITL_STATE_KEY] = {"task_id": "t1", "context_id": "c1"}
+
+        result = asyncio.get_event_loop().run_until_complete(tool._forward_and_continue(ctx))
+        # Should return confirmation_requested
+        assert result["status"] == "confirmation_requested"
+        assert result["subagent_hitl"] is True
+        # Should have re-requested confirmation
+        assert "test_fc_id" in ctx._event_actions.requested_tool_confirmations
+        # State should be updated with new task/context IDs
+        new_state = ctx.state[HitlAwareAgentTool._SUBAGENT_HITL_STATE_KEY]
+        assert new_state["task_id"] == "task-2"
+
+
+class TestSendAndCollect:
+    """Tests for _send_and_collect."""
+
+    def test_completed_task(self):
+        mock_task = MagicMock()
+        mock_task.status = TaskStatus(
+            state=TaskState.completed,
+            message=Message(
+                message_id="m1",
+                role=Role.agent,
+                parts=[Part(TextPart(text="Done"))],
+            ),
+        )
+
+        async def mock_send(**kwargs):
+            yield (mock_task, None)
+
+        ctx = MockToolContext()
+        result_text, needs_input, response_dict = asyncio.get_event_loop().run_until_complete(
+            _send_and_collect(mock_send, MagicMock(), ctx)
+        )
+        assert result_text == "Done"
+        assert needs_input is False
+        assert response_dict is None
+
+    def test_failed_task(self):
+        mock_task = MagicMock()
+        mock_task.status = TaskStatus(
+            state=TaskState.failed,
+            message=Message(
+                message_id="m1",
+                role=Role.agent,
+                parts=[Part(TextPart(text="Crash!"))],
+            ),
+        )
+
+        async def mock_send(**kwargs):
+            yield (mock_task, None)
+
+        ctx = MockToolContext()
+        result_text, needs_input, response_dict = asyncio.get_event_loop().run_until_complete(
+            _send_and_collect(mock_send, MagicMock(), ctx)
+        )
+        assert result_text == "Crash!"
+        assert needs_input is False
+
+    def test_input_required_task(self):
+        mock_task = MagicMock()
+        mock_task.status = TaskStatus(
+            state=TaskState.input_required,
+            message=Message(
+                message_id="m1",
+                role=Role.agent,
+                parts=[Part(TextPart(text="Need approval"))],
+            ),
+        )
+        mock_task.model_dump = MagicMock(return_value={"id": "t1", "status": {"state": "input-required"}})
+
+        async def mock_send(**kwargs):
+            yield (mock_task, None)
+
+        ctx = MockToolContext()
+        result_text, needs_input, response_dict = asyncio.get_event_loop().run_until_complete(
+            _send_and_collect(mock_send, MagicMock(), ctx)
+        )
+        assert needs_input is True
+        assert response_dict is not None


### PR DESCRIPTION
When subagents with HITL-enabled tools enter input_required state, the parent agent now detects this from the A2A response metadata and propagates the approval request to the top-level chat. On resume, the decision is forwarded directly to the subagent via its A2A client, and the parent agent re-runs to process the result.

Key implementation details:
- Detect subagent input_required via ADK event custom_metadata
- Persist subagent HITL context in session state for resume
- Forward decisions to subagents with 5-minute timeout
- Clear HITL state after successful forwarding
- Use SubagentForwardResult NamedTuple for type-safe return values
- Extract shared helpers to avoid code duplication
- Prefer public APIs with private API fallbacks for forward compat
- Emit terminal failure events for all error paths
- Add comprehensive unit tests for all helper methods

Fixes #1475