### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+tab_width = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[{Makefile,*.go,go.*}]
+indent_style = tab
+indent_size = 4
+tab_width = 4
+
+[*.py]
+indent_size = 4
+tab_width = 4


### PR DESCRIPTION
This prevents all kind of whitespacing differences accross many files which I already fixed here and there in the files I touched.

## Go and Makefile

- tabs
- width 4

## Python

- spaces
- width 4 _following PEP8_

## Rest

- spaces
- 2

Follows practices for yaml,js,shell,ts etc etc.

> [!Note]
> Build failure isn't caused by this PR, seems to be broken from main or intermittent.
