### PR TITLE
fix(adk): normalize ca_cert_path in GDCH SA JSON before token exchange

### DIFF
--- a/python/packages/kagent-adk/src/kagent/adk/models/_token_source.py
+++ b/python/packages/kagent-adk/src/kagent/adk/models/_token_source.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import datetime
+import json
 import logging
 import time
 
@@ -12,8 +13,14 @@ class GDCHTokenSource:
     """Exchanges a GDCH service account JSON for short-lived bearer tokens.
 
     Tokens are cached and refreshed automatically with a 30-second buffer
-    before expiry. The CA certificate path is used for custom TLS verification
-    when connecting to the GDCH token endpoint.
+    before expiry.
+
+    The kagent ModelConfig ``tls.*`` fields are authoritative for TLS
+    verification of the STS endpoint. The ``ca_cert_path`` baked into the SA
+    JSON by ``gdcloud iam service-accounts keys create`` points at the
+    operator's laptop and would otherwise override our session settings, so
+    we normalize it on every refresh: rewritten to the kagent-mounted CA
+    path when one is supplied, stripped entirely otherwise.
     """
 
     def __init__(
@@ -45,17 +52,25 @@ class GDCHTokenSource:
             return self._token
 
     def _exchange(self) -> str:
-        import google.auth
         import requests
         from google.auth.transport import requests as google_requests
+        from google.oauth2 import gdch_credentials
 
-        creds, _ = google.auth.load_credentials_from_file(self._sa_path)
+        with open(self._sa_path) as f:
+            info = json.load(f)
+
+        if self._tls_disable_verify or not self._ca_cert_path:
+            info.pop("ca_cert_path", None)
+        else:
+            info["ca_cert_path"] = self._ca_cert_path
+
+        creds = gdch_credentials.ServiceAccountCredentials.from_service_account_info(info)
         creds = creds.with_gdch_audience(self._audience)
+
         session = requests.Session()
         if self._tls_disable_verify:
             session.verify = False
         elif self._ca_cert_path:
-            # Replaces the REQUESTS_CA_BUNDLE environment variable
             session.verify = self._ca_cert_path
         creds.refresh(google_requests.Request(session=session))
         if creds.expiry:

--- a/python/packages/kagent-adk/src/kagent/adk/models/_token_source.py
+++ b/python/packages/kagent-adk/src/kagent/adk/models/_token_source.py
@@ -56,7 +56,7 @@ class GDCHTokenSource:
         from google.auth.transport import requests as google_requests
         from google.oauth2 import gdch_credentials
 
-        with open(self._sa_path) as f:
+        with open(self._sa_path, "r", encoding="utf-8") as f:
             info = json.load(f)
 
         if self._tls_disable_verify or not self._ca_cert_path:
@@ -67,12 +67,12 @@ class GDCHTokenSource:
         creds = gdch_credentials.ServiceAccountCredentials.from_service_account_info(info)
         creds = creds.with_gdch_audience(self._audience)
 
-        session = requests.Session()
-        if self._tls_disable_verify:
-            session.verify = False
-        elif self._ca_cert_path:
-            session.verify = self._ca_cert_path
-        creds.refresh(google_requests.Request(session=session))
+        with requests.Session() as session:
+            if self._tls_disable_verify:
+                session.verify = False
+            elif self._ca_cert_path:
+                session.verify = self._ca_cert_path
+            creds.refresh(google_requests.Request(session=session))
         if creds.expiry:
             expiry = creds.expiry
             # If the expiry is not timezone-aware, set it to UTC

--- a/python/packages/kagent-adk/tests/unittests/models/test_token_source.py
+++ b/python/packages/kagent-adk/tests/unittests/models/test_token_source.py
@@ -1,0 +1,147 @@
+"""Unit tests for GDCHTokenSource.
+
+These tests verify that the kagent ModelConfig TLS configuration is the
+authoritative source of truth for the GDCH STS call: the ``ca_cert_path``
+baked into the SA JSON by ``gdcloud`` must be normalized at refresh time,
+not honored as-is.
+"""
+
+import datetime
+import json
+from unittest import mock
+
+import pytest
+
+from kagent.adk.models._token_source import GDCHTokenSource
+
+SAMPLE_SA_JSON = {
+    "type": "gdch_service_account",
+    "format_version": "1",
+    "project": "test-project",
+    "name": "projects/test-project/serviceAccounts/test-sa",
+    "private_key_id": "abc123",
+    "private_key": "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n",
+    "token_uri": "https://gdch.example/sts/v1/token",
+    "ca_cert_path": "/home/operator/laptop-only/ca.crt",
+}
+
+AUDIENCE = "https://gdch.example/inference"
+
+
+@pytest.fixture
+def sa_file(tmp_path):
+    """Write a sample GDCH SA JSON to disk and return its path."""
+    p = tmp_path / "sa.json"
+    p.write_text(json.dumps(SAMPLE_SA_JSON))
+    return p
+
+
+def _make_fake_creds(token: str = "test-token", expiry: datetime.datetime | None = None):
+    """Build a fake google-auth credentials object with the methods we touch."""
+    fake = mock.MagicMock()
+    fake.with_gdch_audience.return_value = fake
+    fake.token = token
+    fake.expiry = expiry
+    return fake
+
+
+def test_exchange_overwrites_ca_cert_path_when_kagent_ca_set(sa_file):
+    """When kagent ModelConfig provides a CA path, the JSON's ca_cert_path is rewritten."""
+    mounted_ca = "/etc/ssl/certs/custom/ca.crt"
+    src = GDCHTokenSource(
+        service_account_path=str(sa_file),
+        audience=AUDIENCE,
+        ca_cert_path=mounted_ca,
+    )
+
+    with mock.patch("google.oauth2.gdch_credentials.ServiceAccountCredentials") as mock_cls:
+        mock_cls.from_service_account_info.return_value = _make_fake_creds()
+        src._exchange()
+
+    info_passed = mock_cls.from_service_account_info.call_args.args[0]
+    assert info_passed["ca_cert_path"] == mounted_ca
+
+
+def test_exchange_strips_ca_cert_path_when_no_kagent_ca(sa_file):
+    """When kagent provides no CA, the JSON's ca_cert_path is removed entirely."""
+    src = GDCHTokenSource(
+        service_account_path=str(sa_file),
+        audience=AUDIENCE,
+        ca_cert_path=None,
+    )
+
+    with mock.patch("google.oauth2.gdch_credentials.ServiceAccountCredentials") as mock_cls:
+        mock_cls.from_service_account_info.return_value = _make_fake_creds()
+        src._exchange()
+
+    info_passed = mock_cls.from_service_account_info.call_args.args[0]
+    assert "ca_cert_path" not in info_passed
+
+
+def test_exchange_strips_ca_cert_path_when_disable_verify(sa_file):
+    """tls_disable_verify takes priority: ca_cert_path is stripped and session.verify is False."""
+    src = GDCHTokenSource(
+        service_account_path=str(sa_file),
+        audience=AUDIENCE,
+        ca_cert_path="/etc/ssl/certs/custom/ca.crt",
+        tls_disable_verify=True,
+    )
+
+    fake_creds = _make_fake_creds()
+    with (
+        mock.patch("google.oauth2.gdch_credentials.ServiceAccountCredentials") as mock_cls,
+        mock.patch("requests.Session") as mock_session_cls,
+    ):
+        mock_cls.from_service_account_info.return_value = fake_creds
+        session = mock_session_cls.return_value
+        src._exchange()
+
+    info_passed = mock_cls.from_service_account_info.call_args.args[0]
+    assert "ca_cert_path" not in info_passed
+    assert session.verify is False
+
+
+def test_exchange_does_not_modify_sa_json_file(sa_file):
+    """Normalization happens in-memory; the on-disk SA JSON is untouched."""
+    original = sa_file.read_bytes()
+    src = GDCHTokenSource(
+        service_account_path=str(sa_file),
+        audience=AUDIENCE,
+        ca_cert_path="/etc/ssl/certs/custom/ca.crt",
+    )
+
+    with mock.patch("google.oauth2.gdch_credentials.ServiceAccountCredentials") as mock_cls:
+        mock_cls.from_service_account_info.return_value = _make_fake_creds()
+        src._exchange()
+
+    assert sa_file.read_bytes() == original
+
+
+def test_exchange_uses_credential_expiry(sa_file):
+    """When creds expose an expiry, the token cache honors it."""
+    src = GDCHTokenSource(
+        service_account_path=str(sa_file),
+        audience=AUDIENCE,
+    )
+
+    future = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(minutes=10)
+    with mock.patch("google.oauth2.gdch_credentials.ServiceAccountCredentials") as mock_cls:
+        mock_cls.from_service_account_info.return_value = _make_fake_creds(expiry=future)
+        token = src._exchange()
+
+    assert token == "test-token"
+    # _expiry is set relative to time.monotonic(); just confirm it advanced past 0.
+    assert src._expiry > 0
+
+
+async def test_get_token_caches_within_expiry_buffer(sa_file):
+    """Subsequent get_token calls within the 30 s buffer return the cached token."""
+    src = GDCHTokenSource(service_account_path=str(sa_file), audience=AUDIENCE)
+
+    with mock.patch.object(src, "_exchange", return_value="cached-token") as mock_exchange:
+        first = await src.get_token()
+        second = await src.get_token()
+
+    assert first == "cached-token"
+    assert second == "cached-token"
+    assert mock_exchange.call_count == 1

--- a/python/packages/kagent-adk/tests/unittests/models/test_token_source.py
+++ b/python/packages/kagent-adk/tests/unittests/models/test_token_source.py
@@ -94,6 +94,9 @@ def test_exchange_strips_ca_cert_path_when_disable_verify(sa_file):
     ):
         mock_cls.from_service_account_info.return_value = fake_creds
         session = mock_session_cls.return_value
