### PR TITLE
fix(ui): save memory config to spec.declarative.memory

### DIFF
--- a/ui/src/app/actions/agents.ts
+++ b/ui/src/app/actions/agents.ts
@@ -193,7 +193,7 @@ function fromAgentFormDataToAgent(agentFormData: AgentFormData): Agent {
       const memoryModelName = k8sRefUtils.isValidRef(memoryModel)
         ? k8sRefUtils.fromRef(memoryModel).name
         : memoryModel;
-      base.spec!.memory = {
+      base.spec!.declarative!.memory = {
         modelConfig: memoryModelName,
         ttlDays: agentFormData.memory.ttlDays,
       };

--- a/ui/src/app/agents/new/page.tsx
+++ b/ui/src/app/agents/new/page.tsx
@@ -200,7 +200,7 @@ function AgentPageContent({ isEditMode, agentName, agentNamespace }: AgentPageCo
               const useDeclarativeForm = agent.spec.type === "Declarative";
               if (useDeclarativeForm) {
                 const decl = agent.spec?.declarative;
-                const memorySpec = decl?.memory ?? (agent.spec as { memory?: { modelConfig: string; ttlDays?: number } })?.memory;
+                const memorySpec = decl?.memory;
                 const memoryModelConfig = memorySpec?.modelConfig
                   ? `${agent.metadata.namespace}/${memorySpec.modelConfig}`
                   : "";

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -289,7 +289,6 @@ export interface AgentSpec {
   byo?: BYOAgentSpec;
   description: string;
   skills?: SkillForAgent;
-  memory?: MemorySpec;
 }
 
 export interface DeclarativeDeploymentSpec {


### PR DESCRIPTION
Memory was being written to `spec.memory` on the Agent CR, but the v1alpha2 CRD defines `memory` under `spec.declarative`, not at the top level of `AgentSpec` - see https://github.com/kagent-dev/kagent/blob/e03ee3a61be8387f6148d4fae9205e75eb45d2ab/go/api/v1alpha2/agent_types.go#L162-L224. The backend silently ignored the misplaced field, causing memory configuration to appear to save but never actually persist.

Also removed a dead fallback in the edit-load path that attempted to read `spec.memory` (a field that never exists in v1alpha2) masking the underlying issue.