### PR TITLE
feat(helm): expose context compaction in all agent subcharts

### DIFF
--- a/helm/agents/argo-rollouts/templates/agent.yaml
+++ b/helm/agents/argo-rollouts/templates/agent.yaml
@@ -182,6 +182,10 @@ spec:
             - "Should I convert my Deployment directly or use workloadRef for my 'user-service'?"
             - "How can I check if the Argo Rollouts controller is installed and running in my cluster before I start migrating?"
             - "My Deployment YAML is complex. Can you help me get its YAML so I can plan the conversion to a Rollout?"
+    {{- if .Values.compaction }}
+    context:
+      compaction: {{- toYaml .Values.compaction | nindent 8 }}
+    {{- end }}
     deployment:
       {{- with coalesce (empty .Values.imagePullSecrets | ternary nil .Values.imagePullSecrets) .Values.global.imagePullSecrets }}
       imagePullSecrets:

--- a/helm/agents/argo-rollouts/values.yaml
+++ b/helm/agents/argo-rollouts/values.yaml
@@ -14,3 +14,5 @@ resources:
     cpu: 1000m
     memory: 1Gi
 
+
+compaction: {}

--- a/helm/agents/cilium-debug/templates/agent.yaml
+++ b/helm/agents/cilium-debug/templates/agent.yaml
@@ -155,6 +155,10 @@ spec:
             - "Monitor real-time traffic using cilium-dbg monitor"
             - "Check the health status of Cilium endpoints"
             - "Verify encryption status between pods"
+    {{- if .Values.compaction }}
+    context:
+      compaction: {{- toYaml .Values.compaction | nindent 8 }}
+    {{- end }}
     deployment:
       {{- with coalesce (empty .Values.imagePullSecrets | ternary nil .Values.imagePullSecrets) .Values.global.imagePullSecrets }}
       imagePullSecrets:

--- a/helm/agents/cilium-debug/values.yaml
+++ b/helm/agents/cilium-debug/values.yaml
@@ -13,3 +13,5 @@ resources:
   limits:
     cpu: 1000m
     memory: 1Gi
+
+compaction: {}

--- a/helm/agents/cilium-manager/templates/agent.yaml
+++ b/helm/agents/cilium-manager/templates/agent.yaml
@@ -427,6 +427,10 @@ spec:
             - "I need a CiliumNetworkPolicy for my application."
             - "How do I write a policy to allow only specific DNS queries?"
             - "What's the syntax for creating a Cilium egress policy?"
+    {{- if .Values.compaction }}
+    context:
+      compaction: {{- toYaml .Values.compaction | nindent 8 }}
+    {{- end }}
     deployment:
       {{- with coalesce (empty .Values.imagePullSecrets | ternary nil .Values.imagePullSecrets) .Values.global.imagePullSecrets }}
       imagePullSecrets:

--- a/helm/agents/cilium-manager/values.yaml
+++ b/helm/agents/cilium-manager/values.yaml
@@ -13,3 +13,5 @@ resources:
   limits:
     cpu: 1000m
     memory: 1Gi
+
+compaction: {}

--- a/helm/agents/cilium-policy/templates/agent.yaml
+++ b/helm/agents/cilium-policy/templates/agent.yaml
@@ -519,6 +519,10 @@ spec:
             - "I want to restrict traffic between pods in the same namespace, which policy should I use?"
             - "Can you create a Kubernetes NetworkPolicy for me?"
             - "What's the difference between CiliumNetworkPolicy and CiliumClusterwideNetworkPolicy for securing my nodes?"
+    {{- if .Values.compaction }}
+    context:
+      compaction: {{- toYaml .Values.compaction | nindent 8 }}
+    {{- end }}
     deployment:
       {{- with coalesce (empty .Values.imagePullSecrets | ternary nil .Values.imagePullSecrets) .Values.global.imagePullSecrets }}
       imagePullSecrets:

--- a/helm/agents/cilium-policy/values.yaml
+++ b/helm/agents/cilium-policy/values.yaml
@@ -14,3 +14,5 @@ resources:
     cpu: 1000m
     memory: 1Gi
 
+
+compaction: {}

--- a/helm/agents/helm/templates/agent.yaml
+++ b/helm/agents/helm/templates/agent.yaml
@@ -174,6 +174,10 @@ spec:
             - "The latest upgrade of the 'api-gateway' release failed. Can you help identify the problem?"
             - "How do I check the rendered Kubernetes manifests for the 'web-server' release without deploying them?"
             - "The pods managed by the 'message-broker' Helm release are frequently restarting. What should I investigate?"
+    {{- if .Values.compaction }}
+    context:
+      compaction: {{- toYaml .Values.compaction | nindent 8 }}
+    {{- end }}
     deployment:
       {{- with coalesce (empty .Values.imagePullSecrets | ternary nil .Values.imagePullSecrets) .Values.global.imagePullSecrets }}
       imagePullSecrets:

--- a/helm/agents/helm/values.yaml
+++ b/helm/agents/helm/values.yaml
@@ -14,3 +14,5 @@ resources:
     cpu: 1000m
     memory: 1Gi
 
+
+compaction: {}

