### PR TITLE
feat(helm): make controller probes configurable

### DIFF
--- a/helm/kagent/templates/controller-deployment.yaml
+++ b/helm/kagent/templates/controller-deployment.yaml
@@ -103,17 +103,27 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if .Values.controller.startupProbe }}
+          startupProbe:
+            {{- toYaml .Values.controller.startupProbe | nindent 12 }}
+          {{- else }}
           startupProbe:
             httpGet:
               path: /health
               port: http
             periodSeconds: 15
             initialDelaySeconds: 15
+          {{- end }}
+          {{- if .Values.controller.readinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.controller.readinessProbe | nindent 12 }}
+          {{- else }}
           readinessProbe:
             httpGet:
               path: /health
               port: http
             periodSeconds: 30
+          {{- end }}
           {{- if gt (len .Values.controller.volumeMounts) 0 }}
           volumeMounts:
             {{- with .Values.controller.volumeMounts }}

--- a/helm/kagent/tests/controller-deployment_test.yaml
+++ b/helm/kagent/tests/controller-deployment_test.yaml
@@ -496,3 +496,74 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: POSTGRES_PASSWORD
+
+  - it: should use default httpGet startup probe
+    template: controller-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /health
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.periodSeconds
+          value: 15
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.initialDelaySeconds
+          value: 15
+
+  - it: should use default httpGet readiness probe
+    template: controller-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /health
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.periodSeconds
+          value: 30
+
+  - it: should allow overriding startup probe
+    template: controller-deployment.yaml
+    set:
+      controller:
+        startupProbe:
+          httpGet:
+            path: /health
+            port: http
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 20
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /health
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.periodSeconds
+          value: 30
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.initialDelaySeconds
+          value: 30
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.timeoutSeconds
+          value: 10
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 20
+
+  - it: should allow overriding readiness probe
+    template: controller-deployment.yaml
+    set:
+      controller:
+        readinessProbe:
+          exec:
+            command: ["wget", "-q", "-O-", "http://localhost:8083/health"]
+          periodSeconds: 60
+          timeoutSeconds: 10
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.exec.command
+          value: ["wget", "-q", "-O-", "http://localhost:8083/health"]
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.periodSeconds
+          value: 60
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -244,6 +244,16 @@ controller:
   #   mountPath: "/etc/foo"
   #   readOnly: true
 
+  # -- Custom startup probe for the controller container.
+  # Override to adjust thresholds, use exec-based probes, or change the health path.
+  # @default -- httpGet /health on port http, periodSeconds=15, initialDelaySeconds=15
+  startupProbe: {}
+
+  # -- Custom readiness probe for the controller container.
+  # Override to adjust thresholds, use exec-based probes, or change the health path.
+  # @default -- httpGet /health on port http, periodSeconds=30
+  readinessProbe: {}
+
 # ==============================================================================
 # UI CONFIGURATION
 # ==============================================================================

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -245,12 +245,14 @@ controller:
   #   readOnly: true
 
   # -- Custom startup probe for the controller container.
-  # Override to adjust thresholds, use exec-based probes, or change the health path.
+  # Setting a value replaces the default probe entirely — include a handler
+  # (httpGet / exec / tcpSocket / grpc) when overriding.
   # @default -- httpGet /health on port http, periodSeconds=15, initialDelaySeconds=15
   startupProbe: {}
 
   # -- Custom readiness probe for the controller container.
-  # Override to adjust thresholds, use exec-based probes, or change the health path.
+  # Setting a value replaces the default probe entirely — include a handler
+  # (httpGet / exec / tcpSocket / grpc) when overriding.
   # @default -- httpGet /health on port http, periodSeconds=30
   readinessProbe: {}
 


### PR DESCRIPTION
## Summary

The controller `startupProbe` and `readinessProbe` are currently hardcoded in `helm/kagent/templates/controller-deployment.yaml`. This PR makes them overridable via `controller.startupProbe` and `controller.readinessProbe`, mirroring the pattern already used by `ui.startupProbe` / `ui.readinessProbe` in `templates/ui-deployment.yaml`.

Motivation: in clusters where the controller takes longer than 60s to bind `:8083` (slow image pulls, DB migration on cold start, NetworkPolicies between pods and kube-apiserver), the hardcoded `periodSeconds: 15` + default `failureThreshold: 3` gives only 60s before the kubelet SIGKILLs the container, after which it CrashLoopBackOffs indefinitely. Operators currently have no chart-level escape hatch and have to patch the Deployment out-of-band.

## Changes

- `templates/controller-deployment.yaml`: wrap both probes in `{{- if .Values.controller.startupProbe }} ... {{- else }} <existing default> {{- end }}`. Defaults are unchanged; the chart behaves identically when neither value is set. (Same shape as `ui-deployment.yaml`.)
- `values.yaml`: add documented `controller.startupProbe: {}` and `controller.readinessProbe: {}` knobs, matching the UI documentation style.
- `tests/controller-deployment_test.yaml`: 4 new test cases (default startup, default readiness, override startup, override readiness) mirroring the UI suite.

## Verification

`helm unittest helm/kagent -f 'tests/controller-deployment_test.yaml'` — all 46 tests pass, including the 4 new ones.

## Backward compatibility

None: defaults are byte-identical to the previous hardcoded block. Operators who set no values see no change.

## Diff size

91 lines added across 3 files (10 template + 10 values + 71 tests), no deletions — within the "small change" threshold in CONTRIBUTING.md.