### PR TITLE
docs(python): correct KAgent controller port in package READMEs

### DIFF
--- a/python/packages/kagent-langgraph/README.md
+++ b/python/packages/kagent-langgraph/README.md
@@ -36,7 +36,7 @@ app = KAgentApp(
         "defaultInputModes": ["text"],
         "defaultOutputModes": ["text"]
     },
-    kagent_url="http://localhost:8080",
+    kagent_url="http://localhost:8083",
     app_name="my-agent"
 )
 

--- a/python/packages/kagent-openai/README.md
+++ b/python/packages/kagent-openai/README.md
@@ -28,7 +28,7 @@ app = KAgentApp(
         "defaultInputModes": ["text"],
         "defaultOutputModes": ["text"]
     },
-    kagent_url="http://localhost:8080",
+    kagent_url="http://localhost:8083",
     app_name="my-agent"
 )
 
@@ -71,7 +71,7 @@ from agents.run import Runner
 from kagent.openai.agent._session_service import KAgentSession
 import httpx
 
-client = httpx.AsyncClient(base_url="http://localhost:8080")
+client = httpx.AsyncClient(base_url="http://localhost:8083")
 session = KAgentSession(
     session_id="conversation_123",
     client=client,
@@ -92,7 +92,7 @@ Test without KAgent backend using in-memory mode:
 app = KAgentApp(
     agent=agent,
     agent_card=agent_card,
-    kagent_url="http://localhost:8080",
+    kagent_url="http://localhost:8083",
     app_name="test-agent"
 )
 
@@ -130,7 +130,7 @@ Set `KAGENT_URL` environment variable to connect to KAgent backend.
 
 ## Environment Variables
 
-- `KAGENT_URL` - KAgent backend URL (default: http://localhost:8080)
+- `KAGENT_URL` - KAgent backend URL (default: http://localhost:8083)
 - `LOG_LEVEL` - Logging level (default: INFO)
 
 ---


### PR DESCRIPTION
The quickstart examples in the kagent-openai and kagent-langgraph READMEs point to localhost:8080 but the controller runs on 8083. Port 8080 is the UI. Anyone copy-pasting those examples gets a connection refused straight away.

Changed all five occurrences across the two files to 8083.