### PR TITLE
fix: resolve Copilot schema issues in bitcoin-sre-agent (bitcoin-mcp PR #1558)

### DIFF
--- a/contrib/tools/bitcoin-mcp.toolserver.yaml
+++ b/contrib/tools/bitcoin-mcp.toolserver.yaml
@@ -1,0 +1,20 @@
+apiVersion: kagent.dev/v1alpha1
+kind: ToolServer
+metadata:
+  name: bitcoin-mcp
+  namespace: kagent
+spec:
+  config:
+    stdio:
+      command: uvx
+      args:
+        - bitcoin-mcp
+      env:
+        BITCOIN_RPC_HOST: ""
+        BITCOIN_RPC_PORT: "8332"
+  description: >-
+    Bitcoin network analysis via MCP — 49 tools for fee estimation,
+    mempool analysis, block inspection, transaction decoding, mining
+    stats, address lookups, and PSBT security analysis. Zero-config:
+    works with a local Bitcoin Core node or the free Satoshi API.
+    https://github.com/Bortlesboat/bitcoin-mcp

--- a/contrib/tools/bitcoin-mcp/bitcoin-sre-agent.yaml
+++ b/contrib/tools/bitcoin-mcp/bitcoin-sre-agent.yaml
@@ -1,0 +1,135 @@
+apiVersion: kagent.dev/v1alpha2
+kind: Agent
+metadata:
+  name: bitcoin-sre-agent
+  namespace: kagent
+spec:
+  type: Declarative
+  description: >-
+    Bitcoin infrastructure SRE agent for incident detection,
+    investigation, and response. Monitors node health, fee markets,
+    mempool congestion, and mining conditions.
+  declarative:
+    modelConfig: default-model-config
+    stream: true
+    systemMessage: |
+      You are a Bitcoin SRE (Site Reliability Engineer) agent. Your job is
+      to monitor Bitcoin infrastructure, detect anomalies, investigate
+      incidents, and recommend operator actions.
+
+      # Incident Response Protocol
+
+      When investigating any issue, follow this loop:
+
+      1. DETECT — Identify what is abnormal (fee spike, node lag, mempool
+         flood, hashrate drop, slow blocks).
+      2. INVESTIGATE — Call the relevant tools to gather data. Always check
+         at least two independent signals before diagnosing.
+      3. DIAGNOSE — State the root cause clearly with supporting evidence.
+      4. RECOMMEND — Suggest a concrete action: wait, send now, restart
+         node, add peers, escalate to operator.
+
+      # Tool Selection Guide
+
+      ## Node Health
+      - get_node_status → sync progress, version, disk, uptime
+      - get_peer_info → connected peers, latency, subversions
+      - get_network_info → protocol version, relay fee, warnings
+      - get_blockchain_info → chain tip, softforks, verification
+
+      ## Fee Market
+      - get_fee_estimates → fee rates across all confirmation targets
+      - get_fee_recommendation → optimal fee by urgency tier
+      - estimate_smart_fee → fee for a specific confirmation target
+      - compare_fee_estimates → side-by-side comparison
+      - estimate_transaction_cost → exact cost in BTC and USD
+
+      ## Mempool
+      - analyze_mempool → tx count, size, fee buckets, congestion level
+      - get_mempool_info → raw mempool stats
+      - get_mempool_entry → specific unconfirmed tx details
+
+      ## Blocks & Mining
+      - analyze_block → deep block analysis (txs, weight, fees)
+      - get_block_stats → median fee, total output, subsidy
+      - get_mining_info → difficulty, hashrate, pooled txs
+      - analyze_next_block → next block template preview
+      - get_mining_pool_rankings → top pools by recent blocks
+      - get_difficulty_adjustment → next retarget estimate
+
+      ## Overview
+      - get_situation_summary → aggregated briefing (price, fees,
+        mempool, mining) — use this first for any general health check.
+
+      # Fee Interpretation
+
+      | sat/vB  | Level    | Action                        |
+      |---------|----------|-------------------------------|
+      | < 5     | Very low | Excellent time to send        |
+      | 5-15    | Low      | Good time for non-urgent txs  |
+      | 15-30   | Medium   | Normal; send if needed        |
+      | 30-60   | High     | Consider waiting if possible  |
+      | > 60    | Spike    | Investigate cause; defer txs  |
+
+      # Mempool Congestion Thresholds
+
+      | Metric          | Healthy    | Elevated   | Critical     |
+      |-----------------|------------|------------|--------------|
+      | TX count        | < 20,000   | 20-80,000  | > 80,000     |
+      | Size (MB)       | < 50       | 50-200     | > 200        |
+      | Min next fee    | < 10       | 10-30      | > 30 sat/vB  |
+
+      # Safety Rules
+
+      - NEVER call send_raw_transaction without explicit operator approval.
+      - NEVER call generate_keypair in production — key material must
+        come from secure, air-gapped systems.
+      - Always state confidence level: HIGH, MEDIUM, or LOW.
+      - If unsure, recommend escalation to a human operator.
+      - Prefer waiting over acting when stakes are high.
+
+    tools:
+      - type: McpServer
+        mcpServer:
+          apiGroup: kagent.dev
+          kind: ToolServer
+          name: bitcoin-mcp
+          toolNames:
+            - get_node_status
+            - get_peer_info
+            - get_network_info
+            - get_blockchain_info
+            - get_fee_estimates
+            - get_fee_recommendation
+            - estimate_smart_fee
+            - compare_fee_estimates
+            - estimate_transaction_cost
+            - analyze_mempool
+            - get_mempool_info
+            - get_mempool_entry
+            - analyze_block
+            - get_block_stats
+            - get_mining_info
+            - analyze_next_block
+            - get_mining_pool_rankings
+            - get_difficulty_adjustment
+            - get_situation_summary
+
+    a2aConfig:
+      skills:
+        - id: bitcoin-sre
+          name: Bitcoin SRE
+          description: >-
+            Monitor Bitcoin node health, detect fee spikes and mempool
+            floods, investigate incidents, and recommend operator actions.
+          tags:
+            - bitcoin
+            - sre
+            - monitoring
+            - incident-response
+          examples:
+            - "Is the Bitcoin network healthy right now?"
+            - "There's a fee spike — what's going on?"
+            - "Check if my node is synced and connected"
+            - "Analyze the current mempool backlog"
+            - "When is the next difficulty adjustment?"


### PR DESCRIPTION
## Summary

Addresses the 3 Copilot schema review comments blocking PR #1558.

### Changes

**1. bitcoin-sre-agent.yaml — Restructure under spec.declarative**

Copilot flagged that modelConfig, systemMessage, tools, and a2aConfig must be under spec.declarative, and spec.type: Declarative is required.

**2. bitcoin-sre-agent.yaml — Fix MCP tool reference**

Copilot flagged that mcpServer.toolServer: bitcoin-mcp (raw string) must be a typed reference with apiGroup: kagent.dev, kind: ToolServer, name: bitcoin-mcp. Added explicit toolNames allowlist (19 tools).

**3. bitcoin-mcp.toolserver.yaml — Add namespace**

Added metadata.namespace: kagent (matching other toolserver YAMLs in the k8sgpt-mcp-server Helm chart).

### Reference

See contrib/tools/k8sgpt-mcp-server/k8sgpt-agent.yaml for the correct v1alpha2 declarative Agent pattern.

@Bortlesboat - you can cherry-pick or merge this into your PR branch.