### PR TITLE
fix(deps): consolidate dependabot uv ecosystem to single workspace root

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,18 +48,15 @@ updates:
           - "minor"
           - "patch"
 
-  # Python (uv) — workspace root and all packages
+  # Python (uv) — single workspace root.
+  # Dependabot's native `uv` ecosystem detects workspace members through
+  # python/pyproject.toml's [tool.uv.workspace] section and updates the
+  # root python/uv.lock alongside any member's pyproject.toml in the
+  # same PR. Listing each member as its own directory caused Dependabot
+  # to open per-member PRs that did not refresh the root lockfile,
+  # which then failed `uv sync --locked` in CI.
   - package-ecosystem: "uv"
-    directories:
-      - "/python"
-      - "/python/packages/kagent-adk"
-      - "/python/packages/kagent-core"
-      - "/python/packages/kagent-skills"
-      - "/python/packages/kagent-crewai"
-      - "/python/packages/kagent-langgraph"
-      - "/python/packages/kagent-openai"
-      - "/python/packages/agentsts-core"
-      - "/python/packages/agentsts-adk"
+    directory: "/python"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -73,7 +70,24 @@ updates:
       - "peterj"
       - "yuval-k"
     groups:
+      python-opentelemetry:
+        applies-to: version-updates
+        patterns:
+          - "opentelemetry-*"
+        update-types:
+          - "minor"
+          - "patch"
+      python-google-ai:
+        applies-to: version-updates
+        patterns:
+          - "google-adk"
+          - "google-genai"
+          - "google-auth"
+        update-types:
+          - "minor"
+          - "patch"
       python-minor-patch:
+        applies-to: version-updates
         patterns:
           - "*"
         update-types:
@@ -93,6 +107,13 @@ updates:
       prefix: "chore(deps):"
     reviewers:
       - "peterj"
+    ignore:
+      # Suppress major UI dependency bumps (e.g., Next.js, React) until
+      # the frontend is ready for those migrations. Minor/patch updates
+      # still flow through via the npm-minor-patch group below.
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     groups:
       npm-minor-patch:
         patterns:


### PR DESCRIPTION
## Summary
- replace the per-member `directories:` list under `package-ecosystem: uv` with a single `/python` entry so Dependabot uses the root `[tool.uv.workspace]` to discover members and refreshes `python/uv.lock` in the same PR
- group OpenTelemetry and Google AI Python dependencies so lockstep families land in a single PR
- add `applies-to: version-updates` to the Python groups so security updates remain ungrouped
- ignore semver-major `/ui` npm bumps so known-breaking major frontend upgrades stop opening standalone PRs

## Why
Currently Dependabot opens separate PRs for each workspace member's `pyproject.toml` without refreshing the root `python/uv.lock`. Those PRs then fail CI when Docker runs `uv sync --locked`.

In a `uv` workspace the lockfile lives only at the workspace root; members have only a `pyproject.toml`. Dependabot's native `uv` ecosystem already discovers workspace members through the root `[tool.uv.workspace]` section, so a single `directory: /python` entry covers every member and updates the root lockfile alongside any member manifest in the same PR — no separate workflow or write-back step needed.

This replaces #1756, which did the same job via a `pull_request_target` workflow that ran `uv lock` and pushed back to Dependabot's branch. The reviewer flagged that handoff as undesirable; this approach removes it entirely while keeping the orthogonal grouping and ignore improvements that PR introduced.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml")'` (parses cleanly)
- Once merged, the next Dependabot run on a Monday should produce at most one Python PR per group with both `python/pyproject.toml` (or a member's) and `python/uv.lock` updated together.

cc @EItanya