### PR TITLE
cli: add --provider flag to kagent install

### DIFF
--- a/go/core/cli/cmd/kagent/main.go
+++ b/go/core/cli/cmd/kagent/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"os/signal"
 	"syscall"
 	"time"
@@ -64,7 +65,7 @@ func main() {
 	_ = installCmd.RegisterFlagCompletionFunc("profile", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return profiles.Profiles, cobra.ShellCompDirectiveNoFileComp
 	})
-	installCmd.Flags().StringVar(&installCfg.Provider, "provider", "", "LLM provider to use (openAI, anthropic, azureOpenAI, ollama). Overrides KAGENT_DEFAULT_MODEL_PROVIDER.")
+	installCmd.Flags().StringVar(&installCfg.Provider, "provider", "", fmt.Sprintf("LLM provider to use (%s). Overrides KAGENT_DEFAULT_MODEL_PROVIDER.", strings.Join(cli.ValidProviders(), ", ")))
 	_ = installCmd.RegisterFlagCompletionFunc("provider", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return cli.ValidProviders(), cobra.ShellCompDirectiveNoFileComp
 	})

--- a/go/core/cli/cmd/kagent/main.go
+++ b/go/core/cli/cmd/kagent/main.go
@@ -64,6 +64,10 @@ func main() {
 	_ = installCmd.RegisterFlagCompletionFunc("profile", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return profiles.Profiles, cobra.ShellCompDirectiveNoFileComp
 	})
+	installCmd.Flags().StringVar(&installCfg.Provider, "provider", "", "LLM provider to use (openAI, anthropic, azureOpenAI, ollama). Overrides KAGENT_DEFAULT_MODEL_PROVIDER.")
+	_ = installCmd.RegisterFlagCompletionFunc("provider", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return cli.ValidProviders(), cobra.ShellCompDirectiveNoFileComp
+	})
 
 	uninstallCmd := &cobra.Command{
 		Use:   "uninstall",

--- a/go/core/cli/internal/cli/agent/const.go
+++ b/go/core/cli/internal/cli/agent/const.go
@@ -84,5 +84,5 @@ func applyProviderFlag(provider string) error {
 			return os.Setenv(env.KagentDefaultModelProvider.Name(), provider)
 		}
 	}
-	return fmt.Errorf("unknown provider %q — valid values: %s", provider, strings.Join(valid, ", "))
+	return fmt.Errorf("unknown provider %q: valid values: %s", provider, strings.Join(valid, ", "))
 }

--- a/go/core/cli/internal/cli/agent/const.go
+++ b/go/core/cli/internal/cli/agent/const.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -62,4 +63,26 @@ func GetEnvVarWithDefault(envVar, defaultValue string) string {
 		return value
 	}
 	return defaultValue
+}
+
+// ValidProviders returns the accepted --provider flag values (helm key format).
+func ValidProviders() []string {
+	return []string{
+		GetModelProviderHelmValuesKey(v1alpha2.ModelProviderOpenAI),
+		GetModelProviderHelmValuesKey(v1alpha2.ModelProviderAnthropic),
+		GetModelProviderHelmValuesKey(v1alpha2.ModelProviderAzureOpenAI),
+		GetModelProviderHelmValuesKey(v1alpha2.ModelProviderOllama),
+	}
+}
+
+// applyProviderFlag validates the --provider value and sets KAGENT_DEFAULT_MODEL_PROVIDER so
+// that GetModelProvider() picks it up. This lets users avoid setting the env var manually.
+func applyProviderFlag(provider string) error {
+	valid := ValidProviders()
+	for _, v := range valid {
+		if provider == v {
+			return os.Setenv(env.KagentDefaultModelProvider.Name(), provider)
+		}
+	}
+	return fmt.Errorf("unknown provider %q — valid values: %s", provider, strings.Join(valid, ", "))
 }

