### PR TITLE
docs: update go/README.md to reflect single-module structure

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -1,11 +1,11 @@
-# Kagent Go Workspace
+# Kagent Go
 
-This directory is a [Go workspace](https://go.dev/doc/tutorial/workspaces) (`go.work`) containing three modules that make up the Go components of Kagent.
+This directory is a single Go module (`github.com/kagent-dev/kagent/go`) containing three packages that make up the Go components of Kagent.
 
-## Modules
+## Packages
 
-| Module | Path | Description |
-|--------|------|-------------|
+| Package | Path | Description |
+|---------|------|-------------|
 | **api** | `go/api/` | Shared types: CRD definitions, ADK model types, database models, HTTP client SDK |
 | **core** | `go/core/` | Infrastructure: Kubernetes controllers, HTTP server, CLI, database implementation |
 | **adk** | `go/adk/` | Go Agent Development Kit for building and running agents |
@@ -23,7 +23,7 @@ go/core  go/adk
 
 ```
 go/
-├── go.work              # Go workspace file
+├── go.mod               # Single Go module file
 ├── Makefile              # Unified build targets
 ├── Dockerfile            # Shared multi-stage Docker build
 │

--- a/go/README.md
+++ b/go/README.md
@@ -1,6 +1,6 @@
 # Kagent Go
 
-This directory is a single Go module (`github.com/kagent-dev/kagent/go`) containing three packages that make up the Go components of Kagent.
+This directory is a single Go module (`github.com/kagent-dev/kagent/go`) containing three top-level package trees that make up the Go components of Kagent.
 
 ## Packages
 


### PR DESCRIPTION
Closes #1670.

The go.work file was removed in #1485 but go/README.md still described the directory as a Go workspace with three separate modules. It now points to a single go.mod, so updated the title, intro, section heading, table header, and directory tree to match.