### PR TITLE
fix(controller): wrap secret fetch errors with %w to preserve error chain

### DIFF
--- a/go/core/internal/controller/reconciler/reconciler.go
+++ b/go/core/internal/controller/reconciler/reconciler.go
@@ -392,7 +392,7 @@ func (a *kagentReconciler) ReconcileKagentModelConfig(ctx context.Context, req c
 		namespacedName := types.NamespacedName{Namespace: modelConfig.Namespace, Name: modelConfig.Spec.APIKeySecret}
 
 		if kubeErr := a.kube.Get(ctx, namespacedName, secret); kubeErr != nil {
-			err = multierror.Append(err, fmt.Errorf("failed to get secret %s: %v", modelConfig.Spec.APIKeySecret, kubeErr))
+			err = multierror.Append(err, fmt.Errorf("failed to get secret %s: %w", modelConfig.Spec.APIKeySecret, kubeErr))
 		} else {
 			secrets = append(secrets, secretRef{
 				NamespacedName: namespacedName,
@@ -407,7 +407,7 @@ func (a *kagentReconciler) ReconcileKagentModelConfig(ctx context.Context, req c
 		namespacedName := types.NamespacedName{Namespace: modelConfig.Namespace, Name: modelConfig.Spec.TLS.CACertSecretRef}
 
 		if kubeErr := a.kube.Get(ctx, namespacedName, secret); kubeErr != nil {
-			err = multierror.Append(err, fmt.Errorf("failed to get secret %s: %v", modelConfig.Spec.TLS.CACertSecretRef, kubeErr))
+			err = multierror.Append(err, fmt.Errorf("failed to get secret %s: %w", modelConfig.Spec.TLS.CACertSecretRef, kubeErr))
 		} else {
 			secrets = append(secrets, secretRef{
 				NamespacedName: namespacedName,


### PR DESCRIPTION
`ReconcileKagentModelConfig` appends secret fetch errors via `multierror.Append`, but both `fmt.Errorf` calls used `%v` instead of `%w`. This means the original Kubernetes API error is stringified and lost — `errors.Is` and `errors.As` cannot unwrap through the multi-error to inspect the root cause (e.g. `apierrors.IsNotFound`).

Switching to `%w` keeps the error chain intact so callers can inspect or match the underlying error type.

Two lines changed, no behaviour change in the happy path.