### PR TITLE
feat(helm): add extraGetterRules and extraWriterRules to rbac values

### DIFF
--- a/helm/kagent/templates/rbac/getter-role.yaml
+++ b/helm/kagent/templates/rbac/getter-role.yaml
@@ -93,6 +93,9 @@
   - get
   - list
   - watch
+{{- with .Values.rbac.extraGetterRules }}
+{{ toYaml . }}
+{{- end -}}
 {{- end -}}
 
 {{- include "kagent.rbac.validate" . -}}

--- a/helm/kagent/templates/rbac/writer-role.yaml
+++ b/helm/kagent/templates/rbac/writer-role.yaml
@@ -75,6 +75,9 @@
   - update
   - patch
   - delete
+{{- with .Values.rbac.extraWriterRules }}
+{{ toYaml . }}
+{{- end -}}
 {{- end -}}
 
 {{- include "kagent.rbac.validate" . -}}

--- a/helm/kagent/tests/rbac_test.yaml
+++ b/helm/kagent/tests/rbac_test.yaml
@@ -252,3 +252,46 @@ tests:
           path: metadata.namespace
           value: other-ns
         documentIndex: 1
+
+  - it: extraGetterRules are added to getter role
+    set:
+      rbac.extraGetterRules:
+        - apiGroups: ["networking.k8s.io"]
+          resources: ["ingresses"]
+          verbs: ["get", "list", "watch"]
+    template: rbac/getter-role.yaml
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["networking.k8s.io"]
+            resources: ["ingresses"]
+            verbs: ["get", "list", "watch"]
+
+  - it: extraWriterRules are added to writer role
+    set:
+      rbac.extraWriterRules:
+        - apiGroups: ["networking.k8s.io"]
+          resources: ["ingresses"]
+          verbs: ["create", "update", "patch", "delete"]
+    template: rbac/writer-role.yaml
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["networking.k8s.io"]
+            resources: ["ingresses"]
+            verbs: ["create", "update", "patch", "delete"]
+
+  - it: extra rules are empty by default
+    asserts:
+      - notContains:
+          path: rules
+          content:
+            apiGroups: ["networking.k8s.io"]
+        template: rbac/getter-role.yaml
+      - notContains:
+          path: rules
+          content:
+            apiGroups: ["networking.k8s.io"]
+        template: rbac/writer-role.yaml

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -132,6 +132,10 @@ rbac:
   # WATCH_NAMESPACES is derived from this list (unless controller.watchNamespaces is set
   # explicitly, which always takes precedence).
   namespaces: []
+  # -- Additional rules appended to the getter ClusterRole/Role.
+  extraGetterRules: []
+  # -- Additional rules appended to the writer ClusterRole/Role.
+  extraWriterRules: []
 
 # ==============================================================================
 # CONTROLLER CONFIGURATION


### PR DESCRIPTION
Closes #1826

The getter and writer ClusterRoles have no way to add custom rules without editing chart templates directly. 
This adds two new values that append rules to each role.
Both default to empty, so existing installs are unchanged.