### PR TITLE
fix: resolve Copilot schema comments on bitcoin-mcp manifests

### DIFF
--- a/contrib/tools/bitcoin-mcp.toolserver.yaml
+++ b/contrib/tools/bitcoin-mcp.toolserver.yaml
@@ -1,0 +1,20 @@
+apiVersion: kagent.dev/v1alpha1
+kind: ToolServer
+metadata:
+  name: bitcoin-mcp
+  namespace: kagent
+spec:
+  config:
+    stdio:
+      command: uvx
+      args:
+        - bitcoin-mcp
+      env:
+        BITCOIN_RPC_HOST: ""
+        BITCOIN_RPC_PORT: "8332"
+  description: >-
+    Bitcoin network analysis via MCP — 49 tools for fee estimation,
+    mempool analysis, block inspection, transaction decoding, mining
+    stats, address lookups, and PSBT security analysis. Zero-config:
+    works with a local Bitcoin Core node or the free Satoshi API.
+    https://github.com/Bortlesboat/bitcoin-mcp

--- a/contrib/tools/bitcoin-mcp.toolserver.yaml
+++ b/contrib/tools/bitcoin-mcp.toolserver.yaml
@@ -1,5 +1,5 @@
 apiVersion: kagent.dev/v1alpha1
-kind: ToolServer
+kind: MCPServer
 metadata:
   name: bitcoin-mcp
   namespace: kagent

--- a/contrib/tools/bitcoin-mcp/bitcoin-sre-agent.yaml
+++ b/contrib/tools/bitcoin-mcp/bitcoin-sre-agent.yaml
@@ -81,9 +81,6 @@ spec:
 
       # Safety Rules
 
-      - NEVER call send_raw_transaction without explicit operator approval.
-      - NEVER call generate_keypair in production — key material must
-        come from secure, air-gapped systems.
       - Always state confidence level: HIGH, MEDIUM, or LOW.
       - If unsure, recommend escalation to a human operator.
       - Prefer waiting over acting when stakes are high.
@@ -92,7 +89,7 @@ spec:
       - type: McpServer
         mcpServer:
           apiGroup: kagent.dev
-          kind: ToolServer
+          kind: MCPServer
           name: bitcoin-mcp
           toolNames:
             - get_node_status