--- a/go/core/cli/internal/cli/agent/install.go
+++ b/go/core/cli/internal/cli/agent/install.go
@@ -95,7 +95,7 @@ func InstallCmd(ctx context.Context, cfg *InstallCfg) *PortForward {
 	if apiKeyName != "" && apiKeyValue == "" {
 		fmt.Fprintf(os.Stderr, "%s is not set\n", apiKeyName)
 		fmt.Fprintf(os.Stderr, "Please set the %s environment variable\n", apiKeyName)
-		if cfg.Provider == "" {
+		if cfg.Provider == "" && modelProvider == DefaultModelProvider && apiKeyName == env.OpenAIAPIKey.Name() {
 			fmt.Fprintf(os.Stderr, "Tip: use --provider to select a different LLM provider (e.g. --provider anthropic)\n")
 			fmt.Fprintf(os.Stderr, "     or set %s=%s before running install\n", env.KagentDefaultModelProvider.Name(), GetModelProviderHelmValuesKey(v1alpha2.ModelProviderAnthropic))
 		}

--- a/go/core/cli/internal/cli/agent/install.go
+++ b/go/core/cli/internal/cli/agent/install.go
@@ -20,8 +20,9 @@ import (
 )
 
 type InstallCfg struct {
-	Config  *config.Config
-	Profile string
+	Config   *config.Config
+	Profile  string
+	Provider string
 }
 
 // installChart installs or upgrades a Helm chart with the given parameters
@@ -76,16 +77,28 @@ func InstallCmd(ctx context.Context, cfg *InstallCfg) *PortForward {
 		return nil
 	}
 
+	// --provider flag takes precedence over KAGENT_DEFAULT_MODEL_PROVIDER env var
+	if cfg.Provider != "" {
+		if err := applyProviderFlag(cfg.Provider); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return nil
+		}
+	}
+
 	// get model provider from KAGENT_DEFAULT_MODEL_PROVIDER environment variable or use DefaultModelProvider
 	modelProvider := GetModelProvider()
 
-	// If model provider is openai, check if the API key is set
+	// Check if the required API key is set for this provider
 	apiKeyName := GetProviderAPIKey(modelProvider)
 	apiKeyValue := os.Getenv(apiKeyName)
 
 	if apiKeyName != "" && apiKeyValue == "" {
 		fmt.Fprintf(os.Stderr, "%s is not set\n", apiKeyName)
 		fmt.Fprintf(os.Stderr, "Please set the %s environment variable\n", apiKeyName)
+		if cfg.Provider == "" {
+			fmt.Fprintf(os.Stderr, "Tip: use --provider to select a different LLM provider (e.g. --provider anthropic)\n")
+			fmt.Fprintf(os.Stderr, "     or set %s=%s before running install\n", env.KagentDefaultModelProvider.Name(), GetModelProviderHelmValuesKey(v1alpha2.ModelProviderAnthropic))
+		}
 		return nil
 	}
 
@@ -120,13 +133,16 @@ func InteractiveInstallCmd(ctx context.Context, c *ishell.Context) *PortForward 
 	// get model provider from KAGENT_DEFAULT_MODEL_PROVIDER environment variable or use DefaultModelProvider
 	modelProvider := GetModelProvider()
 
-	// if model provider is openai, check if the api key is set
+	// Check if the required API key is set for this provider
 	apiKeyName := GetProviderAPIKey(modelProvider)
 	apiKeyValue := os.Getenv(apiKeyName)
 
 	if apiKeyName != "" && apiKeyValue == "" {
 		fmt.Fprintf(os.Stderr, "%s is not set\n", apiKeyName)
 		fmt.Fprintf(os.Stderr, "Please set the %s environment variable\n", apiKeyName)
+		fmt.Fprintf(os.Stderr, "Tip: set %s to select a different provider (e.g. %s=%s)\n",
+			env.KagentDefaultModelProvider.Name(), env.KagentDefaultModelProvider.Name(),
+			GetModelProviderHelmValuesKey(v1alpha2.ModelProviderAnthropic))
 		return nil
 	}
 


### PR DESCRIPTION
## Problem

`kagent install` defaults silently to OpenAI and has no way to select a different provider via the CLI. Users installing with Anthropic, Ollama, or Azure OpenAI see this confusing error with no guidance:

```
OPENAI_API_KEY is not set
Please set the OPENAI_API_KEY environment variable
```

The actual mechanism (`KAGENT_DEFAULT_MODEL_PROVIDER`) is undocumented and not surfaced in `--help`.

## Solution

Add a `--provider` flag to `kagent install` that sets the provider explicitly:

```bash
ANTHROPIC_API_KEY=sk-ant-... kagent install --provider anthropic --profile demo
OPENAI_API_KEY=sk-...        kagent install --provider openAI    --profile demo
kagent install --provider ollama --profile minimal
```

### Changes

- **`InstallCfg`** — add `Provider string` field
- **`ValidProviders()`** — new helper returning the accepted provider values (`openAI`, `anthropic`, `azureOpenAI`, `ollama`) used for flag validation and shell completion
- **`applyProviderFlag()`** — validates the flag value and sets `KAGENT_DEFAULT_MODEL_PROVIDER` so `GetModelProvider()` picks it up
- **`main.go`** — wire `--provider` flag with shell completion
- **Error messages** — fix stale "If model provider is openai" comments; add a hint pointing to `--provider` and `KAGENT_DEFAULT_MODEL_PROVIDER` when the key is missing and no `--provider` was given

## Before / After

**Before:**
```
$ ANTHROPIC_API_KEY=sk-ant-... kagent install --profile demo
OPENAI_API_KEY is not set
Please set the OPENAI_API_KEY environment variable
```

**After:**
```
$ ANTHROPIC_API_KEY=sk-ant-... kagent install --provider anthropic --profile demo
 Installing kagent [Anthropic] ...
kagent installed successfully
```

Or, if the user forgets the flag:
```
$ kagent install --profile demo
OPENAI_API_KEY is not set
Please set the OPENAI_API_KEY environment variable
Tip: use --provider to select a different LLM provider (e.g. --provider anthropic)
     or set KAGENT_DEFAULT_MODEL_PROVIDER=anthropic before running install
```