### PR TITLE
feat(helm): add openai.secretRef support to querydoc sub-chart

### DIFF
--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -556,6 +556,7 @@ querydoc:
       memory: 512Mi
   openai:
     apiKey: ""
+    # secretRef: ""  # Name of existing Secret containing OPENAI_API_KEY. Takes precedence over apiKey.
 
 # ==============================================================================
 # OAUTH2-PROXY CONFIGURATION (Optional)

--- a/helm/tools/querydoc/templates/deployment.yaml
+++ b/helm/tools/querydoc/templates/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     metadata:
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        {{- if .Values.openai.apiKey }}
+        {{- if and .Values.openai.apiKey (not .Values.openai.secretRef) }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- end }}
       labels:
@@ -46,9 +46,9 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "querydoc.fullname" . }}
-            {{- if .Values.openai.apiKey }}
+            {{- if or .Values.openai.apiKey .Values.openai.secretRef }}
             - secretRef:
-                name: {{ include "querydoc.fullname" . }}
+                name: {{ .Values.openai.secretRef | default (include "querydoc.fullname" .) | quote }}
             {{- end }}
           ports:
             - name: http

--- a/helm/tools/querydoc/templates/secret.yaml
+++ b/helm/tools/querydoc/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.openai.apiKey }}
+{{- if and .Values.openai.apiKey (not .Values.openai.secretRef) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/tools/querydoc/tests/deployment_test.yaml
+++ b/helm/tools/querydoc/tests/deployment_test.yaml
@@ -2,6 +2,7 @@ suite: test querydoc deployment
 templates:
   - deployment.yaml
   - configmap.yaml
+  - secret.yaml
 tests:
   - it: should render deployment with default values
     template: deployment.yaml
@@ -163,3 +164,57 @@ tests:
             value: AI
             effect: NoSchedule
             operator: Equal
+
+  - it: should not include secretRef by default
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].envFrom
+          value:
+            - configMapRef:
+                name: RELEASE-NAME-querydoc
+      - notExists:
+          path: spec.template.metadata.annotations.checksum/secret
+
+  - it: should reference chart-owned Secret when only openai.apiKey is set
+    template: deployment.yaml
+    set:
+      openai:
+        apiKey: foo
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: RELEASE-NAME-querydoc
+      - exists:
+          path: spec.template.metadata.annotations.checksum/secret
+
+  - it: should reference external Secret when openai.secretRef is set
+    template: deployment.yaml
+    set:
+      openai:
+        secretRef: my-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: my-secret
+      - notExists:
+          path: spec.template.metadata.annotations.checksum/secret
+
+  - it: secretRef should win over apiKey when both are set
+    template: deployment.yaml
+    set:
+      openai:
+        apiKey: foo
+        secretRef: my-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: my-secret
+      - notExists:
+          path: spec.template.metadata.annotations.checksum/secret

--- a/helm/tools/querydoc/tests/secret_test.yaml
+++ b/helm/tools/querydoc/tests/secret_test.yaml
@@ -1,0 +1,41 @@
+suite: test querydoc secret
+templates:
+  - secret.yaml
+tests:
+  - it: should not render a Secret with default values
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a Secret when openai.apiKey is set
+    set:
+      openai:
+        apiKey: foo
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-querydoc
+      - equal:
+          path: data.OPENAI_API_KEY
+          value: Zm9v # `foo` base64 encoded
+
+  - it: should not render a Secret when openai.secretRef is set
+    set:
+      openai:
+        secretRef: my-secret
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render a Secret when both apiKey and secretRef are set (secretRef wins)
+    set:
+      openai:
+        apiKey: foo
+        secretRef: my-secret
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/helm/tools/querydoc/values.yaml
+++ b/helm/tools/querydoc/values.yaml
@@ -52,6 +52,7 @@ config:
 # Secret configuration
 openai:
   apiKey: ""
+  # secretRef: ""  # Name of existing Secret containing OPENAI_API_KEY. Takes precedence over apiKey.
 
 # OTEL configuration
 otel:


### PR DESCRIPTION
## Overview

Add `openai.secretRef` to the querydoc sub-chart, mirroring the pattern already supported by the `grafana-mcp` sub-chart. When set, the chart skips rendering its own `Secret` and instead points the Deployment's `envFrom.secretRef.name` at the user-supplied Secret.

- Closes #1910

## Changes

### Precedence logic for `openai.secretRef` vs `openai.apiKey`

| `apiKey` | `secretRef` | Result |
|---|---|---|
| set | unset | Chart renders `Secret` (existing behavior unchanged) |
| unset | set | No chart `Secret`; Deployment references user Secret |
| set | set | `secretRef` wins; no chart `Secret` |
| unset | unset | No `Secret`, no `secretRef` in `envFrom` (existing behavior) |

### Template changes

- `templates/secret.yaml`: guard changed from `{{- if .Values.openai.apiKey }}` to `{{- if and .Values.openai.apiKey (not .Values.openai.secretRef) }}`
- `templates/deployment.yaml`:
  - `envFrom` guard widened to `{{- if or .Values.openai.apiKey .Values.openai.secretRef }}`
  - Secret name resolved via `{{ .Values.openai.secretRef | default (include "querydoc.fullname" .) | quote }}`
  - `checksum/secret` annotation tightened to only appear when the chart owns the Secret

### Values

`openai.secretRef: ""` added (commented out) to both `helm/tools/querydoc/values.yaml` and the parent `helm/kagent/values.yaml`.

### Tests

- `tests/secret_test.yaml` (new): covers the four-row precedence table for Secret creation
- `tests/deployment_test.yaml`: added `secret.yaml` to the rendered templates list (needed for `include`-based checksum), plus four new cases covering `envFrom` and `checksum/secret` annotation behavior for each combination