### PR TITLE
docs(samples): correct KAgent controller port in sample READMEs

### DIFF
--- a/python/samples/crewai/poem_flow/README.md
+++ b/python/samples/crewai/poem_flow/README.md
@@ -72,6 +72,6 @@ When interacting with the agent, you do not need to provide any input because th
 The agent can be configured via environment variables:
 
 - `GEMINI_API_KEY`: Required for LLM access
-- `KAGENT_URL`: KAgent server URL (default: http://localhost:8083)
+- `KAGENT_URL`: Required. KAgent server URL (for local development, you can set it to `http://localhost:8083`)
 - `PORT`: Server port (default: 8080)
 - `HOST`: Server host (default: 0.0.0.0)

--- a/python/samples/crewai/poem_flow/README.md
+++ b/python/samples/crewai/poem_flow/README.md
@@ -48,7 +48,7 @@ When interacting with the agent, you do not need to provide any input because th
 2. **Set environment variables**:
 
    ```bash
-   export KAGENT_URL=http://localhost:8080
+   export KAGENT_URL=http://localhost:8083
    export OPENAI_API_KEY="..."
    ```
 
@@ -72,6 +72,6 @@ When interacting with the agent, you do not need to provide any input because th
 The agent can be configured via environment variables:
 
 - `GEMINI_API_KEY`: Required for LLM access
-- `KAGENT_URL`: KAgent server URL (default: http://localhost:8080)
+- `KAGENT_URL`: KAgent server URL (default: http://localhost:8083)
 - `PORT`: Server port (default: 8080)
 - `HOST`: Server host (default: 0.0.0.0)

--- a/python/samples/crewai/research-crew/README.md
+++ b/python/samples/crewai/research-crew/README.md
@@ -88,6 +88,6 @@ The agent can be configured via environment variables:
 
 - `OPENAI_API_KEY`: Required for LLM access
 - `SERPER_API_KEY`: Required for web search functionality
-- `KAGENT_URL`: KAgent server URL (default: http://localhost:8083)
+- `KAGENT_URL`: Required KAgent server URL (typically `http://localhost:8083` for a local controller)
 - `PORT`: Server port (default: 8080)
 - `HOST`: Server host (default: 0.0.0.0)

--- a/python/samples/crewai/research-crew/README.md
+++ b/python/samples/crewai/research-crew/README.md
@@ -62,7 +62,7 @@ kubectl apply -f agent.yaml
 2. **Set environment variables**:
 
    ```bash
-   export KAGENT_URL=http://localhost:8080
+   export KAGENT_URL=http://localhost:8083
    export OPENAI_API_KEY="sk-..."
    export SERPER_API_KEY="..."
    ```
@@ -88,6 +88,6 @@ The agent can be configured via environment variables:
 
 - `OPENAI_API_KEY`: Required for LLM access
 - `SERPER_API_KEY`: Required for web search functionality
-- `KAGENT_URL`: KAgent server URL (default: http://localhost:8080)
+- `KAGENT_URL`: KAgent server URL (default: http://localhost:8083)
 - `PORT`: Server port (default: 8080)
 - `HOST`: Server host (default: 0.0.0.0)

--- a/python/samples/langgraph/currency/README.md
+++ b/python/samples/langgraph/currency/README.md
@@ -83,7 +83,7 @@ The agent maintains conversation history across sessions using the KAgent REST A
 The agent can be configured via environment variables:
 
 - `GOOGLE_API_KEY`: Required for Gemini API access
-- `KAGENT_URL`: KAgent server URL (default: http://localhost:8083)
+- `KAGENT_URL`: Required. KAgent server URL; for local development, the controller commonly runs at `http://localhost:8083`
 - `PORT`: Server port (default: 8080)
 - `HOST`: Server host (default: 0.0.0.0)
 

--- a/python/samples/langgraph/currency/README.md
+++ b/python/samples/langgraph/currency/README.md
@@ -52,7 +52,7 @@ uv sync
 
 ```bash
 export GOOGLE_API_KEY=your_api_key_here
-export KAGENT_URL=http://localhost:8080
+export KAGENT_URL=http://localhost:8083
 ```
 
 3. Run the agent server:
@@ -83,7 +83,7 @@ The agent maintains conversation history across sessions using the KAgent REST A
 The agent can be configured via environment variables:
 
 - `GOOGLE_API_KEY`: Required for Gemini API access
-- `KAGENT_URL`: KAgent server URL (default: http://localhost:8080)
+- `KAGENT_URL`: KAgent server URL (default: http://localhost:8083)
 - `PORT`: Server port (default: 8080)
 - `HOST`: Server host (default: 0.0.0.0)
 


### PR DESCRIPTION
Same port issue as #1699 but in the sample READMEs. The crewai and langgraph samples tell users to set KAGENT_URL=http://localhost:8080 which is the UI port, not the controller. Updated all six occurrences across the three sample directories to 8083.