### PR TITLE
fix(adk): pass user_id as query param in create_session to fix SessionNotFoundError

### DIFF
--- a/python/packages/kagent-adk/src/kagent/adk/_session_service.py
+++ b/python/packages/kagent-adk/src/kagent/adk/_session_service.py
@@ -46,8 +46,14 @@ class KAgentSessionService(BaseSessionService):
             request_data["source"] = state.get("source", "")
 
         # Make API call to create session
+        # Pass user_id as a query param so the controller's auth middleware
+        # (UnsecureAuthenticator) reads it consistently — matching the user_id
+        # used by get_session, list_sessions, delete_session, and append_event.
+        # Without this, unsecure-mode requests fall back to "admin@kagent.dev"
+        # while all lookups use the A2A-derived user_id, causing SessionNotFoundError.
         response = await self.client.post(
             "/api/sessions",
+            params={"user_id": user_id},
             json=request_data,
         )
         response.raise_for_status()

--- a/python/packages/kagent-adk/tests/unittests/test_session_service.py
+++ b/python/packages/kagent-adk/tests/unittests/test_session_service.py
@@ -67,6 +67,37 @@ def service(mock_client):
 
 
 @pytest.mark.asyncio
+async def test_create_session_passes_user_id_as_query_param():
+    """create_session must include user_id as a query param on POST /api/sessions.
+
+    Regression test for the SessionNotFoundError caused by a user_id mismatch:
+    the controller's UnsecureAuthenticator resolves identity from the query param
+    (or X-User-Id header), not the JSON body.  Without the query param the
+    controller falls back to "admin@kagent.dev" for the session create, while
+    every subsequent GET uses the A2A-derived user_id — guaranteeing a 404.
+    Fixes: https://github.com/kagent-dev/kagent/issues/1882
+    """
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.status_code = 201
+    mock_response.json.return_value = {"data": {"id": "sess-1", "user_id": "A2A_USER_ctx123"}}
+    mock_response.raise_for_status = MagicMock()
+
+    client = MagicMock(spec=httpx.AsyncClient)
+    client.post = AsyncMock(return_value=mock_response)
+
+    svc = KAgentSessionService(client)
+    await svc.create_session(app_name="my-agent", user_id="A2A_USER_ctx123", session_id="ctx123")
+
+    client.post.assert_called_once()
+    call_kwargs = client.post.call_args.kwargs
+    assert call_kwargs.get("params", {}).get("user_id") == "A2A_USER_ctx123", (
+        f"Expected params['user_id']='A2A_USER_ctx123', got params={call_kwargs.get('params')!r}. "
+        "Without this query param the controller's UnsecureAuthenticator falls back "
+        "to 'admin@kagent.dev', causing a SessionNotFoundError on subsequent lookups."
+    )
+
+
+@pytest.mark.asyncio
 async def test_get_session_returns_none_on_404(mock_client):
     """A 404 response returns None without raising."""
     svc = KAgentSessionService(mock_client(response_json=None, status_code=404))


### PR DESCRIPTION
## Summary

Fixes #1882

`POST /api/sessions` was the only `KAgentSessionService` method that did **not** include `user_id` as a query parameter. The controller's `UnsecureAuthenticator` resolves the caller's identity from the query param (or `X-User-Id` header), not the JSON body:

```go
// go/core/internal/httpserver/auth/authn.go — UnsecureAuthenticator
userID := query.Get("user_id")       // reads query param
if userID == "" {
    userID = reqHeaders.Get("X-User-Id")
}
if userID == "" {
    userID = "admin@kagent.dev"      // fallback when neither is set
}
```

Because the `user_id` was only in the JSON body, the create call fell back to `"admin@kagent.dev"` while every subsequent `get_session` / `append_event` call used the A2A-derived user_id (e.g. `"A2A_USER_<contextId>"`). The guaranteed mismatch caused a 404 on the follow-up GET, which surfaced as `SessionNotFoundError` in `google.adk.runners`.

## Root cause trace

| step | call | user_id used | result |
|------|------|--------------|--------|
| 1 | `GET /api/sessions/<CTX>?user_id=A2A_USER_<CTX>` | `A2A_USER_<CTX>` | 404 — not yet created |
| 2 | `POST /api/sessions` (body only, no query param) | `admin@kagent.dev` ← fallback | 201 — session created under wrong identity |
| 3 | `GET /api/sessions/<CTX>?user_id=A2A_USER_<CTX>` | `A2A_USER_<CTX>` | 404 — exists but under `admin@kagent.dev` |
| 4 | `SessionNotFoundError` | | |

## Fix

Add `?user_id={user_id}` to the `POST /api/sessions` URL in `create_session`, consistent with every other method in the same class:

- `get_session` → `f"/api/sessions/{session_id}?user_id={user_id}&..."` ✅
- `list_sessions` → `f"/api/sessions?user_id={user_id}"` ✅
- `delete_session` → `f"/api/sessions/{session_id}?user_id={user_id}"` ✅
- `append_event` → `f"/api/sessions/{session.id}/events?user_id={session.user_id}"` ✅
- `create_session` → `"/api/sessions"` ❌ → `f"/api/sessions?user_id={user_id}"` ✅ (this PR)

## Test

Added `test_create_session_passes_user_id_as_query_param` to `test_session_service.py` — asserts that the URL passed to `client.post` contains `user_id=<value>` as a query param. This is a regression test so the mismatch cannot silently reappear.

## Notes

- Reproducible on every A2A `message/send` invocation with `controller.auth.mode: unsecure` (the default in-cluster setup)
- PR #1775 fixed the authenticated path (`call_context.user.user_name`); this PR fixes the unauthenticated fallback path
- Verified against `UnsecureAuthenticator` source in `go/core/internal/httpserver/auth/authn.go`