### PR TITLE
feat(go-adk): propagate A2A message metadata as OTEL span attributes

### DIFF
--- a/go/adk/pkg/a2a/executor.go
+++ b/go/adk/pkg/a2a/executor.go
@@ -138,6 +138,10 @@ func (e *KAgentExecutor) Execute(ctx context.Context, reqCtx *a2asrv.RequestCont
 	ctx, invocationSpan := telemetry.StartInvocationSpan(ctx)
 	defer invocationSpan.End()
 
+	// Propagate scalar values from the A2A message metadata as span attributes
+	// so callers can attach contextual data (e.g. approver identity) to traces.
+	telemetry.SetMessageMetadataAttributes(ctx, reqCtx.Message.Metadata)
+
 	// 3. Initialize skills session path.
 	if e.skillsDirectory != "" && sessionID != "" {
 		if _, err := skills.InitializeSessionPath(sessionID, e.skillsDirectory); err != nil {

--- a/go/adk/pkg/a2a/executor.go
+++ b/go/adk/pkg/a2a/executor.go
@@ -138,8 +138,6 @@ func (e *KAgentExecutor) Execute(ctx context.Context, reqCtx *a2asrv.RequestCont
 	ctx, invocationSpan := telemetry.StartInvocationSpan(ctx)
 	defer invocationSpan.End()
 
-	// Propagate scalar values from the A2A message metadata as span attributes
-	// so callers can attach contextual data (e.g. approver identity) to traces.
 	telemetry.SetMessageMetadataAttributes(ctx, reqCtx.Message.Metadata)
 
 	// 3. Initialize skills session path.

--- a/go/adk/pkg/telemetry/attributes.go
+++ b/go/adk/pkg/telemetry/attributes.go
@@ -3,6 +3,7 @@ package telemetry
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"strings"
 
@@ -85,6 +86,36 @@ func stringAttributes(attrs map[string]string) []attribute.KeyValue {
 		}
 	}
 	return out
+}
+
+// SetMessageMetadataAttributes reads scalar values from an A2A message's
+// Metadata map and sets them as span attributes using the prefix
+// "a2a.message.metadata.<key>". Non-scalar values (maps, slices) are skipped
+// so that only clean, filterable attributes appear in the trace.
+func SetMessageMetadataAttributes(ctx context.Context, metadata map[string]any) {
+	if len(metadata) == 0 {
+		return
+	}
+	var attrs []attribute.KeyValue
+	for k, v := range metadata {
+		key := "a2a.message.metadata." + k
+		switch val := v.(type) {
+		case string:
+			if val != "" {
+				attrs = append(attrs, attribute.String(key, val))
+			}
+		case bool:
+			attrs = append(attrs, attribute.Bool(key, val))
+		case float64:
+			attrs = append(attrs, attribute.String(key, fmt.Sprintf("%g", val)))
+		case int:
+			attrs = append(attrs, attribute.Int(key, val))
+		case int64:
+			attrs = append(attrs, attribute.Int64(key, val))
+		// skip maps, slices, and other complex types
+		}
+	}
+	setSpanAttributes(ctx, attrs...)
 }
 
 func setSpanAttributes(ctx context.Context, attrs ...attribute.KeyValue) {

--- a/go/adk/pkg/telemetry/attributes.go
+++ b/go/adk/pkg/telemetry/attributes.go
@@ -88,10 +88,7 @@ func stringAttributes(attrs map[string]string) []attribute.KeyValue {
 	return out
 }
 
-// SetMessageMetadataAttributes reads scalar values from an A2A message's
-// Metadata map and sets them as span attributes using the prefix
-// "a2a.message.metadata.<key>". Non-scalar values (maps, slices) are skipped
-// so that only clean, filterable attributes appear in the trace.
+// SetMessageMetadataAttributes sets scalar values from an A2A message's metadata as span attributes.
 func SetMessageMetadataAttributes(ctx context.Context, metadata map[string]any) {
 	if len(metadata) == 0 {
 		return
@@ -112,7 +109,6 @@ func SetMessageMetadataAttributes(ctx context.Context, metadata map[string]any) 
 			attrs = append(attrs, attribute.Int(key, val))
 		case int64:
 			attrs = append(attrs, attribute.Int64(key, val))
-		// skip maps, slices, and other complex types
 		}
 	}
 	setSpanAttributes(ctx, attrs...)

--- a/go/adk/pkg/telemetry/attributes_test.go
+++ b/go/adk/pkg/telemetry/attributes_test.go
@@ -2,6 +2,7 @@ package telemetry
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"go.opentelemetry.io/otel"
@@ -167,6 +168,76 @@ func TestSetLLMAttributes_EmitsEmptyPayloadWhenContentCaptureDisabled(t *testing
 	}
 	if got := attrs["gcp.vertex.agent.llm_response"].AsString(); got != "{}" {
 		t.Errorf("gcp.vertex.agent.llm_response = %q, want %q", got, "{}")
+	}
+}
+
+func TestSetMessageMetadataAttributes(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	tracer := tp.Tracer("test")
+	ctx, span := tracer.Start(context.Background(), "test-span")
+
+	SetMessageMetadataAttributes(ctx, map[string]any{
+		"approver_email": "admin@example.com",
+		"attempt_count":  float64(3),
+		"dry_run":        true,
+		"nested":         map[string]any{"should": "be skipped"},
+		"list_val":       []string{"also", "skipped"},
+		"empty_str":      "",
+	})
+	span.End()
+
+	spans := exporter.GetSpans()
+	if len(spans) == 0 {
+		t.Fatal("no spans recorded")
+	}
+	attrs := make(map[string]attribute.Value)
+	for _, a := range spans[0].Attributes {
+		attrs[string(a.Key)] = a.Value
+	}
+
+	if got := attrs["a2a.message.metadata.approver_email"].AsString(); got != "admin@example.com" {
+		t.Errorf("approver_email: got %q, want %q", got, "admin@example.com")
+	}
+	if got := attrs["a2a.message.metadata.attempt_count"].AsString(); got != "3" {
+		t.Errorf("attempt_count: got %q, want %q", got, "3")
+	}
+	if got := attrs["a2a.message.metadata.dry_run"].AsBool(); !got {
+		t.Errorf("dry_run: got %v, want true", got)
+	}
+	if _, exists := attrs["a2a.message.metadata.nested"]; exists {
+		t.Error("nested map should not be set as span attribute")
+	}
+	if _, exists := attrs["a2a.message.metadata.list_val"]; exists {
+		t.Error("list value should not be set as span attribute")
+	}
+	if _, exists := attrs["a2a.message.metadata.empty_str"]; exists {
+		t.Error("empty string should not be set as span attribute")
+	}
+}
+
+func TestSetMessageMetadataAttributes_NilAndEmpty(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	tracer := tp.Tracer("test")
+	ctx, span := tracer.Start(context.Background(), "test-span")
+
+	SetMessageMetadataAttributes(ctx, nil)
+	SetMessageMetadataAttributes(ctx, map[string]any{})
+	span.End()
+
+	spans := exporter.GetSpans()
+	if len(spans) == 0 {
+		t.Fatal("no spans recorded")
+	}
+	for _, a := range spans[0].Attributes {
+		if strings.HasPrefix(string(a.Key), "a2a.message.metadata.") {
+			t.Errorf("no metadata attributes expected, got %q", a.Key)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #1734

Scalar values from the A2A `message.metadata` map are now set as attributes on the invocation span under the prefix `a2a.message.metadata.<key>`. Non-scalar values (nested objects, lists) are silently skipped so attributes stay flat and filterable in any OTEL backend.

This is useful for human-in-the-loop and external-trigger workflows where the caller needs to attach contextual data to a trace. A common case is an approval flow where a Slack bot sends back the approver identity via `message/send` and that identity needs to appear in audit traces without running a completely separate observability pipeline.

The call happens on the already-active invocation span, right after `StartInvocationSpan`, so all child spans (tool calls, LLM calls) are nested under the same root and the metadata is visible across the full trace.

Supported types: `string`, `bool`, `float64`, `int`, `int64`. Everything else is ignored.

Tests cover the normal path (string, bool, float64), the nil/empty-map no-op case, and that nested maps and lists are not forwarded.

Signed-off-by: mesutoezdil <mesudozdil@gmail.com>