### PR TITLE
Confine kind setup and e2e tests to the kind context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,8 +194,8 @@ create-kind-cluster:
 use-kind-cluster:
 	kind get kubeconfig --name $(KIND_CLUSTER_NAME) > /tmp/kind-config
 	KUBECONFIG=~/.kube/config:/tmp/kind-config kubectl config view --merge --flatten > ~/.kube/config.tmp && mv ~/.kube/config.tmp ~/.kube/config && chmod $(KUBECONFIG_PERM) ~/.kube/config
-	kubectl create namespace kagent || true
-	kubectl config set-context --current --namespace kagent || true
+	kubectl --context kind-$(KIND_CLUSTER_NAME) create namespace kagent || true
+	kubectl config set-context kind-$(KIND_CLUSTER_NAME) --namespace kagent || true
 
 .PHONY: delete-kind-cluster
 delete-kind-cluster:
@@ -425,17 +425,17 @@ kagent-cli-install: use-kind-cluster build-cli-local helm-version helm-install-p
 .PHONY: kagent-cli-port-forward
 kagent-cli-port-forward: use-kind-cluster
 	@echo "Port forwarding to kagent CLI..."
-	kubectl port-forward -n kagent service/kagent-controller 8083:8083
+	kubectl --context kind-$(KIND_CLUSTER_NAME) port-forward -n kagent service/kagent-controller 8083:8083
 
 .PHONY: kagent-ui-port-forward
 kagent-ui-port-forward: use-kind-cluster
 	open http://localhost:8082/
-	kubectl port-forward -n kagent service/kagent-ui 8082:8080
+	kubectl --context kind-$(KIND_CLUSTER_NAME) port-forward -n kagent service/kagent-ui 8082:8080
 
 .PHONY: kagent-addon-install
 kagent-addon-install: use-kind-cluster
 	# to test the kagent addons - installing istio, grafana, prometheus, metrics-server
-	istioctl install --set profile=demo -y
+	istioctl install --context kind-$(KIND_CLUSTER_NAME) --set profile=demo -y
 	kubectl apply --context kind-$(KIND_CLUSTER_NAME) -f contrib/addons/grafana.yaml
 	kubectl apply --context kind-$(KIND_CLUSTER_NAME) -f contrib/addons/prometheus.yaml
 	kubectl apply --context kind-$(KIND_CLUSTER_NAME) -f contrib/addons/metrics-server.yaml

--- a/go/Makefile
+++ b/go/Makefile
@@ -124,9 +124,19 @@ run: fmt vet ## Run a controller from your host.
 test: ## Run all unit tests.
 	UPDATE_GOLDEN=$(UPDATE_GOLDEN) go test -race -skip 'TestE2E.*' -v ./...
 
+# Pin e2e tests to the kind cluster so a stray current-context (or an
+# ambient KUBECONFIG) can't leak resources onto a remote cluster. Override
+# KIND_CLUSTER_NAME to target a differently-named kind cluster.
+KIND_CLUSTER_NAME ?= kagent
+
 .PHONY: e2e
 e2e: ## Run end-to-end tests.
-	go test -v github.com/kagent-dev/kagent/go/core/test/e2e -failfast
+	@kind get clusters 2>/dev/null | grep -qx '$(KIND_CLUSTER_NAME)' || { \
+	  echo "Error: kind cluster '$(KIND_CLUSTER_NAME)' not found. Run 'make create-kind-cluster' first." >&2; \
+	  exit 1; \
+	}
+	@kind get kubeconfig --name $(KIND_CLUSTER_NAME) > /tmp/kind-config-e2e
+	KUBECONFIG=/tmp/kind-config-e2e go test -v github.com/kagent-dev/kagent/go/core/test/e2e -failfast
 
 ##@ Dependencies
 

--- a/scripts/kind/setup-kind.sh
+++ b/scripts/kind/setup-kind.sh
@@ -57,7 +57,7 @@ fi
 
 # 5. Document the local registry
 # https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/generic/1755-communicating-a-local-registry
