### PR TITLE
fix: prevent Namespace informer cache errors and fallbacks

### DIFF
--- a/go/api/v1alpha2/common_types.go
+++ b/go/api/v1alpha2/common_types.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/kagent-dev/kagent/go/api/utils"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -87,6 +88,9 @@ func (a *AllowedNamespaces) AllowsNamespace(ctx context.Context, c client.Client
 		// Get the source namespace to check its labels
 		ns := &corev1.Namespace{}
 		if err := c.Get(ctx, types.NamespacedName{Name: sourceNamespace}, ns); err != nil {
+			if apierrors.IsForbidden(err) || apierrors.IsUnauthorized(err) {
+				return false, fmt.Errorf("allowedNamespaces.from=Selector requires namespace read access: %w", err)
+			}
 			return false, fmt.Errorf("failed to get namespace %s: %w", sourceNamespace, err)
 		}
 

--- a/go/api/v1alpha2/common_types_test.go
+++ b/go/api/v1alpha2/common_types_test.go
@@ -23,9 +23,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl_client "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 func TestAllowedNamespaces_AllowsNamespace(t *testing.T) {
@@ -344,4 +348,29 @@ func TestAllowedNamespaces_AllowsNamespace(t *testing.T) {
 			assert.Equal(t, tt.wantAllowed, allowed)
 		})
 	}
+
+	t.Run("From=Selector returns error when namespace read is forbidden", func(t *testing.T) {
+		forbiddenClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			// Simulates namespaced RBAC where the controller cannot read Namespace objects.
+			WithInterceptorFuncs(interceptor.Funcs{
+				Get: func(ctx context.Context, c ctrl_client.WithWatch, key ctrl_client.ObjectKey, obj ctrl_client.Object, opts ...ctrl_client.GetOption) error {
+					if _, ok := obj.(*corev1.Namespace); ok {
+						return apierrors.NewForbidden(schema.GroupResource{Resource: "namespaces"}, key.Name, nil)
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+			}).
+			Build()
+
+		allowedNs := &AllowedNamespaces{
+			From: NamespacesFromSelector,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"shared-access": "true"},
+			},
+		}
+		_, err := allowedNs.AllowsNamespace(ctx, forbiddenClient, "source-ns", "target-ns")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "allowedNamespaces.from=Selector requires namespace read access")
+	})
 }

