### PR TITLE
fix(ui): correctly display token usage across sessions

### DIFF
--- a/python/packages/kagent-adk/src/kagent/adk/_agent_executor.py
+++ b/python/packages/kagent-adk/src/kagent/adk/_agent_executor.py
@@ -53,7 +53,7 @@ from kagent.core.tracing._span_processor import (
 )
 
 from ._mcp_toolset import is_anyio_cross_task_cancel_scope_error
-from .converters.event_converter import convert_event_to_a2a_events
+from .converters.event_converter import convert_event_to_a2a_events, serialize_metadata_value
 from .converters.part_converter import convert_a2a_part_to_genai_part, convert_genai_part_to_a2a_part
 from .converters.request_converter import convert_a2a_request_to_adk_run_args
 
@@ -585,6 +585,7 @@ class A2aAgentExecutor(UpstreamA2aAgentExecutor):
         # For streaming A2A update events, the invocation_id is added through event converter
         # This adds the invocation_id of the run to the metadata of the FINAL event (completed or failed)
         real_invocation_id: str | None = None
+        last_usage_metadata = None
 
         task_result_aggregator = TaskResultAggregator()
         async with Aclosing(runner.run_async(**run_args)) as agen:
@@ -594,6 +595,12 @@ class A2aAgentExecutor(UpstreamA2aAgentExecutor):
                 if event_inv_id and not real_invocation_id:
                     real_invocation_id = event_inv_id
                     run_metadata[get_kagent_metadata_key("invocation_id")] = real_invocation_id