-cat <<EOF | kubectl apply -f -
+cat <<EOF | kubectl --context "kind-${KIND_CLUSTER_NAME}" apply -f -
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/scripts/kind/setup-metallb.sh
+++ b/scripts/kind/setup-metallb.sh
@@ -5,13 +5,14 @@ set -o pipefail
 set -o nounset
 
 METALLB_VERSION=${METALLB_VERSION:-v0.15.3}
+KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-kagent}
 
-kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/${METALLB_VERSION}/config/manifests/metallb-native.yaml
+kubectl --context "kind-${KIND_CLUSTER_NAME}" apply -f https://raw.githubusercontent.com/metallb/metallb/${METALLB_VERSION}/config/manifests/metallb-native.yaml
 
 # Wait for MetalLB to become available.
-kubectl rollout status -n metallb-system deployment/controller --timeout 5m
-kubectl rollout status -n metallb-system daemonset/speaker --timeout 5m
-kubectl wait -n metallb-system  pod -l app=metallb --for=condition=Ready --timeout=10s
+kubectl --context "kind-${KIND_CLUSTER_NAME}" rollout status -n metallb-system deployment/controller --timeout 5m
+kubectl --context "kind-${KIND_CLUSTER_NAME}" rollout status -n metallb-system daemonset/speaker --timeout 5m
+kubectl --context "kind-${KIND_CLUSTER_NAME}" wait -n metallb-system  pod -l app=metallb --for=condition=Ready --timeout=10s
 
 SUBNET=$(docker network inspect kind | jq -r '.[].IPAM.Config[].Subnet | select(contains(":") | not)' | cut -d '.' -f1,2)
 MIN=${SUBNET}.255.0
@@ -20,7 +21,7 @@ MAX=${SUBNET}.255.231
 # Note: each line below must begin with one tab character; this is to get EOF working within
 # an if block. The `-` in the `<<-EOF`` strips out the leading tab from each line, see
 # https://tldp.org/LDP/abs/html/here-docs.html
-kubectl apply -f - <<-EOF
+kubectl --context "kind-${KIND_CLUSTER_NAME}" apply -f - <<-EOF
 apiVersion: metallb.io/v1beta1
 kind: IPAddressPool
 metadata:


### PR DESCRIPTION
A stray `kubectl config current-context` was enough to make `make create-kind-cluster`, `make use-kind-cluster`, `make kagent-addon-install`, and `make -C go e2e` mutate whichever cluster was active. None of those targets read like "may rewrite an arbitrary cluster," yet that is what they did. Resolves kagent-dev/kagent#1806.

`scripts/kind/setup-{kind,metallb}.sh` now pin every `kubectl` invocation to `--context "kind-${KIND_CLUSTER_NAME}"`. The Makefile targets `use-kind-cluster`, `kagent-cli-port-forward`, `kagent-ui-port-forward`, and the `istioctl install` line inside `kagent-addon-install` get the same treatment; `use-kind-cluster` no longer touches `--current` and instead sets the namespace on the kind context by name, so any other context the user has is left untouched. `go/Makefile`'s `e2e` target materializes the kind cluster's kubeconfig to a temp file and runs `go test` with `KUBECONFIG` forced to it — both `controller-runtime`'s `config.GetConfig()` and the bare `exec.Command("kubectl", ...)` calls inside the test code now have no path to a remote cluster. The target aborts early with a clear message if the kind cluster is missing.

The same `--kube-context kind-$(KIND_CLUSTER_NAME)` discipline already applied to `helm-install*`, `helm-uninstall`, `push-test-agent`, and the `kubectl apply` lines inside `kagent-addon-install`; this brings the rest of the developer tooling to the same baseline.

### Verification

`bash -n` parses both kind scripts. `make -n use-kind-cluster`, `make -n kagent-addon-install`, `make -n kagent-cli-port-forward`, `make -n kagent-ui-port-forward`, and `make -C go -n e2e` all expand with `--context kind-kagent` (or `KUBECONFIG=/tmp/kind-config-e2e`) on every state-mutating line.

### Out of scope

The Go test code itself still calls `kubectl` and `controller-runtime` without an explicit context; the safety here is provided by the wrapping `make e2e` target setting `KUBECONFIG`. Anyone running `go test ./go/core/test/e2e` directly is still responsible for setting `KUBECONFIG` themselves.
