### PR TITLE
feat(controller): set appProtocol on agent Service when a2aConfig is set

### DIFF
--- a/go/core/internal/controller/translator/agent/manifest_builder.go
+++ b/go/core/internal/controller/translator/agent/manifest_builder.go
@@ -516,6 +516,16 @@ func (a *adkApiTranslator) buildWorkloadObjects(
 		return sbObjs, nil
 	}
 
+	svcPort := corev1.ServicePort{
+		Name:       "http",
+		Port:       manifestCtx.deployment.Port,
+		TargetPort: intstr.FromInt(int(manifestCtx.deployment.Port)),
+	}
+	if s := manifestCtx.agent.GetAgentSpec(); s != nil && s.Declarative != nil && s.Declarative.A2AConfig != nil {
+		proto := "kgateway.dev/a2a"
+		svcPort.AppProtocol = &proto
+	}
+
 	return []client.Object{
 		&appsv1.Deployment{
 			TypeMeta:   metav1.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"},
@@ -538,12 +548,8 @@ func (a *adkApiTranslator) buildWorkloadObjects(
 			ObjectMeta: manifestCtx.objectMeta(),
 			Spec: corev1.ServiceSpec{
 				Selector: manifestCtx.selectorLabels,
-				Ports: []corev1.ServicePort{{
-					Name:       "http",
-					Port:       manifestCtx.deployment.Port,
-					TargetPort: intstr.FromInt(int(manifestCtx.deployment.Port)),
-				}},
-				Type: corev1.ServiceTypeClusterIP,
+				Ports:    []corev1.ServicePort{svcPort},
+				Type:     corev1.ServiceTypeClusterIP,
 			},
 		},
 	}, nil

--- a/go/core/internal/controller/translator/agent/testdata/inputs/agent_with_a2a_config.yaml
+++ b/go/core/internal/controller/translator/agent/testdata/inputs/agent_with_a2a_config.yaml
@@ -1,0 +1,38 @@
+operation: translateAgent
+targetObject: a2a-agent
+namespace: test
+objects:
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: openai-secret
+      namespace: test
+    data:
+      api-key: c2stdGVzdC1hcGkta2V5
+  - apiVersion: kagent.dev/v1alpha2
+    kind: ModelConfig
+    metadata:
+      name: default-model
+      namespace: test
+    spec:
+      provider: OpenAI
+      model: gpt-4o
+      apiKeySecret: openai-secret
+      apiKeySecretKey: api-key
+  - apiVersion: kagent.dev/v1alpha2
+    kind: Agent
+    metadata:
+      name: a2a-agent
+      namespace: test
+    spec:
+      type: Declarative
+      declarative:
+        description: An agent with A2A enabled
+        systemMessage: You are a helpful assistant.
+        modelConfig: default-model
+        tools: []
+        a2aConfig:
+          skills:
+            - id: summarize
+              name: Summarize
+              description: Summarizes text

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_a2a_config.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_a2a_config.json
@@ -1,0 +1,293 @@
+{
+  "agentCard": {
+    "capabilities": {
+      "pushNotifications": false,
+      "stateTransitionHistory": true,
+      "streaming": true
+    },
+    "defaultInputModes": [
+      "text"
+    ],
+    "defaultOutputModes": [
+      "text"
+    ],
+    "description": "",
+    "name": "a2a_agent",
+    "preferredTransport": "JSONRPC",
+    "skills": [
+      {
+        "description": "Summarizes text",
+        "name": "Summarize",
+        "tags": null
+      }
+    ],
+    "url": "http://a2a-agent.test:8080",
+    "version": ""
+  },
+  "config": {
+    "description": "",
+    "instruction": "You are a helpful assistant.",
+    "model": {
+      "base_url": "",
+      "model": "gpt-4o",
+      "type": "openai"
+    },
+    "stream": false
+  },
+  "manifest": [
+    {
+      "apiVersion": "v1",
+      "kind": "Secret",
+      "metadata": {
+        "labels": {
+          "app": "kagent",
+          "app.kubernetes.io/managed-by": "kagent",
+          "app.kubernetes.io/name": "a2a-agent",
+          "app.kubernetes.io/part-of": "kagent",
+          "kagent": "a2a-agent"
+        },
+        "name": "a2a-agent",
+        "namespace": "test",
+        "ownerReferences": [
+          {
+            "apiVersion": "kagent.dev/v1alpha2",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "Agent",
+            "name": "a2a-agent",
+            "uid": ""
+          }
+        ]
+      },
+      "stringData": {
+        "agent-card.json": "{\"name\":\"a2a_agent\",\"description\":\"\",\"url\":\"http://a2a-agent.test:8080\",\"version\":\"\",\"capabilities\":{\"streaming\":true,\"pushNotifications\":false,\"stateTransitionHistory\":true},\"defaultInputModes\":[\"text\"],\"defaultOutputModes\":[\"text\"],\"skills\":[{\"id\":\"summarize\",\"name\":\"Summarize\",\"description\":\"Summarizes text\",\"tags\":null}],\"preferredTransport\":\"JSONRPC\"}",
+        "config.json": "{\"model\":{\"type\":\"openai\",\"model\":\"gpt-4o\",\"base_url\":\"\"},\"description\":\"\",\"instruction\":\"You are a helpful assistant.\",\"stream\":false}"
+      }
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "ServiceAccount",
+      "metadata": {
+        "labels": {
+          "app": "kagent",
+          "app.kubernetes.io/managed-by": "kagent",
+          "app.kubernetes.io/name": "a2a-agent",
+          "app.kubernetes.io/part-of": "kagent",
+          "kagent": "a2a-agent"
+        },
+        "name": "a2a-agent",
+        "namespace": "test",
+        "ownerReferences": [
+          {
+            "apiVersion": "kagent.dev/v1alpha2",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "Agent",
+            "name": "a2a-agent",
+            "uid": ""
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "apps/v1",
+      "kind": "Deployment",
+      "metadata": {
+        "labels": {
+          "app": "kagent",
+          "app.kubernetes.io/managed-by": "kagent",
+          "app.kubernetes.io/name": "a2a-agent",
+          "app.kubernetes.io/part-of": "kagent",
+          "kagent": "a2a-agent"
+        },
+        "name": "a2a-agent",
+        "namespace": "test",
+        "ownerReferences": [
+          {
+            "apiVersion": "kagent.dev/v1alpha2",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "Agent",
+            "name": "a2a-agent",
+            "uid": ""
+          }
+        ]
+      },
+      "spec": {
+        "selector": {
+          "matchLabels": {
+            "app": "kagent",
+            "kagent": "a2a-agent"
+          }
+        },
+        "strategy": {
+          "rollingUpdate": {
+            "maxSurge": 1,
+            "maxUnavailable": 0
+          },
+          "type": "RollingUpdate"
+        },
+        "template": {
+          "metadata": {
+            "annotations": {
+              "kagent.dev/config-hash": "16405455094195710426"
+            },
+            "labels": {
+              "app": "kagent",
+              "app.kubernetes.io/managed-by": "kagent",
+              "app.kubernetes.io/name": "a2a-agent",
+              "app.kubernetes.io/part-of": "kagent",
+              "kagent": "a2a-agent"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "args": [
+                  "--host",
+                  "0.0.0.0",
+                  "--port",
+                  "8080",
+                  "--filepath",
+                  "/config"
+                ],
+                "env": [
+                  {
+                    "name": "OPENAI_API_KEY",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "key": "api-key",
+                        "name": "openai-secret"
+                      }
+                    }
+                  },
+                  {
+                    "name": "KAGENT_NAMESPACE",
+                    "valueFrom": {
+                      "fieldRef": {
+                        "fieldPath": "metadata.namespace"
+                      }
+                    }
+                  },
+                  {
+                    "name": "KAGENT_NAME",
+                    "value": "a2a-agent"
+                  },
+                  {
+                    "name": "KAGENT_URL",
+                    "value": "http://kagent-controller.kagent:8083"
+                  }
+                ],
+                "image": "cr.kagent.dev/kagent-dev/kagent/app:dev",
+                "imagePullPolicy": "IfNotPresent",
+                "name": "kagent",
+                "ports": [
+                  {
+                    "containerPort": 8080,
+                    "name": "http"
+                  }
+                ],
+                "readinessProbe": {
+                  "httpGet": {
+                    "path": "/.well-known/agent-card.json",
+                    "port": "http"
+                  },
+                  "initialDelaySeconds": 15,
+                  "periodSeconds": 15,
+                  "timeoutSeconds": 15
+                },
+                "resources": {
+                  "limits": {
+                    "cpu": "2",
+                    "memory": "1Gi"
+                  },
+                  "requests": {
+                    "cpu": "100m",
+                    "memory": "384Mi"
+                  }
+                },
+                "volumeMounts": [
+                  {
+                    "mountPath": "/config",
+                    "name": "config"
+                  },
+                  {
+                    "mountPath": "/var/run/secrets/tokens",
+                    "name": "kagent-token"
+                  }
+                ]
+              }
+            ],
+            "serviceAccountName": "a2a-agent",
+            "volumes": [
+              {
+                "name": "config",
+                "secret": {
+                  "secretName": "a2a-agent"
+                }
+              },
+              {
+                "name": "kagent-token",
+                "projected": {
+                  "sources": [
+                    {
+                      "serviceAccountToken": {
+                        "audience": "kagent",
+                        "expirationSeconds": 3600,
+                        "path": "kagent-token"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      "status": {}
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "Service",
+      "metadata": {
+        "labels": {
+          "app": "kagent",
+          "app.kubernetes.io/managed-by": "kagent",
+          "app.kubernetes.io/name": "a2a-agent",
+          "app.kubernetes.io/part-of": "kagent",
+          "kagent": "a2a-agent"
+        },
+        "name": "a2a-agent",
+        "namespace": "test",
+        "ownerReferences": [
+          {
+            "apiVersion": "kagent.dev/v1alpha2",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "Agent",
+            "name": "a2a-agent",
+            "uid": ""
+          }
+        ]
+      },
+      "spec": {
+        "ports": [
+          {
+            "appProtocol": "kgateway.dev/a2a",
+            "name": "http",
+            "port": 8080,
+            "targetPort": 8080
+          }
+        ],
+        "selector": {
+          "app": "kagent",
+          "kagent": "a2a-agent"
+        },
+        "type": "ClusterIP"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Closes #1808

When an agent has `a2aConfig` set, the operator-managed Service port now gets `appProtocol: kgateway.dev/a2a`. This lets agentgateway detect and handle A2A traffic automatically, without the user having to create a separate wrapper Service per agent.

Without this change, the agent card URL rewriting that agentgateway does for A2A does not work, because the proxy sees the traffic as plain HTTP. The only workaround today is a manually maintained sibling Service for each A2A agent.

Agents without `a2aConfig` are not affected.