### PR TITLE
fix(cli): recognize all providers in install and improve missing key error

### DIFF
--- a/go/core/cli/internal/cli/agent/const.go
+++ b/go/core/cli/internal/cli/agent/const.go
@@ -28,6 +28,14 @@ func GetModelProvider() v1alpha2.ModelProvider {
 		return v1alpha2.ModelProviderAnthropic
 	case GetModelProviderHelmValuesKey(v1alpha2.ModelProviderAzureOpenAI):
 		return v1alpha2.ModelProviderAzureOpenAI
+	case GetModelProviderHelmValuesKey(v1alpha2.ModelProviderGemini):
+		return v1alpha2.ModelProviderGemini
+	case GetModelProviderHelmValuesKey(v1alpha2.ModelProviderGeminiVertexAI):
+		return v1alpha2.ModelProviderGeminiVertexAI
+	case GetModelProviderHelmValuesKey(v1alpha2.ModelProviderAnthropicVertexAI):
+		return v1alpha2.ModelProviderAnthropicVertexAI
+	case GetModelProviderHelmValuesKey(v1alpha2.ModelProviderBedrock):
+		return v1alpha2.ModelProviderBedrock
 	default:
 		return v1alpha2.ModelProviderOpenAI
 	}
@@ -42,7 +50,9 @@ func GetModelProviderHelmValuesKey(provider v1alpha2.ModelProvider) string {
 	return helmKey
 }
 
-// GetProviderAPIKey returns API_KEY env var name from provider type
+// GetProviderAPIKey returns the env var name for the provider's API key.
+// Returns "" for providers that use cloud credentials instead of an API key
+// (Ollama, Bedrock, GeminiVertexAI, AnthropicVertexAI).
 func GetProviderAPIKey(provider v1alpha2.ModelProvider) string {
 	switch provider {
 	case v1alpha2.ModelProviderOpenAI:
@@ -51,7 +61,16 @@ func GetProviderAPIKey(provider v1alpha2.ModelProvider) string {
 		return env.AnthropicAPIKey.Name()
 	case v1alpha2.ModelProviderAzureOpenAI:
 		return env.AzureOpenAIAPIKey.Name()
+	case v1alpha2.ModelProviderGemini:
+		// Prefer GOOGLE_API_KEY, fall back to GEMINI_API_KEY to match the
+		// runtime behaviour in go/adk/pkg/agent/agent.go.
+		if _, ok := os.LookupEnv(env.GoogleAPIKey.Name()); ok {
+			return env.GoogleAPIKey.Name()
+		}
+		return "GEMINI_API_KEY"
 	default:
+		// Ollama, Bedrock, GeminiVertexAI, AnthropicVertexAI use cloud
+		// credentials rather than a simple API key, so no check is needed.
 		return ""
 	}
 }

--- a/go/core/cli/internal/cli/agent/install.go
+++ b/go/core/cli/internal/cli/agent/install.go
@@ -86,6 +86,7 @@ func InstallCmd(ctx context.Context, cfg *InstallCfg) *PortForward {
 	if apiKeyName != "" && apiKeyValue == "" {
 		fmt.Fprintf(os.Stderr, "%s is not set\n", apiKeyName)
 		fmt.Fprintf(os.Stderr, "Please set the %s environment variable\n", apiKeyName)
+		fmt.Fprintf(os.Stderr, "To use a different provider set KAGENT_DEFAULT_MODEL_PROVIDER (e.g. ollama, anthropic, gemini)\n")
 		return nil
 	}
 
@@ -127,6 +128,7 @@ func InteractiveInstallCmd(ctx context.Context, c *ishell.Context) *PortForward 
 	if apiKeyName != "" && apiKeyValue == "" {
 		fmt.Fprintf(os.Stderr, "%s is not set\n", apiKeyName)
 		fmt.Fprintf(os.Stderr, "Please set the %s environment variable\n", apiKeyName)
+		fmt.Fprintf(os.Stderr, "To use a different provider set KAGENT_DEFAULT_MODEL_PROVIDER (e.g. ollama, anthropic, gemini)\n")
 		return nil
 	}
 


### PR DESCRIPTION
Closes #1622.

`GetModelProvider` was missing Gemini, GeminiVertexAI, AnthropicVertexAI and Bedrock from its switch. Any of those values in `KAGENT_DEFAULT_MODEL_PROVIDER` fell through to the default and came back as OpenAI, which then required `OPENAI_API_KEY` even though the user had no intention of using OpenAI.

`GetProviderAPIKey` now also covers Gemini (`GOOGLE_API_KEY`). Providers that rely on cloud credentials rather than an API key (Ollama, Bedrock, VertexAI variants) already returned empty string and are left as is.

The error message now mentions `KAGENT_DEFAULT_MODEL_PROVIDER` so users know they can switch providers instead of being stuck.