### PR TITLE
pss: Make compliant with restricted pss by default

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -203,6 +203,7 @@ jobs:
         run: |
           helm unittest helm/kagent
           helm unittest helm/tools/querydoc
+          helm unittest helm/tools/grafana-mcp
 
   ui-tests:
     runs-on: ubuntu-latest

--- a/helm/kagent/tests/postgresql_test.yaml
+++ b/helm/kagent/tests/postgresql_test.yaml
@@ -238,9 +238,8 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].securityContext.capabilities.drop
           content: ALL
-      - equal:
-          path: spec.template.spec.containers[0].securityContext.seccompProfile.type
-          value: RuntimeDefault
+      - isNull:
+          path: spec.template.spec.containers[0].securityContext.seccompProfile
 
   - it: should allow bundled postgres pod security context override
     template: postgresql.yaml

--- a/helm/kagent/tests/security-context_test.yaml
+++ b/helm/kagent/tests/security-context_test.yaml
@@ -16,6 +16,9 @@ tests:
       - equal:
           path: spec.template.spec.securityContext.runAsNonRoot
           value: true
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
 
   - it: should apply default container security context to controller
     template: controller-deployment.yaml
@@ -23,6 +26,14 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
           value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          content: ALL
+      - isNull:
+          path: spec.template.spec.containers[0].securityContext.seccompProfile
 
   - it: should allow controller pod security context override
     template: controller-deployment.yaml
@@ -87,12 +98,30 @@ tests:
   # =============================================================================
   # UI Security Context Tests
   # =============================================================================
-  - it: should apply UI-specific container security context override
+  - it: should apply default pod security context to UI
+    template: ui-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+
+  - it: should apply default container security context to UI
     template: ui-deployment.yaml
     asserts:
       - equal:
           path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
           value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          content: ALL
+      - isNull:
+          path: spec.template.spec.containers[0].securityContext.seccompProfile
 
   - it: should have nextjs-cache volume for UI
     template: ui-deployment.yaml

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -37,14 +37,17 @@ labels: {}
 # -- Security context for all pods
 podSecurityContext:
   runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
 # fsGroup: 2000
 
 # -- Security context for all containers
 securityContext:
+  allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
-# capabilities:
-#   drop:
-#   - ALL
+  capabilities:
+    drop:
+      - ALL
 # runAsUser: 1000
 
 # ==============================================================================
@@ -117,8 +120,6 @@ database:
         capabilities:
           drop:
             - ALL
-        seccompProfile:
-          type: RuntimeDefault
 
 # ==============================================================================
 # RBAC CONFIGURATION
@@ -398,6 +399,16 @@ kagent-tools:
   enabled: true
   nameOverride: tools
   replicaCount: 1
+  podSecurityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
   resources:
     requests:
       cpu: 50m
@@ -407,7 +418,7 @@ kagent-tools:
   tools:
     loglevel: "debug"
     metrics:
-      port: 8085  # Use a different port than the main service port (8084) to avoid duplicate port definitions
+      port: 8085 # Use a different port than the main service port (8084) to avoid duplicate port definitions
 
 # ==============================================================================
 # PROXY CONFIGURATION