--- a/helm/agents/istio/templates/agent.yaml
+++ b/helm/agents/istio/templates/agent.yaml
@@ -227,6 +227,10 @@ spec:
             - "The sidecar injection is not working for pods in 'app-ns'. What should I check?"
             - "query_documentation for best practices on Istio performance tuning."
             - "Describe the Istio ingress gateway pods in 'istio-system' namespace."
+    {{- if .Values.compaction }}
+    context:
+      compaction: {{- toYaml .Values.compaction | nindent 8 }}
+    {{- end }}
     deployment:
       {{- with coalesce (empty .Values.imagePullSecrets | ternary nil .Values.imagePullSecrets) .Values.global.imagePullSecrets }}
       imagePullSecrets:

--- a/helm/agents/istio/values.yaml
+++ b/helm/agents/istio/values.yaml
@@ -13,3 +13,5 @@ resources:
   limits:
     cpu: 1000m
     memory: 1Gi
+
+compaction: {}

--- a/helm/agents/k8s/templates/agent.yaml
+++ b/helm/agents/k8s/templates/agent.yaml
@@ -145,6 +145,10 @@ spec:
             - "Check for RBAC misconfigurations."
             - "Audit my network policies."
             - "Identify potential security vulnerabilities in my cluster."
+    {{- if .Values.compaction }}
+    context:
+      compaction: {{- toYaml .Values.compaction | nindent 8 }}
+    {{- end }}
     deployment:
       {{- with coalesce (empty .Values.imagePullSecrets | ternary nil .Values.imagePullSecrets) .Values.global.imagePullSecrets }}
       imagePullSecrets:

--- a/helm/agents/k8s/values.yaml
+++ b/helm/agents/k8s/values.yaml
@@ -13,3 +13,5 @@ resources:
   limits:
     cpu: 1000m
     memory: 1Gi
+
+compaction: {}

--- a/helm/agents/kgateway/templates/agent.yaml
+++ b/helm/agents/kgateway/templates/agent.yaml
@@ -309,6 +309,10 @@ spec:
             - "Find the official documentation on kgateway security best practices."
             - "What are the steps to integrate kgateway with Argo CD for GitOps management?"
             - "Tell me more about configuring advanced traffic routing rules like weighted load balancing with kgateway."
+    {{- if .Values.compaction }}
+    context:
+      compaction: {{- toYaml .Values.compaction | nindent 8 }}
+    {{- end }}
     deployment:
       {{- with coalesce (empty .Values.imagePullSecrets | ternary nil .Values.imagePullSecrets) .Values.global.imagePullSecrets }}
       imagePullSecrets:

--- a/helm/agents/kgateway/values.yaml
+++ b/helm/agents/kgateway/values.yaml
@@ -13,3 +13,5 @@ resources:
   limits:
     cpu: 1000m
     memory: 1Gi
+
+compaction: {}

--- a/helm/agents/observability/templates/agent.yaml
+++ b/helm/agents/observability/templates/agent.yaml
@@ -161,6 +161,10 @@ spec:
             - "What's the current resource utilization (CPU/memory) of nodes tagged with 'workload=critical'?"
             - "Show me Kubernetes events related to the 'database' StatefulSet along with its key performance metrics."
             - "Help me identify potential performance bottlenecks in my microservices deployment."
+    {{- if .Values.compaction }}
+    context:
+      compaction: {{- toYaml .Values.compaction | nindent 8 }}
+    {{- end }}
     deployment:
       {{- with coalesce (empty .Values.imagePullSecrets | ternary nil .Values.imagePullSecrets) .Values.global.imagePullSecrets }}
       imagePullSecrets:

--- a/helm/agents/observability/values.yaml
+++ b/helm/agents/observability/values.yaml
@@ -13,3 +13,5 @@ resources:
   limits:
     cpu: 1000m
     memory: 1Gi
+
+compaction: {}

--- a/helm/agents/promql/templates/agent.yaml
+++ b/helm/agents/promql/templates/agent.yaml
@@ -208,6 +208,10 @@ spec:
             - "Explain the Prometheus histogram metric type and how to query it."
             - "What are some best practices for choosing the time window in PromQL range vector selectors?"
             - "How does vector matching work in PromQL, for example, with `on() `and `group_left()`?"
+    {{- if .Values.compaction }}
+    context:
+      compaction: {{- toYaml .Values.compaction | nindent 8 }}
+    {{- end }}
     deployment:
       {{- with coalesce (empty .Values.imagePullSecrets | ternary nil .Values.imagePullSecrets) .Values.global.imagePullSecrets }}
       imagePullSecrets:

--- a/helm/agents/promql/values.yaml
+++ b/helm/agents/promql/values.yaml
@@ -13,3 +13,5 @@ resources:
   limits:
     cpu: 1000m
     memory: 1Gi
+
+compaction: {}


### PR DESCRIPTION
Fixes #1827

All agent subcharts now expose a `compaction` value so users can configure context compaction without replacing the chart-managed Agent CR.

By default `compaction` is empty and no context block is rendered.
Users can set it in their values file:

```yaml
compaction:
  compactionInterval: 5
  overlapSize: 2
```

This adds the same change to all 10 agent subcharts: argo-rollouts, cilium-debug, cilium-manager, cilium-policy, helm, istio, k8s, kgateway, observability, and promql.