### PR TITLE
fix: update otel tracing config for langgraph agent to use agent specific service name

### DIFF
--- a/python/packages/kagent-langgraph/src/kagent/langgraph/_a2a.py
+++ b/python/packages/kagent-langgraph/src/kagent/langgraph/_a2a.py
@@ -126,7 +126,7 @@ class KAgentApp:
         # Configure tracing/instrumentation if enabled
         if self._enable_tracing:
             try:
-                configure_tracing(app)
+                configure_tracing(self.config.name, self.config.namespace, app)
                 logger.info("Tracing configured for KAgent LangGraph app")
             except Exception:
                 logger.exception("Failed to configure tracing")


### PR DESCRIPTION
### Description: 

fix: update otel tracing config for langgraph agent to use agent specific service name instead of hardcoded `kagent` service name. 

Related [PR] (https://github.com/kagent-dev/kagent/pull/1257)

