### PR TITLE
feat: add context.Context to database client interface

### DIFF
--- a/go/api/database/client.go
+++ b/go/api/database/client.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"context"
 	"time"
 
 	"github.com/kagent-dev/kagent/go/api/v1alpha2"
@@ -20,63 +21,63 @@ type LangGraphCheckpointTuple struct {
 
 type Client interface {
 	// Store methods
-	StoreFeedback(feedback *Feedback) error
-	StoreSession(session *Session) error
-	StoreAgent(agent *Agent) error
-	StoreTask(task *protocol.Task) error
-	StorePushNotification(config *protocol.TaskPushNotificationConfig) error
-	StoreToolServer(toolServer *ToolServer) (*ToolServer, error)
-	StoreEvents(messages ...*Event) error
+	StoreFeedback(ctx context.Context, feedback *Feedback) error
+	StoreSession(ctx context.Context, session *Session) error
+	StoreAgent(ctx context.Context, agent *Agent) error
+	StoreTask(ctx context.Context, task *protocol.Task) error
+	StorePushNotification(ctx context.Context, config *protocol.TaskPushNotificationConfig) error
+	StoreToolServer(ctx context.Context, toolServer *ToolServer) (*ToolServer, error)
+	StoreEvents(ctx context.Context, messages ...*Event) error
 
 	// Delete methods
-	DeleteSession(sessionID string, userID string) error
-	DeleteAgent(agentID string) error
-	DeleteToolServer(serverName string, groupKind string) error
-	DeleteTask(taskID string) error
-	DeletePushNotification(taskID string) error
-	DeleteToolsForServer(serverName string, groupKind string) error
+	DeleteSession(ctx context.Context, sessionID string, userID string) error
+	DeleteAgent(ctx context.Context, agentID string) error
+	DeleteToolServer(ctx context.Context, serverName string, groupKind string) error
+	DeleteTask(ctx context.Context, taskID string) error
+	DeletePushNotification(ctx context.Context, taskID string) error
+	DeleteToolsForServer(ctx context.Context, serverName string, groupKind string) error
 
 	// Get methods
-	GetSession(sessionID string, userID string) (*Session, error)
-	GetAgent(name string) (*Agent, error)
-	GetTask(id string) (*protocol.Task, error)
-	GetTool(name string) (*Tool, error)
-	GetToolServer(name string) (*ToolServer, error)
-	GetPushNotification(taskID string, configID string) (*protocol.TaskPushNotificationConfig, error)
+	GetSession(ctx context.Context, sessionID string, userID string) (*Session, error)
+	GetAgent(ctx context.Context, name string) (*Agent, error)
+	GetTask(ctx context.Context, id string) (*protocol.Task, error)
+	GetTool(ctx context.Context, name string) (*Tool, error)
+	GetToolServer(ctx context.Context, name string) (*ToolServer, error)
+	GetPushNotification(ctx context.Context, taskID string, configID string) (*protocol.TaskPushNotificationConfig, error)
 
 	// List methods
-	ListTools() ([]Tool, error)
-	ListFeedback(userID string) ([]Feedback, error)
-	ListTasksForSession(sessionID string) ([]*protocol.Task, error)
-	ListSessions(userID string) ([]Session, error)
-	ListSessionsForAgent(agentID string, userID string) ([]Session, error)
-	ListAgents() ([]Agent, error)
-	ListToolServers() ([]ToolServer, error)
-	ListToolsForServer(serverName string, groupKind string) ([]Tool, error)
-	ListEventsForSession(sessionID, userID string, options QueryOptions) ([]*Event, error)
-	ListPushNotifications(taskID string) ([]*protocol.TaskPushNotificationConfig, error)
+	ListTools(ctx context.Context) ([]Tool, error)
+	ListFeedback(ctx context.Context, userID string) ([]Feedback, error)
+	ListTasksForSession(ctx context.Context, sessionID string) ([]*protocol.Task, error)
+	ListSessions(ctx context.Context, userID string) ([]Session, error)
+	ListSessionsForAgent(ctx context.Context, agentID string, userID string) ([]Session, error)
+	ListAgents(ctx context.Context) ([]Agent, error)
+	ListToolServers(ctx context.Context) ([]ToolServer, error)
+	ListToolsForServer(ctx context.Context, serverName string, groupKind string) ([]Tool, error)
+	ListEventsForSession(ctx context.Context, sessionID, userID string, options QueryOptions) ([]*Event, error)
+	ListPushNotifications(ctx context.Context, taskID string) ([]*protocol.TaskPushNotificationConfig, error)
 
 	// Helper methods
-	RefreshToolsForServer(serverName string, groupKind string, tools ...*v1alpha2.MCPTool) error
+	RefreshToolsForServer(ctx context.Context, serverName string, groupKind string, tools ...*v1alpha2.MCPTool) error
 
 	// LangGraph Checkpoint methods
-	StoreCheckpoint(checkpoint *LangGraphCheckpoint) error
-	StoreCheckpointWrites(writes []*LangGraphCheckpointWrite) error
-	ListCheckpoints(userID, threadID, checkpointNS string, checkpointID *string, limit int) ([]*LangGraphCheckpointTuple, error)
-	DeleteCheckpoint(userID, threadID string) error
+	StoreCheckpoint(ctx context.Context, checkpoint *LangGraphCheckpoint) error
+	StoreCheckpointWrites(ctx context.Context, writes []*LangGraphCheckpointWrite) error
+	ListCheckpoints(ctx context.Context, userID, threadID, checkpointNS string, checkpointID *string, limit int) ([]*LangGraphCheckpointTuple, error)
+	DeleteCheckpoint(ctx context.Context, userID, threadID string) error
 
 	// CrewAI methods
-	StoreCrewAIMemory(memory *CrewAIAgentMemory) error
-	SearchCrewAIMemoryByTask(userID, threadID, taskDescription string, limit int) ([]*CrewAIAgentMemory, error)
-	ResetCrewAIMemory(userID, threadID string) error
-	StoreCrewAIFlowState(state *CrewAIFlowState) error
-	GetCrewAIFlowState(userID, threadID string) (*CrewAIFlowState, error)
+	StoreCrewAIMemory(ctx context.Context, memory *CrewAIAgentMemory) error
+	SearchCrewAIMemoryByTask(ctx context.Context, userID, threadID, taskDescription string, limit int) ([]*CrewAIAgentMemory, error)
+	ResetCrewAIMemory(ctx context.Context, userID, threadID string) error
+	StoreCrewAIFlowState(ctx context.Context, state *CrewAIFlowState) error
+	GetCrewAIFlowState(ctx context.Context, userID, threadID string) (*CrewAIFlowState, error)
 
 	// Agent memory (vector search) methods
-	StoreAgentMemory(memory *Memory) error
-	StoreAgentMemories(memories []*Memory) error
-	SearchAgentMemory(agentName, userID string, embedding pgvector.Vector, limit int) ([]AgentMemorySearchResult, error)
-	ListAgentMemories(agentName, userID string) ([]Memory, error)
-	DeleteAgentMemory(agentName, userID string) error
-	PruneExpiredMemories() error
+	StoreAgentMemory(ctx context.Context, memory *Memory) error
+	StoreAgentMemories(ctx context.Context, memories []*Memory) error
+	SearchAgentMemory(ctx context.Context, agentName, userID string, embedding pgvector.Vector, limit int) ([]AgentMemorySearchResult, error)
+	ListAgentMemories(ctx context.Context, agentName, userID string) ([]Memory, error)
+	DeleteAgentMemory(ctx context.Context, agentName, userID string) error
+	PruneExpiredMemories(ctx context.Context) error
 }

--- a/go/core/internal/controller/reconciler/reconciler.go
+++ b/go/core/internal/controller/reconciler/reconciler.go
@@ -85,7 +85,7 @@ func (a *kagentReconciler) ReconcileKagentAgent(ctx context.Context, req ctrl.Re
 	agent := &v1alpha2.Agent{}
 	if err := a.kube.Get(ctx, req.NamespacedName, agent); err != nil {
 		if apierrors.IsNotFound(err) {
-			return a.handleAgentDeletion(req)
+			return a.handleAgentDeletion(ctx, req)
 		}
 
 		return fmt.Errorf("failed to get agent %s: %w", req.NamespacedName, err)
@@ -99,9 +99,9 @@ func (a *kagentReconciler) ReconcileKagentAgent(ctx context.Context, req ctrl.Re
 	return a.reconcileAgentStatus(ctx, agent, err)
 }
 
-func (a *kagentReconciler) handleAgentDeletion(req ctrl.Request) error {
+func (a *kagentReconciler) handleAgentDeletion(ctx context.Context, req ctrl.Request) error {
 	id := utils.ConvertToPythonIdentifier(req.String())
-	if err := a.dbClient.DeleteAgent(id); err != nil {
+	if err := a.dbClient.DeleteAgent(ctx, id); err != nil {
 		return fmt.Errorf("failed to delete agent %s: %w",
 			req.String(), err)
 	}
@@ -205,11 +205,11 @@ func (a *kagentReconciler) ReconcileKagentMCPService(ctx context.Context, req ct
 				Name:      req.String(),
 				GroupKind: schema.GroupKind{Group: "", Kind: "Service"}.String(),
 			}
-			if err := a.dbClient.DeleteToolServer(dbService.Name, dbService.GroupKind); err != nil {
+			if err := a.dbClient.DeleteToolServer(ctx, dbService.Name, dbService.GroupKind); err != nil {
 				reconcileLog.Error(err, "failed to delete tool server for mcp service", "service", req.String())
 			}
 			reconcileLog.Info("mcp service was deleted", "service", req.String())
-			if err := a.dbClient.DeleteToolsForServer(dbService.Name, dbService.GroupKind); err != nil {
+			if err := a.dbClient.DeleteToolsForServer(ctx, dbService.Name, dbService.GroupKind); err != nil {
 				reconcileLog.Error(err, "failed to delete tools for mcp service", "service", req.String())
 			}
 			return nil
@@ -378,11 +378,11 @@ func (a *kagentReconciler) ReconcileKagentMCPServer(ctx context.Context, req ctr
 				Name:      req.String(),
 				GroupKind: schema.GroupKind{Group: "kagent.dev", Kind: "MCPServer"}.String(),
 			}
-			if err := a.dbClient.DeleteToolServer(dbServer.Name, dbServer.GroupKind); err != nil {
+			if err := a.dbClient.DeleteToolServer(ctx, dbServer.Name, dbServer.GroupKind); err != nil {
 				reconcileLog.Error(err, "failed to delete tool server for mcp server", "mcpServer", req.String())
 			}
 			reconcileLog.Info("mcp server was deleted", "mcpServer", req.String())
-			if err := a.dbClient.DeleteToolsForServer(dbServer.Name, dbServer.GroupKind); err != nil {
+			if err := a.dbClient.DeleteToolsForServer(ctx, dbServer.Name, dbServer.GroupKind); err != nil {
 				reconcileLog.Error(err, "failed to delete tools for mcp server", "mcpServer", req.String())
 			}
 			return nil
@@ -428,11 +428,11 @@ func (a *kagentReconciler) ReconcileKagentRemoteMCPServer(ctx context.Context, r
 				GroupKind: schema.GroupKind{Group: "kagent.dev", Kind: "RemoteMCPServer"}.String(),
 			}
 
-			if err := a.dbClient.DeleteToolServer(dbServer.Name, dbServer.GroupKind); err != nil {
+			if err := a.dbClient.DeleteToolServer(ctx, dbServer.Name, dbServer.GroupKind); err != nil {
 				l.Error(err, "failed to delete tool server for remote mcp server")
 			}
 
-			if err := a.dbClient.DeleteToolsForServer(dbServer.Name, dbServer.GroupKind); err != nil {
+			if err := a.dbClient.DeleteToolsForServer(ctx, dbServer.Name, dbServer.GroupKind); err != nil {
 				l.Error(err, "failed to delete tools for remote mcp server")
 			}
 
@@ -835,7 +835,7 @@ func (a *kagentReconciler) upsertAgent(ctx context.Context, agent *v1alpha2.Agen
 		Config: agentOutputs.Config,
 	}
 
-	if err := a.dbClient.StoreAgent(dbAgent); err != nil {
+	if err := a.dbClient.StoreAgent(ctx, dbAgent); err != nil {
 		return fmt.Errorf("failed to store agent %s: %w", id, err)
 	}
 
@@ -843,7 +843,7 @@ func (a *kagentReconciler) upsertAgent(ctx context.Context, agent *v1alpha2.Agen
 }
 
 func (a *kagentReconciler) upsertToolServerForRemoteMCPServer(ctx context.Context, toolServer *database.ToolServer, remoteMcpServer *v1alpha2.RemoteMCPServer) ([]*v1alpha2.MCPTool, error) {
-	if _, err := a.dbClient.StoreToolServer(toolServer); err != nil {
+	if _, err := a.dbClient.StoreToolServer(ctx, toolServer); err != nil {
 		return nil, fmt.Errorf("failed to store toolServer %s: %w", toolServer.Name, err)
 	}
 
@@ -858,7 +858,7 @@ func (a *kagentReconciler) upsertToolServerForRemoteMCPServer(ctx context.Contex
 	}
 
 	// Refresh tools in database - uses transaction for atomicity
-	if err := a.dbClient.RefreshToolsForServer(toolServer.Name, toolServer.GroupKind, tools...); err != nil {
+	if err := a.dbClient.RefreshToolsForServer(ctx, toolServer.Name, toolServer.GroupKind, tools...); err != nil {
 		return nil, fmt.Errorf("failed to refresh tools for toolServer %s: %w", toolServer.Name, err)
 	}
 
@@ -956,7 +956,7 @@ func (a *kagentReconciler) listTools(ctx context.Context, tsp mcp.Transport, too
 
 func (a *kagentReconciler) getDiscoveredMCPTools(ctx context.Context, serverRef string) ([]*v1alpha2.MCPTool, error) {
 	// This function is currently only used for RemoteMCPServer
-	allTools, err := a.dbClient.ListToolsForServer(serverRef, schema.GroupKind{Group: "kagent.dev", Kind: "RemoteMCPServer"}.String())
+	allTools, err := a.dbClient.ListToolsForServer(ctx, serverRef, schema.GroupKind{Group: "kagent.dev", Kind: "RemoteMCPServer"}.String())
 	if err != nil {
 		return nil, err
 	}

--- a/go/core/internal/database/client.go
+++ b/go/core/internal/database/client.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -26,26 +27,26 @@ func NewClient(dbManager *Manager) dbpkg.Client {
 }
 
 // CreateFeedback creates a new feedback record
-func (c *clientImpl) StoreFeedback(feedback *dbpkg.Feedback) error {
-	if err := c.db.Create(feedback).Error; err != nil {
+func (c *clientImpl) StoreFeedback(ctx context.Context, feedback *dbpkg.Feedback) error {
+	if err := c.db.WithContext(ctx).Create(feedback).Error; err != nil {
 		return fmt.Errorf("failed to create feedback: %w", err)
 	}
 	return nil
 }
 
 // CreateSession creates a new session record
-func (c *clientImpl) StoreSession(session *dbpkg.Session) error {
-	return save(c.db, session)
+func (c *clientImpl) StoreSession(ctx context.Context, session *dbpkg.Session) error {
+	return save(c.db.WithContext(ctx), session)
 }
 
 // CreateAgent creates a new agent record
-func (c *clientImpl) StoreAgent(agent *dbpkg.Agent) error {
-	return save(c.db, agent)
+func (c *clientImpl) StoreAgent(ctx context.Context, agent *dbpkg.Agent) error {
+	return save(c.db.WithContext(ctx), agent)
 }
 
 // CreateToolServer creates a new tool server record
-func (c *clientImpl) StoreToolServer(toolServer *dbpkg.ToolServer) (*dbpkg.ToolServer, error) {
-	err := save(c.db, toolServer)
+func (c *clientImpl) StoreToolServer(ctx context.Context, toolServer *dbpkg.ToolServer) (*dbpkg.ToolServer, error) {
+	err := save(c.db.WithContext(ctx), toolServer)
 	if err != nil {
 		return nil, err
 	}
@@ -53,43 +54,43 @@ func (c *clientImpl) StoreToolServer(toolServer *dbpkg.ToolServer) (*dbpkg.ToolS
 }
 
 // CreateTool creates a new tool record
-func (c *clientImpl) StoreTool(tool *dbpkg.Tool) error {
-	return save(c.db, tool)
+func (c *clientImpl) StoreTool(ctx context.Context, tool *dbpkg.Tool) error {
+	return save(c.db.WithContext(ctx), tool)
 }
 
 // DeleteTask deletes a task by ID
-func (c *clientImpl) DeleteTask(taskID string) error {
-	return delete[dbpkg.Task](c.db, Clause{Key: "id", Value: taskID})
+func (c *clientImpl) DeleteTask(ctx context.Context, taskID string) error {
+	return delete[dbpkg.Task](c.db.WithContext(ctx), Clause{Key: "id", Value: taskID})
 }
 
 // DeleteSession deletes a session by id and user ID
-func (c *clientImpl) DeleteSession(sessionID string, userID string) error {
-	return delete[dbpkg.Session](c.db,
+func (c *clientImpl) DeleteSession(ctx context.Context, sessionID string, userID string) error {
+	return delete[dbpkg.Session](c.db.WithContext(ctx),
 		Clause{Key: "id", Value: sessionID},
 		Clause{Key: "user_id", Value: userID})
 }
 
 // DeleteAgent deletes an agent by name and user ID
-func (c *clientImpl) DeleteAgent(agentID string) error {
-	return delete[dbpkg.Agent](c.db, Clause{Key: "id", Value: agentID})
+func (c *clientImpl) DeleteAgent(ctx context.Context, agentID string) error {
+	return delete[dbpkg.Agent](c.db.WithContext(ctx), Clause{Key: "id", Value: agentID})
 }
 
 // DeleteToolServer deletes a tool server by name and user ID
-func (c *clientImpl) DeleteToolServer(serverName string, groupKind string) error {
-	return delete[dbpkg.ToolServer](c.db,
+func (c *clientImpl) DeleteToolServer(ctx context.Context, serverName string, groupKind string) error {
+	return delete[dbpkg.ToolServer](c.db.WithContext(ctx),
 		Clause{Key: "name", Value: serverName},
 		Clause{Key: "group_kind", Value: groupKind})
 }
 
-func (c *clientImpl) DeleteToolsForServer(serverName string, groupKind string) error {
-	return delete[dbpkg.Tool](c.db,
+func (c *clientImpl) DeleteToolsForServer(ctx context.Context, serverName string, groupKind string) error {
+	return delete[dbpkg.Tool](c.db.WithContext(ctx),
 		Clause{Key: "server_name", Value: serverName},
 		Clause{Key: "group_kind", Value: groupKind})
 }
 
 // GetTaskMessages retrieves messages for a specific task
-func (c *clientImpl) GetTaskMessages(taskID int) ([]*protocol.Message, error) {
-	messages, err := list[dbpkg.Event](c.db, Clause{Key: "task_id", Value: taskID})
+func (c *clientImpl) GetTaskMessages(ctx context.Context, taskID int) ([]*protocol.Message, error) {
+	messages, err := list[dbpkg.Event](c.db.WithContext(ctx), Clause{Key: "task_id", Value: taskID})
 	if err != nil {
 		return nil, err
 	}
@@ -107,30 +108,30 @@ func (c *clientImpl) GetTaskMessages(taskID int) ([]*protocol.Message, error) {
 }
 
 // GetSession retrieves a session by id and user ID
-func (c *clientImpl) GetSession(sessionID string, userID string) (*dbpkg.Session, error) {
-	return get[dbpkg.Session](c.db,
+func (c *clientImpl) GetSession(ctx context.Context, sessionID string, userID string) (*dbpkg.Session, error) {
+	return get[dbpkg.Session](c.db.WithContext(ctx),
 		Clause{Key: "id", Value: sessionID},
 		Clause{Key: "user_id", Value: userID})
 }
 
 // GetAgent retrieves an agent by name and user ID
-func (c *clientImpl) GetAgent(agentID string) (*dbpkg.Agent, error) {
-	return get[dbpkg.Agent](c.db, Clause{Key: "id", Value: agentID})
+func (c *clientImpl) GetAgent(ctx context.Context, agentID string) (*dbpkg.Agent, error) {
+	return get[dbpkg.Agent](c.db.WithContext(ctx), Clause{Key: "id", Value: agentID})
 }
 
 // GetTool retrieves a tool by provider (name) and user ID
-func (c *clientImpl) GetTool(provider string) (*dbpkg.Tool, error) {
-	return get[dbpkg.Tool](c.db, Clause{Key: "name", Value: provider})
+func (c *clientImpl) GetTool(ctx context.Context, provider string) (*dbpkg.Tool, error) {
+	return get[dbpkg.Tool](c.db.WithContext(ctx), Clause{Key: "name", Value: provider})
 }
 
 // GetToolServer retrieves a tool server by name and user ID
-func (c *clientImpl) GetToolServer(serverName string) (*dbpkg.ToolServer, error) {
-	return get[dbpkg.ToolServer](c.db, Clause{Key: "name", Value: serverName})
+func (c *clientImpl) GetToolServer(ctx context.Context, serverName string) (*dbpkg.ToolServer, error) {
+	return get[dbpkg.ToolServer](c.db.WithContext(ctx), Clause{Key: "name", Value: serverName})
 }
 
 // ListFeedback lists all feedback for a user
-func (c *clientImpl) ListFeedback(userID string) ([]dbpkg.Feedback, error) {
-	feedback, err := list[dbpkg.Feedback](c.db, Clause{Key: "user_id", Value: userID})
+func (c *clientImpl) ListFeedback(ctx context.Context, userID string) ([]dbpkg.Feedback, error) {
+	feedback, err := list[dbpkg.Feedback](c.db.WithContext(ctx), Clause{Key: "user_id", Value: userID})
 	if err != nil {
 		return nil, err
 	}
@@ -138,9 +139,9 @@ func (c *clientImpl) ListFeedback(userID string) ([]dbpkg.Feedback, error) {
 	return feedback, nil
 }
 
-func (c *clientImpl) StoreEvents(events ...*dbpkg.Event) error {
+func (c *clientImpl) StoreEvents(ctx context.Context, events ...*dbpkg.Event) error {
 	for _, event := range events {
-		err := save(c.db, event)
+		err := save(c.db.WithContext(ctx), event)
 		if err != nil {
 			return fmt.Errorf("failed to create event: %w", err)
 		}
@@ -149,8 +150,8 @@ func (c *clientImpl) StoreEvents(events ...*dbpkg.Event) error {
 }
 
 // ListSessionRuns lists all runs for a specific session
-func (c *clientImpl) ListTasksForSession(sessionID string) ([]*protocol.Task, error) {
-	tasks, err := list[dbpkg.Task](c.db,
+func (c *clientImpl) ListTasksForSession(ctx context.Context, sessionID string) ([]*protocol.Task, error) {
+	tasks, err := list[dbpkg.Task](c.db.WithContext(ctx),
 		Clause{Key: "session_id", Value: sessionID},
 	)
 	if err != nil {
@@ -160,35 +161,35 @@ func (c *clientImpl) ListTasksForSession(sessionID string) ([]*protocol.Task, er
 	return dbpkg.ParseTasks(tasks)
 }
 
-func (c *clientImpl) ListSessionsForAgent(agentID string, userID string) ([]dbpkg.Session, error) {
-	return list[dbpkg.Session](c.db,
+func (c *clientImpl) ListSessionsForAgent(ctx context.Context, agentID string, userID string) ([]dbpkg.Session, error) {
+	return list[dbpkg.Session](c.db.WithContext(ctx),
 		Clause{Key: "agent_id", Value: agentID},
 		Clause{Key: "user_id", Value: userID})
 }
 
 // ListSessions lists all sessions for a user
-func (c *clientImpl) ListSessions(userID string) ([]dbpkg.Session, error) {
-	return list[dbpkg.Session](c.db, Clause{Key: "user_id", Value: userID})
+func (c *clientImpl) ListSessions(ctx context.Context, userID string) ([]dbpkg.Session, error) {
+	return list[dbpkg.Session](c.db.WithContext(ctx), Clause{Key: "user_id", Value: userID})
 }
 
 // ListAgents lists all agents
-func (c *clientImpl) ListAgents() ([]dbpkg.Agent, error) {
-	return list[dbpkg.Agent](c.db)
+func (c *clientImpl) ListAgents(ctx context.Context) ([]dbpkg.Agent, error) {
+	return list[dbpkg.Agent](c.db.WithContext(ctx))
 }
 
 // ListToolServers lists all tool servers for a user
-func (c *clientImpl) ListToolServers() ([]dbpkg.ToolServer, error) {
-	return list[dbpkg.ToolServer](c.db)
+func (c *clientImpl) ListToolServers(ctx context.Context) ([]dbpkg.ToolServer, error) {
+	return list[dbpkg.ToolServer](c.db.WithContext(ctx))
 }
 
 // ListTools lists all tools for a user
-func (c *clientImpl) ListTools() ([]dbpkg.Tool, error) {
-	return list[dbpkg.Tool](c.db)
+func (c *clientImpl) ListTools(ctx context.Context) ([]dbpkg.Tool, error) {
+	return list[dbpkg.Tool](c.db.WithContext(ctx))
 }
 
 // ListToolsForServer lists all tools for a specific server and group kind
-func (c *clientImpl) ListToolsForServer(serverName string, groupKind string) ([]dbpkg.Tool, error) {
-	return list[dbpkg.Tool](c.db,
+func (c *clientImpl) ListToolsForServer(ctx context.Context, serverName string, groupKind string) ([]dbpkg.Tool, error) {
+	return list[dbpkg.Tool](c.db.WithContext(ctx),
 		Clause{Key: "server_name", Value: serverName},
 		Clause{Key: "group_kind", Value: groupKind})
 }
@@ -200,8 +201,8 @@ func (c *clientImpl) ListToolsForServer(serverName string, groupKind string) ([]
 // Network I/O (e.g., fetching tools from remote MCP servers) must happen
 // BEFORE calling this function, not inside it. Holding a database transaction
 // during slow operations can cause contention and degrade performance.
-func (c *clientImpl) RefreshToolsForServer(serverName string, groupKind string, tools ...*v1alpha2.MCPTool) error {
-	return c.db.Transaction(func(tx *gorm.DB) error {
+func (c *clientImpl) RefreshToolsForServer(ctx context.Context, serverName string, groupKind string, tools ...*v1alpha2.MCPTool) error {
+	return c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// Delete all existing tools for this server in the transaction
 		if err := delete[dbpkg.Tool](tx,
 			Clause{Key: "server_name", Value: serverName},
@@ -226,8 +227,8 @@ func (c *clientImpl) RefreshToolsForServer(serverName string, groupKind string, 
 }
 
 // ListMessagesForRun retrieves messages for a specific run (helper method)
-func (c *clientImpl) ListMessagesForTask(taskID, userID string) ([]*protocol.Message, error) {
-	messages, err := list[dbpkg.Event](c.db,
+func (c *clientImpl) ListMessagesForTask(ctx context.Context, taskID, userID string) ([]*protocol.Message, error) {
+	messages, err := list[dbpkg.Event](c.db.WithContext(ctx),
 		Clause{Key: "task_id", Value: taskID},
 		Clause{Key: "user_id", Value: userID})
 	if err != nil {
@@ -239,13 +240,13 @@ func (c *clientImpl) ListMessagesForTask(taskID, userID string) ([]*protocol.Mes
 
 // ListEventsForSession retrieves events for a specific session
 // Use Limit with DESC for getting latest events, ASC with no limit for chronological order
-func (c *clientImpl) ListEventsForSession(sessionID, userID string, options dbpkg.QueryOptions) ([]*dbpkg.Event, error) {
+func (c *clientImpl) ListEventsForSession(ctx context.Context, sessionID, userID string, options dbpkg.QueryOptions) ([]*dbpkg.Event, error) {
 	var events []dbpkg.Event
 	order := "created_at DESC"
 	if options.OrderAsc {
 		order = "created_at ASC"
 	}
-	query := c.db.
+	query := c.db.WithContext(ctx).
 		Where("session_id = ?", sessionID).
 		Where("user_id = ?", userID).
 		Order(order)
@@ -272,8 +273,8 @@ func (c *clientImpl) ListEventsForSession(sessionID, userID string, options dbpk
 }
 
 // GetMessage retrieves a protocol message from the database
-func (c *clientImpl) GetMessage(messageID string) (*protocol.Message, error) {
-	dbMessage, err := get[dbpkg.Event](c.db, Clause{Key: "id", Value: messageID})
+func (c *clientImpl) GetMessage(ctx context.Context, messageID string) (*protocol.Message, error) {
+	dbMessage, err := get[dbpkg.Event](c.db.WithContext(ctx), Clause{Key: "id", Value: messageID})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get message: %w", err)
 	}
@@ -287,14 +288,14 @@ func (c *clientImpl) GetMessage(messageID string) (*protocol.Message, error) {
 }
 
 // DeleteMessage deletes a protocol message from the database
-func (c *clientImpl) DeleteMessage(messageID string) error {
-	return delete[dbpkg.Event](c.db, Clause{Key: "id", Value: messageID})
+func (c *clientImpl) DeleteMessage(ctx context.Context, messageID string) error {
+	return delete[dbpkg.Event](c.db.WithContext(ctx), Clause{Key: "id", Value: messageID})
 }
 
 // ListMessagesByContextID retrieves messages by context ID with optional limit
-func (c *clientImpl) ListMessagesByContextID(contextID string, limit int) ([]protocol.Message, error) {
+func (c *clientImpl) ListMessagesByContextID(ctx context.Context, contextID string, limit int) ([]protocol.Message, error) {
 	var dbMessages []dbpkg.Event
-	query := c.db.Where("session_id = ?", contextID).Order("created_at DESC")
+	query := c.db.WithContext(ctx).Where("session_id = ?", contextID).Order("created_at DESC")
 
 	if limit > 0 {
 		query = query.Limit(limit)
@@ -318,7 +319,7 @@ func (c *clientImpl) ListMessagesByContextID(contextID string, limit int) ([]pro
 }
 
 // StoreTask stores a MemoryCancellableTask in the database
-func (c *clientImpl) StoreTask(task *protocol.Task) error {
+func (c *clientImpl) StoreTask(ctx context.Context, task *protocol.Task) error {
 	data, err := json.Marshal(task)
 	if err != nil {
 		return fmt.Errorf("failed to serialize task: %w", err)
@@ -330,12 +331,12 @@ func (c *clientImpl) StoreTask(task *protocol.Task) error {
 		SessionID: task.ContextID,
 	}
 
-	return save(c.db, &dbTask)
+	return save(c.db.WithContext(ctx), &dbTask)
 }
 
 // GetTask retrieves a MemoryCancellableTask from the database
-func (c *clientImpl) GetTask(taskID string) (*protocol.Task, error) {
-	dbTask, err := get[dbpkg.Task](c.db, Clause{Key: "id", Value: taskID})
+func (c *clientImpl) GetTask(ctx context.Context, taskID string) (*protocol.Task, error) {
+	dbTask, err := get[dbpkg.Task](c.db.WithContext(ctx), Clause{Key: "id", Value: taskID})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get task: %w", err)
 	}
@@ -349,14 +350,14 @@ func (c *clientImpl) GetTask(taskID string) (*protocol.Task, error) {
 }
 
 // TaskExists checks if a task exists in the database
-func (c *clientImpl) TaskExists(taskID string) bool {
+func (c *clientImpl) TaskExists(ctx context.Context, taskID string) bool {
 	var count int64
-	c.db.Model(&dbpkg.Task{}).Where("id = ?", taskID).Count(&count)
+	c.db.WithContext(ctx).Model(&dbpkg.Task{}).Where("id = ?", taskID).Count(&count)
 	return count > 0
 }
 
 // StorePushNotification stores a push notification configuration in the database
-func (c *clientImpl) StorePushNotification(config *protocol.TaskPushNotificationConfig) error {
+func (c *clientImpl) StorePushNotification(ctx context.Context, config *protocol.TaskPushNotificationConfig) error {
 	data, err := json.Marshal(config)
 	if err != nil {
 		return fmt.Errorf("failed to serialize push notification config: %w", err)
@@ -368,12 +369,12 @@ func (c *clientImpl) StorePushNotification(config *protocol.TaskPushNotification
 		Data:   string(data),
 	}
 
-	return save(c.db, &dbPushNotification)
+	return save(c.db.WithContext(ctx), &dbPushNotification)
 }
 
 // GetPushNotification retrieves a push notification configuration from the database
-func (c *clientImpl) GetPushNotification(taskID string, configID string) (*protocol.TaskPushNotificationConfig, error) {
-	dbPushNotification, err := get[dbpkg.PushNotification](c.db,
+func (c *clientImpl) GetPushNotification(ctx context.Context, taskID string, configID string) (*protocol.TaskPushNotificationConfig, error) {
+	dbPushNotification, err := get[dbpkg.PushNotification](c.db.WithContext(ctx),
 		Clause{Key: "task_id", Value: taskID},
 		Clause{Key: "id", Value: configID})
 	if err != nil {
@@ -388,8 +389,8 @@ func (c *clientImpl) GetPushNotification(taskID string, configID string) (*proto
 	return &config, nil
 }
 
-func (c *clientImpl) ListPushNotifications(taskID string) ([]*protocol.TaskPushNotificationConfig, error) {
-	pushNotifications, err := list[dbpkg.PushNotification](c.db, Clause{Key: "task_id", Value: taskID})
+func (c *clientImpl) ListPushNotifications(ctx context.Context, taskID string) ([]*protocol.TaskPushNotificationConfig, error) {
+	pushNotifications, err := list[dbpkg.PushNotification](c.db.WithContext(ctx), Clause{Key: "task_id", Value: taskID})
 	if err != nil {
 		return nil, err
 	}
@@ -407,13 +408,13 @@ func (c *clientImpl) ListPushNotifications(taskID string) ([]*protocol.TaskPushN
 }
 
 // DeletePushNotification deletes a push notification configuration from the database
-func (c *clientImpl) DeletePushNotification(taskID string) error {
-	return delete[dbpkg.PushNotification](c.db, Clause{Key: "task_id", Value: taskID})
+func (c *clientImpl) DeletePushNotification(ctx context.Context, taskID string) error {
+	return delete[dbpkg.PushNotification](c.db.WithContext(ctx), Clause{Key: "task_id", Value: taskID})
 }
 
 // StoreCheckpoint stores a LangGraph checkpoint and its writes atomically
-func (c *clientImpl) StoreCheckpoint(checkpoint *dbpkg.LangGraphCheckpoint) error {
-	err := save(c.db, checkpoint)
+func (c *clientImpl) StoreCheckpoint(ctx context.Context, checkpoint *dbpkg.LangGraphCheckpoint) error {
+	err := save(c.db.WithContext(ctx), checkpoint)
 	if err != nil {
 		return fmt.Errorf("failed to store checkpoint: %w", err)
 	}
@@ -421,8 +422,8 @@ func (c *clientImpl) StoreCheckpoint(checkpoint *dbpkg.LangGraphCheckpoint) erro
 	return nil
 }
 
-func (c *clientImpl) StoreCheckpointWrites(writes []*dbpkg.LangGraphCheckpointWrite) error {
-	return c.db.Transaction(func(tx *gorm.DB) error {
+func (c *clientImpl) StoreCheckpointWrites(ctx context.Context, writes []*dbpkg.LangGraphCheckpointWrite) error {
+	return c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		for _, write := range writes {
 			if err := save(tx, write); err != nil {
 				return fmt.Errorf("failed to store checkpoint write: %w", err)
@@ -433,10 +434,11 @@ func (c *clientImpl) StoreCheckpointWrites(writes []*dbpkg.LangGraphCheckpointWr
 }
 
 // ListCheckpoints lists checkpoints for a thread, optionally filtered by beforeCheckpointID
-func (c *clientImpl) ListCheckpoints(userID, threadID, checkpointNS string, checkpointID *string, limit int) ([]*dbpkg.LangGraphCheckpointTuple, error) {
+func (c *clientImpl) ListCheckpoints(ctx context.Context, userID, threadID, checkpointNS string, checkpointID *string, limit int) ([]*dbpkg.LangGraphCheckpointTuple, error) {
 	var checkpointTuples []*dbpkg.LangGraphCheckpointTuple
-	if err := c.db.Transaction(func(tx *gorm.DB) error {
-		query := c.db.Where(
+	db := c.db.WithContext(ctx)
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		query := db.Where(
 			"user_id = ? AND thread_id = ? AND checkpoint_ns = ?",
 			userID, threadID, checkpointNS,
 		)
@@ -479,12 +481,12 @@ func (c *clientImpl) ListCheckpoints(userID, threadID, checkpointNS string, chec
 }
 
 // DeleteCheckpoint deletes a checkpoint and its writes atomically
-func (c *clientImpl) DeleteCheckpoint(userID, threadID string) error {
+func (c *clientImpl) DeleteCheckpoint(ctx context.Context, userID, threadID string) error {
 	clauses := []Clause{
 		{Key: "user_id", Value: userID},
 		{Key: "thread_id", Value: threadID},
 	}
-	return c.db.Transaction(func(tx *gorm.DB) error {
+	return c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := delete[dbpkg.LangGraphCheckpoint](tx, clauses...); err != nil {
 			return fmt.Errorf("failed to delete checkpoint: %w", err)
 		}
@@ -498,8 +500,8 @@ func (c *clientImpl) DeleteCheckpoint(userID, threadID string) error {
 // CrewAI methods
 
 // StoreCrewAIMemory stores CrewAI agent memory
-func (c *clientImpl) StoreCrewAIMemory(memory *dbpkg.CrewAIAgentMemory) error {
-	err := save(c.db, memory)
+func (c *clientImpl) StoreCrewAIMemory(ctx context.Context, memory *dbpkg.CrewAIAgentMemory) error {
+	err := save(c.db.WithContext(ctx), memory)
 	if err != nil {
 		return fmt.Errorf("failed to store CrewAI agent memory: %w", err)
 	}
@@ -507,13 +509,13 @@ func (c *clientImpl) StoreCrewAIMemory(memory *dbpkg.CrewAIAgentMemory) error {
 }
 
 // SearchCrewAIMemoryByTask searches CrewAI agent memory by task description across all agents for a session
-func (c *clientImpl) SearchCrewAIMemoryByTask(userID, threadID, taskDescription string, limit int) ([]*dbpkg.CrewAIAgentMemory, error) {
+func (c *clientImpl) SearchCrewAIMemoryByTask(ctx context.Context, userID, threadID, taskDescription string, limit int) ([]*dbpkg.CrewAIAgentMemory, error) {
 	var memories []*dbpkg.CrewAIAgentMemory
 
 	// Search for task_description within the JSON memory_data field
 	// Using JSON_EXTRACT or JSON_UNQUOTE for MySQL/PostgreSQL, or simple LIKE for SQLite
 	// Sort by created_at DESC, then by score ASC (if score exists in JSON)
-	query := c.db.Where(
+	query := c.db.WithContext(ctx).Where(
 		"user_id = ? AND thread_id = ? AND (memory_data LIKE ? OR JSON_EXTRACT(memory_data, '$.task_description') LIKE ?)",
 		userID, threadID, "%"+taskDescription+"%", "%"+taskDescription+"%",
 	).Order("created_at DESC, JSON_EXTRACT(memory_data, '$.score') ASC")
@@ -532,8 +534,8 @@ func (c *clientImpl) SearchCrewAIMemoryByTask(userID, threadID, taskDescription 
 }
 
 // ResetCrewAIMemory deletes all CrewAI agent memory for a session
-func (c *clientImpl) ResetCrewAIMemory(userID, threadID string) error {
-	result := c.db.Where(
+func (c *clientImpl) ResetCrewAIMemory(ctx context.Context, userID, threadID string) error {
+	result := c.db.WithContext(ctx).Where(
 		"user_id = ? AND thread_id = ?",
 		userID, threadID,
 	).Delete(&dbpkg.CrewAIAgentMemory{})
@@ -546,8 +548,8 @@ func (c *clientImpl) ResetCrewAIMemory(userID, threadID string) error {
 }
 
 // StoreCrewAIFlowState stores CrewAI flow state
-func (c *clientImpl) StoreCrewAIFlowState(state *dbpkg.CrewAIFlowState) error {
-	err := save(c.db, state)
+func (c *clientImpl) StoreCrewAIFlowState(ctx context.Context, state *dbpkg.CrewAIFlowState) error {
+	err := save(c.db.WithContext(ctx), state)
 	if err != nil {
 		return fmt.Errorf("failed to store CrewAI flow state: %w", err)
 	}
@@ -555,12 +557,12 @@ func (c *clientImpl) StoreCrewAIFlowState(state *dbpkg.CrewAIFlowState) error {
 }
 
 // GetCrewAIFlowState retrieves the most recent CrewAI flow state
-func (c *clientImpl) GetCrewAIFlowState(userID, threadID string) (*dbpkg.CrewAIFlowState, error) {
+func (c *clientImpl) GetCrewAIFlowState(ctx context.Context, userID, threadID string) (*dbpkg.CrewAIFlowState, error) {
 	var state dbpkg.CrewAIFlowState
 
 	// Get the most recent state by ordering by created_at DESC
 	// Thread_id is equivalent to flow_uuid used by CrewAI because in each session there is only one flow
-	err := c.db.Where(
+	err := c.db.WithContext(ctx).Where(
 		"user_id = ? AND thread_id = ?",
 		userID, threadID,
 	).Order("created_at DESC").First(&state).Error
@@ -577,12 +579,12 @@ func (c *clientImpl) GetCrewAIFlowState(userID, threadID string) (*dbpkg.CrewAIF
 
 // AgentMemory methods
 
-func (c *clientImpl) StoreAgentMemory(memory *dbpkg.Memory) error {
-	return save(c.db, memory)
+func (c *clientImpl) StoreAgentMemory(ctx context.Context, memory *dbpkg.Memory) error {
+	return save(c.db.WithContext(ctx), memory)
 }
 
-func (c *clientImpl) StoreAgentMemories(memories []*dbpkg.Memory) error {
-	return c.db.Transaction(func(tx *gorm.DB) error {
+func (c *clientImpl) StoreAgentMemories(ctx context.Context, memories []*dbpkg.Memory) error {
+	return c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		for _, memory := range memories {
 			if err := save(tx, memory); err != nil {
 				return err
@@ -592,10 +594,11 @@ func (c *clientImpl) StoreAgentMemories(memories []*dbpkg.Memory) error {
 	})
 }
 
-func (c *clientImpl) SearchAgentMemory(agentName, userID string, embedding pgvector.Vector, limit int) ([]dbpkg.AgentMemorySearchResult, error) {
+func (c *clientImpl) SearchAgentMemory(ctx context.Context, agentName, userID string, embedding pgvector.Vector, limit int) ([]dbpkg.AgentMemorySearchResult, error) {
 	var results []dbpkg.AgentMemorySearchResult
 
-	if c.db.Name() == "sqlite" {
+	db := c.db.WithContext(ctx)
+	if db.Name() == "sqlite" {
 		// libSQL/Turso syntax: vector_distance_cos(embedding, vector32('JSON_ARRAY'))
 		// We must use fmt.Sprintf to inline the JSON array because vector32() requires a string literal
 		// and parameter binding with ? fails with "unexpected token" errors (GORM limitation)
@@ -614,7 +617,7 @@ func (c *clientImpl) SearchAgentMemory(agentName, userID string, embedding pgvec
 			LIMIT ?
 		`, string(embeddingJSON), string(embeddingJSON))
 
-		if err := c.db.Raw(query, agentName, userID, limit).Scan(&results).Error; err != nil {
+		if err := db.Raw(query, agentName, userID, limit).Scan(&results).Error; err != nil {
 			return nil, fmt.Errorf("failed to search agent memory (sqlite): %w", err)
 		}
 	} else {
@@ -628,7 +631,7 @@ func (c *clientImpl) SearchAgentMemory(agentName, userID string, embedding pgvec
 			ORDER BY embedding <=> ? ASC
 			LIMIT ?
 		`
-		if err := c.db.Raw(query, embedding, agentName, userID, embedding, limit).Scan(&results).Error; err != nil {
+		if err := db.Raw(query, embedding, agentName, userID, embedding, limit).Scan(&results).Error; err != nil {
 			return nil, fmt.Errorf("failed to search agent memory (postgres): %w", err)
 		}
 	}
@@ -639,7 +642,7 @@ func (c *clientImpl) SearchAgentMemory(agentName, userID string, embedding pgvec
 		for i, m := range results {
 			ids[i] = m.ID
 		}
-		if err := c.db.Model(&dbpkg.Memory{}).Where("id IN ?", ids).UpdateColumn("access_count", gorm.Expr("access_count + ?", 1)).Error; err != nil {
+		if err := db.Model(&dbpkg.Memory{}).Where("id IN ?", ids).UpdateColumn("access_count", gorm.Expr("access_count + ?", 1)).Error; err != nil {
 			return nil, fmt.Errorf("failed to increment access count: %w", err)
 		}
 	}
@@ -649,8 +652,8 @@ func (c *clientImpl) SearchAgentMemory(agentName, userID string, embedding pgvec
 
 // PruneExpiredMemories deletes expired memories if they haven't been accessed enough,
 // otherwise extends their TTL.
-func (c *clientImpl) PruneExpiredMemories() error {
-	return c.db.Transaction(func(tx *gorm.DB) error {
+func (c *clientImpl) PruneExpiredMemories(ctx context.Context) error {
+	return c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		now := time.Now()
 
 		// 1. Extend TTL for popular memories (AccessCount >= 10)
@@ -677,11 +680,11 @@ func (c *clientImpl) PruneExpiredMemories() error {
 	})
 }
 
-func (c *clientImpl) ListAgentMemories(agentName, userID string) ([]dbpkg.Memory, error) {
+func (c *clientImpl) ListAgentMemories(ctx context.Context, agentName, userID string) ([]dbpkg.Memory, error) {
 	normalizedName := strings.ReplaceAll(agentName, "-", "_")
 
 	var memories []dbpkg.Memory
-	query := c.db.Where("(agent_name = ? OR agent_name = ?) AND user_id = ?", agentName, normalizedName, userID).
+	query := c.db.WithContext(ctx).Where("(agent_name = ? OR agent_name = ?) AND user_id = ?", agentName, normalizedName, userID).
 		Order("access_count DESC")
 
 	if err := query.Find(&memories).Error; err != nil {
@@ -690,27 +693,27 @@ func (c *clientImpl) ListAgentMemories(agentName, userID string) ([]dbpkg.Memory
 	return memories, nil
 }
 
-func (c *clientImpl) DeleteAgentMemory(agentName, userID string) error {
-	if err := c.deleteAgentMemoryByQuery(agentName, userID); err != nil {
+func (c *clientImpl) DeleteAgentMemory(ctx context.Context, agentName, userID string) error {
+	if err := c.deleteAgentMemoryByQuery(ctx, agentName, userID); err != nil {
 		return err
 	}
 	normalizedName := strings.ReplaceAll(agentName, "-", "_")
 	if normalizedName != agentName {
-		return c.deleteAgentMemoryByQuery(normalizedName, userID)
+		return c.deleteAgentMemoryByQuery(ctx, normalizedName, userID)
 	}
 	return nil
 }
 
-func (c *clientImpl) deleteAgentMemoryByQuery(agentName, userID string) error {
+func (c *clientImpl) deleteAgentMemoryByQuery(ctx context.Context, agentName, userID string) error {
 	var ids []string
-	if err := c.db.Table("memory").Where("agent_name = ? AND user_id = ?", agentName, userID).Pluck("id", &ids).Error; err != nil {
+	if err := c.db.WithContext(ctx).Table("memory").Where("agent_name = ? AND user_id = ?", agentName, userID).Pluck("id", &ids).Error; err != nil {
 		return fmt.Errorf("failed to list memory ids: %w", err)
 	}
 	if len(ids) == 0 {
 		return nil
 	}
 	// DELETE by primary key only to avoid Turso multi-index scan on DELETE which causes a bug
-	if err := c.db.Exec("DELETE FROM memory WHERE id IN ?", ids).Error; err != nil {
+	if err := c.db.WithContext(ctx).Exec("DELETE FROM memory WHERE id IN ?", ids).Error; err != nil {
 		return fmt.Errorf("failed to delete agent memory: %w", err)
 	}
 	return nil

--- a/go/core/internal/database/client_test.go
+++ b/go/core/internal/database/client_test.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"testing"
@@ -18,6 +19,7 @@ import (
 func TestConcurrentAgentUpserts(t *testing.T) {
 	db := setupTestDB(t)
 	client := NewClient(db)
+	ctx := context.Background()
 
 	const numGoroutines = 10
 	const numUpserts = 50
@@ -36,7 +38,7 @@ func TestConcurrentAgentUpserts(t *testing.T) {
 					ID:   agentID,
 					Type: fmt.Sprintf("type-%d-%d", goroutineID, j),
 				}
-				err := client.StoreAgent(agent)
+				err := client.StoreAgent(ctx, agent)
 				assert.NoError(t, err, "StoreAgent should not fail")
 			}
 		}(i)
@@ -45,7 +47,7 @@ func TestConcurrentAgentUpserts(t *testing.T) {
 	wg.Wait()
 
 	// Verify the agent exists and has valid data (not corrupted)
-	agent, err := client.GetAgent(agentID)
+	agent, err := client.GetAgent(ctx, agentID)
 	require.NoError(t, err)
 	assert.Equal(t, agentID, agent.ID)
 	assert.NotEmpty(t, agent.Type) // Should have some valid type from one of the upserts
@@ -56,6 +58,7 @@ func TestConcurrentAgentUpserts(t *testing.T) {
 func TestConcurrentToolServerUpserts(t *testing.T) {
 	db := setupTestDB(t)
 	client := NewClient(db)
+	ctx := context.Background()
 
 	const numGoroutines = 10
 	const numUpserts = 50
@@ -75,7 +78,7 @@ func TestConcurrentToolServerUpserts(t *testing.T) {
 					GroupKind:   groupKind,
 					Description: fmt.Sprintf("Description from goroutine %d iteration %d", goroutineID, j),
 				}
-				_, err := client.StoreToolServer(toolServer)
+				_, err := client.StoreToolServer(ctx, toolServer)
 				assert.NoError(t, err, "StoreToolServer should not fail")
 			}
 		}(i)
@@ -84,7 +87,7 @@ func TestConcurrentToolServerUpserts(t *testing.T) {
 	wg.Wait()
 
 	// Verify the tool server exists and has valid data
-	server, err := client.GetToolServer(serverName)
+	server, err := client.GetToolServer(ctx, serverName)
 	require.NoError(t, err)
 	assert.Equal(t, serverName, server.Name)
 	assert.NotEmpty(t, server.Description)
@@ -96,12 +99,13 @@ func TestConcurrentToolServerUpserts(t *testing.T) {
 func TestConcurrentRefreshToolsForServer(t *testing.T) {
 	db := setupTestDB(t)
 	client := NewClient(db)
+	ctx := context.Background()
 
 	serverName := "test-server"
 	groupKind := "RemoteMCPServer"
 
 	// Create the tool server first
-	_, err := client.StoreToolServer(&dbpkg.ToolServer{
+	_, err := client.StoreToolServer(ctx, &dbpkg.ToolServer{
 		Name:        serverName,
 		GroupKind:   groupKind,
 		Description: "Test server",
@@ -121,7 +125,7 @@ func TestConcurrentRefreshToolsForServer(t *testing.T) {
 				{Name: fmt.Sprintf("tool-a-%d", goroutineID), Description: "Tool A"},
 				{Name: fmt.Sprintf("tool-b-%d", goroutineID), Description: "Tool B"},
 			}
-			err := client.RefreshToolsForServer(serverName, groupKind, tools...)
+			err := client.RefreshToolsForServer(ctx, serverName, groupKind, tools...)
 			assert.NoError(t, err, "RefreshToolsForServer should not fail")
 		}(i)
 	}
@@ -129,7 +133,7 @@ func TestConcurrentRefreshToolsForServer(t *testing.T) {
 	wg.Wait()
 
 	// Verify the tools exist (we don't know which goroutine's tools "won", but the state should be consistent)
-	tools, err := client.ListToolsForServer(serverName, groupKind)
+	tools, err := client.ListToolsForServer(ctx, serverName, groupKind)
 	require.NoError(t, err)
 	// Should have exactly 2 tools from one of the refresh operations
 	assert.Len(t, tools, 2, "Should have exactly 2 tools after concurrent refreshes")
@@ -141,6 +145,7 @@ func TestConcurrentRefreshToolsForServer(t *testing.T) {
 func TestStoreAgentIdempotence(t *testing.T) {
 	db := setupTestDB(t)
 	client := NewClient(db)
+	ctx := context.Background()
 
 	agent := &dbpkg.Agent{
 		ID:   "idempotent-agent",
@@ -148,20 +153,20 @@ func TestStoreAgentIdempotence(t *testing.T) {
 	}
 
 	// First store should succeed
-	err := client.StoreAgent(agent)
+	err := client.StoreAgent(ctx, agent)
 	require.NoError(t, err, "First StoreAgent should succeed")
 
 	// Second store with same data should also succeed (idempotent)
-	err = client.StoreAgent(agent)
+	err = client.StoreAgent(ctx, agent)
 	require.NoError(t, err, "Second StoreAgent should succeed (idempotent)")
 
 	// Third store with updated data should succeed (upsert)
 	agent.Type = "byo"
-	err = client.StoreAgent(agent)
+	err = client.StoreAgent(ctx, agent)
 	require.NoError(t, err, "Third StoreAgent with updated data should succeed")
 
 	// Verify final state
-	retrieved, err := client.GetAgent(agent.ID)
+	retrieved, err := client.GetAgent(ctx, agent.ID)
 	require.NoError(t, err)
 	assert.Equal(t, "byo", retrieved.Type, "Agent should have updated type")
 }
@@ -170,6 +175,7 @@ func TestStoreAgentIdempotence(t *testing.T) {
 func TestStoreToolServerIdempotence(t *testing.T) {
 	db := setupTestDB(t)
 	client := NewClient(db)
+	ctx := context.Background()
 
 	server := &dbpkg.ToolServer{
 		Name:        "idempotent-server",
@@ -178,20 +184,20 @@ func TestStoreToolServerIdempotence(t *testing.T) {
 	}
 
 	// First store
-	_, err := client.StoreToolServer(server)
+	_, err := client.StoreToolServer(ctx, server)
 	require.NoError(t, err, "First StoreToolServer should succeed")
 
 	// Second store with same data (idempotent)
-	_, err = client.StoreToolServer(server)
+	_, err = client.StoreToolServer(ctx, server)
 	require.NoError(t, err, "Second StoreToolServer should succeed")
 
 	// Third store with updated data (upsert)
 	server.Description = "Updated description"
-	_, err = client.StoreToolServer(server)
+	_, err = client.StoreToolServer(ctx, server)
 	require.NoError(t, err, "Third StoreToolServer with updated data should succeed")
 
 	// Verify final state
-	retrieved, err := client.GetToolServer(server.Name)
+	retrieved, err := client.GetToolServer(ctx, server.Name)
 	require.NoError(t, err)
 	assert.Equal(t, "Updated description", retrieved.Description)
 }
@@ -222,6 +228,7 @@ func setupTestDB(t *testing.T) *Manager {
 func TestListEventsForSession(t *testing.T) {
 	db := setupTestDB(t)
 	client := NewClient(db)
+	ctx := context.Background()
 	userID := "test-user"
 	sessionID := "test-session"
 
@@ -233,7 +240,7 @@ func TestListEventsForSession(t *testing.T) {
 			UserID:    userID,
 			Data:      "{}",
 		}
-		err := client.StoreEvents(event)
+		err := client.StoreEvents(ctx, event)
 		require.NoError(t, err)
 	}
 
@@ -254,7 +261,7 @@ func TestListEventsForSession(t *testing.T) {
 			opts := dbpkg.QueryOptions{
 				Limit: tc.limit,
 			}
-			events, err := client.ListEventsForSession(sessionID, userID, opts)
+			events, err := client.ListEventsForSession(ctx, sessionID, userID, opts)
 			require.NoError(t, err)
 			assert.Len(t, events, tc.expectedCount)
 		})
@@ -264,6 +271,7 @@ func TestListEventsForSession(t *testing.T) {
 func TestListEventsForSessionOrdering(t *testing.T) {
 	db := setupTestDB(t)
 	client := NewClient(db)
+	ctx := context.Background()
 	userID := "test-user"
 	sessionID := "test-session"
 
@@ -279,13 +287,13 @@ func TestListEventsForSessionOrdering(t *testing.T) {
 			CreatedAt: baseTime.Add(time.Duration(i) * time.Hour),
 			Data:      "{}",
 		}
-		err := client.StoreEvents(event)
+		err := client.StoreEvents(ctx, event)
 		require.NoError(t, err)
 	}
 
 	t.Run("Default (Desc)", func(t *testing.T) {
 		opts := dbpkg.QueryOptions{}
-		events, err := client.ListEventsForSession(sessionID, userID, opts)
+		events, err := client.ListEventsForSession(ctx, sessionID, userID, opts)
 		require.NoError(t, err)
 		require.Len(t, events, 3)
 		// Should be 2, 1, 0
@@ -298,7 +306,7 @@ func TestListEventsForSessionOrdering(t *testing.T) {
 		opts := dbpkg.QueryOptions{
 			OrderAsc: true,
 		}
-		events, err := client.ListEventsForSession(sessionID, userID, opts)
+		events, err := client.ListEventsForSession(ctx, sessionID, userID, opts)
 		require.NoError(t, err)
 		require.Len(t, events, 3)
 		// Should be 0, 1, 2
@@ -349,6 +357,7 @@ func makeEmbedding(v float32) pgvector.Vector {
 func TestStoreAndSearchAgentMemory(t *testing.T) {
 	db := setupVectorTestDB(t)
 	client := NewClient(db)
+	ctx := context.Background()
 
 	agentName := "test-agent"
 	userID := "test-user"
@@ -378,12 +387,12 @@ func TestStoreAndSearchAgentMemory(t *testing.T) {
 	}
 
 	for _, m := range memories {
-		err := client.StoreAgentMemory(m)
+		err := client.StoreAgentMemory(ctx, m)
 		require.NoError(t, err)
 	}
 
 	// Query with embedding; all three memories should be returned with high similarity.
-	results, err := client.SearchAgentMemory(agentName, userID, makeEmbedding(0.5), 3)
+	results, err := client.SearchAgentMemory(ctx, agentName, userID, makeEmbedding(0.5), 3)
 	require.NoError(t, err)
 	require.Len(t, results, 3, "Should return all 3 memories")
 	// Scores should be in [0, 1] (cosine similarity)
@@ -397,6 +406,7 @@ func TestStoreAndSearchAgentMemory(t *testing.T) {
 func TestStoreAgentMemoriesBatch(t *testing.T) {
 	db := setupVectorTestDB(t)
 	client := NewClient(db)
+	ctx := context.Background()
 
 	agentName := "batch-agent"
 	userID := "batch-user"
@@ -407,10 +417,10 @@ func TestStoreAgentMemoriesBatch(t *testing.T) {
 		{ID: "b-3", AgentName: agentName, UserID: userID, Content: "batch memory 3", Embedding: makeEmbedding(0.6)},
 	}
 
-	err := client.StoreAgentMemories(memories)
+	err := client.StoreAgentMemories(ctx, memories)
 	require.NoError(t, err)
 
-	results, err := client.SearchAgentMemory(agentName, userID, makeEmbedding(0.5), 10)
+	results, err := client.SearchAgentMemory(ctx, agentName, userID, makeEmbedding(0.5), 10)
 	require.NoError(t, err)
 	assert.Len(t, results, 3, "All 3 batch-stored memories should be found")
 }
@@ -420,12 +430,13 @@ func TestStoreAgentMemoriesBatch(t *testing.T) {
 func TestSearchAgentMemoryLimit(t *testing.T) {
 	db := setupVectorTestDB(t)
 	client := NewClient(db)
+	ctx := context.Background()
 
 	agentName := "limit-agent"
 	userID := "limit-user"
 
 	for i := range 5 {
-		err := client.StoreAgentMemory(&dbpkg.Memory{
+		err := client.StoreAgentMemory(ctx, &dbpkg.Memory{
 			ID:        fmt.Sprintf("lim-%d", i),
 			AgentName: agentName,
 			UserID:    userID,
@@ -447,7 +458,7 @@ func TestSearchAgentMemoryLimit(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(fmt.Sprintf("limit_%d", tc.limit), func(t *testing.T) {
-			results, err := client.SearchAgentMemory(agentName, userID, makeEmbedding(0.5), tc.limit)
+			results, err := client.SearchAgentMemory(ctx, agentName, userID, makeEmbedding(0.5), tc.limit)
 			require.NoError(t, err)
 			assert.Len(t, results, tc.expected)
 		})
@@ -459,21 +470,22 @@ func TestSearchAgentMemoryLimit(t *testing.T) {
 func TestSearchAgentMemoryIsolation(t *testing.T) {
 	db := setupVectorTestDB(t)
 	client := NewClient(db)
+	ctx := context.Background()
 
-	require.NoError(t, client.StoreAgentMemory(&dbpkg.Memory{
+	require.NoError(t, client.StoreAgentMemory(ctx, &dbpkg.Memory{
 		ID: "iso-1", AgentName: "agent-a", UserID: "user-1",
 		Content: "agent-a user-1 memory", Embedding: makeEmbedding(0.5),
 	}))
-	require.NoError(t, client.StoreAgentMemory(&dbpkg.Memory{
+	require.NoError(t, client.StoreAgentMemory(ctx, &dbpkg.Memory{
 		ID: "iso-2", AgentName: "agent-b", UserID: "user-1",
 		Content: "agent-b user-1 memory", Embedding: makeEmbedding(0.5),
 	}))
-	require.NoError(t, client.StoreAgentMemory(&dbpkg.Memory{
+	require.NoError(t, client.StoreAgentMemory(ctx, &dbpkg.Memory{
 		ID: "iso-3", AgentName: "agent-a", UserID: "user-2",
 		Content: "agent-a user-2 memory", Embedding: makeEmbedding(0.5),
 	}))
 
-	results, err := client.SearchAgentMemory("agent-a", "user-1", makeEmbedding(0.5), 10)
+	results, err := client.SearchAgentMemory(ctx, "agent-a", "user-1", makeEmbedding(0.5), 10)
 	require.NoError(t, err)
 	require.Len(t, results, 1, "Should only return memories for agent-a / user-1")
 	assert.Equal(t, "iso-1", results[0].ID)
@@ -484,12 +496,13 @@ func TestSearchAgentMemoryIsolation(t *testing.T) {
 func TestDeleteAgentMemory(t *testing.T) {
 	db := setupVectorTestDB(t)
 	client := NewClient(db)
+	ctx := context.Background()
 
 	agentName := "my-agent"
 	userID := "del-user"
 
 	for i := range 3 {
-		err := client.StoreAgentMemory(&dbpkg.Memory{
+		err := client.StoreAgentMemory(ctx, &dbpkg.Memory{
 			ID:        fmt.Sprintf("del-%d", i),
 			AgentName: agentName,
 			UserID:    userID,
@@ -500,14 +513,14 @@ func TestDeleteAgentMemory(t *testing.T) {
 	}
 
 	// Confirm they exist before deletion
-	before, err := client.SearchAgentMemory(agentName, userID, makeEmbedding(0.5), 10)
+	before, err := client.SearchAgentMemory(ctx, agentName, userID, makeEmbedding(0.5), 10)
 	require.NoError(t, err)
 	require.Len(t, before, 3)
 
-	err = client.DeleteAgentMemory(agentName, userID)
+	err = client.DeleteAgentMemory(ctx, agentName, userID)
 	require.NoError(t, err)
 
-	after, err := client.SearchAgentMemory(agentName, userID, makeEmbedding(0.5), 10)
+	after, err := client.SearchAgentMemory(ctx, agentName, userID, makeEmbedding(0.5), 10)
 	require.NoError(t, err)
 	assert.Empty(t, after, "All memories should be deleted")
 }
@@ -517,6 +530,7 @@ func TestDeleteAgentMemory(t *testing.T) {
 func TestPruneExpiredMemories(t *testing.T) {
 	db := setupVectorTestDB(t)
 	client := NewClient(db)
+	ctx := context.Background()
 
 	agentName := "prune-agent"
 	userID := "prune-user"
@@ -524,7 +538,7 @@ func TestPruneExpiredMemories(t *testing.T) {
 	past := time.Now().Add(-1 * time.Hour)
 
 	// Memory that is expired and unpopular — should be deleted
-	require.NoError(t, client.StoreAgentMemory(&dbpkg.Memory{
+	require.NoError(t, client.StoreAgentMemory(ctx, &dbpkg.Memory{
 		ID:          "prune-cold",
 		AgentName:   agentName,
 		UserID:      userID,
@@ -535,7 +549,7 @@ func TestPruneExpiredMemories(t *testing.T) {
 	}))
 
 	// Memory that is expired but popular (AccessCount >= 10) — TTL should be extended
-	require.NoError(t, client.StoreAgentMemory(&dbpkg.Memory{
+	require.NoError(t, client.StoreAgentMemory(ctx, &dbpkg.Memory{
 		ID:          "prune-hot",
 		AgentName:   agentName,
 		UserID:      userID,
@@ -547,7 +561,7 @@ func TestPruneExpiredMemories(t *testing.T) {
 
 	// Memory that has not expired — should be untouched
 	future := time.Now().Add(24 * time.Hour)
-	require.NoError(t, client.StoreAgentMemory(&dbpkg.Memory{
+	require.NoError(t, client.StoreAgentMemory(ctx, &dbpkg.Memory{
 		ID:          "prune-live",
 		AgentName:   agentName,
 		UserID:      userID,
@@ -557,10 +571,10 @@ func TestPruneExpiredMemories(t *testing.T) {
 		AccessCount: 0,
 	}))
 
-	err := client.PruneExpiredMemories()
+	err := client.PruneExpiredMemories(ctx)
 	require.NoError(t, err)
 
-	results, err := client.SearchAgentMemory(agentName, userID, makeEmbedding(0.5), 10)
+	results, err := client.SearchAgentMemory(ctx, agentName, userID, makeEmbedding(0.5), 10)
 	require.NoError(t, err)
 
 	ids := make([]string, 0, len(results))

--- a/go/core/internal/database/fake/client.go
+++ b/go/core/internal/database/fake/client.go
@@ -1,6 +1,7 @@
 package fake
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -61,7 +62,7 @@ func (c *InMemoryFakeClient) sessionKey(sessionID, userID string) string {
 	return fmt.Sprintf("%s_%s", sessionID, userID)
 }
 
-func (c *InMemoryFakeClient) DeletePushNotification(taskID string) error {
+func (c *InMemoryFakeClient) DeletePushNotification(_ context.Context, taskID string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -69,14 +70,14 @@ func (c *InMemoryFakeClient) DeletePushNotification(taskID string) error {
 	return nil
 }
 
-func (c *InMemoryFakeClient) GetPushNotification(taskID string, configID string) (*protocol.TaskPushNotificationConfig, error) {
+func (c *InMemoryFakeClient) GetPushNotification(_ context.Context, taskID string, configID string) (*protocol.TaskPushNotificationConfig, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
 	return c.pushNotifications[taskID], nil
 }
 
-func (c *InMemoryFakeClient) GetTask(taskID string) (*protocol.Task, error) {
+func (c *InMemoryFakeClient) GetTask(_ context.Context, taskID string) (*protocol.Task, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -92,7 +93,7 @@ func (c *InMemoryFakeClient) GetTask(taskID string) (*protocol.Task, error) {
 	return parsedTask, nil
 }
 
-func (c *InMemoryFakeClient) DeleteTask(taskID string) error {
+func (c *InMemoryFakeClient) DeleteTask(_ context.Context, taskID string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -101,7 +102,7 @@ func (c *InMemoryFakeClient) DeleteTask(taskID string) error {
 }
 
 // StoreFeedback creates a new feedback record
-func (c *InMemoryFakeClient) StoreFeedback(feedback *database.Feedback) error {
+func (c *InMemoryFakeClient) StoreFeedback(_ context.Context, feedback *database.Feedback) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -116,7 +117,7 @@ func (c *InMemoryFakeClient) StoreFeedback(feedback *database.Feedback) error {
 }
 
 // StoreEvents creates a new event record
-func (c *InMemoryFakeClient) StoreEvents(events ...*database.Event) error {
+func (c *InMemoryFakeClient) StoreEvents(_ context.Context, events ...*database.Event) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -129,7 +130,7 @@ func (c *InMemoryFakeClient) StoreEvents(events ...*database.Event) error {
 }
 
 // StoreSession creates a new session record
-func (c *InMemoryFakeClient) StoreSession(session *database.Session) error {
+func (c *InMemoryFakeClient) StoreSession(_ context.Context, session *database.Session) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -139,7 +140,7 @@ func (c *InMemoryFakeClient) StoreSession(session *database.Session) error {
 }
 
 // StoreAgent creates a new agent record
-func (c *InMemoryFakeClient) StoreAgent(agent *database.Agent) error {
+func (c *InMemoryFakeClient) StoreAgent(_ context.Context, agent *database.Agent) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -148,7 +149,7 @@ func (c *InMemoryFakeClient) StoreAgent(agent *database.Agent) error {
 }
 
 // StoreTask creates a new task record
-func (c *InMemoryFakeClient) StoreTask(task *protocol.Task) error {
+func (c *InMemoryFakeClient) StoreTask(_ context.Context, task *protocol.Task) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -164,7 +165,7 @@ func (c *InMemoryFakeClient) StoreTask(task *protocol.Task) error {
 }
 
 // StorePushNotification creates a new push notification record
-func (c *InMemoryFakeClient) StorePushNotification(config *protocol.TaskPushNotificationConfig) error {
+func (c *InMemoryFakeClient) StorePushNotification(_ context.Context, config *protocol.TaskPushNotificationConfig) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -173,7 +174,7 @@ func (c *InMemoryFakeClient) StorePushNotification(config *protocol.TaskPushNoti
 }
 
 // StoreToolServer creates a new tool server record
-func (c *InMemoryFakeClient) StoreToolServer(toolServer *database.ToolServer) (*database.ToolServer, error) {
+func (c *InMemoryFakeClient) StoreToolServer(_ context.Context, toolServer *database.ToolServer) (*database.ToolServer, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -182,7 +183,7 @@ func (c *InMemoryFakeClient) StoreToolServer(toolServer *database.ToolServer) (*
 }
 
 // CreateTool creates a new tool record
-func (c *InMemoryFakeClient) CreateTool(tool *database.Tool) error {
+func (c *InMemoryFakeClient) CreateTool(_ context.Context, tool *database.Tool) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -191,7 +192,7 @@ func (c *InMemoryFakeClient) CreateTool(tool *database.Tool) error {
 }
 
 // DeleteSession deletes a session by ID and user ID
-func (c *InMemoryFakeClient) DeleteSession(sessionID string, userID string) error {
+func (c *InMemoryFakeClient) DeleteSession(_ context.Context, sessionID string, userID string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -201,7 +202,7 @@ func (c *InMemoryFakeClient) DeleteSession(sessionID string, userID string) erro
 }
 
 // DeleteAgent deletes an agent by name
-func (c *InMemoryFakeClient) DeleteAgent(agentName string) error {
+func (c *InMemoryFakeClient) DeleteAgent(_ context.Context, agentName string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -216,7 +217,7 @@ func (c *InMemoryFakeClient) DeleteAgent(agentName string) error {
 }
 
 // DeleteToolServer deletes a tool server by name
-func (c *InMemoryFakeClient) DeleteToolServer(serverName string, groupKind string) error {
+func (c *InMemoryFakeClient) DeleteToolServer(_ context.Context, serverName string, groupKind string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -225,7 +226,7 @@ func (c *InMemoryFakeClient) DeleteToolServer(serverName string, groupKind strin
 }
 
 // DeleteToolsForServer deletes tools for a tool server by name
-func (c *InMemoryFakeClient) DeleteToolsForServer(serverName string, groupKind string) error {
+func (c *InMemoryFakeClient) DeleteToolsForServer(_ context.Context, serverName string, groupKind string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -239,7 +240,7 @@ func (c *InMemoryFakeClient) DeleteToolsForServer(serverName string, groupKind s
 }
 
 // GetSession retrieves a session by ID and user ID
-func (c *InMemoryFakeClient) GetSession(sessionID string, userID string) (*database.Session, error) {
+func (c *InMemoryFakeClient) GetSession(_ context.Context, sessionID string, userID string) (*database.Session, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -252,7 +253,7 @@ func (c *InMemoryFakeClient) GetSession(sessionID string, userID string) (*datab
 }
 
 // GetAgent retrieves an agent by name
-func (c *InMemoryFakeClient) GetAgent(agentName string) (*database.Agent, error) {
+func (c *InMemoryFakeClient) GetAgent(_ context.Context, agentName string) (*database.Agent, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -264,7 +265,7 @@ func (c *InMemoryFakeClient) GetAgent(agentName string) (*database.Agent, error)
 }
 
 // GetTool retrieves a tool by name
-func (c *InMemoryFakeClient) GetTool(toolName string) (*database.Tool, error) {
+func (c *InMemoryFakeClient) GetTool(_ context.Context, toolName string) (*database.Tool, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -276,7 +277,7 @@ func (c *InMemoryFakeClient) GetTool(toolName string) (*database.Tool, error) {
 }
 
 // GetToolServer retrieves a tool server by name
-func (c *InMemoryFakeClient) GetToolServer(serverName string) (*database.ToolServer, error) {
+func (c *InMemoryFakeClient) GetToolServer(_ context.Context, serverName string) (*database.ToolServer, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -288,7 +289,7 @@ func (c *InMemoryFakeClient) GetToolServer(serverName string) (*database.ToolSer
 }
 
 // ListFeedback lists all feedback for a user
-func (c *InMemoryFakeClient) ListFeedback(userID string) ([]database.Feedback, error) {
+func (c *InMemoryFakeClient) ListFeedback(_ context.Context, userID string) ([]database.Feedback, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -301,7 +302,7 @@ func (c *InMemoryFakeClient) ListFeedback(userID string) ([]database.Feedback, e
 	return result, nil
 }
 
-func (c *InMemoryFakeClient) ListTasksForSession(sessionID string) ([]*protocol.Task, error) {
+func (c *InMemoryFakeClient) ListTasksForSession(_ context.Context, sessionID string) ([]*protocol.Task, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -319,7 +320,7 @@ func (c *InMemoryFakeClient) ListTasksForSession(sessionID string) ([]*protocol.
 }
 
 // ListSessions lists all sessions for a user
-func (c *InMemoryFakeClient) ListSessions(userID string) ([]database.Session, error) {
+func (c *InMemoryFakeClient) ListSessions(_ context.Context, userID string) ([]database.Session, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -336,7 +337,7 @@ func (c *InMemoryFakeClient) ListSessions(userID string) ([]database.Session, er
 }
 
 // ListSessionsForAgent lists all sessions for an agent
-func (c *InMemoryFakeClient) ListSessionsForAgent(agentID string, userID string) ([]database.Session, error) {
+func (c *InMemoryFakeClient) ListSessionsForAgent(_ context.Context, agentID string, userID string) ([]database.Session, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -353,7 +354,7 @@ func (c *InMemoryFakeClient) ListSessionsForAgent(agentID string, userID string)
 }
 
 // ListAgents lists all agents
-func (c *InMemoryFakeClient) ListAgents() ([]database.Agent, error) {
+func (c *InMemoryFakeClient) ListAgents(_ context.Context) ([]database.Agent, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -368,7 +369,7 @@ func (c *InMemoryFakeClient) ListAgents() ([]database.Agent, error) {
 }
 
 // ListToolServers lists all tool servers
-func (c *InMemoryFakeClient) ListToolServers() ([]database.ToolServer, error) {
+func (c *InMemoryFakeClient) ListToolServers(_ context.Context) ([]database.ToolServer, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -383,7 +384,7 @@ func (c *InMemoryFakeClient) ListToolServers() ([]database.ToolServer, error) {
 }
 
 // ListTools lists all tools for a user
-func (c *InMemoryFakeClient) ListTools() ([]database.Tool, error) {
+func (c *InMemoryFakeClient) ListTools(_ context.Context) ([]database.Tool, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -398,7 +399,7 @@ func (c *InMemoryFakeClient) ListTools() ([]database.Tool, error) {
 }
 
 // ListToolsForServer lists all tools for a specific server and toolserver type
-func (c *InMemoryFakeClient) ListToolsForServer(serverName string, groupKind string) ([]database.Tool, error) {
+func (c *InMemoryFakeClient) ListToolsForServer(_ context.Context, serverName string, groupKind string) ([]database.Tool, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -420,7 +421,7 @@ func (c *InMemoryFakeClient) ListToolsForServer(serverName string, groupKind str
 	return result, nil
 }
 
-func (c *InMemoryFakeClient) ListPushNotifications(taskID string) ([]*protocol.TaskPushNotificationConfig, error) {
+func (c *InMemoryFakeClient) ListPushNotifications(_ context.Context, taskID string) ([]*protocol.TaskPushNotificationConfig, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -433,7 +434,7 @@ func (c *InMemoryFakeClient) ListPushNotifications(taskID string) ([]*protocol.T
 }
 
 // ListEventsForSession retrieves events for a specific session
-func (c *InMemoryFakeClient) ListEventsForSession(sessionID, userID string, options database.QueryOptions) ([]*database.Event, error) {
+func (c *InMemoryFakeClient) ListEventsForSession(_ context.Context, sessionID, userID string, options database.QueryOptions) ([]*database.Event, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -457,7 +458,7 @@ func (c *InMemoryFakeClient) ListEventsForSession(sessionID, userID string, opti
 }
 
 // RefreshToolsForServer refreshes a tool server
-func (c *InMemoryFakeClient) RefreshToolsForServer(serverName string, groupKind string, tools ...*v1alpha2.MCPTool) error {
+func (c *InMemoryFakeClient) RefreshToolsForServer(_ context.Context, serverName string, groupKind string, tools ...*v1alpha2.MCPTool) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -482,7 +483,7 @@ func (c *InMemoryFakeClient) RefreshToolsForServer(serverName string, groupKind 
 }
 
 // UpdateSession updates a session
-func (c *InMemoryFakeClient) UpdateSession(session *database.Session) error {
+func (c *InMemoryFakeClient) UpdateSession(_ context.Context, session *database.Session) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -492,7 +493,7 @@ func (c *InMemoryFakeClient) UpdateSession(session *database.Session) error {
 }
 
 // UpdateToolServer updates a tool server
-func (c *InMemoryFakeClient) UpdateToolServer(server *database.ToolServer) error {
+func (c *InMemoryFakeClient) UpdateToolServer(_ context.Context, server *database.ToolServer) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -501,7 +502,7 @@ func (c *InMemoryFakeClient) UpdateToolServer(server *database.ToolServer) error
 }
 
 // UpdateAgent updates an agent record
-func (c *InMemoryFakeClient) UpdateAgent(agent *database.Agent) error {
+func (c *InMemoryFakeClient) UpdateAgent(_ context.Context, agent *database.Agent) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -510,7 +511,7 @@ func (c *InMemoryFakeClient) UpdateAgent(agent *database.Agent) error {
 }
 
 // UpdateTask updates a task record
-func (c *InMemoryFakeClient) UpdateTask(task *database.Task) error {
+func (c *InMemoryFakeClient) UpdateTask(_ context.Context, task *database.Task) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -555,7 +556,7 @@ func (c *InMemoryFakeClient) Clear() {
 }
 
 // UpsertAgent upserts an agent record
-func (c *InMemoryFakeClient) UpsertAgent(agent *database.Agent) error {
+func (c *InMemoryFakeClient) UpsertAgent(_ context.Context, agent *database.Agent) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -569,7 +570,7 @@ func (c *InMemoryFakeClient) checkpointKey(userID, threadID, checkpointNS, check
 }
 
 // StoreCheckpoint stores a LangGraph checkpoint
-func (c *InMemoryFakeClient) StoreCheckpoint(checkpoint *database.LangGraphCheckpoint) error {
+func (c *InMemoryFakeClient) StoreCheckpoint(_ context.Context, checkpoint *database.LangGraphCheckpoint) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -590,7 +591,7 @@ func (c *InMemoryFakeClient) StoreCheckpoint(checkpoint *database.LangGraphCheck
 }
 
 // StoreCheckpointWrites stores checkpoint writes
-func (c *InMemoryFakeClient) StoreCheckpointWrites(writes []*database.LangGraphCheckpointWrite) error {
+func (c *InMemoryFakeClient) StoreCheckpointWrites(_ context.Context, writes []*database.LangGraphCheckpointWrite) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -610,7 +611,7 @@ func (c *InMemoryFakeClient) StoreCheckpointWrites(writes []*database.LangGraphC
 }
 
 // GetLatestCheckpoint retrieves the most recent checkpoint for a thread
-func (c *InMemoryFakeClient) GetLatestCheckpoint(userID, threadID, checkpointNS string) (*database.LangGraphCheckpoint, []*database.LangGraphCheckpointWrite, error) {
+func (c *InMemoryFakeClient) GetLatestCheckpoint(_ context.Context, userID, threadID, checkpointNS string) (*database.LangGraphCheckpoint, []*database.LangGraphCheckpointWrite, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -638,7 +639,7 @@ func (c *InMemoryFakeClient) GetLatestCheckpoint(userID, threadID, checkpointNS 
 }
 
 // GetCheckpoint retrieves a specific checkpoint by ID
-func (c *InMemoryFakeClient) GetCheckpoint(userID, threadID, checkpointNS, checkpointID string) (*database.LangGraphCheckpoint, []*database.LangGraphCheckpointWrite, error) {
+func (c *InMemoryFakeClient) GetCheckpoint(_ context.Context, userID, threadID, checkpointNS, checkpointID string) (*database.LangGraphCheckpoint, []*database.LangGraphCheckpointWrite, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -655,7 +656,7 @@ func (c *InMemoryFakeClient) GetCheckpoint(userID, threadID, checkpointNS, check
 }
 
 // ListCheckpoints lists checkpoints for a thread, optionally filtered by checkpointID
-func (c *InMemoryFakeClient) ListCheckpoints(userID, threadID, checkpointNS string, checkpointID *string, limit int) ([]*database.LangGraphCheckpointTuple, error) {
+func (c *InMemoryFakeClient) ListCheckpoints(_ context.Context, userID, threadID, checkpointNS string, checkpointID *string, limit int) ([]*database.LangGraphCheckpointTuple, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -700,7 +701,7 @@ func (c *InMemoryFakeClient) ListCheckpoints(userID, threadID, checkpointNS stri
 }
 
 // DeleteCheckpoint deletes a checkpoint and its writes atomically
-func (c *InMemoryFakeClient) DeleteCheckpoint(userID, threadID string) error {
+func (c *InMemoryFakeClient) DeleteCheckpoint(_ context.Context, userID, threadID string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -722,7 +723,7 @@ func (c *InMemoryFakeClient) DeleteCheckpoint(userID, threadID string) error {
 }
 
 // ListWrites retrieves writes for a specific checkpoint
-func (c *InMemoryFakeClient) ListWrites(userID, threadID, checkpointNS, checkpointID string, offset, limit int) ([]*database.LangGraphCheckpointWrite, error) {
+func (c *InMemoryFakeClient) ListWrites(_ context.Context, userID, threadID, checkpointNS, checkpointID string, offset, limit int) ([]*database.LangGraphCheckpointWrite, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -750,7 +751,7 @@ func (c *InMemoryFakeClient) ListWrites(userID, threadID, checkpointNS, checkpoi
 // CrewAI methods
 
 // StoreCrewAIMemory stores CrewAI agent memory
-func (c *InMemoryFakeClient) StoreCrewAIMemory(memory *database.CrewAIAgentMemory) error {
+func (c *InMemoryFakeClient) StoreCrewAIMemory(_ context.Context, memory *database.CrewAIAgentMemory) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -765,7 +766,7 @@ func (c *InMemoryFakeClient) StoreCrewAIMemory(memory *database.CrewAIAgentMemor
 }
 
 // SearchCrewAIMemoryByTask searches CrewAI agent memory by task description across all agents for a session
-func (c *InMemoryFakeClient) SearchCrewAIMemoryByTask(userID, threadID, taskDescription string, limit int) ([]*database.CrewAIAgentMemory, error) {
+func (c *InMemoryFakeClient) SearchCrewAIMemoryByTask(_ context.Context, userID, threadID, taskDescription string, limit int) ([]*database.CrewAIAgentMemory, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -842,7 +843,7 @@ func (c *InMemoryFakeClient) SearchCrewAIMemoryByTask(userID, threadID, taskDesc
 }
 
 // ResetCrewAIMemory deletes all CrewAI agent memory for a session
-func (c *InMemoryFakeClient) ResetCrewAIMemory(userID, threadID string) error {
+func (c *InMemoryFakeClient) ResetCrewAIMemory(_ context.Context, userID, threadID string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -868,7 +869,7 @@ func (c *InMemoryFakeClient) ResetCrewAIMemory(userID, threadID string) error {
 }
 
 // StoreCrewAIFlowState stores CrewAI flow state
-func (c *InMemoryFakeClient) StoreCrewAIFlowState(state *database.CrewAIFlowState) error {
+func (c *InMemoryFakeClient) StoreCrewAIFlowState(_ context.Context, state *database.CrewAIFlowState) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -883,7 +884,7 @@ func (c *InMemoryFakeClient) StoreCrewAIFlowState(state *database.CrewAIFlowStat
 }
 
 // GetCrewAIFlowState retrieves CrewAI flow state
-func (c *InMemoryFakeClient) GetCrewAIFlowState(userID, threadID string) (*database.CrewAIFlowState, error) {
+func (c *InMemoryFakeClient) GetCrewAIFlowState(_ context.Context, userID, threadID string) (*database.CrewAIFlowState, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -903,7 +904,7 @@ func (c *InMemoryFakeClient) memoryKey(agentName, userID, id string) string {
 }
 
 // StoreAgentMemory stores agent memory
-func (c *InMemoryFakeClient) StoreAgentMemory(memory *database.Memory) error {
+func (c *InMemoryFakeClient) StoreAgentMemory(_ context.Context, memory *database.Memory) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -916,7 +917,7 @@ func (c *InMemoryFakeClient) StoreAgentMemory(memory *database.Memory) error {
 }
 
 // StoreAgentMemories stores multiple agent memories
-func (c *InMemoryFakeClient) StoreAgentMemories(memories []*database.Memory) error {
+func (c *InMemoryFakeClient) StoreAgentMemories(_ context.Context, memories []*database.Memory) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -951,7 +952,7 @@ func cosineSimilarity(a, b []float32) float64 {
 }
 
 // SearchAgentMemory searches agent memory by vector similarity
-func (c *InMemoryFakeClient) SearchAgentMemory(agentName, userID string, embedding pgvector.Vector, limit int) ([]database.AgentMemorySearchResult, error) {
+func (c *InMemoryFakeClient) SearchAgentMemory(_ context.Context, agentName, userID string, embedding pgvector.Vector, limit int) ([]database.AgentMemorySearchResult, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -992,7 +993,7 @@ func (c *InMemoryFakeClient) SearchAgentMemory(agentName, userID string, embeddi
 }
 
 // ListAgentMemories lists agent memories ordered by access count descending
-func (c *InMemoryFakeClient) ListAgentMemories(agentName, userID string) ([]database.Memory, error) {
+func (c *InMemoryFakeClient) ListAgentMemories(_ context.Context, agentName, userID string) ([]database.Memory, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -1017,7 +1018,7 @@ func (c *InMemoryFakeClient) ListAgentMemories(agentName, userID string) ([]data
 }
 
 // DeleteAgentMemory deletes all agent memory for a given agent and user
-func (c *InMemoryFakeClient) DeleteAgentMemory(agentName, userID string) error {
+func (c *InMemoryFakeClient) DeleteAgentMemory(_ context.Context, agentName, userID string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -1030,7 +1031,7 @@ func (c *InMemoryFakeClient) DeleteAgentMemory(agentName, userID string) error {
 }
 
 // PruneExpiredMemories removes all memories whose ExpiresAt is in the past
-func (c *InMemoryFakeClient) PruneExpiredMemories() error {
+func (c *InMemoryFakeClient) PruneExpiredMemories(_ context.Context) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/go/core/internal/httpserver/handlers/agents_test.go
+++ b/go/core/internal/httpserver/handlers/agents_test.go
@@ -2,6 +2,7 @@ package handlers_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -89,7 +90,7 @@ func createAgent(client database.Client, agent *v1alpha2.Agent) {
 		Config: &adk.AgentConfig{},
 		ID:     common.GetObjectRef(agent),
 	}
-	client.StoreAgent(dbAgent) //nolint:errcheck
+	client.StoreAgent(context.Background(), dbAgent) //nolint:errcheck
 }
 
 func TestHandleGetAgent(t *testing.T) {

--- a/go/core/internal/httpserver/handlers/checkpoints.go
+++ b/go/core/internal/httpserver/handlers/checkpoints.go
@@ -114,7 +114,7 @@ func (h *CheckpointsHandler) HandlePutCheckpoint(w ErrorResponseWriter, r *http.
 		CheckpointType:     req.Type,
 	}
 	// Store checkpoint and writes atomically
-	if err := h.DatabaseService.StoreCheckpoint(checkpoint); err != nil {
+	if err := h.DatabaseService.StoreCheckpoint(r.Context(), checkpoint); err != nil {
 		w.RespondWithError(errors.NewInternalServerError("Failed to store checkpoint", err))
 		return
 	}
@@ -157,7 +157,7 @@ func (h *CheckpointsHandler) HandleListCheckpoints(w ErrorResponseWriter, r *htt
 	log = log.WithValues("userID", userID, "threadID", threadID, "checkpointNS", checkpointNS, "limit", limit)
 
 	log.V(1).Info("Listing checkpoints")
-	checkpoints, err := h.DatabaseService.ListCheckpoints(userID, threadID, checkpointNS, checkpointID, limit)
+	checkpoints, err := h.DatabaseService.ListCheckpoints(r.Context(), userID, threadID, checkpointNS, checkpointID, limit)
 	if err != nil {
 		w.RespondWithError(errors.NewInternalServerError("Failed to list checkpoints", err))
 		return
@@ -243,7 +243,7 @@ func (h *CheckpointsHandler) HandlePutWrites(w ErrorResponseWriter, r *http.Requ
 	log.V(1).Info("Storing checkpoint with writes", "writesCount", len(writes))
 
 	// Store checkpoint and writes atomically
-	if err := h.DatabaseService.StoreCheckpointWrites(writes); err != nil {
+	if err := h.DatabaseService.StoreCheckpointWrites(r.Context(), writes); err != nil {
 		w.RespondWithError(errors.NewInternalServerError("Failed to store checkpoint writes", err))
 		return
 	}
@@ -271,7 +271,7 @@ func (h *CheckpointsHandler) HandleDeleteThread(w ErrorResponseWriter, r *http.R
 
 	log = log.WithValues("userID", userID, "threadID", threadID)
 
-	if err := h.DatabaseService.DeleteCheckpoint(userID, threadID); err != nil {
+	if err := h.DatabaseService.DeleteCheckpoint(r.Context(), userID, threadID); err != nil {
 		w.RespondWithError(errors.NewInternalServerError("Failed to delete thread", err))
 		return
 	}

--- a/go/core/internal/httpserver/handlers/crewai.go
+++ b/go/core/internal/httpserver/handlers/crewai.go
@@ -90,7 +90,7 @@ func (h *CrewAIHandler) HandleStoreMemory(w ErrorResponseWriter, r *http.Request
 	}
 
 	// Store memory
-	if err := h.DatabaseService.StoreCrewAIMemory(memory); err != nil {
+	if err := h.DatabaseService.StoreCrewAIMemory(r.Context(), memory); err != nil {
 		w.RespondWithError(errors.NewInternalServerError("Failed to store CrewAI memory", err))
 		return
 	}
@@ -132,7 +132,7 @@ func (h *CrewAIHandler) HandleGetMemory(w ErrorResponseWriter, r *http.Request) 
 	// Otherwise, list memories for a specific agent
 	if taskDescription != "" {
 		log.V(1).Info("Searching CrewAI memory by task description")
-		memories, err = h.DatabaseService.SearchCrewAIMemoryByTask(userID, threadID, taskDescription, limit)
+		memories, err = h.DatabaseService.SearchCrewAIMemoryByTask(r.Context(), userID, threadID, taskDescription, limit)
 	} else {
 		w.RespondWithError(errors.NewBadRequestError("Either agent_id or q (task description) parameter is required", nil))
 		return
@@ -182,7 +182,7 @@ func (h *CrewAIHandler) HandleResetMemory(w ErrorResponseWriter, r *http.Request
 	log = log.WithValues("userID", userID, "threadID", threadID)
 
 	log.V(1).Info("Resetting CrewAI memory")
-	err = h.DatabaseService.ResetCrewAIMemory(userID, threadID)
+	err = h.DatabaseService.ResetCrewAIMemory(r.Context(), userID, threadID)
 	if err != nil {
 		w.RespondWithError(errors.NewInternalServerError("Failed to reset CrewAI memory", err))
 		return
@@ -241,7 +241,7 @@ func (h *CrewAIHandler) HandleStoreFlowState(w ErrorResponseWriter, r *http.Requ
 	}
 
 	// Store flow state
-	if err := h.DatabaseService.StoreCrewAIFlowState(state); err != nil {
+	if err := h.DatabaseService.StoreCrewAIFlowState(r.Context(), state); err != nil {
 		w.RespondWithError(errors.NewInternalServerError("Failed to store CrewAI flow state", err))
 		return
 	}
@@ -270,7 +270,7 @@ func (h *CrewAIHandler) HandleGetFlowState(w ErrorResponseWriter, r *http.Reques
 	log = log.WithValues("userID", userID, "threadID", threadID)
 
 	log.V(1).Info("Getting CrewAI flow state")
-	state, err := h.DatabaseService.GetCrewAIFlowState(userID, threadID)
+	state, err := h.DatabaseService.GetCrewAIFlowState(r.Context(), userID, threadID)
 	if err != nil {
 		w.RespondWithError(errors.NewInternalServerError("Failed to get CrewAI flow state", err))
 		return

--- a/go/core/internal/httpserver/handlers/feedback.go
+++ b/go/core/internal/httpserver/handlers/feedback.go
@@ -50,7 +50,7 @@ func (h *FeedbackHandler) HandleCreateFeedback(w ErrorResponseWriter, r *http.Re
 		return
 	}
 
-	err = h.DatabaseService.StoreFeedback(&feedbackReq)
+	err = h.DatabaseService.StoreFeedback(r.Context(), &feedbackReq)
 	if err != nil {
 		log.Error(err, "Failed to create feedback")
 		w.RespondWithError(errors.NewInternalServerError("Failed to create feedback", err))
@@ -74,7 +74,7 @@ func (h *FeedbackHandler) HandleListFeedback(w ErrorResponseWriter, r *http.Requ
 		return
 	}
 
-	feedback, err := h.DatabaseService.ListFeedback(userID)
+	feedback, err := h.DatabaseService.ListFeedback(r.Context(), userID)
 	if err != nil {
 		log.Error(err, "Failed to list feedback")
 		w.RespondWithError(errors.NewInternalServerError("Failed to list feedback", err))

--- a/go/core/internal/httpserver/handlers/memory.go
+++ b/go/core/internal/httpserver/handlers/memory.go
@@ -105,7 +105,7 @@ func (h *MemoryHandler) AddSession(w ErrorResponseWriter, r *http.Request) {
 		ExpiresAt: &expiresAt,
 	}
 
-	if err := h.DatabaseService.StoreAgentMemory(memory); err != nil {
+	if err := h.DatabaseService.StoreAgentMemory(r.Context(), memory); err != nil {
 		log.Printf("Failed to store agent memory: %v", err)
 		RespondWithError(w, http.StatusInternalServerError, fmt.Sprintf("failed to save memory: %v", err))
 		return
@@ -173,7 +173,7 @@ func (h *MemoryHandler) AddSessionBatch(w ErrorResponseWriter, r *http.Request) 
 		})
 	}
 
-	if err := h.DatabaseService.StoreAgentMemories(memories); err != nil {
+	if err := h.DatabaseService.StoreAgentMemories(r.Context(), memories); err != nil {
 		log.Printf("Failed to store agent memory batch: %v", err)
 		RespondWithError(w, http.StatusInternalServerError, fmt.Sprintf("failed to save memory batch: %v", err))
 		return
@@ -209,7 +209,7 @@ func (h *MemoryHandler) Search(w ErrorResponseWriter, r *http.Request) {
 	vector := pgvector.NewVector(req.Vector)
 
 	// Update DB client call to pass pgvector.Vector
-	results, err := h.DatabaseService.SearchAgentMemory(req.AgentName, req.UserID, vector, req.Limit)
+	results, err := h.DatabaseService.SearchAgentMemory(r.Context(), req.AgentName, req.UserID, vector, req.Limit)
 	if err != nil {
 		RespondWithError(w, http.StatusInternalServerError, fmt.Sprintf("search failed: %v", err))
 		return
@@ -250,7 +250,7 @@ func (h *MemoryHandler) List(w ErrorResponseWriter, r *http.Request) {
 		return
 	}
 
-	memories, err := h.DatabaseService.ListAgentMemories(agentName, userID)
+	memories, err := h.DatabaseService.ListAgentMemories(r.Context(), agentName, userID)
 	if err != nil {
 		log.Printf("Failed to list agent memories: %v", err)
 		RespondWithError(w, http.StatusInternalServerError, fmt.Sprintf("failed to list memories: %v", err))
@@ -284,7 +284,7 @@ func (h *MemoryHandler) Delete(w ErrorResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.DatabaseService.DeleteAgentMemory(agentName, userID); err != nil {
+	if err := h.DatabaseService.DeleteAgentMemory(r.Context(), agentName, userID); err != nil {
 		log.Printf("Failed to delete agent memory: %v", err)
 		RespondWithError(w, http.StatusInternalServerError, fmt.Sprintf("failed to delete memory: %v", err))
 		return

--- a/go/core/internal/httpserver/handlers/sessions.go
+++ b/go/core/internal/httpserver/handlers/sessions.go
@@ -53,14 +53,14 @@ func (h *SessionsHandler) HandleGetSessionsForAgent(w ErrorResponseWriter, r *ht
 	}
 
 	// Get agent ID from agent ref
-	agent, err := h.DatabaseService.GetAgent(utils.ConvertToPythonIdentifier(namespace + "/" + agentName))
+	agent, err := h.DatabaseService.GetAgent(r.Context(), utils.ConvertToPythonIdentifier(namespace+"/"+agentName))
 	if err != nil {
 		w.RespondWithError(errors.NewNotFoundError("Agent not found", err))
 		return
 	}
 
 	log.V(1).Info("Getting sessions for agent from database")
-	sessions, err := h.DatabaseService.ListSessionsForAgent(agent.ID, userID)
+	sessions, err := h.DatabaseService.ListSessionsForAgent(r.Context(), agent.ID, userID)
 	if err != nil {
 		w.RespondWithError(errors.NewInternalServerError("Failed to get sessions for agent", err))
 		return
@@ -83,7 +83,7 @@ func (h *SessionsHandler) HandleListSessions(w ErrorResponseWriter, r *http.Requ
 	log = log.WithValues("userID", userID)
 
 	log.V(1).Info("Listing sessions from database")
-	sessions, err := h.DatabaseService.ListSessions(userID)
+	sessions, err := h.DatabaseService.ListSessions(r.Context(), userID)
 	if err != nil {
 		w.RespondWithError(errors.NewInternalServerError("Failed to list sessions", err))
 		return
@@ -125,7 +125,7 @@ func (h *SessionsHandler) HandleCreateSession(w ErrorResponseWriter, r *http.Req
 
 	log.V(1).Info("Getting agent from database", "session_request", sessionRequest)
 
-	agent, err := h.DatabaseService.GetAgent(utils.ConvertToPythonIdentifier(*sessionRequest.AgentRef))
+	agent, err := h.DatabaseService.GetAgent(r.Context(), utils.ConvertToPythonIdentifier(*sessionRequest.AgentRef))
 	if err != nil {
 		w.RespondWithError(errors.NewBadRequestError(fmt.Sprintf("Agent ref is invalid, please check the agent ref %s", *sessionRequest.AgentRef), err))
 		return
@@ -142,7 +142,7 @@ func (h *SessionsHandler) HandleCreateSession(w ErrorResponseWriter, r *http.Req
 		"agentRef", sessionRequest.AgentRef,
 		"name", sessionRequest.Name)
 
-	if err := h.DatabaseService.StoreSession(session); err != nil {
+	if err := h.DatabaseService.StoreSession(r.Context(), session); err != nil {
 		w.RespondWithError(errors.NewInternalServerError("Failed to create session", err))
 		return
 	}
@@ -176,7 +176,7 @@ func (h *SessionsHandler) HandleGetSession(w ErrorResponseWriter, r *http.Reques
 	log = log.WithValues("userID", userID)
 
 	log.V(1).Info("Getting session from database")
-	session, err := h.DatabaseService.GetSession(sessionID, userID)
+	session, err := h.DatabaseService.GetSession(r.Context(), sessionID, userID)
 	if err != nil {
 		w.RespondWithError(errors.NewNotFoundError("Session not found", err))
 		return
@@ -207,7 +207,7 @@ func (h *SessionsHandler) HandleGetSession(w ErrorResponseWriter, r *http.Reques
 		}
 	}
 
-	events, err := h.DatabaseService.ListEventsForSession(sessionID, userID, queryOptions)
+	events, err := h.DatabaseService.ListEventsForSession(r.Context(), sessionID, userID, queryOptions)
 	if err != nil {
 		w.RespondWithError(errors.NewInternalServerError("Failed to get events for session", err))
 		return
@@ -248,13 +248,13 @@ func (h *SessionsHandler) HandleUpdateSession(w ErrorResponseWriter, r *http.Req
 		return
 	}
 	// Get existing session
-	session, err := h.DatabaseService.GetSession(*sessionRequest.Name, userID)
+	session, err := h.DatabaseService.GetSession(r.Context(), *sessionRequest.Name, userID)
 	if err != nil {
 		w.RespondWithError(errors.NewNotFoundError("Session not found", err))
 		return
 	}
 
-	agent, err := h.DatabaseService.GetAgent(utils.ConvertToPythonIdentifier(*sessionRequest.AgentRef))
+	agent, err := h.DatabaseService.GetAgent(r.Context(), utils.ConvertToPythonIdentifier(*sessionRequest.AgentRef))
 	if err != nil {
 		w.RespondWithError(errors.NewNotFoundError("Agent not found", err))
 		return
@@ -263,7 +263,7 @@ func (h *SessionsHandler) HandleUpdateSession(w ErrorResponseWriter, r *http.Req
 	// Update fields
 	session.AgentID = &agent.ID
 
-	if err := h.DatabaseService.StoreSession(session); err != nil {
+	if err := h.DatabaseService.StoreSession(r.Context(), session); err != nil {
 		w.RespondWithError(errors.NewInternalServerError("Failed to update session", err))
 		return
 	}
@@ -291,7 +291,7 @@ func (h *SessionsHandler) HandleDeleteSession(w ErrorResponseWriter, r *http.Req
 	}
 	log = log.WithValues("session_id", sessionID)
 
-	if err := h.DatabaseService.DeleteSession(sessionID, userID); err != nil {
+	if err := h.DatabaseService.DeleteSession(r.Context(), sessionID, userID); err != nil {
 		w.RespondWithError(errors.NewInternalServerError("Failed to delete session", err))
 		return
 	}
@@ -320,14 +320,14 @@ func (h *SessionsHandler) HandleListTasksForSession(w ErrorResponseWriter, r *ht
 	log = log.WithValues("userID", userID)
 
 	// Verify session exists
-	_, err = h.DatabaseService.GetSession(sessionID, userID)
+	_, err = h.DatabaseService.GetSession(r.Context(), sessionID, userID)
 	if err != nil {
 		w.RespondWithError(errors.NewNotFoundError("Session not found for given ID", err))
 		return
 	}
 
 	log.V(1).Info("Getting session tasks from database")
-	tasks, err := h.DatabaseService.ListTasksForSession(sessionID)
+	tasks, err := h.DatabaseService.ListTasksForSession(r.Context(), sessionID)
 	if err != nil {
 		w.RespondWithError(errors.NewInternalServerError("Failed to get session runs", err))
 		return
@@ -369,7 +369,7 @@ func (h *SessionsHandler) HandleAddEventToSession(w ErrorResponseWriter, r *http
 	}
 
 	// Get session to verify it exists
-	session, err := h.DatabaseService.GetSession(sessionID, userID)
+	session, err := h.DatabaseService.GetSession(r.Context(), sessionID, userID)
 	if err != nil {
 		w.RespondWithError(errors.NewNotFoundError("Session not found", err))
 		return
@@ -385,7 +385,7 @@ func (h *SessionsHandler) HandleAddEventToSession(w ErrorResponseWriter, r *http
 		Data:      eventData.Data,
 		UserID:    userID,
 	}
-	if err := h.DatabaseService.StoreEvents(event); err != nil {
+	if err := h.DatabaseService.StoreEvents(r.Context(), event); err != nil {
 		w.RespondWithError(errors.NewInternalServerError("Failed to store event", err))
 		return
 	}

--- a/go/core/internal/httpserver/handlers/sessions_test.go
+++ b/go/core/internal/httpserver/handlers/sessions_test.go
@@ -2,6 +2,7 @@ package handlers_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -59,7 +60,7 @@ func TestSessionsHandler(t *testing.T) {
 		agent := &database.Agent{
 			ID: agentRef,
 		}
-		dbClient.StoreAgent(agent) //nolint:errcheck
+		dbClient.StoreAgent(context.Background(), agent) //nolint:errcheck
 		// The fake client should assign an ID, but we'll use a default for testing
 		agent.ID = "1" // Simulate the ID that would be assigned by GORM
 		return agent
@@ -72,7 +73,7 @@ func TestSessionsHandler(t *testing.T) {
 			UserID:  userID,
 			AgentID: &agentID,
 		}
-		dbClient.StoreSession(session) //nolint:errcheck
+		dbClient.StoreSession(context.Background(), session) //nolint:errcheck
 		return session
 	}
 
@@ -287,7 +288,7 @@ func TestSessionsHandler(t *testing.T) {
 				CreatedAt: time.Now().Add(-1 * time.Hour),
 				Data:      "{}",
 			}
-			dbClient.StoreEvents(event1, event2)
+			dbClient.StoreEvents(context.Background(), event1, event2)
 
 			req := httptest.NewRequest("GET", "/api/sessions/"+sessionID+"?order=asc", nil)
 			req = mux.SetURLVars(req, map[string]string{"session_id": sessionID})

--- a/go/core/internal/httpserver/handlers/tasks.go
+++ b/go/core/internal/httpserver/handlers/tasks.go
@@ -29,7 +29,7 @@ func (h *TasksHandler) HandleGetTask(w ErrorResponseWriter, r *http.Request) {
 	}
 	log = log.WithValues("task_id", taskID)
 
-	task, err := h.DatabaseService.GetTask(taskID)
+	task, err := h.DatabaseService.GetTask(r.Context(), taskID)
 	if err != nil {
 		w.RespondWithError(errors.NewNotFoundError("Task not found", err))
 		return
@@ -53,7 +53,7 @@ func (h *TasksHandler) HandleCreateTask(w ErrorResponseWriter, r *http.Request) 
 	}
 	log = log.WithValues("task_id", task.ID)
 
-	if err := h.DatabaseService.StoreTask(&task); err != nil {
+	if err := h.DatabaseService.StoreTask(r.Context(), &task); err != nil {
 		w.RespondWithError(errors.NewInternalServerError("Failed to create task", err))
 		return
 	}
@@ -73,7 +73,7 @@ func (h *TasksHandler) HandleDeleteTask(w ErrorResponseWriter, r *http.Request) 
 	}
 	log = log.WithValues("task_id", taskID)
 
-	if err := h.DatabaseService.DeleteTask(taskID); err != nil {
+	if err := h.DatabaseService.DeleteTask(r.Context(), taskID); err != nil {
 		w.RespondWithError(errors.NewInternalServerError("Failed to delete task", err))
 		return
 	}

--- a/go/core/internal/httpserver/handlers/tools.go
+++ b/go/core/internal/httpserver/handlers/tools.go
@@ -30,7 +30,7 @@ func (h *ToolsHandler) HandleListTools(w ErrorResponseWriter, r *http.Request) {
 	log = log.WithValues("userID", userID)
 
 	log.V(1).Info("Listing tools from database")
-	tools, err := h.DatabaseService.ListTools()
+	tools, err := h.DatabaseService.ListTools(r.Context())
 	if err != nil {
 		w.RespondWithError(errors.NewInternalServerError("Failed to list tools", err))
 		return

--- a/go/core/internal/httpserver/handlers/toolservers.go
+++ b/go/core/internal/httpserver/handlers/toolservers.go
@@ -50,7 +50,7 @@ func (h *ToolServersHandler) HandleListToolServers(w ErrorResponseWriter, r *htt
 		return
 	}
 
-	toolServers, err := h.DatabaseService.ListToolServers()
+	toolServers, err := h.DatabaseService.ListToolServers(r.Context())
 	if err != nil {
 		w.RespondWithError(errors.NewInternalServerError("Failed to list ToolServers from database", err))
 		return
@@ -58,7 +58,7 @@ func (h *ToolServersHandler) HandleListToolServers(w ErrorResponseWriter, r *htt
 
 	toolServerWithTools := make([]api.ToolServerResponse, len(toolServers))
 	for i, toolServer := range toolServers {
-		tools, err := h.DatabaseService.ListToolsForServer(toolServer.Name, toolServer.GroupKind)
+		tools, err := h.DatabaseService.ListToolsForServer(r.Context(), toolServer.Name, toolServer.GroupKind)
 		if err != nil {
 			w.RespondWithError(errors.NewInternalServerError("Failed to list tools for ToolServer from database", err))
 			return
@@ -218,7 +218,7 @@ func (h *ToolServersHandler) HandleDeleteToolServer(w ErrorResponseWriter, r *ht
 
 	// Find the tool server in the database to get its groupKind
 	ref := fmt.Sprintf("%s/%s", namespace, toolServerName)
-	toolServers, err := h.DatabaseService.ListToolServers()
+	toolServers, err := h.DatabaseService.ListToolServers(r.Context())
 	if err != nil {
 		log.Error(err, "Failed to list tool servers from database")
 		w.RespondWithError(errors.NewInternalServerError("Failed to list tool servers from database", err))

--- a/go/core/internal/httpserver/handlers/toolservers_test.go
+++ b/go/core/internal/httpserver/handlers/toolservers_test.go
@@ -85,9 +85,9 @@ func TestToolServersHandler(t *testing.T) {
 			}
 
 			// Store tool servers in database
-			_, err := dbClient.StoreToolServer(toolServer1)
+			_, err := dbClient.StoreToolServer(context.Background(), toolServer1)
 			require.NoError(t, err)
-			_, err = dbClient.StoreToolServer(toolServer2)
+			_, err = dbClient.StoreToolServer(context.Background(), toolServer2)
 			require.NoError(t, err)
 
 			// Create test tools in database
@@ -97,7 +97,7 @@ func TestToolServersHandler(t *testing.T) {
 				GroupKind:   "kagent.dev/RemoteMCPServer",
 				Description: "Test tool",
 			}
-			err = dbClient.CreateTool(tool1)
+			err = dbClient.CreateTool(context.Background(), tool1)
 			require.NoError(t, err)
 
 			req := httptest.NewRequest("GET", "/api/toolservers/", nil)
@@ -442,7 +442,7 @@ func TestToolServersHandler(t *testing.T) {
 			err := kubeClient.Create(context.Background(), toolServer)
 			require.NoError(t, err)
 
-			_, err = dbClient.StoreToolServer(&database.ToolServer{
+			_, err = dbClient.StoreToolServer(context.Background(), &database.ToolServer{
 				Name:      "default/test-toolserver",
 				GroupKind: "RemoteMCPServer.kagent.dev",
 			})

--- a/go/core/internal/httpserver/server.go
+++ b/go/core/internal/httpserver/server.go
@@ -166,7 +166,7 @@ func (m *MemoryCleanupRunnable) Start(ctx context.Context) error {
 	for {
 		select {
 		case <-ticker.C:
-			if err := m.DbClient.PruneExpiredMemories(); err != nil {
+			if err := m.DbClient.PruneExpiredMemories(ctx); err != nil {
 				log.Error(err, "Failed to prune expired memories")
 			}
 		case <-ctx.Done():


### PR DESCRIPTION
## Description
Closes: #1488

- Add context.Context as the first parameter to all Client interface methods in the database layer
- Update `gormClient`, `fakeClient`, and all HTTP handler/controller call sites to pass context through
- Enables request cancellation and tracing to propagate from HTTP handlers and the controller reconciler down to database operations

# Testing

- Existing unit tests updated to pass `context.Background()` — all pass locally
- Fake client updated to match new interface signatures
- No behavioral changes; purely a mechanical refactor to follow Go context idioms