+        # Session is used as a context manager; have __enter__ yield the same mock
+        # so attributes set inside the `with` block are observable here.
+        session.__enter__.return_value = session
         src._exchange()
 
     info_passed = mock_cls.from_service_account_info.call_args.args[0]


### PR DESCRIPTION
## Summary

- GDCH service-account JSON generated by `gdcloud iam service-accounts keys create` includes a `ca_cert_path` pointing at the machine where the key was created — invalid inside the agent pod. `google.oauth2.gdch_credentials` honors this field and overrides `requests.Session.verify`, breaking token exchange.
- Make the kagent ModelConfig `tls.*` fields authoritative for the STS call: rewrite the JSON's `ca_cert_path` to the kagent-mounted CA path when one is configured, strip it otherwise. The on-disk Secret is not modified.
- Load credentials from the mutated dict via `gdch_credentials.ServiceAccountCredentials.from_service_account_info` rather than `load_credentials_from_file`.

## Test plan

- [x] Unit tests added for all three normalization branches, on-disk JSON immutability, expiry handling, and token caching (`tests/unittests/models/test_token_source.py`, 6 cases).
- [x] `uv run ruff check` clean on changed files.
- [x] `uv run pytest tests/unittests/models/` — no regressions beyond pre-existing `test_tls_e2e.py` fixture failures unrelated to this change.
- [ ] Manual end-to-end against a GDC inference endpoint with: (a) no `tls.caCertSecretRef` and a system-trusted STS CA, (b) `tls.caCertSecretRef` set to a private CA secret, (c) `tls.disableVerify=true` against a self-signed STS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)