### PR TITLE
fix: bubblewrap in ci environment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,6 +43,13 @@ jobs:
         uses: actions/checkout@v6
       - name: Initialize Environment
         uses: ./.github/actions/initialize-environment
+      - name: Allow unprivileged user namespaces
+        # Ubuntu 24.04 (ubuntu-latest) enables AppArmor-based restrictions on
+        # unprivileged user namespaces by default, which causes bubblewrap
+        # to fail with EPERM on unshare(CLONE_NEWUSER)
+        # See https://github.com/openai/codex/issues/14919
+        run: |
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
         with:

--- a/go/Dockerfile.full
+++ b/go/Dockerfile.full
@@ -45,11 +45,6 @@ RUN --mount=type=cache,target=/var/cache/apk,rw \
     apk add --no-cache \
     bash ca-certificates curl nodejs bubblewrap socat python-${TOOLS_PYTHON_VERSION} ripgrep libstdc++
 
-# Make bwrap setuid-root so it can create user/network namespaces when invoked
-# by non-root users on hosts with kernel.apparmor_restrict_unprivileged_userns=1
-# (Ubuntu 23.10+). See https://github.com/openai/codex/issues/14919
-RUN chmod u+s /usr/bin/bwrap
-
 RUN addgroup -g 1001 goagent && \
     adduser -u 1001 -G goagent -s /bin/bash -D goagent
 

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -64,11 +64,6 @@ RUN --mount=type=cache,target=/var/cache/apk,rw \
     apk add \
     nodejs npm node-gyp bubblewrap socat ripgrep
 
-# Make bwrap setuid-root so it can create user/network namespaces when invoked
-# by non-root users on hosts with kernel.apparmor_restrict_unprivileged_userns=1
-# (Ubuntu 23.10+). See https://github.com/openai/codex/issues/14919
-RUN chmod u+s /usr/bin/bwrap
-
 # Install sandbox runtime from a specific commit of the GitHub repo without using global prefix
 # This avoids scope-related rename issues in global node_modules
 # Using BuildKit cache for npm to speed up rebuilds


### PR DESCRIPTION
The root cause is the same as identified in #1690 (Ubuntu AppArmor-based restrictions on unprivileged user namespaces causing `bwrap` to throw an error) but had to switch the fix to be more robust.

My suspicion on why it worked before: chainguard image was shipping a version of `bwrap` that allows for `setuid` which is a valid solution suggested by the creator of bubblewrap, but it now changes to a build of `bwrap` that does not allow `setuid`, thus we're seeing `bwrap: setuid use of bubblewrap is not supported in this build`

This fix is functionally the same as the previous one, but disables the specific AppArmor blocking unprivileged processes from creating new user namespaces entirely (which is totally fine in CI). This means that whatever Chainguard chooses to include in its apk repository for `bwrap` this will always work.

---

If anyone is running into this in their own setup (Ubuntu 24.04), you can either use the same approach here, or alternatively install and set the official `bwrap-userns-restrict` AppArmor profile that allows `bwrap` to create namespaces. I noticed that this should be set by default in the next major release [since it's in the 25.04 release notes](https://documentation.ubuntu.com/release-notes/25.04/#apparmor-profile-for-bwrap). 

See discussion in [this issue](https://github.com/openai/codex/issues/14919) from OpenAI Codex regarding `bwrap` sandboxing