+
+                # Track the last usage_metadata so it can be included in the final
+                # event's run_metadata. The A2A task_manager merges run_metadata into
+                # task.metadata, making it available to callers (e.g. KAgentRemoteA2ATool).
+                if getattr(adk_event, "usage_metadata", None) is not None:
+                    last_usage_metadata = adk_event.usage_metadata
 
                 for a2a_event in convert_event_to_a2a_events(
                     adk_event, invocation_context, context.task_id, context.context_id
@@ -607,6 +614,11 @@ class A2aAgentExecutor(UpstreamA2aAgentExecutor):
                 # Break on confirmation events that use long running tools
                 if getattr(adk_event, "long_running_tool_ids", None):
                     break
+
+        # Attach the last LLM usage to run_metadata so the A2A task_manager
+        # merges it into task.metadata on the completed Task object.
+        if last_usage_metadata is not None:
+            run_metadata[get_kagent_metadata_key("usage_metadata")] = serialize_metadata_value(last_usage_metadata)
 
         # publish the task result event - this is final
         if (

--- a/python/packages/kagent-adk/src/kagent/adk/_remote_a2a_tool.py
+++ b/python/packages/kagent-adk/src/kagent/adk/_remote_a2a_tool.py
@@ -83,6 +83,21 @@ def _extract_text_from_task(task: Task) -> str:
     return ""
 
 
+def _extract_usage_from_task(task: Task) -> Optional[dict]:
+    """Extract kagent_usage_metadata from a completed task.
+
+    The A2A task_manager merges the final TaskStatusUpdateEvent.metadata into
+    task.metadata. The agent executor now adds the last LLM invocation's
+    usage_metadata to run_metadata before publishing the final event, so it
+    is available here for non-streaming callers like KAgentRemoteA2ATool.
+    """
+    if task.metadata:
+        usage = task.metadata.get("kagent_usage_metadata")
+        if usage and isinstance(usage, dict):
+            return usage
+    return None
+
+
 class KAgentRemoteA2ATool(BaseTool):
     """A tool that calls a remote A2A agent and propagates HITL state."""
 
@@ -215,8 +230,13 @@ class KAgentRemoteA2ATool(BaseTool):
             error_text = _extract_text_from_task(task)
             return error_text or f"Remote agent '{self.name}' failed."
 
-        # completed or any other terminal state
-        return _extract_text_from_task(task) or ""
+        # completed — include the sub-agent's final LLM usage from task.metadata
+        # so the parent can display it on the AgentCall card in the UI.
+        result_text = _extract_text_from_task(task)
+        usage = _extract_usage_from_task(task)
+        if usage:
+            return {"result": result_text, "kagent_usage_metadata": usage}
+        return result_text or ""
 
     def _handle_input_required(self, task: Task, tool_context: ToolContext) -> dict[str, Any]:
         """Handle a subagent that returned input_required (HITL).
@@ -351,7 +371,11 @@ class KAgentRemoteA2ATool(BaseTool):
             error_text = _extract_text_from_task(task)
             return error_text or f"Remote agent '{subagent_name}' failed after resume."
 
-        return _extract_text_from_task(task) or ""
+        result_text = _extract_text_from_task(task)
+        usage = _extract_usage_from_task(task)
+        if usage:
+            return {"result": result_text, "kagent_usage_metadata": usage}
+        return result_text or ""
 
     @staticmethod
     def _extract_text_from_message(message: A2AMessage) -> str:

--- a/python/packages/kagent-adk/src/kagent/adk/converters/event_converter.py
+++ b/python/packages/kagent-adk/src/kagent/adk/converters/event_converter.py
@@ -33,7 +33,7 @@ ARTIFACT_ID_SEPARATOR = "-"
 logger = logging.getLogger("kagent_adk." + __name__)
 
 
-def _serialize_metadata_value(value: Any) -> str:
+def serialize_metadata_value(value: Any) -> str:
     """Safely serializes metadata values to string format.
 
     Args:
@@ -90,7 +90,7 @@ def _get_context_metadata(event: Event, invocation_context: InvocationContext) -
 
         for field_name, field_value in optional_fields:
             if field_value is not None:
-                metadata[get_kagent_metadata_key(field_name)] = _serialize_metadata_value(field_value)
+                metadata[get_kagent_metadata_key(field_name)] = serialize_metadata_value(field_value)
 
         return metadata
 

--- a/ui/src/components/ToolDisplay.tsx
+++ b/ui/src/components/ToolDisplay.tsx
@@ -1,10 +1,11 @@
 import { useState } from "react";
-import { FunctionCall } from "@/types";
+import { FunctionCall, TokenStats } from "@/types";
 import { ScrollArea } from "@radix-ui/react-scroll-area";
 import { FunctionSquare, CheckCircle, Clock, Code, ChevronUp, ChevronDown, Loader2, Text, Check, Copy, AlertCircle, ShieldAlert } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import TokenStatsTooltip from "@/components/chat/TokenStatsTooltip";
 import { convertToUserFriendlyName } from "@/lib/utils";
 
 export type ToolCallStatus = "requested" | "executing" | "completed" | "pending_approval" | "approved" | "rejected";
@@ -23,9 +24,10 @@ interface ToolDisplayProps {
   subagentName?: string;
   onApprove?: () => void;
   onReject?: (reason?: string) => void;
+  tokenStats?: TokenStats;
 }
 
-const ToolDisplay = ({ call, result, status = "requested", isError = false, isDecided = false, subagentName, onApprove, onReject }: ToolDisplayProps) => {
+const ToolDisplay = ({ call, result, status = "requested", isError = false, isDecided = false, subagentName, onApprove, onReject, tokenStats }: ToolDisplayProps) => {
   const [areArgumentsExpanded, setAreArgumentsExpanded] = useState(status === "pending_approval");
   const [areResultsExpanded, setAreResultsExpanded] = useState(false);
   const [isCopied, setIsCopied] = useState(false);
@@ -166,7 +168,8 @@ const ToolDisplay = ({ call, result, status = "requested", isError = false, isDe
           )}
           <div className="font-light">{call.id}</div>
         </CardTitle>
-        <div className="flex justify-center items-center text-xs">
+        <div className="flex items-center gap-2 text-xs">
+          {tokenStats && <TokenStatsTooltip stats={tokenStats} />}
           {getStatusDisplay()}
         </div>
       </CardHeader>

--- a/ui/src/components/chat/AgentCallDisplay.tsx
+++ b/ui/src/components/chat/AgentCallDisplay.tsx
@@ -1,9 +1,10 @@
 import { useMemo, useState } from "react";
-import { FunctionCall } from "@/types";
+import { FunctionCall, TokenStats } from "@/types";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { convertToUserFriendlyName } from "@/lib/utils";
 import { ChevronDown, ChevronUp, MessageSquare, Loader2, AlertCircle, CheckCircle } from "lucide-react";
 import KagentLogo from "../kagent-logo";
+import TokenStatsTooltip from "@/components/chat/TokenStatsTooltip";
 
 export type AgentCallStatus = "requested" | "executing" | "completed";
 
@@ -15,9 +16,10 @@ interface AgentCallDisplayProps {
   };
   status?: AgentCallStatus;
   isError?: boolean;
+  tokenStats?: TokenStats;
 }
 
-const AgentCallDisplay = ({ call, result, status = "requested", isError = false }: AgentCallDisplayProps) => {
+const AgentCallDisplay = ({ call, result, status = "requested", isError = false, tokenStats }: AgentCallDisplayProps) => {
   const [areInputsExpanded, setAreInputsExpanded] = useState(false);
   const [areResultsExpanded, setAreResultsExpanded] = useState(false);
 
@@ -78,7 +80,8 @@ const AgentCallDisplay = ({ call, result, status = "requested", isError = false 
           </div>
           <div className="font-light">{call.id}</div>
         </CardTitle>
-        <div className="flex justify-center items-center text-xs">
+        <div className="flex items-center gap-2 text-xs">
+          {tokenStats && <TokenStatsTooltip stats={tokenStats} />}
           {getStatusDisplay()}
         </div>
       </CardHeader>

--- a/ui/src/components/chat/ChatInterface.tsx
+++ b/ui/src/components/chat/ChatInterface.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type React from "react";
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useMemo } from "react";
 import { ArrowBigUp, X, Loader2, Mic, Square } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -15,7 +15,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import ChatMessage from "@/components/chat/ChatMessage";
 import StreamingMessage from "./StreamingMessage";
-import TokenStatsDisplay from "./TokenStats";
+import SessionTokenStatsDisplay from "@/components/chat/TokenStats";
 import type { TokenStats, Session, ChatStatus, ToolDecision } from "@/types";
 import StatusDisplay from "./StatusDisplay";
 import { createSession, getSessionTasks, checkSessionExists } from "@/app/actions/sessions";
@@ -39,11 +39,6 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
   const router = useRouter();
   const containerRef = useRef<HTMLDivElement>(null);
   const [currentInputMessage, setCurrentInputMessage] = useState("");
-  const [tokenStats, setTokenStats] = useState<TokenStats>({
-    total: 0,
-    input: 0,
-    output: 0,
-  });
 
   const [chatStatus, setChatStatus] = useState<ChatStatus>("ready");
 
@@ -58,6 +53,9 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
   const [sessionNotFound, setSessionNotFound] = useState<boolean>(false);
   const isCreatingSessionRef = useRef<boolean>(false);
   const [isFirstMessage, setIsFirstMessage] = useState<boolean>(!sessionId);
+  const [sessionStats, setSessionStats] = useState<TokenStats>({ total: 0, prompt: 0, completion: 0 });
+  // Mutable ref so pendingTurnStats survives re-renders between A2A stream events
+  const pendingTurnStatsRef = useRef<TokenStats | undefined>(undefined);
   const [pendingDecisions, setPendingDecisions] = useState<Record<string, ToolDecision>>({});
   const pendingDecisionsRef = useRef<Record<string, ToolDecision>>({});
   /** Per-tool rejection reasons collected as the user rejects individual tools. */
@@ -78,25 +76,27 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
     },
   });
 
-  const { handleMessageEvent } = createMessageHandlers({
+  const { handleMessageEvent } = useMemo(() => createMessageHandlers({
     setMessages: setStreamingMessages,
     setIsStreaming,
     setStreamingContent,
-    setTokenStats,
     setChatStatus,
+    setSessionStats,
+    pendingTurnStats: pendingTurnStatsRef,
     agentContext: {
       namespace: selectedNamespace,
       agentName: selectedAgentName
     }
-  });
+  }), [selectedNamespace, selectedAgentName]);
 
   useEffect(() => {
     async function initializeChat() {
-      setTokenStats({ total: 0, input: 0, output: 0 });
+      setSessionStats({ total: 0, prompt: 0, completion: 0 });
       setStreamingMessages([]);
       setPendingDecisions({});
       pendingDecisionsRef.current = {};
       pendingRejectionReasonsRef.current = {};
+      pendingTurnStatsRef.current = undefined;
 
       // Skip completely if this is a first message session creation flow
       if (isFirstMessage || isCreatingSessionRef.current) {
@@ -129,11 +129,11 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
         }
         if (!messagesResponse.data || messagesResponse?.data?.length === 0) {
           setStoredMessages([]);
-          setTokenStats({ total: 0, input: 0, output: 0 });
+          setSessionStats({ total: 0, prompt: 0, completion: 0 });
         }
         else {
           const extractedMessages = extractMessagesFromTasks(messagesResponse.data);
-          const extractedTokenStats = extractTokenStatsFromTasks(messagesResponse.data);
+          setSessionStats(extractTokenStatsFromTasks(messagesResponse.data));
 
           // Resolved approvals are already inline in extractedMessages (with
           // approved/rejected badges). Only pending approvals need appending.
@@ -144,7 +144,6 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
               ? [...extractedMessages, ...pendingApprovalMessages]
               : extractedMessages
           );
-          setTokenStats(extractedTokenStats);
 
           if (hasPendingApproval) {
             setChatStatus("input_required");
@@ -192,6 +191,7 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
     setPendingDecisions({});
     pendingDecisionsRef.current = {};
     pendingRejectionReasonsRef.current = {};
+    pendingTurnStatsRef.current = undefined;
 
     // For new sessions or when no stored messages exist, show the user message immediately
     const userMessage: Message = {
@@ -682,7 +682,7 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
       <div className="w-full sticky bg-secondary bottom-0 md:bottom-2 rounded-none md:rounded-lg p-4 border  overflow-hidden transition-all duration-300 ease-in-out">
         <div className="flex items-center justify-between mb-4">
           <StatusDisplay chatStatus={chatStatus} />
-          <TokenStatsDisplay stats={tokenStats} />
+          {sessionStats.total > 0 && <SessionTokenStatsDisplay stats={sessionStats} />}
         </div>
 
         <form onSubmit={handleSendMessage}>

--- a/ui/src/components/chat/ChatMessage.tsx
+++ b/ui/src/components/chat/ChatMessage.tsx
@@ -4,6 +4,8 @@ import ToolCallDisplay from "@/components/chat/ToolCallDisplay";
 import AskUserDisplay, { AskUserQuestion } from "@/components/chat/AskUserDisplay";
 import KagentLogo from "../kagent-logo";
 import { ThumbsUp, ThumbsDown } from "lucide-react";
+import TokenStatsTooltip from "@/components/chat/TokenStatsTooltip";
+import type { TokenStats } from "@/types";
 import { useState } from "react";
 import { FeedbackDialog } from "./FeedbackDialog";
 import { toast } from "sonner";
@@ -28,10 +30,13 @@ export default function ChatMessage({ message, allMessages, agentContext, onAppr
   const [feedbackDialogOpen, setFeedbackDialogOpen] = useState(false);
   const [isPositiveFeedback, setIsPositiveFeedback] = useState(true);
 
+  if (!message) return null;
+
   const textParts = message.parts?.filter(part => part.kind === "text") || [];
   const content = textParts.map(part => (part as TextPart).text).join("");
 
   const source = message.role === "user" ? "user" : "assistant";
+  const tokenStats = (message.metadata as Record<string, unknown> | undefined)?.tokenStats as TokenStats | undefined;
   const messageId = message.messageId;
 
   // Extract agent name from metadata for display
@@ -67,10 +72,6 @@ export default function ChatMessage({ message, allMessages, agentContext, onAppr
     a = ((a << 5) - a) + b.charCodeAt(0);
     return a & a;
   }, 0)) : 0;
-
-  if (!message) {
-    return null;
-  }
 
   const metadata = message.metadata as ADKMetadata;
   const originalType = metadata?.originalType;
@@ -168,22 +169,27 @@ export default function ChatMessage({ message, allMessages, agentContext, onAppr
         <div className="text-xs font-bold">{displayName}</div>
       </div> : <div className="text-xs font-bold">{displayName}</div>}
       <TruncatableText content={String(content)} className="break-all text-primary-foreground" />
-      {source !== "user" && messageId !== undefined && (
+      {source !== "user" && (
         <div className="flex mt-2 justify-end items-center gap-2">
-          <button
-            onClick={() => handleFeedback(true)}
-            className="p-1 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
-            aria-label="Thumbs up"
-          >
-            <ThumbsUp className="w-4 h-4" />
-          </button>
-          <button
-            onClick={() => handleFeedback(false)}
-            className="p-1 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
-            aria-label="Thumbs down"
-          >
-            <ThumbsDown className="w-4 h-4" />
-          </button>
+          {tokenStats && <TokenStatsTooltip stats={tokenStats} />}
+          {messageId !== undefined && (
+            <>
+              <button
+                onClick={() => handleFeedback(true)}
+                className="p-1 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+                aria-label="Thumbs up"
+              >
+                <ThumbsUp className="w-4 h-4" />
+              </button>
+              <button
+                onClick={() => handleFeedback(false)}
+                className="p-1 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+                aria-label="Thumbs down"
+              >
+                <ThumbsDown className="w-4 h-4" />
+              </button>
+            </>
+          )}
         </div>
       )}
     </div>

--- a/ui/src/components/chat/TokenStats.tsx
+++ b/ui/src/components/chat/TokenStats.tsx
@@ -1,11 +1,11 @@
 import { ArrowLeft, ArrowRightFromLine } from "lucide-react";
 import { TokenStats } from "@/types";
 
-interface TokenStatsDisplayProps {
+interface SessionTokenStatsDisplayProps {
   stats: TokenStats;
 }
 
-export default function TokenStatsDisplay({ stats }: TokenStatsDisplayProps) {
+export default function SessionTokenStatsDisplay({ stats }: SessionTokenStatsDisplayProps) {
   return (
     <div className="flex items-center gap-2 text-xs">
       <span>Usage: </span>
@@ -13,11 +13,11 @@ export default function TokenStatsDisplay({ stats }: TokenStatsDisplayProps) {
       <div className="flex items-center gap-2">
         <div className="flex items-center gap-1">
           <ArrowLeft className="h-3 w-3" />
-          <span>{stats.input}</span>
+          <span>{stats.prompt}</span>
         </div>
         <div className="flex items-center gap-1">
           <ArrowRightFromLine className="h-3 w-3" />
-          <span>{stats.output}</span>
+          <span>{stats.completion}</span>
         </div>
       </div>
     </div>

--- a/ui/src/components/chat/TokenStatsTooltip.tsx
+++ b/ui/src/components/chat/TokenStatsTooltip.tsx
@@ -1,0 +1,26 @@
+import { BarChart2 } from "lucide-react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import type { TokenStats } from "@/types";
+
+interface TokenStatsTooltipProps {
+  stats: TokenStats;
+}
+
+export default function TokenStatsTooltip({ stats }: TokenStatsTooltipProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button type="button" className="p-1 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors" aria-label="Token usage">
+          <BarChart2 className="w-4 h-4" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="top">
+        <div className="flex flex-col gap-1 text-xs">
+          <span>Total: {stats.total}</span>
+          <span>Prompt: {stats.prompt}</span>
+          <span>Completion: {stats.completion}</span>
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/ui/src/components/chat/ToolCallDisplay.tsx
+++ b/ui/src/components/chat/ToolCallDisplay.tsx
@@ -4,7 +4,7 @@ import ToolDisplay, { ToolCallStatus } from "@/components/ToolDisplay";
 import AgentCallDisplay, { AgentCallStatus } from "@/components/chat/AgentCallDisplay";
 import { isAgentToolName } from "@/lib/utils";
 import { ADKMetadata, ProcessedToolResultData, ToolResponseData, normalizeToolResultToText, getMetadataValue } from "@/lib/messageHandlers";
-import { FunctionCall, ToolDecision } from "@/types";
+import { FunctionCall, ToolDecision, TokenStats } from "@/types";
 
 interface ToolCallDisplayProps {
   currentMessage: Message;
@@ -302,6 +302,8 @@ const ToolCallDisplay = ({ currentMessage, allMessages, onApprove, onReject, pen
   const currentDisplayableCalls = Array.from(toolCalls.values()).filter(call => ownedCallIds.has(call.id));
   if (currentDisplayableCalls.length === 0) return null;
 
+  const tokenStats = (currentMessage.metadata as Record<string, unknown> | undefined)?.tokenStats as TokenStats | undefined;
+
   return (
     <div className="space-y-2">
       {currentDisplayableCalls.map(toolCall => {
@@ -328,6 +330,7 @@ const ToolCallDisplay = ({ currentMessage, allMessages, onApprove, onReject, pen
             result={toolCall.result}
             status={effectiveStatus === "pending_approval" ? "requested" : effectiveStatus as AgentCallStatus}
             isError={toolCall.result?.is_error}
+            tokenStats={tokenStats}
           />
         ) : (
           <ToolDisplay
@@ -340,6 +343,7 @@ const ToolCallDisplay = ({ currentMessage, allMessages, onApprove, onReject, pen
             subagentName={subagentName}
             onApprove={showButtons && onApprove ? () => onApprove(toolCall.id) : undefined}
             onReject={showButtons && onReject ? (reason?: string) => onReject(toolCall.id, reason) : undefined}
+            tokenStats={tokenStats}
           />
         );
       })}

--- a/ui/src/lib/__tests__/messageHandlers.test.ts
+++ b/ui/src/lib/__tests__/messageHandlers.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from '@jest/globals';
 import { v4 as uuidv4 } from 'uuid';
-import { Message } from '@a2a-js/sdk';
+import { Message, Task } from '@a2a-js/sdk';
 import {
   extractMessagesFromTasks,
   extractTokenStatsFromTasks,
@@ -11,6 +11,7 @@ import {
   type ADKMetadata,
   createMessageHandlers,
 } from '@/lib/messageHandlers';
+import type { TokenStats } from '@/types';
 
 describe('messageHandlers helpers', () => {
   test('normalizeToolResultToText handles string result', () => {
@@ -47,15 +48,50 @@ describe('messageHandlers helpers', () => {
     expect(out[0].messageId).toBe(mId);
   });
 
-  test('extractTokenStatsFromTasks picks max token counts', () => {
+  test('extractMessagesFromTasks injects tokenStats into non-user agent messages only', () => {
+    const tasks = [
+      {
+        history: [
+          { kind: 'message', messageId: 'a1', role: 'agent', parts: [],
+            metadata: { kagent_usage_metadata: { totalTokenCount: 10, promptTokenCount: 3, candidatesTokenCount: 7 } } },
+          { kind: 'message', messageId: 'u1', role: 'user', parts: [],
+            metadata: { kagent_usage_metadata: { totalTokenCount: 5, promptTokenCount: 2, candidatesTokenCount: 3 } } },
+          { kind: 'message', messageId: 'a2', role: 'agent', parts: [], metadata: {} },
+        ],
+      },
+    ] as unknown as Task[];
+    const messages = extractMessagesFromTasks(tasks);
+    // Agent message with usage metadata gets tokenStats injected
+    expect((messages[0].metadata as ADKMetadata & { tokenStats?: TokenStats })?.tokenStats)
+      .toEqual({ total: 10, prompt: 3, completion: 7 });
+    // User message is NOT enriched even if it carries usage metadata
+    expect((messages[1].metadata as ADKMetadata & { tokenStats?: TokenStats })?.tokenStats)
+      .toBeUndefined();
+    // Agent message without usage metadata is passed through unchanged
+    expect((messages[2].metadata as ADKMetadata & { tokenStats?: TokenStats })?.tokenStats)
+      .toBeUndefined();
+  });
+
+  test('extractTokenStatsFromTasks sums usage across all history messages', () => {
     const tasks: any = [
-      { metadata: { kagent_usage_metadata: { totalTokenCount: 10, promptTokenCount: 3, candidatesTokenCount: 7 } } as ADKMetadata },
-      { metadata: { kagent_usage_metadata: { totalTokenCount: 12, promptTokenCount: 1, candidatesTokenCount: 9 } } as ADKMetadata },
+      { history: [{ kind: 'message', metadata: { kagent_usage_metadata: { totalTokenCount: 10, promptTokenCount: 3, candidatesTokenCount: 7 } } }] },
+      { history: [{ kind: 'message', metadata: { kagent_usage_metadata: { totalTokenCount: 12, promptTokenCount: 1, candidatesTokenCount: 9 } } }] },
     ];
     const stats = extractTokenStatsFromTasks(tasks);
-    expect(stats.total).toBe(12);
-    expect(stats.input).toBe(3);
-    expect(stats.output).toBe(9);
+    expect(stats.total).toBe(22);
+    expect(stats.prompt).toBe(4);
+    expect(stats.completion).toBe(16);
+  });
+
+  test('extractTokenStatsFromTasks skips history items without usage metadata', () => {
+    const tasks = [
+      { history: [{ kind: 'message', messageId: uuidv4(), role: 'agent', parts: [], metadata: { kagent_usage_metadata: { totalTokenCount: 10, promptTokenCount: 3, candidatesTokenCount: 7 } } }] },
+      { history: [{ kind: 'message', messageId: uuidv4(), role: 'agent', parts: [], metadata: {} }] },
+    ] as unknown as Task[];
+    const stats = extractTokenStatsFromTasks(tasks);
+    expect(stats.total).toBe(10);
+    expect(stats.prompt).toBe(3);
+    expect(stats.completion).toBe(7);
   });
 });
 
@@ -70,7 +106,6 @@ describe('createMessageHandlers test', () => {
       },
       setIsStreaming: () => {},
       setStreamingContent: () => {},
-      setTokenStats: () => {},
       setChatStatus: () => {},
       agentContext: { namespace: 'kagent', agentName: 'testagent' },
     });
@@ -136,7 +171,6 @@ describe('createMessageHandlers test', () => {
       },
       setIsStreaming: () => {},
       setStreamingContent: () => {},
-      setTokenStats: () => {},
       agentContext: { namespace: 'kagent', agentName: 'testagent' },
     });
 
@@ -167,7 +201,6 @@ describe('createMessageHandlers test', () => {
       },
       setIsStreaming: () => {},
       setStreamingContent: () => {},
-      setTokenStats: () => {},
       agentContext: { namespace: 'kagent', agentName: 'testagent' },
     });
 
@@ -192,7 +225,6 @@ describe('createMessageHandlers test', () => {
       },
       setIsStreaming: () => {},
       setStreamingContent: () => {},
-      setTokenStats: () => {},
       agentContext: { namespace: 'kagent', agentName: 'testagent' },
     });
 
@@ -214,9 +246,9 @@ describe('createMessageHandlers test', () => {
     expect((emitted[2].metadata as any).originalType).toBe('ToolCallSummaryMessage');
   });
 
-  test('token usage updates on status-update metadata', () => {
-    let capturedStats: any = { total: 0, input: 0, output: 0 };
+  test('each invocation keeps its own token stats and session total accumulates correctly', () => {
     const emitted: Message[] = [];
+    let capturedSessionTotal = { total: 0, prompt: 0, completion: 0 };
     const handlers = createMessageHandlers({
       setMessages: (updater) => {
         const next = updater(emitted);
@@ -225,20 +257,100 @@ describe('createMessageHandlers test', () => {
       },
       setIsStreaming: () => {},
       setStreamingContent: () => {},
-      setTokenStats: (updater: any) => {
-        capturedStats = updater(capturedStats);
-      },
+      setSessionStats: (updater) => { capturedSessionTotal = updater(capturedSessionTotal); },
       agentContext: { namespace: 'kagent', agentName: 'testagent' },
     });
 
-    const statusWithUsage: any = {
+    // Invocation 1: LLM decides to call a tool (usage arrives with the function_call)
+    const toolCallUpdate = {
       kind: 'status-update', contextId: 'ctx', taskId: 'task', final: false,
-      metadata: { kagent_usage_metadata: { totalTokenCount: 5, promptTokenCount: 2, candidatesTokenCount: 3 } },
-      status: { state: 'working' }
-    };
-    handlers.handleMessageEvent(statusWithUsage);
+      metadata: { kagent_usage_metadata: { totalTokenCount: 5, promptTokenCount: 3, candidatesTokenCount: 2 } },
+      status: {
+        state: 'working',
+        message: {
+          role: 'agent',
+          parts: [{ kind: 'data', data: { id: 'call_1', name: 'my_tool', args: {} }, metadata: { kagent_type: 'function_call' } }]
+        }
+      }
+    } as unknown as Message;
+    handlers.handleMessageEvent(toolCallUpdate);
 
-    expect(capturedStats).toEqual({ total: 5, input: 2, output: 3 });
+    // Tool executes and returns a result
+    const toolResponseUpdate = {
+      kind: 'status-update', contextId: 'ctx', taskId: 'task', final: false,
+      status: {
+        state: 'working',
+        message: {
+          role: 'agent',
+          parts: [{ kind: 'data', data: { id: 'call_1', name: 'my_tool', response: { result: 'ok' } }, metadata: { kagent_type: 'function_response' } }]
+        }
+      }
+    } as unknown as Message;
+    handlers.handleMessageEvent(toolResponseUpdate);
+
+    // Invocation 2: LLM generates the final text response
+    const finalUpdate = {
+      kind: 'status-update', contextId: 'ctx', taskId: 'task', final: true,
+      metadata: { kagent_usage_metadata: { totalTokenCount: 10, promptTokenCount: 7, candidatesTokenCount: 3 } },
+      status: {
+        state: 'completed',
+        message: { role: 'agent', parts: [{ kind: 'text', text: 'done' }] }
+      }
+    } as unknown as Message;
+    handlers.handleMessageEvent(finalUpdate);
+
+    const toolCallMsg = emitted.find(m => (m.metadata as ADKMetadata)?.originalType === 'ToolCallRequestEvent');
+    const textMsg = emitted.find(m => (m.metadata as ADKMetadata)?.originalType === 'TextMessage');
+    // Each invocation keeps its own stats — the tool call is not overwritten by the text response
+    expect((toolCallMsg?.metadata as ADKMetadata & { tokenStats?: TokenStats })?.tokenStats).toEqual({ total: 5, prompt: 3, completion: 2 });
+    expect((textMsg?.metadata as ADKMetadata & { tokenStats?: TokenStats })?.tokenStats).toEqual({ total: 10, prompt: 7, completion: 3 });
+    // Session total accumulates both invocations
+    expect(capturedSessionTotal).toEqual({ total: 15, prompt: 10, completion: 5 });
+  });
+
+  test('HITL interrupt accumulates pending turn stats and clears them', () => {
+    const emitted: Message[] = [];
+    let capturedSessionTotal: TokenStats = { total: 0, prompt: 0, completion: 0 };
+    const handlers = createMessageHandlers({
+      setMessages: (updater) => {
+        const next = updater(emitted);
+        emitted.length = 0;
+        emitted.push(...next);
+      },
+      setIsStreaming: () => {},
+      setStreamingContent: () => {},
+      setChatStatus: () => {},
+      setSessionStats: (updater) => { capturedSessionTotal = updater(capturedSessionTotal); },
+      agentContext: { namespace: 'kagent', agentName: 'testagent' },
+    });
+
+    // Status update: LLM decides to call a confirmation tool (HITL), usage arrives here
+    const hitlUpdate = {
+      kind: 'status-update', contextId: 'ctx', taskId: 'task', final: false,
+      metadata: { kagent_usage_metadata: { totalTokenCount: 8, promptTokenCount: 5, candidatesTokenCount: 3 } },
+      status: {
+        state: 'input-required',
+        message: {
+          role: 'agent',
+          parts: [{
+            kind: 'data',
+            data: {
+              name: 'adk_request_confirmation',
+              id: 'confirm_1',
+              args: { originalFunctionCall: { name: 'my_tool', args: { x: 1 }, id: 'call_1' } },
+            },
+            metadata: { kagent_type: 'function_call', kagent_is_long_running: true },
+          }],
+        },
+      },
+    } as unknown as Message;
+    handlers.handleMessageEvent(hitlUpdate);
+
+    // Session stats should be accumulated at the HITL boundary (not at stream end)
+    expect(capturedSessionTotal).toEqual({ total: 8, prompt: 5, completion: 3 });
+    // A ToolApprovalRequest message should have been emitted
+    const approvalMsg = emitted.find(m => (m.metadata as ADKMetadata)?.originalType === 'ToolApprovalRequest');
+    expect(approvalMsg).toBeDefined();
   });
 });
 
@@ -274,12 +386,12 @@ describe('getMetadataValue', () => {
 describe('dual-prefix integration', () => {
   test('extractTokenStatsFromTasks works with adk_usage_metadata', () => {
     const tasks: any = [
-      { metadata: { adk_usage_metadata: { totalTokenCount: 20, promptTokenCount: 8, candidatesTokenCount: 12 } } },
+      { history: [{ kind: 'message', metadata: { adk_usage_metadata: { totalTokenCount: 20, promptTokenCount: 8, candidatesTokenCount: 12 } } }] },
     ];
     const stats = extractTokenStatsFromTasks(tasks);
     expect(stats.total).toBe(20);
-    expect(stats.input).toBe(8);
-    expect(stats.output).toBe(12);
+    expect(stats.prompt).toBe(8);
+    expect(stats.completion).toBe(12);
   });
 
   test('status-update handler works with adk_type metadata on parts', () => {
@@ -292,7 +404,6 @@ describe('dual-prefix integration', () => {
       },
       setIsStreaming: () => {},
       setStreamingContent: () => {},
-      setTokenStats: () => {},
       setChatStatus: () => {},
       agentContext: { namespace: 'kagent', agentName: 'testagent' },
     });

--- a/ui/src/lib/messageHandlers.ts
+++ b/ui/src/lib/messageHandlers.ts
@@ -1,6 +1,6 @@
 import { Message, Task, TaskStatusUpdateEvent, TaskArtifactUpdateEvent, TextPart, Part, DataPart } from "@a2a-js/sdk";
 import { v4 as uuidv4 } from "uuid";
-import { convertToUserFriendlyName, messageUtils } from "@/lib/utils";
+import { convertToUserFriendlyName, isAgentToolName, messageUtils } from "@/lib/utils";
 import { ApprovalDecision, AdkRequestConfirmationData, HitlPartInfo, ToolDecision, TokenStats, ChatStatus } from "@/types";
 import { mapA2AStateToStatus } from "@/lib/statusUtils";
 
@@ -10,46 +10,135 @@ export function extractMessagesFromTasks(tasks: Task[]): Message[] {
   const seenMessageIds = new Set<string>();
 
   for (const task of tasks) {
-    if (task.history) {
-      // Loop over task history to reconstruct chat messages
-      for (let i = 0; i < task.history.length; i++) {
-        const historyItem = task.history[i];
-        if (historyItem.kind === "message") {
-          // Deduplicate by messageId to avoid showing the same message twice
-          if (seenMessageIds.has(historyItem.messageId)) continue;
+    if (!task.history) continue;
 
-          // If this history message IS an adk_request_confirmation, replace
-          // it with a ToolApprovalRequest card carrying the decision status.
-          const confirmationParts = findConfirmationParts(historyItem);
-          if (confirmationParts.length > 0) {
-            // Find the decision that applies to THIS confirmation (first decision AFTER this message)
-            const decision = findDecisionAfterIndex(
-              task.history as Array<{ kind?: string; role?: string; parts?: Part[] }>,
-              i
-            );
+    // Track the most recent LLM usage seen so far within this task so we can
+    // attach it to HITL confirmation cards (which share the same invocation as
+    // the preceding function_call but don't carry usage_metadata themselves).
+    let lastSeenStats: TokenStats | undefined;
 
-            // Skip unresolved confirmations — extractApprovalMessagesFromTasks
-            // handles pending ones via task.status.message to avoid duplicates.
-            if (!decision) {
-              seenMessageIds.add(historyItem.messageId);
-              continue;
-            }
+    for (let i = 0; i < task.history.length; i++) {
+      const historyItem = task.history[i];
+      if (historyItem.kind !== "message") continue;
 
-            for (const confPart of confirmationParts) {
-              const approvalMsg = buildApprovalMessage(confPart, task.contextId, task.id, decision);
-              messages.push(approvalMsg);
-            }
-            seenMessageIds.add(historyItem.messageId);
-            continue;
-          }
+      // Deduplicate by messageId to avoid showing the same message twice
+      if (seenMessageIds.has(historyItem.messageId)) continue;
+      seenMessageIds.add(historyItem.messageId);
 
-          // Skip user decision messages — the decision is shown on the
-          // approval card itself, not as a separate chat bubble.
-          if (isUserDecisionMessage(historyItem)) continue;
+      // If this history message IS an adk_request_confirmation, replace
+      // it with a ToolApprovalRequest card carrying the decision status.
+      const confirmationParts = findConfirmationParts(historyItem);
+      if (confirmationParts.length > 0) {
+        // Find the decision that applies to THIS confirmation (first decision AFTER this message)
+        const decision = findDecisionAfterIndex(
+          task.history as Array<{ kind?: string; role?: string; parts?: Part[] }>,
+          i
+        );
 
-          seenMessageIds.add(historyItem.messageId);
-          messages.push(historyItem);
+        // Skip unresolved confirmations — extractApprovalMessagesFromTasks
+        // handles pending ones via task.status.message to avoid duplicates.
+        if (!decision) continue;
+
+        for (const confPart of confirmationParts) {
+          // Use lastSeenStats: the confirmation message shares an invocation with
+          // the preceding function_call message that carries the usage.
+          messages.push(buildApprovalMessage(confPart, task.contextId, task.id, decision, lastSeenStats));
         }
+        continue;
+      }
+
+      // Skip user decision messages — the decision is shown on the
+      // approval card itself, not as a separate chat bubble.
+      if (isUserDecisionMessage(historyItem)) continue;
+
+      // User messages: push as-is (no tokenStats needed).
+      if (historyItem.role === "user") {
+        messages.push(historyItem);
+        continue;
+      }
+
+      // Agent messages: convert function_call / function_response DataParts to
+      // the same ToolCallRequestEvent / ToolCallExecutionEvent format produced
+      // by the live-stream handlers so the rendering component can display them.
+      const msgContextId = historyItem.contextId ?? task.contextId;
+      const msgTaskId = historyItem.taskId ?? task.id;
+      const source = getSourceFromMetadata(historyItem.metadata as ADKMetadata | undefined, "assistant");
+      const msgStats = getMessageTokenStats(historyItem.metadata as Record<string, unknown>);
+
+      if (msgStats) lastSeenStats = msgStats;
+
+      let hasConvertedParts = false;
+      for (const part of historyItem.parts ?? []) {
+        if (part.kind !== "data") continue;
+        const dp = part as DataPart;
+        const partMeta = dp.metadata as Record<string, unknown> | undefined;
+        const partType = getMetadataValue<string>(partMeta, "type");
+
+        if (partType === "function_call") {
+          const fcName = (dp.data as Record<string, unknown>)?.name as string | undefined;
+          // Skip ADK internal calls — confirmations are handled above.
+          if (fcName === "adk_request_confirmation" || fcName === "adk_request_credential") continue;
+
+          const toolData = dp.data as unknown as ToolCallData;
+          // Agent calls get no initial tokenStats; child stats arrive later via
+          // the function_response and are stamped on this card below.
+          // Regular tool calls use the message's own invocation stats.
+          const toolStats = isAgentToolName(toolData.name) ? undefined : msgStats;
+          messages.push(createMessage("", source, {
+            originalType: "ToolCallRequestEvent",
+            contextId: msgContextId,
+            taskId: msgTaskId,
+            additionalMetadata: {
+              toolCallData: [{ id: toolData.id, name: toolData.name, args: (toolData.args as Record<string, unknown>) || {} }],
+              ...(toolStats && { tokenStats: toolStats }),
+            },
+          }));
+          hasConvertedParts = true;
+
+        } else if (partType === "function_response") {
+          const toolData = dp.data as unknown as ToolResponseData;
+          messages.push(createMessage("", source, {
+            originalType: "ToolCallExecutionEvent",
+            contextId: msgContextId,
+            taskId: msgTaskId,
+            additionalMetadata: {
+              toolResultData: [{
+                call_id: toolData.id,
+                name: toolData.name,
+                content: normalizeToolResultToText(toolData),
+                is_error: toolData.response?.isError || false,
+              }],
+            },
+          }));
+          hasConvertedParts = true;
+
+          // For agent tools, extract child usage from the response dict and
+          // stamp it on the matching ToolCallRequestEvent card.
+          if (isAgentToolName(toolData.name)) {
+            const responseUsage = (toolData.response as Record<string, unknown> | undefined)?.kagent_usage_metadata;
+            if (responseUsage) {
+              const agentCallStats = getMessageTokenStats({ kagent_usage_metadata: responseUsage } as Record<string, unknown>);
+              if (agentCallStats) {
+                for (let j = messages.length - 2; j >= 0; j--) {
+                  const prevMeta = messages[j].metadata as ADKMetadata | undefined;
+                  if (prevMeta?.originalType === "ToolCallRequestEvent" &&
+                      prevMeta?.toolCallData?.some(tc => tc.id === toolData.id)) {
+                    messages[j] = { ...messages[j], metadata: { ...(messages[j].metadata as object || {}), tokenStats: agentCallStats } };
+                    break;
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      // Text messages (or any message without data parts): push with tokenStats.
+      if (!hasConvertedParts) {
+        messages.push(msgStats
+          ? { ...historyItem, metadata: { ...(historyItem.metadata as object || {}), tokenStats: msgStats } }
+          : historyItem
+        );
       }
     }
   }
@@ -163,7 +252,8 @@ export function buildApprovalMessage(
   confPart: DataPart,
   contextId: string | undefined,
   taskId: string | undefined,
-  decisionData?: Record<string, unknown>
+  decisionData?: Record<string, unknown>,
+  tokenStats?: TokenStats
 ): Message {
   const data = confPart.data as unknown as AdkRequestConfirmationData;
   const origFc = data.args.originalFunctionCall;
@@ -186,6 +276,7 @@ export function buildApprovalMessage(
         askUserAnswers: askUserAnswers || null,
         // Track the decision type so we know it was resolved
         approvalDecision: decisionData?.decision_type ? "approve" : undefined,
+        ...(tokenStats && { tokenStats }),
       },
     });
   }
@@ -215,6 +306,7 @@ export function buildApprovalMessage(
         askUserAnswers: askUserAnswers || null,
         approvalDecision: decisionData?.decision_type ? "approve" : undefined,
         subagentName: subagentNameForAskUser,
+        ...(tokenStats && { tokenStats }),
       },
     });
   }
@@ -256,32 +348,61 @@ export function buildApprovalMessage(
       toolCallData: toolCallContent,
       approvalDecision,
       subagentName,
+      ...(tokenStats && { tokenStats }),
     },
   });
 }
 
+/**
+ * Extract token stats from a single message's own metadata (if the message
+ * was generated by an LLM call and carries per-call usage).
+ */
+function getMessageTokenStats(metadata: Record<string, unknown> | undefined): TokenStats | undefined {
+  const usage = getMetadataValue<ADKMetadata["kagent_usage_metadata"]>(metadata, "usage_metadata");
+  if (!usage) return undefined;
+  return {
+    total: usage.totalTokenCount ?? 0,
+    prompt: usage.promptTokenCount ?? 0,
+    completion: usage.candidatesTokenCount ?? 0,
+  };
+}
+
 export function extractTokenStatsFromTasks(tasks: Task[]): TokenStats {
-  let maxTotal = 0;
-  let maxInput = 0;
-  let maxOutput = 0;
-  
+  let total = 0, prompt = 0, completion = 0;
   for (const task of tasks) {
-    if (task.metadata) {
-      const usage = getMetadataValue<ADKMetadata["kagent_usage_metadata"]>(task.metadata as Record<string, unknown>, "usage_metadata");
-      
-      if (usage) {
-        maxTotal = Math.max(maxTotal, usage.totalTokenCount || 0);
-        maxInput = Math.max(maxInput, usage.promptTokenCount || 0);
-        maxOutput = Math.max(maxOutput, usage.candidatesTokenCount || 0);
+    for (const item of task.history ?? []) {
+      const msg = item as unknown as { kind?: string; role?: string; metadata?: Record<string, unknown>; parts?: Part[] };
+      if (msg.kind !== "message" || msg.role === "user") continue;
+
+      // Message-level usage (most agent messages carry this).
+      const stats = getMessageTokenStats(msg.metadata);
+      if (stats) {
+        total += stats.total;
+        prompt += stats.prompt;
+        completion += stats.completion;
+      }
+
+      // function_response from agent tools carries child-agent usage inside the
+      // response dict rather than in message-level metadata — include it here.
+      for (const part of msg.parts ?? []) {
+        if (part.kind !== "data") continue;
+        const dp = part as DataPart;
+        const partMeta = dp.metadata as Record<string, unknown> | undefined;
+        if (getMetadataValue<string>(partMeta, "type") !== "function_response") continue;
+        const toolData = dp.data as unknown as ToolResponseData;
+        if (!isAgentToolName(toolData.name)) continue;
+        const responseUsage = (toolData.response as Record<string, unknown> | undefined)?.kagent_usage_metadata;
+        if (!responseUsage) continue;
+        const childStats = getMessageTokenStats({ kagent_usage_metadata: responseUsage } as Record<string, unknown>);
+        if (childStats) {
+          total += childStats.total;
+          prompt += childStats.prompt;
+          completion += childStats.completion;
+        }
       }
     }
   }
-  
-  return {
-    total: maxTotal,
-    input: maxInput,
-    output: maxOutput
-  };
+  return { total, prompt, completion };
 }
 
 export type OriginalMessageType =
@@ -460,8 +581,15 @@ export type MessageHandlers = {
   setMessages: (updater: (prev: Message[]) => Message[]) => void;
   setIsStreaming: (value: boolean) => void;
   setStreamingContent: (updater: (prev: string) => string) => void;
-  setTokenStats: (updater: (prev: TokenStats) => TokenStats) => void;
   setChatStatus?: (status: ChatStatus) => void;
+  setSessionStats?: (updater: (prev: TokenStats) => TokenStats) => void;
+  /**
+   * External mutable container for pending turn stats. Pass a ref-like object
+   * (`useRef<TokenStats | undefined>(undefined)`) from the component so that
+   * `pendingTurnStats` survives re-renders instead of being reset to `undefined`
+   * every time `createMessageHandlers` is called.
+   */
+  pendingTurnStats?: { current: TokenStats | undefined };
   agentContext?: {
     namespace: string;
     agentName: string;
@@ -473,19 +601,23 @@ export const createMessageHandlers = (handlers: MessageHandlers) => {
     handlers.setMessages(prev => [...prev, message]);
   };
 
-  const updateTokenStatsFromMetadata = (adkMetadata: ADKMetadata | undefined) => {
+  // Stores the latest usage stats from the current turn.
+  // Usage arrives on intermediate status-update events (before the TextMessage
+  // is created via artifact update), so we carry it forward here.
+  //
+  // We use an external ref-like container (if provided) so that the value
+  // survives React re-renders between A2A stream events.  If no container is
+  // provided we fall back to a local one (fine for tests / non-React usage).
+  const pts = handlers.pendingTurnStats ?? { current: undefined as TokenStats | undefined };
+
+  const getTokenStatsFromMetadata = (adkMetadata: ADKMetadata | undefined): TokenStats | undefined => {
     const usage = getMetadataValue<ADKMetadata["kagent_usage_metadata"]>(adkMetadata as Record<string, unknown>, "usage_metadata");
-    if (!usage) return;
-    const tokenStats = {
-      total: usage.totalTokenCount || 0,
-      input: usage.promptTokenCount || 0,
-      output: usage.candidatesTokenCount || 0,
+    if (!usage) return undefined;
+    return {
+      total: usage.totalTokenCount ?? 0,
+      prompt: usage.promptTokenCount ?? 0,
+      completion: usage.candidatesTokenCount ?? 0,
     };
-    handlers.setTokenStats(prev => ({
-      total: Math.max(prev.total, tokenStats.total),
-      input: Math.max(prev.input, tokenStats.input),
-      output: Math.max(prev.output, tokenStats.output),
-    }));
   };
 
   const aggregatePartsToText = (parts: Part[]): string => {
@@ -505,9 +637,23 @@ export const createMessageHandlers = (handlers: MessageHandlers) => {
     }).join("");
   };
 
+  const accumulateSessionStats = (stats: TokenStats) => {
+    if (handlers.setSessionStats) {
+      handlers.setSessionStats(prev => ({
+        total: prev.total + stats.total,
+        prompt: prev.prompt + stats.prompt,
+        completion: prev.completion + stats.completion,
+      }));
+    }
+  };
+
   const finalizeStreaming = () => {
     handlers.setIsStreaming(false);
     handlers.setStreamingContent(() => "");
+    if (pts.current) {
+      accumulateSessionStats(pts.current);
+    }
+    pts.current = undefined;
     if (handlers.setChatStatus) {
       handlers.setChatStatus("ready");
     }
@@ -518,7 +664,7 @@ export const createMessageHandlers = (handlers: MessageHandlers) => {
     contextId: string | undefined,
     taskId: string | undefined,
     source: string,
-    options?: { setProcessingStatus?: boolean }
+    options?: { setProcessingStatus?: boolean; tokenStats?: TokenStats }
   ) => {
     if (options?.setProcessingStatus && handlers.setChatStatus) {
       handlers.setChatStatus("processing_tools");
@@ -535,7 +681,7 @@ export const createMessageHandlers = (handlers: MessageHandlers) => {
         originalType: "ToolCallRequestEvent",
         contextId,
         taskId,
-        additionalMetadata: { toolCallData: toolCallContent }
+        additionalMetadata: { toolCallData: toolCallContent, ...(options?.tokenStats && { tokenStats: options.tokenStats }) }
       }
     );
     appendMessage(convertedMessage);
@@ -564,6 +710,29 @@ export const createMessageHandlers = (handlers: MessageHandlers) => {
       }
     );
     appendMessage(execEvent);
+
+    // If the sub-agent included its own usage metadata in the response dict,
+    // tag the matching AgentCall card (ToolCallRequestEvent) with those stats.
+    // We match by call ID to be precise regardless of message ordering.
+    const responseUsage = (toolData.response as Record<string, unknown> | undefined)?.kagent_usage_metadata;
+    if (responseUsage && isAgentToolName(toolData.name)) {
+      const agentCallStats = getTokenStatsFromMetadata({ kagent_usage_metadata: responseUsage } as ADKMetadata);
+      if (agentCallStats) {
+        handlers.setMessages(prev => {
+          const updated = [...prev];
+          for (let i = updated.length - 1; i >= 0; i--) {
+            const msgMeta = updated[i].metadata as ADKMetadata | undefined;
+            if (msgMeta?.originalType === "ToolCallRequestEvent" &&
+                msgMeta?.toolCallData?.some(tc => tc.id === toolData.id)) {
+              updated[i] = { ...updated[i], metadata: { ...(updated[i].metadata as object || {}), tokenStats: agentCallStats } };
+              break;
+            }
+          }
+          return updated;
+        });
+        accumulateSessionStats(agentCallStats);
+      }
+    }
   };
 
   const isUserMessage = (message: Message): boolean => message.role === "user";
@@ -576,8 +745,46 @@ export const createMessageHandlers = (handlers: MessageHandlers) => {
   const handleA2ATaskStatusUpdate = (statusUpdate: TaskStatusUpdateEvent) => {
     try {
       const adkMetadata = getADKMetadata(statusUpdate);
+      const turnStats = getTokenStatsFromMetadata(adkMetadata);
 
-      updateTokenStatsFromMetadata(adkMetadata);
+      // When usage arrives, retroactively tag all agent messages from the
+      // current invocation. The loop stops at an invocation boundary so that
+      // messages from earlier LLM calls keep their own stats.
+      if (turnStats) {
+        // If a previous invocation already deposited stats that DIFFER from the
+        // current event's stats, accumulate them before replacing — each LLM
+        // call within a turn is independent.
+        // When stats are identical the current event is a state transition from
+        // the same LLM call (e.g. working→input-required both carry {470}).
+        // Accumulating in that case would double-count; the input-required
+        // branch handles the single accumulation instead.
+        const isNewInvocation = pts.current && (
+          pts.current.total !== turnStats.total ||
+          pts.current.prompt !== turnStats.prompt ||
+          pts.current.completion !== turnStats.completion
+        );
+        if (isNewInvocation) {
+          accumulateSessionStats(pts.current!);
+        }
+        pts.current = turnStats;
+        handlers.setMessages(prev => {
+          const updated = [...prev];
+          for (let i = updated.length - 1; i >= 0; i--) {
+            if (updated[i].role === "user") break;
+            // Stop at an invocation boundary — everything before belongs to an
+            // earlier LLM call and must not be tagged with this turn's stats.
+            // ToolApprovalRequest: HITL boundary; ToolCallExecutionEvent: the
+            // tool response that separates two back-to-back LLM invocations.
+            const iterMeta = updated[i].metadata as ADKMetadata | undefined;
+            const type = iterMeta?.originalType;
+            if (type === "ToolApprovalRequest" || type === "ToolCallExecutionEvent") break;
+            // AgentCall cards get stats from the child agent's function_response — don't overwrite with parent synthesis stats
+            if (type === "ToolCallRequestEvent" && iterMeta?.toolCallData?.some(tc => isAgentToolName(tc.name))) break;
+            updated[i] = { ...updated[i], metadata: { ...(updated[i].metadata as object || {}), tokenStats: turnStats } };
+          }
+          return updated;
+        });
+      }
 
       // Check for tool approval interrupt
       if (
@@ -588,8 +795,18 @@ export const createMessageHandlers = (handlers: MessageHandlers) => {
 
         if (confirmationParts.length > 0) {
           for (const confPart of confirmationParts) {
-            appendMessage(buildApprovalMessage(confPart, statusUpdate.contextId, statusUpdate.taskId));
+            // Use pts.current (accumulated turn stats) in preference to turnStats
+            // (current event's stats) — the confirmation event often carries no
+            // usage_metadata of its own; the stats live in the preceding event.
+            appendMessage(buildApprovalMessage(confPart, statusUpdate.contextId, statusUpdate.taskId, undefined, pts.current ?? turnStats));
           }
+
+          // Accumulate this turn's stats now — the HITL interrupt ends the
+          // current invocation and the stream will pause until the user decides.
+          if (pts.current) {
+            accumulateSessionStats(pts.current);
+          }
+          pts.current = undefined;
 
           if (handlers.setChatStatus) {
             handlers.setChatStatus("input_required");
@@ -620,7 +837,8 @@ export const createMessageHandlers = (handlers: MessageHandlers) => {
                 {
                   originalType: "TextMessage",
                   contextId: statusUpdate.contextId,
-                  taskId: statusUpdate.taskId
+                  taskId: statusUpdate.taskId,
+                  additionalMetadata: { ...(turnStats && { tokenStats: turnStats }) }
                 }
               );
               handlers.setMessages(prevMessages => [...prevMessages, displayMessage]);
@@ -647,7 +865,10 @@ export const createMessageHandlers = (handlers: MessageHandlers) => {
               }
               const toolData = data as unknown as ToolCallData;
               const source = getSourceFromMetadata(adkMetadata, defaultAgentSource);
-              processFunctionCallPart(toolData, statusUpdate.contextId, statusUpdate.taskId, source, { setProcessingStatus: true });
+              // Don't stamp AgentCall cards with the parent invocation's stats —
+              // those belong on the confirmation dialog. The AgentCall card gets
+              // its own stats from the child agent's function_response.
+              processFunctionCallPart(toolData, statusUpdate.contextId, statusUpdate.taskId, source, { setProcessingStatus: true, tokenStats: isAgentToolName(toolData.name) ? undefined : turnStats });
 
             } else if (partType === "function_response") {
               // Skip internal HITL markers: the before_tool_callback stub and
@@ -684,7 +905,8 @@ export const createMessageHandlers = (handlers: MessageHandlers) => {
       adkMetadata = getADKMetadata(artifactUpdate.artifact);
     }
 
-    updateTokenStatsFromMetadata(adkMetadata);
+    // Usage metadata arrives on status-update events, not artifact events.
+    const turnStats = pts.current;
 
     // Add artifact content and convert tool parts to messages
     let artifactText = "";
@@ -703,7 +925,7 @@ export const createMessageHandlers = (handlers: MessageHandlers) => {
         if (partType === "function_call") {
           const toolData = data as unknown as ToolCallData;
           const toolCallContent: ProcessedToolCallData[] = [{ id: toolData.id, name: toolData.name, args: toolData.args || {} }];
-          const convertedMessage = createMessage("", source, { originalType: "ToolCallRequestEvent", contextId: artifactUpdate.contextId, taskId: artifactUpdate.taskId, additionalMetadata: { toolCallData: toolCallContent } });
+          const convertedMessage = createMessage("", source, { originalType: "ToolCallRequestEvent", contextId: artifactUpdate.contextId, taskId: artifactUpdate.taskId, additionalMetadata: { toolCallData: toolCallContent, ...(turnStats && { tokenStats: turnStats }) } });
           convertedMessages.push(convertedMessage);
           continue;
         }
@@ -734,6 +956,10 @@ export const createMessageHandlers = (handlers: MessageHandlers) => {
     if (artifactUpdate.lastChunk) {
       handlers.setIsStreaming(false);
       handlers.setStreamingContent(() => "");
+      // Do NOT accumulate pts.current here — the final status update that always
+      // follows a completed artifact will call finalizeStreaming(), which does
+      // the single accumulation.  Accumulating here AND in finalizeStreaming()
+      // would double-count the last turn's stats.
 
       const source = getSourceFromMetadata(adkMetadata, defaultAgentSource);
       if (artifactText) {
@@ -743,7 +969,8 @@ export const createMessageHandlers = (handlers: MessageHandlers) => {
           {
             originalType: "TextMessage",
             contextId: artifactUpdate.contextId,
-            taskId: artifactUpdate.taskId
+            taskId: artifactUpdate.taskId,
+            additionalMetadata: { ...(turnStats && { tokenStats: turnStats }) }
           }
         );
         handlers.setMessages(prevMessages => [...prevMessages, displayMessage]);

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -25,8 +25,8 @@ export interface BaseResponse<T> {
 
 export interface TokenStats {
   total: number;
-  input: number;
-  output: number;
+  prompt: number;
+  completion: number;
 }
 
 export interface Provider {


### PR DESCRIPTION
When testing #1500, I struggled to visually demonstrate the affect of the duplicated session history (aka context bloat) when chatting with agents. The current implementation of "Usage" within the UI (introduced in #679) uses `Math.max` independently per field (`total`, `prompt`, `completion`) across all tasks in a session. This produces incoherent values where `total` does not necessarily match `prompt` + `completion`, since each field[^1] (most notably `prompt`) can peak during differing tasks. And, it doesn't correctly update to reflect usage across multiple API calls in a multi-turn conversation. All we see is which API call has the greatest of each type of token usage.

This PR addresses those shortcomings by:

- Updating the existing token usage display to reflect session total across multiple turns
- Show per-call token usage tooltip on tool call cards and text messages

[^1]: not 100% certain here but I think that fields other than input could also peak at different levels within cached prompt scenarios.