### PR TITLE
fix: CLI config values are not used

### DIFF
--- a/go/core/cli/cmd/kagent/main.go
+++ b/go/core/cli/cmd/kagent/main.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	cli "github.com/kagent-dev/kagent/go/core/cli/internal/cli/agent"
 	"github.com/kagent-dev/kagent/go/core/cli/internal/cli/envdoc"
@@ -34,7 +33,17 @@ func main() {
 
 		cancel()
 	}()
-	cfg := &config.Config{}
+	// Initialize config before flag registration so config file values are used as defaults
+	if err := config.Init(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error initializing config: %v\n", err)
+		os.Exit(1)
+	}
+
+	cfg, err := config.Get()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error getting config: %v\n", err)
+		os.Exit(1)
+	}
 
 	rootCmd := &cobra.Command{
 		Use:   "kagent",
@@ -43,11 +52,11 @@ func main() {
 		Run:   runInteractive,
 	}
 
-	rootCmd.PersistentFlags().StringVar(&cfg.KAgentURL, "kagent-url", "http://localhost:8083", "KAgent URL")
-	rootCmd.PersistentFlags().StringVarP(&cfg.Namespace, "namespace", "n", "kagent", "Namespace")
-	rootCmd.PersistentFlags().StringVarP(&cfg.OutputFormat, "output-format", "o", "table", "Output format")
-	rootCmd.PersistentFlags().BoolVarP(&cfg.Verbose, "verbose", "v", false, "Verbose output")
-	rootCmd.PersistentFlags().DurationVar(&cfg.Timeout, "timeout", 300*time.Second, "Timeout")
+	rootCmd.PersistentFlags().StringVar(&cfg.KAgentURL, "kagent-url", cfg.KAgentURL, "KAgent URL")
+	rootCmd.PersistentFlags().StringVarP(&cfg.Namespace, "namespace", "n", cfg.Namespace, "Namespace")
+	rootCmd.PersistentFlags().StringVarP(&cfg.OutputFormat, "output-format", "o", cfg.OutputFormat, "Output format")
+	rootCmd.PersistentFlags().BoolVarP(&cfg.Verbose, "verbose", "v", cfg.Verbose, "Verbose output")
+	rootCmd.PersistentFlags().DurationVar(&cfg.Timeout, "timeout", cfg.Timeout, "Timeout")
 	installCfg := &cli.InstallCfg{
 		Config: cfg,
 	}
@@ -348,7 +357,7 @@ Examples:
 	// Add flags for deploy command
 	deployCmd.Flags().StringVarP(&deployCfg.Image, "image", "i", "", "Image to use (defaults to localhost:5001/{agentName}:latest)")
 	deployCmd.Flags().StringVar(&deployCfg.EnvFile, "env-file", "", "Path to .env file containing environment variables (including API keys)")
-	deployCmd.Flags().StringVar(&deployCfg.Config.Namespace, "namespace", "kagent", "Kubernetes namespace to deploy to")
+	deployCmd.Flags().StringVar(&deployCfg.Config.Namespace, "namespace", cfg.Namespace, "Kubernetes namespace to deploy to")
 	deployCmd.Flags().BoolVar(&deployCfg.DryRun, "dry-run", false, "Output YAML manifests without applying them to the cluster")
 	deployCmd.Flags().StringVar(&deployCfg.Platform, "platform", "", "Target platform for Docker build (e.g., linux/amd64, linux/arm64)")
 
@@ -428,12 +437,6 @@ Examples:
 	runCmd.Flags().BoolVar(&runCfg.Build, "build", false, "Rebuild the Docker image before running")
 
 	rootCmd.AddCommand(installCmd, uninstallCmd, invokeCmd, bugReportCmd, versionCmd, dashboardCmd, getCmd, initCmd, buildCmd, deployCmd, addMcpCmd, runCmd, mcp.NewMCPCmd(), envdoc.NewEnvCmd())
-
-	// Initialize config
-	if err := config.Init(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error initializing config: %v\n", err)
-		os.Exit(1)
-	}
 
 	if err := rootCmd.ExecuteContext(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)


### PR DESCRIPTION
Fixes #973

## Changes

`config.Init()` was called after Cobra flag registration in `main.go`, so
`~/.kagent/config.yaml` values were never used as flag defaults. The hardcoded
defaults in `StringVar`/`DurationVar` calls always took precedence.

This moves `config.Init()` and `config.Get()` before flag registration so that
config file values serve as defaults when flags are not explicitly provided on
the command line. Also fixes the deploy command's `--namespace` flag which
shadowed the root persistent flag with its own hardcoded default.

Precedence is now: CLI flag > config file value > built-in default.

## Test Plan

- Existing unit tests pass: `go test -race -skip 'TestE2E.*' ./core/cli/...`
- Manual: create `~/.kagent/config.yaml` with custom namespace/url, run
  `kagent dashboard` or `kagent get agent` and confirm config values are used