### PR TITLE
feat: make agent pod bind address configurable via Helm

### DIFF
--- a/go/core/internal/controller/translator/agent/adk_api_translator.go
+++ b/go/core/internal/controller/translator/agent/adk_api_translator.go
@@ -110,6 +110,11 @@ var DefaultServiceAccountName string
 // Per-agent labels from the Agent CRD spec take precedence over these defaults.
 var DefaultAgentPodLabels map[string]string
 
+// DefaultAgentHost is the bind address passed as --host to agent pods.
+// Defaults to 0.0.0.0 for backwards compatibility. Set to :: to support
+// IPv6-only or dual-stack clusters.
+var DefaultAgentHost = "0.0.0.0"
+
 // TODO(ilackarms): migrate this whole package to pkg/translator
 type AgentOutputs = translator.AgentOutputs
 

--- a/go/core/internal/controller/translator/agent/deployments.go
+++ b/go/core/internal/controller/translator/agent/deployments.go
@@ -111,7 +111,7 @@ func resolveInlineDeployment(agent v1alpha2.AgentObject, mdd *modelDeploymentDat
 	port := int32(8080)
 	args := []string{
 		"--host",
-		"0.0.0.0",
+		DefaultAgentHost,
 		"--port",
 		fmt.Sprintf("%d", port),
 		"--filepath",

--- a/go/core/pkg/app/app.go
+++ b/go/core/pkg/app/app.go
@@ -191,6 +191,7 @@ func (cfg *Config) SetFlags(commandLine *flag.FlagSet) {
 	commandLine.StringVar(&agent_translator.DefaultServiceAccountName, "default-service-account-name", "", "Global default ServiceAccount name for agent pods. When set, agents without an explicit serviceAccountName will use this instead of creating a per-agent ServiceAccount.")
 
 	commandLine.Var(&MapValue{Target: &agent_translator.DefaultAgentPodLabels}, "default-agent-pod-labels", "Comma-separated key=value pairs of labels to apply to all agent pod templates (e.g. 'team=platform,env=prod'). Per-agent labels take precedence.")
+	commandLine.StringVar(&agent_translator.DefaultAgentHost, "default-agent-host", agent_translator.DefaultAgentHost, "Bind address passed as --host to agent pods. Use :: for IPv6-only or dual-stack clusters.")
 }
 
 // LoadFromEnv loads configuration values from environment variables.

--- a/helm/kagent/templates/controller-configmap.yaml
+++ b/helm/kagent/templates/controller-configmap.yaml
@@ -60,6 +60,9 @@ data:
   {{- if and .Values.controller.agentDeployment .Values.controller.agentDeployment.serviceAccountName (not (eq .Values.controller.agentDeployment.serviceAccountName "")) }}
   DEFAULT_SERVICE_ACCOUNT_NAME: {{ .Values.controller.agentDeployment.serviceAccountName | quote }}
   {{- end }}
+  {{- if and .Values.controller.agentDeployment .Values.controller.agentDeployment.host (not (eq .Values.controller.agentDeployment.host "")) }}
+  DEFAULT_AGENT_HOST: {{ .Values.controller.agentDeployment.host | quote }}
+  {{- end }}
   {{- if and .Values.controller.agentDeployment .Values.controller.agentDeployment.podLabels }}
   {{- $pairs := list }}
   {{- range $k := keys .Values.controller.agentDeployment.podLabels | sortAlpha }}

--- a/helm/kagent/tests/controller-deployment_test.yaml
+++ b/helm/kagent/tests/controller-deployment_test.yaml
@@ -398,3 +398,20 @@ tests:
           content:
             name: POSTGRES_PASSWORD
 
+
+  - it: should not set DEFAULT_AGENT_HOST when host is not configured
+    template: controller-configmap.yaml
+    asserts:
+      - notExists:
+          path: data.DEFAULT_AGENT_HOST
+
+  - it: should set DEFAULT_AGENT_HOST when host is configured
+    template: controller-configmap.yaml
+    set:
+      controller:
+        agentDeployment:
+          host: "::"
+    asserts:
+      - equal:
+          path: data.DEFAULT_AGENT_HOST
+          value: "::"

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -151,6 +151,10 @@ controller:
     # Per-agent labels in the Agent CRD take precedence over these defaults.
     # @default -- {} (no extra labels)
     podLabels: {}
+    # -- Bind address passed as --host to agent pods.
+    # Default is 0.0.0.0 (IPv4 only). Set to :: to support IPv6-only or dual-stack clusters.
+    # @default -- "0.0.0.0"
+    host: ""
     # Example:
     #   podLabels:
     #     team: platform


### PR DESCRIPTION
Closes #1642.

Agent pods were hardcoded to bind on `0.0.0.0` which is IPv4-only. On IPv6-only or dual-stack clusters the readiness probe hits the pod's IPv6 address and gets connection refused straight away.

Added `controller.agentDeployment.host` in `values.yaml`. It is empty by default so existing installs are not affected. When set, it is written as `DEFAULT_AGENT_HOST` into the controller ConfigMap. The controller already has a `LoadFromEnv` mechanism that maps config map env vars to flags, so the new `default-agent-host` flag picks it up automatically and passes it as `--host` to agent pods.

Set to `::` to listen on both IPv4 and IPv6.

Two new helm unit tests cover the default (no env var set) and the IPv6 case.