### PR TITLE
feat(cli): add --no-default-agents flag to kagent install

### DIFF
--- a/go/core/cli/cmd/kagent/main.go
+++ b/go/core/cli/cmd/kagent/main.go
@@ -64,6 +64,7 @@ func main() {
 	_ = installCmd.RegisterFlagCompletionFunc("profile", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return profiles.Profiles, cobra.ShellCompDirectiveNoFileComp
 	})
+	installCmd.Flags().BoolVar(&installCfg.NoDefaultAgents, "no-default-agents", false, "Disable all default agents for a minimal installation")
 
 	uninstallCmd := &cobra.Command{
 		Use:   "uninstall",

--- a/go/core/cli/internal/cli/agent/install.go
+++ b/go/core/cli/internal/cli/agent/install.go
@@ -20,8 +20,24 @@ import (
 )
 
 type InstallCfg struct {
-	Config  *config.Config
-	Profile string
+	Config          *config.Config
+	Profile         string
+	NoDefaultAgents bool
+}
+
+// defaultAgents is the list of agent names installed by the kagent helm chart.
+// Used by --no-default-agents to disable all of them via helm --set flags.
+var defaultAgents = []string{
+	"k8s-agent",
+	"kgateway-agent",
+	"istio-agent",
+	"promql-agent",
+	"observability-agent",
+	"argo-rollouts-agent",
+	"helm-agent",
+	"cilium-policy-agent",
+	"cilium-manager-agent",
+	"cilium-debug-agent",
 }
 
 // installChart installs or upgrades a Helm chart with the given parameters
@@ -99,6 +115,14 @@ func InstallCmd(ctx context.Context, cfg *InstallCfg) *PortForward {
 		}
 
 		helmConfig.inlineValues = profiles.GetProfileYaml(cfg.Profile)
+	}
+
+	// --no-default-agents: disable every default agent via --set flags.
+	// Using --set ensures this takes precedence over any inline profile values.
+	if cfg.NoDefaultAgents {
+		for _, agent := range defaultAgents {
+			helmConfig.values = append(helmConfig.values, fmt.Sprintf("agents.%s.enabled=false", agent))
+		}
 	}
 
 	return install(ctx, cfg.Config, helmConfig, modelProvider)


### PR DESCRIPTION
## Summary

  Closes #766

  Adds a `--no-default-agents` flag to `kagent install` that disables all default agents, enabling a minimal
  installation without editing the helm values file or passing multiple `--set` flags.

  ```bash
  kagent install --no-default-agents

  - Disables all 10 default agents (k8s-agent, kgateway-agent, istio-agent, promql-agent, observability-agent,
  argo-rollouts-agent, helm-agent, cilium-policy-agent, cilium-manager-agent, cilium-debug-agent)
  - Uses helm --set flags so it takes precedence over any --profile value
  - Can be combined with --profile (e.g. --profile demo --no-default-agents)

  Files changed

  - go/core/cli/internal/cli/agent/install.go — NoDefaultAgents field on InstallCfg, defaultAgents list, flag handling
  - go/core/cli/cmd/kagent/main.go — register --no-default-agents cobra flag

  Test plan

  - All Go unit tests pass (make -C go test)
  - kagent install --no-default-agents installs kagent with no agents deployed
  - kagent install --profile demo --no-default-agents installs with demo profile settings but agents disabled
  - kagent install (no flag) still installs default agents as before