### PR TITLE
define a2a mcp timeout

### DIFF
--- a/go/core/internal/mcp/mcp_handler.go
+++ b/go/core/internal/mcp/mcp_handler.go
@@ -59,6 +59,9 @@ type InvokeAgentOutput struct {
 // NewMCPHandler creates a new MCP handler
 // Wraps the StreamableHTTPHandler and adds A2A bridging and context management.
 func NewMCPHandler(kubeClient client.Client, a2aBaseURL string, authenticator auth.AuthProvider, a2aTimeout time.Duration) (*MCPHandler, error) {
+	if a2aTimeout <= 0 {
+		return nil, fmt.Errorf("a2aTimeout must be greater than 0 and no more than %s", 30*time.Minute)
+	}
 	if a2aTimeout > 30*time.Minute {
 		a2aTimeout = 30 * time.Minute
 	}

--- a/go/core/internal/mcp/mcp_handler.go
+++ b/go/core/internal/mcp/mcp_handler.go
@@ -29,6 +29,7 @@ type MCPHandler struct {
 	httpHandler   *mcpsdk.StreamableHTTPHandler
 	server        *mcpsdk.Server
 	a2aClients    sync.Map
+	a2aTimeout    time.Duration
 }
 
 // Input types for MCP tools
@@ -57,11 +58,15 @@ type InvokeAgentOutput struct {
 
 // NewMCPHandler creates a new MCP handler
 // Wraps the StreamableHTTPHandler and adds A2A bridging and context management.
-func NewMCPHandler(kubeClient client.Client, a2aBaseURL string, authenticator auth.AuthProvider) (*MCPHandler, error) {
+func NewMCPHandler(kubeClient client.Client, a2aBaseURL string, authenticator auth.AuthProvider, a2aTimeout time.Duration) (*MCPHandler, error) {
+	if a2aTimeout > 30*time.Minute {
+		a2aTimeout = 30 * time.Minute
+	}
 	handler := &MCPHandler{
 		kubeClient:    kubeClient,
 		a2aBaseURL:    a2aBaseURL,
 		authenticator: authenticator,
+		a2aTimeout:    a2aTimeout,
 	}
 
 	// Create MCP server
@@ -209,7 +214,7 @@ func (h *MCPHandler) handleInvokeAgent(ctx context.Context, req *mcpsdk.CallTool
 	if a2aClient == nil {
 		// Build A2A client options with authentication propagation
 		a2aOpts := []a2aclient.Option{
-			a2aclient.WithTimeout(30 * time.Second),
+			a2aclient.WithTimeout(h.a2aTimeout),
 			a2aclient.WithHTTPReqHandler(
 				authimpl.A2ARequestHandler(
 					h.authenticator,

--- a/go/core/pkg/app/app.go
+++ b/go/core/pkg/app/app.go
@@ -124,6 +124,7 @@ type Config struct {
 	HttpServerAddr     string
 	WatchNamespaces    string
 	A2ABaseUrl         string
+	A2AMCPTimeout      time.Duration
 	Database           struct {
 		Url           string
 		UrlFile       string
@@ -155,6 +156,7 @@ func (cfg *Config) SetFlags(commandLine *flag.FlagSet) {
 	commandLine.StringVar(&cfg.DefaultModelConfig.Namespace, "default-model-config-namespace", kagentNamespace, "The namespace of the default model config.")
 	commandLine.StringVar(&cfg.HttpServerAddr, "http-server-address", ":8083", "The address the HTTP server binds to.")
 	commandLine.StringVar(&cfg.A2ABaseUrl, "a2a-base-url", "http://127.0.0.1:8083", "The base URL of the A2A Server endpoint, as advertised to clients.")
+	commandLine.DurationVar(&cfg.A2AMCPTimeout, "a2a-mcp-timeout", 30*time.Second, "The timeout for the A2A protocol connection with MCP.")
 	commandLine.StringVar(&cfg.Database.Url, "postgres-database-url", "postgres://postgres:kagent@kagent-postgresql.kagent.svc.cluster.local:5432/postgres", "The URL of the PostgreSQL database.")
 	commandLine.StringVar(&cfg.Database.UrlFile, "postgres-database-url-file", "", "Path to a file containing the PostgreSQL database URL. Takes precedence over --postgres-database-url.")
 	commandLine.BoolVar(&cfg.Database.VectorEnabled, "database-vector-enabled", true, "Enable pgvector extension and memory table. Requires pgvector to be installed on the PostgreSQL server.")
@@ -533,6 +535,7 @@ func Start(getExtensionConfig GetExtensionConfig) {
 		mgr.GetClient(),
 		cfg.A2ABaseUrl+httpserver.APIPathA2A,
 		extensionCfg.Authenticator,
+		cfg.A2AMCPTimeout,
 	)
 	if err != nil {
 		setupLog.Error(err, "unable to create MCP handler")

--- a/helm/kagent/templates/controller-configmap.yaml
+++ b/helm/kagent/templates/controller-configmap.yaml
@@ -7,6 +7,7 @@ metadata:
     {{- include "kagent.controller.labels" . | nindent 4 }}
 data:
   A2A_BASE_URL: {{ include "kagent.a2aBaseUrl" . | quote }}
+  A2A_MCP_TIMEOUT: {{ .Values.controller.a2aMcpTimeout | quote }}
   DEFAULT_MODEL_CONFIG_NAME: {{ include "kagent.defaultModelConfigName" . | quote }}
   KAGENT_CONTROLLER_NAME: {{ include "kagent.fullname" . }}-controller
   IMAGE_PULL_POLICY: {{ .Values.controller.agentImage.pullPolicy | default .Values.imagePullPolicy | quote }}

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -150,6 +150,9 @@ controller:
   # -- The base URL of the A2A Server endpoint, as advertised to clients.
   # @default -- `http://<fullname>-controller.<namespace>.svc.cluster.local:<port>`
   a2aBaseUrl: ""
+  # -- Timeout for A2A internal protocol connection with MCP.
+  # @default -- 30s
+  a2aMcpTimeout: "30s"
   agentImage:
     registry: ""
     repository: kagent-dev/kagent/app


### PR DESCRIPTION
# Configurable A2A MCP Timeout

## Description
This MR introduces a configurable timeout for the internal A2A connections established between the KAgent Controller's MCP handler and the destination Agent Pods.

Previously, when an MCP client requested the `invoke_agent` tool, the controller established a network channel to the agent with a hard-coded constraint of `30 * time.Second`. If the agent's LLM generation or tool execution took longer than 30 seconds, the connection forcefully terminated, preventing the use of long-running skills.

This change paramaterizes that constraint, making it fully configurable down from Helm charts to the Go application runtime, while enforcing a definitive ceiling of 30 minutes to prevent zombie connections.

## Changes Included
* **Go Application (`app.go`, `mcp_handler.go`)**
  * Added `--a2a-mcp-timeout` CLI flag with backward compatibility defaulting to `30s`.
  * Updated the controller's `MCPHandler` to dynamically adopt the new configuration value.
  * Implemented an absolute ceiling check: if a system administrator passes a timeout longer than `30m`, it correctly caps at `30m` max. 
* **Helm Deployment (`values.yaml`, `controller-configmap.yaml`)**
  * Exposed `controller.a2aMcpTimeout` in `values.yaml` (default: `"30s"`).
  * Mapped the helm configuration value seamlessly into the controller's pod context under the `A2A_MCP_TIMEOUT` environment variable.

## Verification & Testing
* Validated that a provided `a2aMcpTimeout` smoothly propagates across the deployment components to the lowest networking level in the `a2aclient`.
* Verified backward compatibility (retains 30s timeout without interference if no custom param is provided).