### PR TITLE
docs: document KAGENT_DEFAULT_MODEL_PROVIDER in .env example

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -72,7 +72,13 @@ loaded by the Makefile (via `-include .env`) to inject environment variables
 when you run `make` targets:
 
 ```shell
+# Set your provider (supported: openAI, anthropic, azureOpenAI, gemini, ollama)
+KAGENT_DEFAULT_MODEL_PROVIDER=openAI
+
+# Set the corresponding API key for your provider
 OPENAI_API_KEY=your-openai-api-key
+# ANTHROPIC_API_KEY=your-anthropic-api-key
+# GOOGLE_API_KEY=your-google-api-key
 ```
 
 1. Build images, load them into kind cluster and deploy everything using Helm:


### PR DESCRIPTION
## Summary
The `.env` example in `DEVELOPMENT.md` only showed `OPENAI_API_KEY`, 
leaving users on non-OpenAI providers (Anthropic, Gemini, Ollama) without 
guidance on setting `KAGENT_DEFAULT_MODEL_PROVIDER`.

Without this variable, `make helm-install` silently defaults to `openAI` 
and fails with a confusing error even when a valid Anthropic or Gemini key is set.

## Changes
- Updated `.env` example in `DEVELOPMENT.md` to include `KAGENT_DEFAULT_MODEL_PROVIDER`
- Added commented examples for `ANTHROPIC_API_KEY` and `GOOGLE_API_KEY`

## Related issue
Fixes #1510

## Testing
Verified locally on macOS with Anthropic provider and kagent v0.8.0-beta7.