### PR TITLE
fix(controller): preserve nil replicas in BYO deployment to allow HPA management

### DIFF
--- a/go/core/internal/controller/translator/agent/deployments.go
+++ b/go/core/internal/controller/translator/agent/deployments.go
@@ -259,9 +259,6 @@ func resolveByoDeployment(agent v1alpha2.AgentObject) (*resolvedDeployment, erro
 	}
 
 	replicas := spec.Replicas
-	if replicas == nil {
-		replicas = new(int32(1))
-	}
 
 	if err := validateExtraContainers(spec.ExtraContainers); err != nil {
 		return nil, err

--- a/go/core/internal/controller/translator/agent/deployments_test.go
+++ b/go/core/internal/controller/translator/agent/deployments_test.go
@@ -3,8 +3,31 @@ package agent
 import (
 	"testing"
 
+	"github.com/kagent-dev/kagent/go/api/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func TestResolveByoDeployment_NilReplicasPreserved(t *testing.T) {
+	agent := &v1alpha2.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec: v1alpha2.AgentSpec{
+			Type: v1alpha2.AgentType_BYO,
+			BYO: &v1alpha2.BYOAgentSpec{
+				Deployment: &v1alpha2.ByoDeploymentSpec{
+					Image: "my-image:latest",
+				},
+			},
+		},
+	}
+	dep, err := resolveByoDeployment(agent)
+	if err != nil {
+		t.Fatalf("resolveByoDeployment() error = %v", err)
+	}
+	if dep.Replicas != nil {
+		t.Errorf("Replicas = %v, want nil so HPA can manage replicas", *dep.Replicas)
+	}
+}
 
 func TestValidateExtraContainers(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Fixes #1844

When `spec.byo.deployment.replicas` is not set, the controller was writing 1 as the replica count into the Deployment. The guard in `mutate.go` only skips updating replicas when the value is nil, so the hardcoded default caused the controller to override the HPA on every reconcile loop.

Removing the default lets the nil value pass through. The guard in `mutate.go` then works correctly and the HPA can manage replicas freely.

Declarative agents are not affected.