### PR TITLE
ui: Display the authenticated user by configured userIdClaim

### DIFF
--- a/helm/kagent/templates/ui-deployment.yaml
+++ b/helm/kagent/templates/ui-deployment.yaml
@@ -60,13 +60,17 @@ spec:
               value: {{ .Values.ui.publicBackendUrl | quote }}
             - name: BACKEND_INTERNAL_URL
               value: {{ .Values.ui.backendInternalUrl | default (include "kagent.controllerInternalHttpApiBase" .) | quote }}
-            {{- if .Values.ui.auth }}
+            {{- with .Values.ui.auth }}
             - name: SSO_REDIRECT_PATH
-              value: {{ .Values.ui.auth.ssoRedirectPath | default "/oauth2/start" | quote }}
+              value: {{ .ssoRedirectPath | default "/oauth2/start" | quote }}
             {{- end }}
             {{- if .Values.ui.streamTimeoutSeconds }}
             - name: KAGENT_STREAM_TIMEOUT_MS
               value: {{ mul (int .Values.ui.streamTimeoutSeconds) 1000 | quote }}
+            {{- end }}
+            {{- with .Values.controller.auth.userIdClaim }}
+            - name: KAGENT_USER_ID_CLAIM
+              value: {{ . | quote }}
             {{- end }}
             {{- with .Values.ui.additionalForwardedHeaders }}
             - name: KAGENT_ADDITIONAL_FORWARDED_HEADERS

--- a/ui/src/app/actions/auth.ts
+++ b/ui/src/app/actions/auth.ts
@@ -28,3 +28,7 @@ export async function getCurrentUser(): Promise<CurrentUser | null> {
 
   return claims as CurrentUser;
 }
+
+export async function getUserIdClaim(): Promise<string> {
+  return process.env.KAGENT_USER_ID_CLAIM || "sub";
+}

--- a/ui/src/components/AppInitializer.tsx
+++ b/ui/src/components/AppInitializer.tsx
@@ -3,6 +3,8 @@
 import React, { useEffect, useState } from "react";
 import { usePathname } from "next/navigation";
 import { OnboardingWizard } from "./onboarding/OnboardingWizard";
+import { useAuth } from "@/contexts/AuthContext";
+import { useUserStore } from "@/lib/userStore";
 
 const LOCAL_STORAGE_KEY = "kagent-onboarding";
 
@@ -10,6 +12,15 @@ export function AppInitializer({ children }: { children: React.ReactNode }) {
   /** `null` = not read yet (must match server + first client paint to avoid hydration mismatch) */
   const [isOnboarding, setIsOnboarding] = useState<boolean | null>(null);
   const pathname = usePathname();
+  const { user, userIdClaim } = useAuth();
+  const setUserId = useUserStore((s) => s.setUserId);
+
+  useEffect(() => {
+    const identity = user?.[userIdClaim] as string | undefined;
+    if (identity) {
+      setUserId(identity);
+    }
+  }, [user, userIdClaim, setUserId]);
 
   useEffect(() => {
     const hasOnboarded = localStorage.getItem(LOCAL_STORAGE_KEY) === "true";

--- a/ui/src/contexts/AuthContext.tsx
+++ b/ui/src/contexts/AuthContext.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import React, { createContext, useContext, useEffect, useState, ReactNode } from "react";
-import { getCurrentUser, CurrentUser } from "@/app/actions/auth";
+import { getCurrentUser, getUserIdClaim, CurrentUser } from "@/app/actions/auth";
 
 interface AuthContextValue {
   user: CurrentUser | null;
+  userIdClaim: string;
   isLoading: boolean;
   error: Error | null;
   refetch: () => Promise<void>;
@@ -14,6 +15,7 @@ const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<CurrentUser | null>(null);
+  const [userIdClaim, setUserIdClaim] = useState<string>("sub");
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
@@ -21,8 +23,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setIsLoading(true);
     setError(null);
     try {
-      const currentUser = await getCurrentUser();
+      const [currentUser, claim] = await Promise.all([getCurrentUser(), getUserIdClaim()]);
       setUser(currentUser);
+      setUserIdClaim(claim);
     } catch (e) {
       setError(e instanceof Error ? e : new Error("Failed to fetch user"));
     } finally {
@@ -35,7 +38,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   return (
-    <AuthContext.Provider value={{ user, isLoading, error, refetch: fetchUser }}>
+    <AuthContext.Provider value={{ user, userIdClaim, isLoading, error, refetch: fetchUser }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Summary

- Adds `KAGENT_USER_ID_CLAIM` environment variable to the UI pod, sourced from `controller.auth.userIdClaim` in `values.yaml`
- Exposes a `getUserIdClaim()` server action that reads `KAGENT_USER_ID_CLAIM` (defaults to `"sub"`)
- Extends `AuthContext` to fetch the configured claim name alongside the JWT and expose it as `userIdClaim`
- Updates `AppInitializer` to sync the authenticated user's identity into `userStore` using the configured claim (e.g. `email`, `preferred_username`, `sub`) so the correct value is displayed in the UI

## Motivation

When deploying with `auth.mode: trusted-proxy` and `controller.auth.userIdClaim: email`, the UI was still showing the raw `sub` value (typically an opaque ID) instead of the user's email. This was because `userStore` was seeded from `localStorage` and never synchronized with the authenticated JWT claims.

## How it works

```
values.yaml
  controller.auth.userIdClaim: email
        │
        ▼
ui-deployment.yaml
  KAGENT_USER_ID_CLAIM=email
        │
        ▼
auth.ts: getUserIdClaim()   +   getCurrentUser() (JWT decode)
        │                               │
        └───────────┬───────────────────┘
                    ▼
           AuthContext: { user, userIdClaim }
                    │
                    ▼
          AppInitializer: setUserId(user[userIdClaim])
                    │
                    ▼
             userStore (displayed in UI)
```

## Test plan

- [ ] Deploy with `controller.auth.userIdClaim: email` and `auth.mode: trusted-proxy` — UI should display the email from the JWT
- [ ] Deploy with `controller.auth.userIdClaim: preferred_username` — UI should display the preferred username
- [ ] Deploy without setting `userIdClaim` (default) — UI should fall back to `sub`
- [ ] Deploy in `unsecure` mode (no JWT) — UI should fall back to the default `admin@kagent.dev`