--- a/helm/tools/grafana-mcp/templates/deployment.yaml
+++ b/helm/tools/grafana-mcp/templates/deployment.yaml
@@ -19,6 +19,10 @@ spec:
         {{- include "grafana-mcp.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "grafana-mcp.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/tools/grafana-mcp/tests/deployment_test.yaml
+++ b/helm/tools/grafana-mcp/tests/deployment_test.yaml
@@ -1,7 +1,8 @@
-suite: test querydoc deployment
+suite: test grafana-mcp deployment
 templates:
   - deployment.yaml
   - configmap.yaml
+  - secret.yaml
 tests:
   - it: should render deployment with default values
     template: deployment.yaml
@@ -10,72 +11,37 @@ tests:
           of: Deployment
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-querydoc
+          value: RELEASE-NAME-grafana-mcp
       - equal:
           path: spec.replicas
           value: 1
       - hasDocuments:
           count: 1
 
-  - it: should render deployment with custom replica count
-    template: deployment.yaml
-    set:
-      replicas: 2
-    asserts:
-      - equal:
-          path: spec.replicas
-          value: 2
-
-  - it: should have correct container image
+  - it: should have correct container name
     template: deployment.yaml
     asserts:
       - equal:
           path: spec.template.spec.containers[0].name
-          value: querydoc
-      - equal:
-          path: spec.template.spec.containers[0].image
-          value: ghcr.io/kagent-dev/doc2vec/mcp:1.1.10
-
-  - it: should use custom image tag when set
-    template: deployment.yaml
-    set:
-      image:
-        tag: "v2.0.0"
-    asserts:
-      - equal:
-          path: spec.template.spec.containers[0].image
-          value: ghcr.io/kagent-dev/doc2vec/mcp:v2.0.0
+          value: grafana-mcp
 
   - it: should have correct service account name
     template: deployment.yaml
     asserts:
       - equal:
           path: spec.template.spec.serviceAccountName
-          value: RELEASE-NAME-querydoc
+          value: RELEASE-NAME-grafana-mcp
 
   - it: should have correct container port
     template: deployment.yaml
     asserts:
       - equal:
           path: spec.template.spec.containers[0].ports[0].containerPort
-          value: 8080
+          value: 8000
 
-  - it: should have correct labels
-    template: deployment.yaml
-    asserts:
-      - equal:
-          path: metadata.labels["app.kubernetes.io/name"]
-          value: querydoc
-      - equal:
-          path: metadata.labels["app.kubernetes.io/instance"]
-          value: RELEASE-NAME
-      - equal:
-          path: spec.template.metadata.labels["app.kubernetes.io/name"]
-          value: querydoc
-      - equal:
-          path: spec.template.metadata.labels["app.kubernetes.io/instance"]
-          value: RELEASE-NAME
-
+  # =============================================================================
+  # Security Context Tests
+  # =============================================================================
   - it: should apply default pod security context
     template: deployment.yaml
     asserts:
@@ -100,10 +66,10 @@ tests:
           value: true
       - equal:
           path: spec.template.spec.containers[0].securityContext.runAsUser
-          value: 14000
+          value: 1000
       - equal:
           path: spec.template.spec.containers[0].securityContext.runAsGroup
-          value: 14000
+          value: 999
       - isNull:
           path: spec.template.spec.containers[0].securityContext.seccompProfile
 
@@ -112,14 +78,14 @@ tests:
     set:
       podSecurityContext:
         runAsNonRoot: true
-        fsGroup: 1000
+        fsGroup: 2000
     asserts:
       - equal:
           path: spec.template.spec.securityContext.runAsNonRoot
           value: true
       - equal:
           path: spec.template.spec.securityContext.fsGroup
-          value: 1000
+          value: 2000
 
   - it: should allow container security context override
     template: deployment.yaml
@@ -134,32 +100,3 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].securityContext.runAsUser
           value: 1000
-
-  - it: should set nodeSelector
-    template: deployment.yaml
-    set:
-      nodeSelector:
-        role: AI
-    asserts:
-      - equal:
-          path: spec.template.spec.nodeSelector
-          value:
-            role: AI
-
-  - it: should set tolerations
-    template: deployment.yaml
-    set:
-      tolerations:
-        - key: role
-          operator: Equal
-          value: AI
-          effect: NoSchedule
-    asserts:
-      - contains:
-          any: true
-          path: spec.template.spec.tolerations
-          content:
-            key: role
-            value: AI
-            effect: NoSchedule
-            operator: Equal

--- a/helm/tools/grafana-mcp/values.yaml
+++ b/helm/tools/grafana-mcp/values.yaml
@@ -9,7 +9,7 @@ grafana:
 image:
   registry: mcp
   repository: grafana
-  pullPolicy: Always 
+  pullPolicy: Always
   tag: "latest" # Only latest is available via docker hub at present. See https://github.com/grafana/mcp-grafana/issues/180
 
 nameOverride: ""
@@ -20,8 +20,20 @@ serviceAccount:
   annotations: {}
   name: ""
 
-securityContext: {}
-  
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  runAsUser: 1000
+  runAsGroup: 999
+
 tolerations: []
 
 nodeSelector: {}
@@ -57,4 +69,3 @@ volumeMounts: []
 # Deployment configuration - used to populate the ConfigMap template.
 # Add custom configuration values here as needed.
 config:
-

--- a/helm/tools/querydoc/values.yaml
+++ b/helm/tools/querydoc/values.yaml
@@ -14,9 +14,19 @@ serviceAccount:
   annotations: {}
   name: ""
 
-podSecurityContext: {}
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
 
-securityContext: {}
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  runAsUser: 14000
+  runAsGroup: 14000
 
 tolerations: []
 


### PR DESCRIPTION
To ensure security configured the securityContexts to be complianted with the restricted PSS.

This way a user can annotate the namespace as restricted without having to finetune the deployments.
