### PR TITLE
fix(skills-init): install openssh-client so ssh-keyscan is available

### DIFF
--- a/docker/skills-init/Dockerfile
+++ b/docker/skills-init/Dockerfile
@@ -17,7 +17,13 @@ FROM alpine:3.23
 ARG PYTHON_UID=1001
 ARG PYTHON_GID=1001
 
-RUN apk upgrade --no-cache && apk add --no-cache git jq
+RUN apk upgrade --no-cache && apk add --no-cache git jq openssh-client
+
+# ssh-keyscan is required by skills-init.sh when an Agent uses SSH-based git
+# auth (gitAuthSecretRef -> kubernetes.io/ssh-auth). Verify it is on PATH so a
+# future package change cannot silently reintroduce the missing-binary regression.
+RUN command -v ssh-keyscan >/dev/null
+
 COPY --from=krane-builder /build/krane /usr/local/bin/krane
 
 # Run as the same UID/GID as the main agent container (python user) so that


### PR DESCRIPTION
## summary

closes #1770

- skills-init image only had `git` in apk, so `ssh-keyscan` was unavailable when an agent used ssh-based git auth (`gitAuthSecretRef` -> `kubernetes.io/ssh-auth`). the init container exited under `set -e` with `ssh-keyscan: not found` and the agent pod went into crashloopbackoff.
- add `openssh-client` to the apk install list in `docker/skills-init/Dockerfile` and verify `ssh-keyscan` resolves at build time so the same regression cannot ship silently again.

## ai model disclosure

used claude code (claude opus 4.7) to triage candidate issues and draft the diff. self-reviewed against `docker/skills-init/Dockerfile` and `go/core/internal/controller/translator/agent/skills-init.sh.tmpl` to confirm the reporter's root cause. verified via:

```bash
docker build -t kagent-skills-init:test docker/skills-init
docker run --rm kagent-skills-init:test ssh-keyscan github.com
# returns real host keys, confirming openssh-client is present and functional
```