--- a/go/core/internal/controller/translator/agent/adk_api_translator.go
+++ b/go/core/internal/controller/translator/agent/adk_api_translator.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kagent-dev/kmcp/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -161,8 +162,13 @@ func getRuntimeProbeConfig(runtime v1alpha2.DeclarativeRuntime) probeConfig {
 type TranslatorPlugin = translator.TranslatorPlugin
 
 func NewAdkApiTranslator(kube client.Client, defaultModelConfig types.NamespacedName, plugins []TranslatorPlugin, globalProxyURL string, sandboxBackend sandboxbackend.Backend) AdkApiTranslator {
+	return NewAdkApiTranslatorWithWatchedNamespaces(kube, nil, defaultModelConfig, plugins, globalProxyURL, sandboxBackend)
+}
+
+func NewAdkApiTranslatorWithWatchedNamespaces(kube client.Client, watchedNamespaces []string, defaultModelConfig types.NamespacedName, plugins []TranslatorPlugin, globalProxyURL string, sandboxBackend sandboxbackend.Backend) AdkApiTranslator {
 	return &adkApiTranslator{
 		kube:               kube,
+		watchedNamespaces:  watchedNamespaces,
 		defaultModelConfig: defaultModelConfig,
 		plugins:            plugins,
 		globalProxyURL:     globalProxyURL,
@@ -172,6 +178,7 @@ func NewAdkApiTranslator(kube client.Client, defaultModelConfig types.Namespaced
 
 type adkApiTranslator struct {
 	kube               client.Client
+	watchedNamespaces  []string
 	defaultModelConfig types.NamespacedName
 	plugins            []TranslatorPlugin
 	globalProxyURL     string
@@ -902,6 +909,10 @@ func (a *adkApiTranslator) isInternalK8sURL(ctx context.Context, urlStr, namespa
 		if err == nil {
 			// Namespace exists, so this is an internal k8s URL
 			return true
+		}
+		// Controller is using namespaced RBAC, so check if the namespace is watched
+		if (apierrors.IsForbidden(err) || apierrors.IsUnauthorized(err)) && len(a.watchedNamespaces) > 0 {
+			return slices.Contains(a.watchedNamespaces, potentialNamespace)
 		}
 		// If namespace doesn't exist, it's likely a TLD or external domain
 	}

--- a/go/core/internal/controller/translator/agent/proxy_test.go
+++ b/go/core/internal/controller/translator/agent/proxy_test.go
@@ -7,10 +7,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	schemev1 "k8s.io/client-go/kubernetes/scheme"
+	ctrl_client "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/kagent-dev/kagent/go/api/v1alpha2"
 	agenttranslator "github.com/kagent-dev/kagent/go/core/internal/controller/translator/agent"
@@ -174,6 +178,91 @@ func TestProxyConfiguration_ThroughTranslateAgent(t *testing.T) {
 			assert.False(t, hasHost, "Proxy header should not be set when no proxy")
 		}
 	})
+}
+
+func TestProxyConfiguration_RemoteMCPServer_FallsBackToWatchedNamespacesWhenNamespaceReadsForbidden(t *testing.T) {
+	ctx := context.Background()
+	scheme := schemev1.Scheme
+	err := v1alpha2.AddToScheme(scheme)
+	require.NoError(t, err)
+
+	modelConfig := &v1alpha2.ModelConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default-model",
+			Namespace: "test",
+		},
+		Spec: v1alpha2.ModelConfigSpec{
+			Provider: "OpenAI",
+			Model:    "gpt-4o",
+		},
+	}
+
+	remoteMcpServer := &v1alpha2.RemoteMCPServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-mcp",
+			Namespace: "test",
+		},
+		Spec: v1alpha2.RemoteMCPServerSpec{
+			URL:      "http://test-mcp-server.kagent:8084/mcp",
+			Protocol: v1alpha2.RemoteMCPServerProtocolStreamableHttp,
+		},
+	}
+
+	agent := &v1alpha2.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-agent",
+			Namespace: "test",
+		},
+		Spec: v1alpha2.AgentSpec{
+			Type: v1alpha2.AgentType_Declarative,
+			Declarative: &v1alpha2.DeclarativeAgentSpec{
+				SystemMessage: "Test",
+				ModelConfig:   "default-model",
+				Tools: []*v1alpha2.Tool{
+					{
+						Type: v1alpha2.ToolProviderType_McpServer,
+						McpServer: &v1alpha2.McpServerTool{
+							TypedReference: v1alpha2.TypedReference{
+								Name: "test-mcp",
+								Kind: "RemoteMCPServer",
+							},
+							ToolNames: []string{"test-tool"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Build a client that has the objects but returns Forbidden for Namespace reads,
+	// simulating namespaced RBAC where the controller cannot read Namespace objects.
+	kubeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(agent, remoteMcpServer, modelConfig).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c ctrl_client.WithWatch, key ctrl_client.ObjectKey, obj ctrl_client.Object, opts ...ctrl_client.GetOption) error {
+				if _, ok := obj.(*corev1.Namespace); ok {
+					return apierrors.NewForbidden(schema.GroupResource{Resource: "namespaces"}, "", nil)
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	translator := agenttranslator.NewAdkApiTranslatorWithWatchedNamespaces(
+		kubeClient,
+		[]string{"test", "kagent"},
+		types.NamespacedName{Name: "default-model", Namespace: "test"},
+		nil,
+		"http://proxy.kagent.svc.cluster.local:8080",
+		nil,
+	)
+
+	result, err := agenttranslator.TranslateAgent(ctx, translator, agent)
+	require.NoError(t, err)
+	require.Len(t, result.Config.HttpTools, 1)
+	assert.Equal(t, "http://proxy.kagent.svc.cluster.local:8080/mcp", result.Config.HttpTools[0].Params.Url)
+	assert.Equal(t, "test-mcp-server.kagent", result.Config.HttpTools[0].Params.Headers[agenttranslator.ProxyHostHeader])
 }
 
 // TestProxyConfiguration_RemoteMCPServer_ExternalURL tests that RemoteMCPServer with external URLs does NOT use proxy

--- a/go/core/internal/httpserver/handlers/agents.go
+++ b/go/core/internal/httpserver/handlers/agents.go
@@ -168,8 +168,9 @@ func (h *AgentsHandler) getAgentResponse(ctx context.Context, log logr.Logger, a
 }
 
 func (h *AgentsHandler) buildTranslator(kubeClient client.Client) agent_translator.AdkApiTranslator {
-	return agent_translator.NewAdkApiTranslator(
+	return agent_translator.NewAdkApiTranslatorWithWatchedNamespaces(
 		kubeClient,
+		h.WatchedNamespaces,
 		h.DefaultModelConfig,
 		nil,
 		h.ProxyURL,

--- a/go/core/internal/httpserver/handlers/handlers.go
+++ b/go/core/internal/httpserver/handlers/handlers.go
@@ -66,7 +66,7 @@ func NewHandlers(kubeClient client.Client, defaultModelConfig types.NamespacedNa
 		ToolServerTypes:     NewToolServerTypesHandler(base),
 		Memory:              NewMemoryHandler(base),
 		Feedback:            NewFeedbackHandler(base),
-		Namespaces:          NewNamespacesHandler(base, watchedNamespaces),
+		Namespaces:          NewNamespacesHandler(base),
 		PromptTemplates:     NewPromptTemplatesHandler(base),
 		Tasks:               NewTasksHandler(base),
 		Checkpoints:         NewCheckpointsHandler(base),

--- a/go/core/internal/httpserver/handlers/handlers.go
+++ b/go/core/internal/httpserver/handlers/handlers.go
@@ -38,6 +38,7 @@ type Base struct {
 	DatabaseService    database.Client
 	Authorizer         auth.Authorizer // Interface for authorization checks
 	ProxyURL           string
+	WatchedNamespaces  []string
 	SandboxBackend     sandboxbackend.Backend
 }
 
@@ -49,6 +50,7 @@ func NewHandlers(kubeClient client.Client, defaultModelConfig types.NamespacedNa
 		DatabaseService:    dbService,
 		Authorizer:         authorizer,
 		ProxyURL:           proxyURL,
+		WatchedNamespaces:  watchedNamespaces,
 		SandboxBackend:     sandboxBackend,
 	}
 

--- a/go/core/internal/httpserver/handlers/namespaces.go
+++ b/go/core/internal/httpserver/handlers/namespaces.go
@@ -8,7 +8,8 @@ import (
 	api "github.com/kagent-dev/kagent/go/api/httpapi"
 	"github.com/kagent-dev/kagent/go/core/internal/httpserver/errors"
 	corev1 "k8s.io/api/core/v1"
-	ctrl_client "sigs.k8s.io/controller-runtime/pkg/client"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -59,31 +60,37 @@ func (h *NamespacesHandler) HandleListNamespaces(w ErrorResponseWriter, r *http.
 		return
 	}
 
-	// Filter to only show watched namespaces that exist in the cluster
-	log.Info("Listing watched namespaces only", "watchedNamespaces", h.WatchedNamespaces)
-	var namespaces []api.NamespaceResponse
-
+	// In reduced-scope mode, avoid Namespace reads entirely and return the configured
+	// watch set as the namespace source of truth.
+	log.Info("Listing configured watched namespaces only", "watchedNamespaces", h.WatchedNamespaces)
+	namespaces := make([]api.NamespaceResponse, 0, len(h.WatchedNamespaces))
 	for _, watchedNS := range h.WatchedNamespaces {
 		namespace := &corev1.Namespace{}
-		if err := h.KubeClient.Get(r.Context(), ctrl_client.ObjectKey{Name: watchedNS}, namespace); err != nil {
-			if ctrl_client.IgnoreNotFound(err) != nil {
-				log.Error(err, "Failed to get namespace", "namespace", watchedNS)
-				continue // Skip this namespace
+		if err := h.KubeClient.Get(r.Context(), client.ObjectKey{Name: watchedNS}, namespace); err != nil {
+			if apierrors.IsForbidden(err) || apierrors.IsUnauthorized(err) {
+				namespaces = namespaceResponsesFromNames(h.WatchedNamespaces)
+				break
 			}
-			log.Info("Watched namespace not found", "namespace", watchedNS)
+			log.Error(err, "Failed to get namespace", "namespace", watchedNS)
 			continue
 		}
-
 		namespaces = append(namespaces, api.NamespaceResponse{
 			Name:   namespace.Name,
 			Status: string(namespace.Status.Phase),
 		})
 	}
-
 	slices.SortStableFunc(namespaces, func(i, j api.NamespaceResponse) int {
 		return strings.Compare(strings.ToLower(i.Name), strings.ToLower(j.Name))
 	})
 
 	data := api.NewResponse(namespaces, "Successfully listed namespaces", false)
 	RespondWithJSON(w, http.StatusOK, data)
+}
+
+func namespaceResponsesFromNames(names []string) []api.NamespaceResponse {
+	responses := make([]api.NamespaceResponse, 0, len(names))
+	for _, name := range names {
+		responses = append(responses, api.NamespaceResponse{Name: name})
+	}
+	return responses
 }

--- a/go/core/internal/httpserver/handlers/namespaces.go
+++ b/go/core/internal/httpserver/handlers/namespaces.go
@@ -16,17 +16,11 @@ import (
 // NamespacesHandler handles namespace-related requests
 type NamespacesHandler struct {
 	*Base
-	// List of namespaces being watched, empty means watch all. Used for listing namespaces.
-	// Can be moved to the base handler if any other handlers need it
-	WatchedNamespaces []string
 }
 
 // NewNamespacesHandler creates a new NamespacesHandler
-func NewNamespacesHandler(base *Base, watchedNamespaces []string) *NamespacesHandler {
-	return &NamespacesHandler{
-		Base:              base,
-		WatchedNamespaces: watchedNamespaces,
-	}
+func NewNamespacesHandler(base *Base) *NamespacesHandler {
+	return &NamespacesHandler{Base: base}
 }
 
 // HandleListNamespaces returns a list of namespaces based on the watch configuration
@@ -60,8 +54,9 @@ func (h *NamespacesHandler) HandleListNamespaces(w ErrorResponseWriter, r *http.
 		return
 	}
 
-	// In reduced-scope mode, avoid Namespace reads entirely and return the configured
-	// watch set as the namespace source of truth.
+	// Enrich each watched namespace with live status from the API server when
+	// namespace reads are permitted. If reads are forbidden or unauthorized,
+	// fall back to the configured watch list without status information.
 	log.Info("Listing configured watched namespaces only", "watchedNamespaces", h.WatchedNamespaces)
 	namespaces := make([]api.NamespaceResponse, 0, len(h.WatchedNamespaces))
 	for _, watchedNS := range h.WatchedNamespaces {
@@ -70,6 +65,10 @@ func (h *NamespacesHandler) HandleListNamespaces(w ErrorResponseWriter, r *http.
 			if apierrors.IsForbidden(err) || apierrors.IsUnauthorized(err) {
 				namespaces = namespaceResponsesFromNames(h.WatchedNamespaces)
 				break
+			}
+			if apierrors.IsNotFound(err) {
+				log.Info("Skipping watched namespace that was not found", "namespace", watchedNS)
+				continue
 			}
 			log.Error(err, "Failed to get namespace", "namespace", watchedNS)
 			continue

--- a/go/core/internal/httpserver/handlers/namespaces_test.go
+++ b/go/core/internal/httpserver/handlers/namespaces_test.go
@@ -37,8 +37,9 @@ func TestNamespacesHandler(t *testing.T) {
 		base := &handlers.Base{
 			KubeClient:         kubeClient,
 			DefaultModelConfig: types.NamespacedName{Namespace: "default", Name: "default"},
+			WatchedNamespaces:  watchedNamespaces,
 		}
-		handler := handlers.NewNamespacesHandler(base, watchedNamespaces)
+		handler := handlers.NewNamespacesHandler(base)
 		responseRecorder := newMockErrorResponseWriter()
 		return handler, kubeClient, responseRecorder
 	}
@@ -258,7 +259,7 @@ func TestNamespacesHandler(t *testing.T) {
 
 			// Replace kubeClient with one that returns Forbidden for Namespace reads,
 			// simulating namespaced RBAC where the controller cannot list/get Namespaces.
-			handler.Base.KubeClient = fake.NewClientBuilder().
+			handler.KubeClient = fake.NewClientBuilder().
 				WithScheme(scheme).
 				WithInterceptorFuncs(interceptor.Funcs{
 					Get: func(ctx context.Context, c ctrl_client.WithWatch, key ctrl_client.ObjectKey, obj ctrl_client.Object, opts ...ctrl_client.GetOption) error {

--- a/go/core/internal/httpserver/handlers/namespaces_test.go
+++ b/go/core/internal/httpserver/handlers/namespaces_test.go
@@ -10,11 +10,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl_client "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	api "github.com/kagent-dev/kagent/go/api/httpapi"
 	"github.com/kagent-dev/kagent/go/core/internal/httpserver/handlers"
@@ -161,12 +164,16 @@ func TestNamespacesHandler(t *testing.T) {
 			// Check that only watched namespaces are returned
 			assert.Len(t, responseNamespaces.Data, 2)
 			namespaceNames := make([]string, len(responseNamespaces.Data))
+			namespaceStatuses := make(map[string]string)
 			for i, ns := range responseNamespaces.Data {
 				namespaceNames[i] = ns.Name
+				namespaceStatuses[ns.Name] = ns.Status
 			}
 			assert.Contains(t, namespaceNames, "default")
 			assert.Contains(t, namespaceNames, "test-ns")
 			assert.NotContains(t, namespaceNames, "kube-system")
+			assert.Equal(t, "Active", namespaceStatuses["default"])
+			assert.Equal(t, "Active", namespaceStatuses["test-ns"])
 		})
 
 		t.Run("Success_WatchedNamespaceNotFound", func(t *testing.T) {
@@ -192,7 +199,7 @@ func TestNamespacesHandler(t *testing.T) {
 			err = json.Unmarshal(responseRecorder.Body.Bytes(), &responseNamespaces)
 			require.NoError(t, err)
 
-			// Check that only existing watched namespaces were returned
+			// Check that only existing watched namespaces were returned.
 			assert.Len(t, responseNamespaces.Data, 2)
 			namespaceNames := make([]string, len(responseNamespaces.Data))
 			for i, ns := range responseNamespaces.Data {
@@ -226,7 +233,7 @@ func TestNamespacesHandler(t *testing.T) {
 			err = json.Unmarshal(responseRecorder.Body.Bytes(), &responseNamespaces)
 			require.NoError(t, err)
 
-			// We should get an empty list because we are only watching non-existent namespaces
+			// We should get an empty list because we are only watching non-existent namespaces.
 			assert.Len(t, responseNamespaces.Data, 0)
 		})
 
@@ -243,6 +250,39 @@ func TestNamespacesHandler(t *testing.T) {
 			err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseNamespaces)
 			require.NoError(t, err)
 			assert.Len(t, responseNamespaces.Data, 0)
+		})
+
+		t.Run("Success_FallbackToConfiguredWatchedNamespacesWhenNamespaceReadsForbidden", func(t *testing.T) {
+			watchedNamespaces := []string{"default", "team-a"}
+			handler, _, responseRecorder := setupHandler(watchedNamespaces)
+
+			// Replace kubeClient with one that returns Forbidden for Namespace reads,
+			// simulating namespaced RBAC where the controller cannot list/get Namespaces.
+			handler.Base.KubeClient = fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(ctx context.Context, c ctrl_client.WithWatch, key ctrl_client.ObjectKey, obj ctrl_client.Object, opts ...ctrl_client.GetOption) error {
+						if _, ok := obj.(*corev1.Namespace); ok {
+							return apierrors.NewForbidden(schema.GroupResource{Resource: "namespaces"}, "", nil)
+						}
+						return c.Get(ctx, key, obj, opts...)
+					},
+				}).
+				Build()
+
+			req := httptest.NewRequest("GET", "/api/namespaces", nil)
+			handler.HandleListNamespaces(responseRecorder, req)
+
+			assert.Equal(t, http.StatusOK, responseRecorder.Code)
+
+			var responseNamespaces api.StandardResponse[[]api.NamespaceResponse]
+			err := json.Unmarshal(responseRecorder.Body.Bytes(), &responseNamespaces)
+			require.NoError(t, err)
+			assert.Len(t, responseNamespaces.Data, 2)
+			assert.Equal(t, "default", responseNamespaces.Data[0].Name)
+			assert.Equal(t, "", responseNamespaces.Data[0].Status)
+			assert.Equal(t, "team-a", responseNamespaces.Data[1].Name)
+			assert.Equal(t, "", responseNamespaces.Data[1].Status)
 		})
 	})
 }

--- a/go/core/pkg/app/app.go
+++ b/go/core/pkg/app/app.go
@@ -76,7 +76,9 @@ import (
 	"github.com/kagent-dev/kagent/go/core/internal/controller"
 	"github.com/kagent-dev/kagent/go/core/internal/goruntime"
 	"github.com/kagent-dev/kmcp/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	agentsandboxv1 "sigs.k8s.io/agent-sandbox/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -414,6 +416,15 @@ func Start(getExtensionConfig GetExtensionConfig, migrationRunner MigrationRunne
 		HealthProbeBindAddress: cfg.ProbeAddr,
 		LeaderElection:         cfg.LeaderElection,
 		LeaderElectionID:       "0e9f6799.kagent.dev",
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				// Prevent the cached client from starting a cluster-scoped
+				// Namespace informer. In namespaced RBAC mode a Role cannot
+				// grant access to cluster-scoped resources, so an informer
+				// list/watch would crash keep crashing and cannot be handled.
+				DisableFor: []client.Object{&corev1.Namespace{}},
+			},
+		},
 		Cache: cache.Options{
 			DefaultNamespaces: configureNamespaceWatching(watchNamespacesList),
 		},
@@ -481,8 +492,9 @@ func Start(getExtensionConfig GetExtensionConfig, migrationRunner MigrationRunne
 		os.Exit(1)
 	}
 
-	apiTranslator := agent_translator.NewAdkApiTranslator(
+	apiTranslator := agent_translator.NewAdkApiTranslatorWithWatchedNamespaces(
 		mgr.GetClient(),
+		watchNamespacesList,
 		cfg.DefaultModelConfig,
 		extensionCfg.AgentPlugins,
 		cfg.Proxy.URL,

--- a/go/core/pkg/app/app.go
+++ b/go/core/pkg/app/app.go
@@ -421,7 +421,7 @@ func Start(getExtensionConfig GetExtensionConfig, migrationRunner MigrationRunne
 				// Prevent the cached client from starting a cluster-scoped
 				// Namespace informer. In namespaced RBAC mode a Role cannot
 				// grant access to cluster-scoped resources, so an informer
-				// list/watch would crash keep crashing and cannot be handled.
+				// list/watch would keep crashing and cannot be handled.
 				DisableFor: []client.Object{&corev1.Namespace{}},
 			},
 		},

--- a/go/core/pkg/app/app.go
+++ b/go/core/pkg/app/app.go
@@ -410,21 +410,23 @@ func Start(getExtensionConfig GetExtensionConfig, migrationRunner MigrationRunne
 	// filter out invalid namespaces from the watchNamespaces flag (comma separated list)
 	watchNamespacesList := filterValidNamespaces(strings.Split(cfg.WatchNamespaces, ","))
 
+	clientOpts := client.Options{}
+	if len(watchNamespacesList) > 0 {
+		// In namespaced RBAC mode a Role cannot grant access to cluster-scoped
+		// resources, so prevent the cached client from starting a cluster-scoped
+		// Namespace informer whose list/watch would keep crashing.
+		clientOpts.Cache = &client.CacheOptions{
+			DisableFor: []client.Object{&corev1.Namespace{}},
+		}
+	}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsServerOptions,
 		HealthProbeBindAddress: cfg.ProbeAddr,
 		LeaderElection:         cfg.LeaderElection,
 		LeaderElectionID:       "0e9f6799.kagent.dev",
-		Client: client.Options{
-			Cache: &client.CacheOptions{
-				// Prevent the cached client from starting a cluster-scoped
-				// Namespace informer. In namespaced RBAC mode a Role cannot
-				// grant access to cluster-scoped resources, so an informer
-				// list/watch would keep crashing and cannot be handled.
-				DisableFor: []client.Object{&corev1.Namespace{}},
-			},
-		},
+		Client:                 clientOpts,
 		Cache: cache.Options{
 			DefaultNamespaces: configureNamespaceWatching(watchNamespacesList),
 		},


### PR DESCRIPTION
## Summary

In namespaced RBAC mode, any code path that read a `Namespace` object via the cached client would lazily start a cluster-scoped list/watch informer. Since a Role cannot grant access to cluster-scoped resources, this informer repeatedly fails with a 403 error. The simple repro is listing namespaces from the UI and the following will show up repeated in the controller logs:

```
failed to list *v1.Namespace: namespaces is forbidden: User \"system:serviceaccount:kagent:kagent-controller\" cannot list resource \"namespaces\" in API group \"\" at the cluster
```

This PR disables controller-runtime's informer cache for `Namespace` objects, which automatically uses direct API reads, and thus we have the ability to catch authorization errors and use a fallback and prevent the error loop. When available, we use `watchedNamespaces` as a fallback for `isInternalK8sURL` and `/api/namespaces` call sites. For `AllowedNamespaces.from=Selector`, it returns a clear error since reading namespace labels requires cluster role. 

## Testing

The following scenarios have been manually tested:

- Listing namespaces from the UI no longer causes UI and controller error
- The above informer error spam is no longer there
- Cross NS reference with `AllowNamespaces.from=All`, `AllowedNamespaces.from=Selector` (both allowed and rejected paths and unwatched namespace rejection)
- `isInternalK8sURL` will fallback to `watchedNamespaces` during agent translation

## Alternatives

Other than catching the error, I've also thought of using some mechanism to "inform" the controller if it has cluster wide access or not. I considered `watchedNamespaces` (which is always set if using namespaced RBAC) or creating another flag, but eventually both has some complex logic or edge cases troubles and gracefully handling errors / fallback seems the best solution to me right now.