### PR TITLE
add ui for configuring allowed domains for agentharness objects

### DIFF
--- a/ui/src/app/agents/new-harness/page.tsx
+++ b/ui/src/app/agents/new-harness/page.tsx
@@ -316,7 +316,7 @@ function AgentHarnessPageContent() {
                   }))
                 }
                 disabled={disabled}
-                sectionError={state.errors.openClawSandbox}
+                validationError={state.errors.openClawSandbox}
               />
 
               <div className="flex justify-end border-t border-border/50 pt-6">

--- a/ui/src/components/AgentsProvider.tsx
+++ b/ui/src/components/AgentsProvider.tsx
@@ -18,26 +18,12 @@ import type {
 } from "@/types";
 import { getModelConfigs } from "@/app/actions/modelConfigs";
 import { formUsesByoSections, formUsesDeclarativeSections } from "@/lib/agentFormLayout";
+import type { AgentFormValidationErrors } from "@/components/agent-form/agent-form-types";
 import type { OpenClawSandboxFormSlice } from "@/lib/openClawSandboxForm";
 import { validateOpenClawSandboxForm } from "@/lib/openClawSandboxForm";
 import { isResourceNameValid } from "@/lib/utils";
 
-export interface ValidationErrors {
-  name?: string;
-  namespace?: string;
-  description?: string;
-  type?: string;
-  systemPrompt?: string;
-  model?: string;
-  knowledgeSources?: string;
-  tools?: string;
-  skills?: string;
-  memoryModel?: string;
-  memoryTtl?: string;
-  serviceAccountName?: string;
-  promptSources?: string;
-  openClawSandbox?: string;
-}
+export type ValidationErrors = AgentFormValidationErrors;
 
 export interface AgentFormData {
   name: string;

--- a/ui/src/components/agent-form/OpenClawSandboxFields.tsx
+++ b/ui/src/components/agent-form/OpenClawSandboxFields.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { FormSection, FieldRoot, FieldLabel, FieldHint, FieldError } from "@/components/agent-form/form-primitives";
 import { cn } from "@/lib/utils";
@@ -484,6 +485,34 @@ export function OpenClawSandboxFields({ value, onChange, disabled, sectionError 
           </ul>
         )}
       </FieldRoot>
+      </FormSection>
+
+      <FormSection
+        id="section-openclaw-network"
+        title="Network"
+        description="Restrict outbound HTTP(S) traffic from the harness to a list of allowed domains. Each entry allows all HTTP methods (GET, POST, PUT, DELETE, …) and all paths on that host."
+      >
+        <FieldRoot>
+          <FieldLabel htmlFor="agent-field-openclaw-allowed-domains">Allowed domains</FieldLabel>
+          <FieldHint>
+            One host per line (commas and spaces also work). Use bare DNS names like{" "}
+            <span className="font-mono">api.github.com</span> or glob labels like{" "}
+            <span className="font-mono">*.slack.com</span> — no scheme or path. Domains are merged with the harness baseline and
+            channel-derived egress policies.
+          </FieldHint>
+          <Textarea
+            id="agent-field-openclaw-allowed-domains"
+            name="allowedDomains"
+            value={value.allowedDomains}
+            onChange={(e) => set({ allowedDomains: e.target.value })}
+            placeholder={"api.github.com\nregistry.npmjs.org\n*.slack.com"}
+            rows={4}
+            spellCheck={false}
+            autoComplete="off"
+            disabled={disabled}
+            className="font-mono text-sm"
+          />
+        </FieldRoot>
       </FormSection>
 
       <section className="rounded-lg border border-border/90 bg-card text-card-foreground shadow-sm">

--- a/ui/src/components/agent-form/OpenClawSandboxFields.tsx
+++ b/ui/src/components/agent-form/OpenClawSandboxFields.tsx
@@ -11,7 +11,11 @@ import { Textarea } from "@/components/ui/textarea";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { FormSection, FieldRoot, FieldLabel, FieldHint, FieldError } from "@/components/agent-form/form-primitives";
 import { cn } from "@/lib/utils";
-import type { OpenClawChannelRow, OpenClawSandboxFormSlice } from "@/lib/openClawSandboxForm";
+import type {
+  OpenClawChannelRow,
+  OpenClawSandboxFormSlice,
+  OpenClawSandboxFormValidationError,
+} from "@/lib/openClawSandboxForm";
 import { newOpenClawChannelRow } from "@/lib/openClawSandboxForm";
 
 const OPENCLAW_DOCS_ROOT = "https://docs.openclaw.ai";
@@ -113,21 +117,27 @@ interface OpenClawSandboxFieldsProps {
   value: OpenClawSandboxFormSlice;
   onChange: (next: OpenClawSandboxFormSlice) => void;
   disabled: boolean;
-  sectionError?: string;
+  /** From {@link validateOpenClawSandboxForm}; includes `section` for placement + focus. */
+  validationError?: OpenClawSandboxFormValidationError;
 }
 
-export function OpenClawSandboxFields({ value, onChange, disabled, sectionError }: OpenClawSandboxFieldsProps) {
+export function OpenClawSandboxFields({ value, onChange, disabled, validationError }: OpenClawSandboxFieldsProps) {
   const set = (patch: Partial<OpenClawSandboxFormSlice>) => onChange({ ...value, ...patch });
   const [advancedOpen, setAdvancedOpen] = React.useState(false);
+  const section = validationError?.section ?? null;
 
   return (
-    <div className="space-y-8">
+    <div id="section-openclaw-sandbox" className="space-y-8">
+      <FieldError>
+        {section === "general" ? validationError?.message : null}
+      </FieldError>
+
       <FormSection
         id="section-openclaw-channels"
         title="Channels integrations"
         description="Optional channel accounts: pick a provider, then credentials (inline or a Kubernetes Secret key in this namespace)."
       >
-        <FieldError>{sectionError}</FieldError>
+        <FieldError>{section === "channels" ? validationError?.message : null}</FieldError>
 
         <FieldRoot>
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
@@ -492,6 +502,7 @@ export function OpenClawSandboxFields({ value, onChange, disabled, sectionError 
         title="Network"
         description="Restrict outbound HTTP(S) traffic from the harness to a list of allowed domains. Each entry allows all HTTP methods (GET, POST, PUT, DELETE, …) and all paths on that host."
       >
+        <FieldError>{section === "allowedDomains" ? validationError?.message : null}</FieldError>
         <FieldRoot>
           <FieldLabel htmlFor="agent-field-openclaw-allowed-domains">Allowed domains</FieldLabel>
           <FieldHint>

--- a/ui/src/components/agent-form/agent-form-types.ts
+++ b/ui/src/components/agent-form/agent-form-types.ts
@@ -1,3 +1,5 @@
+import type { OpenClawSandboxFormValidationError } from "@/lib/openClawSandboxForm";
+
 export interface AgentFormValidationErrors {
   name?: string;
   namespace?: string;
@@ -12,5 +14,5 @@ export interface AgentFormValidationErrors {
   memoryTtl?: string;
   serviceAccountName?: string;
   promptSources?: string;
-  openClawSandbox?: string;
+  openClawSandbox?: OpenClawSandboxFormValidationError;
 }

--- a/ui/src/components/agent-form/focusFirstFormError.ts
+++ b/ui/src/components/agent-form/focusFirstFormError.ts
@@ -55,13 +55,27 @@ export function focusFirstFormError(
         return;
       }
     }
+    if (key === "openClawSandbox") {
+      const err = errors.openClawSandbox;
+      if (err) {
+        const focusId =
+          err.section === "allowedDomains"
+            ? "agent-field-openclaw-allowed-domains"
+            : err.section === "channels"
+              ? "section-openclaw-channels"
+              : "section-openclaw-sandbox";
+        if (focusElementById(focusId)) {
+          return;
+        }
+      }
+      continue;
+    }
     const idMap: Partial<Record<keyof AgentFormValidationErrors, string>> = {
       name: "agent-field-name",
       namespace: "agent-field-namespace",
       description: "agent-desc",
       systemPrompt: "agent-field-system",
       model: "agent-field-model",
-      openClawSandbox: "section-openclaw-channels",
       memoryModel: "agent-field-memory-model",
       memoryTtl: "agent-field-memory-ttl",
       skills: "section-skills",

--- a/ui/src/lib/__tests__/openClawSandboxForm.test.ts
+++ b/ui/src/lib/__tests__/openClawSandboxForm.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "@jest/globals";
 import {
   buildSandboxCRDraft,
   defaultOpenClawSandboxFormSlice,
+  newOpenClawChannelRow,
   parseAllowedDomainsList,
   validateOpenClawSandboxForm,
 } from "../openClawSandboxForm";
@@ -9,6 +10,42 @@ import {
 function withAllowedDomains(allowedDomains: string) {
   return { ...defaultOpenClawSandboxFormSlice(), allowedDomains };
 }
+
+describe("validateOpenClawSandboxForm sections", () => {
+  it("tags missing model as general", () => {
+    expect(
+      validateOpenClawSandboxForm({
+        openClaw: defaultOpenClawSandboxFormSlice(),
+        modelRef: "",
+      }),
+    ).toEqual({
+      section: "general",
+      message: "Please select a model config for this sandbox.",
+    });
+  });
+
+  it("tags allowed domain failures as allowedDomains", () => {
+    const r = validateOpenClawSandboxForm({
+      openClaw: withAllowedDomains("https://api.github.com"),
+      modelRef: "ns/m1",
+    });
+    expect(r?.section).toBe("allowedDomains");
+    expect(r?.message).toContain("not a valid hostname");
+  });
+
+  it("tags channel credential failures as channels", () => {
+    const row = newOpenClawChannelRow();
+    row.name = "slack1";
+    row.channelType = "slack";
+    row.botToken = "";
+    const r = validateOpenClawSandboxForm({
+      openClaw: { ...defaultOpenClawSandboxFormSlice(), channels: [row] },
+      modelRef: "ns/m1",
+    });
+    expect(r?.section).toBe("channels");
+    expect(r?.message).toContain("slack1");
+  });
+});
 
 describe("openClawSandboxForm allowedDomains", () => {
   describe("parseAllowedDomainsList", () => {
@@ -64,7 +101,8 @@ describe("openClawSandboxForm allowedDomains", () => {
         openClaw: withAllowedDomains(entry),
         modelRef: "ns/m1",
       });
-      expect(result).toMatch(/not a valid hostname/);
+      expect(result?.section).toBe("allowedDomains");
+      expect(result?.message).toMatch(/not a valid hostname/);
     });
   });
 

--- a/ui/src/lib/__tests__/openClawSandboxForm.test.ts
+++ b/ui/src/lib/__tests__/openClawSandboxForm.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  buildSandboxCRDraft,
+  defaultOpenClawSandboxFormSlice,
+  parseAllowedDomainsList,
+  validateOpenClawSandboxForm,
+} from "../openClawSandboxForm";
+
+function withAllowedDomains(allowedDomains: string) {
+  return { ...defaultOpenClawSandboxFormSlice(), allowedDomains };
+}
+
+describe("openClawSandboxForm allowedDomains", () => {
+  describe("parseAllowedDomainsList", () => {
+    it("returns an empty list for empty / whitespace input", () => {
+      expect(parseAllowedDomainsList("")).toEqual([]);
+      expect(parseAllowedDomainsList("   \n\t  ")).toEqual([]);
+    });
+
+    it("splits on newlines, commas, and whitespace", () => {
+      expect(parseAllowedDomainsList("api.github.com\nregistry.npmjs.org")).toEqual([
+        "api.github.com",
+        "registry.npmjs.org",
+      ]);
+      expect(parseAllowedDomainsList("api.github.com, registry.npmjs.org   *.slack.com")).toEqual([
+        "api.github.com",
+        "registry.npmjs.org",
+        "*.slack.com",
+      ]);
+    });
+
+    it("dedupes case-insensitively and preserves first-seen order", () => {
+      expect(parseAllowedDomainsList("API.github.com\napi.github.com\nRegistry.npmjs.org")).toEqual([
+        "API.github.com",
+        "Registry.npmjs.org",
+      ]);
+    });
+  });
+
+  describe("validateOpenClawSandboxForm", () => {
+    it("accepts an empty allowedDomains list", () => {
+      const result = validateOpenClawSandboxForm({
+        openClaw: withAllowedDomains(""),
+        modelRef: "ns/m1",
+      });
+      expect(result).toBeUndefined();
+    });
+
+    it("accepts plain hosts and glob labels", () => {
+      const result = validateOpenClawSandboxForm({
+        openClaw: withAllowedDomains("api.github.com\n*.slack.com\nregistry.npmjs.org"),
+        modelRef: "ns/m1",
+      });
+      expect(result).toBeUndefined();
+    });
+
+    it.each([
+      ["https://api.github.com", "scheme not allowed"],
+      ["api.github.com/path", "path not allowed"],
+      ["..", "empty labels"],
+      ["-bad.example.com", "bad label start"],
+    ])("rejects malformed entry %p (%s)", (entry) => {
+      const result = validateOpenClawSandboxForm({
+        openClaw: withAllowedDomains(entry),
+        modelRef: "ns/m1",
+      });
+      expect(result).toMatch(/not a valid hostname/);
+    });
+  });
+
+  describe("buildSandboxCRDraft", () => {
+    it("omits spec.network when allowedDomains is empty", () => {
+      const draft = buildSandboxCRDraft({
+        name: "h1",
+        namespace: "ns",
+        description: "",
+        modelRef: "m1",
+        openClaw: withAllowedDomains(""),
+      });
+      expect("error" in draft).toBe(false);
+      if ("error" in draft) return;
+      expect(draft.spec.network).toBeUndefined();
+    });
+
+    it("writes spec.network.allowedDomains preserving order and deduping", () => {
+      const draft = buildSandboxCRDraft({
+        name: "h1",
+        namespace: "ns",
+        description: "",
+        modelRef: "m1",
+        openClaw: withAllowedDomains("api.github.com\nregistry.npmjs.org\napi.github.com\n*.slack.com"),
+      });
+      expect("error" in draft).toBe(false);
+      if ("error" in draft) return;
+      expect(draft.spec.network).toEqual({
+        allowedDomains: ["api.github.com", "registry.npmjs.org", "*.slack.com"],
+      });
+    });
+
+    it("targets the AgentHarness CR with the openclaw backend", () => {
+      const draft = buildSandboxCRDraft({
+        name: "h1",
+        namespace: "ns",
+        description: "",
+        modelRef: "m1",
+        openClaw: withAllowedDomains("api.github.com"),
+      });
+      expect("error" in draft).toBe(false);
+      if ("error" in draft) return;
+      expect(draft.apiVersion).toBe("kagent.dev/v1alpha2");
+      expect(draft.kind).toBe("AgentHarness");
+      expect(draft.spec.backend).toBe("openclaw");
+    });
+  });
+});

--- a/ui/src/lib/openClawSandboxForm.ts
+++ b/ui/src/lib/openClawSandboxForm.ts
@@ -48,12 +48,20 @@ export interface OpenClawSandboxFormSlice {
   /** Optional override for Sandbox.spec.image (OpenShell VM template image). Empty → controller default. */
   image: string;
   channels: OpenClawChannelRow[];
+  /**
+   * Free-text DNS host list (newline / comma / space separated) that maps to
+   * `AgentHarness.spec.network.allowedDomains`. Each host opens an L7 REST endpoint
+   * allowing all HTTP methods and paths in the OpenShell sandbox policy; the
+   * controller merges these with baseline + channel fragments.
+   */
+  allowedDomains: string;
 }
 
 export function defaultOpenClawSandboxFormSlice(): OpenClawSandboxFormSlice {
   return {
     image: "",
     channels: [],
+    allowedDomains: "",
   };
 }
 
@@ -62,6 +70,46 @@ function trimSplitList(raw: string): string[] {
     .split(/[\s,]+/)
     .map((s) => s.trim())
     .filter(Boolean);
+}
+
+/**
+ * Hostname / glob shape gate for allowedDomains rows. Mirrors what the controller's
+ * `NormalizeAllowedDomainHost` will end up storing: bare DNS names, optional `*` /
+ * `**` glob labels, no schemes, no paths, no whitespace.
+ */
+const ALLOWED_DOMAIN_LABEL_RE = /^(\*\*?|[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)$/;
+
+function isPlausibleAllowedDomainHost(raw: string): boolean {
+  const s = raw.trim();
+  if (!s || s.length > 253) {
+    return false;
+  }
+  if (/[\s/]/.test(s) || s.includes("://")) {
+    return false;
+  }
+  const labels = s.split(".");
+  if (labels.length === 0) {
+    return false;
+  }
+  return labels.every((label) => ALLOWED_DOMAIN_LABEL_RE.test(label));
+}
+
+/**
+ * Splits the textarea contents, dedupes (case-insensitive) and preserves first-seen order.
+ * Caller decides whether to send `spec.network.allowedDomains` based on the result length.
+ */
+export function parseAllowedDomainsList(raw: string): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of trimSplitList(raw)) {
+    const key = entry.toLowerCase();
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    out.push(entry);
+  }
+  return out;
 }
 
 function credentialFromRow(
@@ -94,6 +142,12 @@ export function validateOpenClawSandboxForm(args: {
   const mr = (args.modelRef || "").trim();
   if (!mr) {
     return "Please select a model config for this sandbox.";
+  }
+
+  for (const entry of trimSplitList(args.openClaw.allowedDomains)) {
+    if (!isPlausibleAllowedDomainHost(entry)) {
+      return `Allowed domain "${entry}" is not a valid hostname. Use bare DNS names like api.github.com (no scheme or path).`;
+    }
   }
 
   for (const ch of args.openClaw.channels) {
@@ -253,6 +307,11 @@ export function buildSandboxCRDraft(args: {
   const img = args.openClaw.image.trim();
   if (img) {
     spec.image = img;
+  }
+
+  const allowedDomains = parseAllowedDomainsList(args.openClaw.allowedDomains);
+  if (allowedDomains.length > 0) {
+    spec.network = { allowedDomains };
   }
 
   return {

--- a/ui/src/lib/openClawSandboxForm.ts
+++ b/ui/src/lib/openClawSandboxForm.ts
@@ -112,6 +112,21 @@ export function parseAllowedDomainsList(raw: string): string[] {
   return out;
 }
 
+/** Where to show a harness OpenClaw validation message and which element to focus. */
+export type OpenClawSandboxSectionErrorKind = "allowedDomains" | "channels" | "general";
+
+export interface OpenClawSandboxFormValidationError {
+  message: string;
+  section: OpenClawSandboxSectionErrorKind;
+}
+
+function openClawValidationFail(
+  section: OpenClawSandboxSectionErrorKind,
+  message: string,
+): OpenClawSandboxFormValidationError {
+  return { section, message };
+}
+
 function credentialFromRow(
   source: "inline" | "secret",
   inlineVal: string,
@@ -134,19 +149,22 @@ function credentialFromRow(
   return { valueFrom: { type: "Secret", name: n, key: k } };
 }
 
-/** Client-side validation for OpenClaw Sandbox CR create. Returns a single message or undefined. */
+/** Client-side validation for OpenClaw Sandbox CR create. */
 export function validateOpenClawSandboxForm(args: {
   openClaw: OpenClawSandboxFormSlice;
   modelRef: string | undefined;
-}): string | undefined {
+}): OpenClawSandboxFormValidationError | undefined {
   const mr = (args.modelRef || "").trim();
   if (!mr) {
-    return "Please select a model config for this sandbox.";
+    return openClawValidationFail("general", "Please select a model config for this sandbox.");
   }
 
   for (const entry of trimSplitList(args.openClaw.allowedDomains)) {
     if (!isPlausibleAllowedDomainHost(entry)) {
-      return `Allowed domain "${entry}" is not a valid hostname. Use bare DNS names like api.github.com (no scheme or path).`;
+      return openClawValidationFail(
+        "allowedDomains",
+        `Allowed domain "${entry}" is not a valid hostname. Use bare DNS names like api.github.com (no scheme or path).`,
+      );
     }
   }
 
@@ -159,7 +177,7 @@ export function validateOpenClawSandboxForm(args: {
         (ch.botTokenSource === "secret" && (ch.botSecretName || ch.botSecretKey)) ||
         (ch.appTokenSource === "secret" && (ch.appSecretName || ch.appSecretKey))
       ) {
-        return "Each channel with tokens configured needs a binding name.";
+        return openClawValidationFail("channels", "Each channel with tokens configured needs a binding name.");
       }
       continue;
     }
@@ -172,7 +190,7 @@ export function validateOpenClawSandboxForm(args: {
       `Channel "${cn}" bot token`,
     );
     if ("error" in bot) {
-      return bot.error;
+      return openClawValidationFail("channels", bot.error);
     }
 
     if (ch.channelType === "slack") {
@@ -184,7 +202,7 @@ export function validateOpenClawSandboxForm(args: {
         `Channel "${cn}" Slack app token`,
       );
       if ("error" in app) {
-        return app.error;
+        return openClawValidationFail("channels", app.error);
       }
     }
 
@@ -192,7 +210,10 @@ export function validateOpenClawSandboxForm(args: {
       if (ch.channelAccess === "allowlist") {
         const list = trimSplitList(ch.allowlistChannels);
         if (list.length === 0) {
-          return `Channel "${cn}": allowlist mode requires at least one channel ID.`;
+          return openClawValidationFail(
+            "channels",
+            `Channel "${cn}": allowlist mode requires at least one channel ID.`,
+          );
         }
       }
     }


### PR DESCRIPTION
add ui for configuring alloweddomains that get translated into policy in the sandbox.
<img width="822" height="363" alt="Screenshot 2026-05-11 at 12 38 25 PM" src="https://github.com/user-attachments/assets/630145f2-123a-4eab-aca8-96db9771931f" />