--- a/contrib/tools/bitcoin-mcp/bitcoin-sre-agent.yaml
+++ b/contrib/tools/bitcoin-mcp/bitcoin-sre-agent.yaml
@@ -1,0 +1,135 @@
+apiVersion: kagent.dev/v1alpha2
+kind: Agent
+metadata:
+  name: bitcoin-sre-agent
+  namespace: kagent
+spec:
+  type: Declarative
+  description: >-
+    Bitcoin infrastructure SRE agent for incident detection,
+    investigation, and response. Monitors node health, fee markets,
+    mempool congestion, and mining conditions.
+  declarative:
+    modelConfig: default-model-config
+    stream: true
+    systemMessage: |
+      You are a Bitcoin SRE (Site Reliability Engineer) agent. Your job is
+      to monitor Bitcoin infrastructure, detect anomalies, investigate
+      incidents, and recommend operator actions.
+
+      # Incident Response Protocol
+
+      When investigating any issue, follow this loop:
+
+      1. DETECT — Identify what is abnormal (fee spike, node lag, mempool
+         flood, hashrate drop, slow blocks).
+      2. INVESTIGATE — Call the relevant tools to gather data. Always check
+         at least two independent signals before diagnosing.
+      3. DIAGNOSE — State the root cause clearly with supporting evidence.
+      4. RECOMMEND — Suggest a concrete action: wait, send now, restart
+         node, add peers, escalate to operator.
+
+      # Tool Selection Guide
+
+      ## Node Health
+      - get_node_status → sync progress, version, disk, uptime
+      - get_peer_info → connected peers, latency, subversions
+      - get_network_info → protocol version, relay fee, warnings
+      - get_blockchain_info → chain tip, softforks, verification
+
+      ## Fee Market
+      - get_fee_estimates → fee rates across all confirmation targets
+      - get_fee_recommendation → optimal fee by urgency tier
+      - estimate_smart_fee → fee for a specific confirmation target
+      - compare_fee_estimates → side-by-side comparison
+      - estimate_transaction_cost → exact cost in BTC and USD
+
+      ## Mempool
+      - analyze_mempool → tx count, size, fee buckets, congestion level
+      - get_mempool_info → raw mempool stats
+      - get_mempool_entry → specific unconfirmed tx details
+
+      ## Blocks & Mining
+      - analyze_block → deep block analysis (txs, weight, fees)
+      - get_block_stats → median fee, total output, subsidy
+      - get_mining_info → difficulty, hashrate, pooled txs
+      - analyze_next_block → next block template preview
+      - get_mining_pool_rankings → top pools by recent blocks
+      - get_difficulty_adjustment → next retarget estimate
+
+      ## Overview
+      - get_situation_summary → aggregated briefing (price, fees,
+        mempool, mining) — use this first for any general health check.
+
+      # Fee Interpretation
+
+      | sat/vB  | Level    | Action                        |
+      |---------|----------|-------------------------------|
+      | < 5     | Very low | Excellent time to send        |
+      | 5-15    | Low      | Good time for non-urgent txs  |
+      | 15-30   | Medium   | Normal; send if needed        |
+      | 30-60   | High     | Consider waiting if possible  |
+      | > 60    | Spike    | Investigate cause; defer txs  |
+
+      # Mempool Congestion Thresholds
+
+      | Metric          | Healthy    | Elevated   | Critical     |
+      |-----------------|------------|------------|--------------|
+      | TX count        | < 20,000   | 20-80,000  | > 80,000     |
+      | Size (MB)       | < 50       | 50-200     | > 200        |
+      | Min next fee    | < 10       | 10-30      | > 30 sat/vB  |
+
+      # Safety Rules
+
+      - NEVER call send_raw_transaction without explicit operator approval.
+      - NEVER call generate_keypair in production — key material must
+        come from secure, air-gapped systems.
+      - Always state confidence level: HIGH, MEDIUM, or LOW.
+      - If unsure, recommend escalation to a human operator.
+      - Prefer waiting over acting when stakes are high.
+
+    tools:
+      - type: McpServer
+        mcpServer:
+          apiGroup: kagent.dev
+          kind: ToolServer
+          name: bitcoin-mcp
+          toolNames:
+            - get_node_status
+            - get_peer_info
+            - get_network_info
+            - get_blockchain_info
+            - get_fee_estimates
+            - get_fee_recommendation
+            - estimate_smart_fee
+            - compare_fee_estimates
+            - estimate_transaction_cost
+            - analyze_mempool
+            - get_mempool_info
+            - get_mempool_entry
+            - analyze_block
+            - get_block_stats
+            - get_mining_info
+            - analyze_next_block
+            - get_mining_pool_rankings
+            - get_difficulty_adjustment
+            - get_situation_summary
+
+    a2aConfig:
+      skills:
+        - id: bitcoin-sre
+          name: Bitcoin SRE
+          description: >-
+            Monitor Bitcoin node health, detect fee spikes and mempool
+            floods, investigate incidents, and recommend operator actions.
+          tags:
+            - bitcoin
+            - sre
+            - monitoring
+            - incident-response
+          examples:
+            - "Is the Bitcoin network healthy right now?"
+            - "There's a fee spike — what's going on?"
+            - "Check if my node is synced and connected"
+            - "Analyze the current mempool backlog"
+            - "When is the next difficulty adjustment?"


### PR DESCRIPTION
Resolves the 3 Copilot review comments on PR #1677:

1. **ToolServer → MCPServer in toolserver manifest**: Changed `kind: ToolServer` to `kind: MCPServer` — kagent controllers only reconcile MCPServer/RemoteMCPServer/Service resources, not ToolServer
2. **ToolServer → MCPServer in agent tool reference**: Updated the `kind` in the agent YAML's `tools[].mcpServer` block to `MCPServer` to match the corrected resource type  
3. **Removed mismatched safety rules**: Removed `send_raw_transaction` and `generate_keypair` from the safety rules since they are not in the `toolNames` allowlist

References:
- https://github.com/kagent-dev/kagent/pull/1677#discussion-r3083844574
- https://github.com/kagent-dev/kagent/pull/1677#discussion-r3083844594
- https://github.com/kagent-dev/kagent/pull/1677#discussion-r3083844609