### PR TITLE
fix: use python user in skills-init container

### DIFF
--- a/docker/skills-init/Dockerfile
+++ b/docker/skills-init/Dockerfile
@@ -14,12 +14,17 @@ RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /build/krane .
 
 FROM alpine:3.23
 
+ARG PYTHON_UID=1001
+ARG PYTHON_GID=1001
+
 RUN apk upgrade --no-cache && apk add --no-cache git
 COPY --from=krane-builder /build/krane /usr/local/bin/krane
 
 # Run as the same UID/GID as the main agent container (python user) so that
 # files written to the shared /skills volume are readable by the main container.
-RUN addgroup -g 1001 pythongroup && \
-    adduser -u 1001 -G pythongroup -s /bin/sh -D python
+# Keep these defaults aligned with the canonical main agent image definition
+# (for example, python/Dockerfile) to avoid UID/GID drift across images.
+RUN addgroup -g ${PYTHON_GID} pythongroup && \
+    adduser -u ${PYTHON_UID} -G pythongroup -s /bin/sh -D python
 
-USER 1001:1001
+USER ${PYTHON_UID}:${PYTHON_GID}

--- a/docker/skills-init/Dockerfile
+++ b/docker/skills-init/Dockerfile
@@ -16,3 +16,10 @@ FROM alpine:3.23
 
 RUN apk upgrade --no-cache && apk add --no-cache git
 COPY --from=krane-builder /build/krane /usr/local/bin/krane
+
+# Run as the same UID/GID as the main agent container (python user) so that
+# files written to the shared /skills volume are readable by the main container.
+RUN addgroup -g 1001 pythongroup && \
+    adduser -u 1001 -G pythongroup -s /bin/sh -D python
+
+USER 1001:1001


### PR DESCRIPTION
fixes https://github.com/kagent-dev/kagent/issues/1761