### PR TITLE
fix(app): wire signal-aware context through controller startup

### DIFF
--- a/go/core/pkg/app/app.go
+++ b/go/core/pkg/app/app.go
@@ -294,8 +294,8 @@ func Start(getExtensionConfig GetExtensionConfig, migrationRunner MigrationRunne
 	var tlsOpts []func(*tls.Config)
 	var cfg Config
 
-	// TODO setup signal handlers
-	ctx := context.Background()
+	// Reused below for mgr.Start; SetupSignalHandler must be called once per process.
+	ctx := ctrl.SetupSignalHandler()
 
 	cfg.SetFlags(flag.CommandLine)
 
@@ -667,7 +667,7 @@ func Start(getExtensionConfig GetExtensionConfig, migrationRunner MigrationRunne
 	}
 
 	setupLog.Info("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+	if err := mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}


### PR DESCRIPTION
## summary

- `app.Start` constructed two independent signal-handling setups: an early `ctx := context.Background()` used for tracing init and db connect, and a separate `ctrl.SetupSignalHandler()` passed to `mgr.Start` later. controller-runtime requires the signal handler be set up exactly once per process, so the second call is a latent panic risk if a future caller adds another signal-handler setup. addresses the long-standing `// TODO setup signal handlers` at `go/core/pkg/app/app.go:297`.
- call `ctrl.SetupSignalHandler()` once at the top of `Start` and reuse the returned context for both startup work and `mgr.Start`. tracing init, db connect, and the manager now share a single signal-aware ctx; the duplicate setup is gone.
- note: the default migration runner (`app.go:462`) discards its ctx argument and `migrations.RunUp` does not accept ctx, so migrations themselves are still not cancellable by this PR. threading ctx through `migrations.RunUp` is a separate change; happy to follow up.

## ai model disclosure

used claude code (claude opus 4.7) to triage and draft the diff. self-reviewed `go/core/pkg/app/app.go` to confirm the second `ctrl.SetupSignalHandler()` call site at line 670 and the manager's downstream use of `ctx`. verified locally via:

```bash
go vet ./core/pkg/app/...
./bin/golangci-lint run ./core/pkg/app/...      # 0 issues
go test -race -skip 'TestE2E.*' -count=1 ./core/pkg/app/...   # ok
```