### PR TITLE
docs: bump required Go version to 1.26.1 in DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -17,7 +17,7 @@ Before you can run kagent in Kubernetes, you need to have the following tools in
 - **Kind** (v0.27.0+)
 - **kubectl** (v1.33.4+)
 - **Helm**
-- **Go** (v1.24.6+)
+- **Go** (v1.26.1+)
 - **Docker**
 - **Docker Buildx** (v0.23.0+)
 - **Make**


### PR DESCRIPTION
The Go version listed in DEVELOPMENT.md was v1.24.6 but go/go.mod says go 1.26.1. Anyone following the setup guide on Go 1.24 will hit a build error. Just aligning the docs with what the module actually requires.