### PR TITLE
feat(bedrock): add prompt caching via CachePoint markers

### DIFF
--- a/go/adk/pkg/agent/agent.go
+++ b/go/adk/pkg/agent/agent.go
@@ -305,6 +305,7 @@ func CreateLLM(ctx context.Context, m adk.Model, log logr.Logger) (adkmodel.LLM,
 			Region:                       region,
 			AdditionalModelRequestFields: m.AdditionalModelRequestFields,
 			PromptCaching:                m.PromptCaching,
+			CacheTTL:                     m.CacheTTL,
 		}
 		return models.NewBedrockModelWithLogger(ctx, cfg, log)
 

--- a/go/adk/pkg/agent/agent.go
+++ b/go/adk/pkg/agent/agent.go
@@ -304,6 +304,7 @@ func CreateLLM(ctx context.Context, m adk.Model, log logr.Logger) (adkmodel.LLM,
 			Model:                        modelName,
 			Region:                       region,
 			AdditionalModelRequestFields: m.AdditionalModelRequestFields,
+			PromptCaching:                m.PromptCaching,
 		}
 		return models.NewBedrockModelWithLogger(ctx, cfg, log)
 

--- a/go/adk/pkg/models/bedrock.go
+++ b/go/adk/pkg/models/bedrock.go
@@ -79,11 +79,31 @@ type BedrockConfig struct {
 	AdditionalModelRequestFields map[string]any
 	// PromptCaching, when true, appends a default CachePoint block at the
 	// end of the Converse request's system content array and the end of
-	// the tools array. Bedrock caches up to and including those markers
+	// the toolConfig.tools array. Bedrock caches up to and including those markers
 	// across requests in the same region; cached prefix is billed at a
 	// reduced rate. The marker is silently ignored by Bedrock for models
 	// that do not support prompt caching.
 	PromptCaching bool
+	// CacheTTL selects the cache retention window when PromptCaching is on.
+	// "" or "5m" uses Bedrock's default 5-minute cache (broadest model
+	// support); "1h" opts into extended-TTL caching. See bedrockCachePointBlock.
+	CacheTTL string
+}
+
+// bedrockCachePointBlock builds a Converse CachePoint marker honoring the
+// configured cache TTL.
+//
+// An empty or "5m" ttl leaves the SDK Ttl field unset: Bedrock then applies its
+// standard 5-minute sliding cache, which is supported by every prompt-caching
+// model. Only "1h" sets the Ttl explicitly, opting into extended-TTL caching —
+// supported on fewer models and billed at a higher cache-write rate, so it is
+// not a free upgrade over 5m.
+func bedrockCachePointBlock(cacheTTL string) types.CachePointBlock {
+	block := types.CachePointBlock{Type: types.CachePointTypeDefault}
+	if cacheTTL == string(types.CacheTTLOneHour) {
+		block.Ttl = types.CacheTTLOneHour
+	}
+	return block
 }
 
 // BedrockModel implements model.LLM for Amazon Bedrock using the Converse API.
@@ -158,7 +178,7 @@ func (m *BedrockModel) GenerateContent(ctx context.Context, req *model.LLMReques
 		var toolConfig *types.ToolConfiguration
 		nameMap := make(map[string]string)
 		if req.Config != nil && len(req.Config.Tools) > 0 {
-			tools, nm := convertGenaiToolsToBedrock(req.Config.Tools, m.Config.PromptCaching)
+			tools, nm := convertGenaiToolsToBedrock(req.Config.Tools, m.Config.PromptCaching, m.Config.CacheTTL)
 			nameMap = nm
 			if len(tools) > 0 {
 				toolConfig = &types.ToolConfiguration{
@@ -196,7 +216,7 @@ func (m *BedrockModel) GenerateContent(ctx context.Context, req *model.LLMReques
 		// that wastes a marker.
 		if m.Config.PromptCaching && len(systemPrompt) > 0 {
 			systemPrompt = append(systemPrompt, &types.SystemContentBlockMemberCachePoint{
-				Value: types.CachePointBlock{Type: types.CachePointTypeDefault},
+				Value: bedrockCachePointBlock(m.Config.CacheTTL),
 			})
 		}
 
@@ -674,9 +694,10 @@ func convertGenaiContentsToBedrockMessages(contents []*genai.Content, nameMap ma
 //
 // When promptCaching is true, a CachePoint marker is appended after the
 // last tool spec — Bedrock then caches the entire (typically large) tool
-// definitions array for ~5 minutes, billing the prefix at a reduced rate
-// on cache hits.
-func convertGenaiToolsToBedrock(tools []*genai.Tool, promptCaching bool) ([]types.Tool, map[string]string) {
+// definitions array, billing the prefix at a reduced rate on cache hits. The
+// cacheTTL argument selects the retention window for that marker (see
+// bedrockCachePointBlock).
+func convertGenaiToolsToBedrock(tools []*genai.Tool, promptCaching bool, cacheTTL string) ([]types.Tool, map[string]string) {
 	if len(tools) == 0 {
 		return nil, nil
 	}
@@ -740,7 +761,7 @@ func convertGenaiToolsToBedrock(tools []*genai.Tool, promptCaching bool) ([]type
 	// Skipped when there are no tools — a cache marker by itself is a no-op.
 	if promptCaching && len(bedrockTools) > 0 {
 		bedrockTools = append(bedrockTools, &types.ToolMemberCachePoint{
-			Value: types.CachePointBlock{Type: types.CachePointTypeDefault},
+			Value: bedrockCachePointBlock(cacheTTL),
 		})
 	}
 

--- a/go/adk/pkg/models/bedrock.go
+++ b/go/adk/pkg/models/bedrock.go
@@ -77,6 +77,13 @@ type BedrockConfig struct {
 	Temperature                  *float64
 	TopP                         *float64
 	AdditionalModelRequestFields map[string]any
+	// PromptCaching, when true, appends a default CachePoint block at the
+	// end of the Converse request's system content array and the end of
+	// the tools array. Bedrock caches up to and including those markers
+	// across requests in the same region; cached prefix is billed at a
+	// reduced rate. The marker is silently ignored by Bedrock for models
+	// that do not support prompt caching.
+	PromptCaching bool
 }
 
 // BedrockModel implements model.LLM for Amazon Bedrock using the Converse API.
@@ -151,7 +158,7 @@ func (m *BedrockModel) GenerateContent(ctx context.Context, req *model.LLMReques
 		var toolConfig *types.ToolConfiguration
 		nameMap := make(map[string]string)
 		if req.Config != nil && len(req.Config.Tools) > 0 {
-			tools, nm := convertGenaiToolsToBedrock(req.Config.Tools)
+			tools, nm := convertGenaiToolsToBedrock(req.Config.Tools, m.Config.PromptCaching)
 			nameMap = nm
 			if len(tools) > 0 {
 				toolConfig = &types.ToolConfiguration{
@@ -180,6 +187,16 @@ func (m *BedrockModel) GenerateContent(ctx context.Context, req *model.LLMReques
 		if systemInstruction != "" {
 			systemPrompt = append(systemPrompt, &types.SystemContentBlockMemberText{
 				Value: systemInstruction,
+			})
+		}
+		// If prompt caching is enabled, mark the end of the system content
+		// as a cache breakpoint. Bedrock caches everything up to and including
+		// this point for ~5 minutes; subsequent requests with the same prefix
+		// hit the cache. Skipped for empty systems — caching nothing is a no-op
+		// that wastes a marker.
+		if m.Config.PromptCaching && len(systemPrompt) > 0 {
+			systemPrompt = append(systemPrompt, &types.SystemContentBlockMemberCachePoint{
+				Value: types.CachePointBlock{Type: types.CachePointTypeDefault},
 			})
 		}
 
@@ -654,7 +671,12 @@ func convertGenaiContentsToBedrockMessages(contents []*genai.Content, nameMap ma
 // It sanitizes tool names to satisfy Bedrock's [a-zA-Z0-9_-]+ constraint and
 // returns the original->sanitized name mapping so callers can apply it to
 // conversation history and reverse it when restoring names from responses.
-func convertGenaiToolsToBedrock(tools []*genai.Tool) ([]types.Tool, map[string]string) {
+//
+// When promptCaching is true, a CachePoint marker is appended after the
+// last tool spec — Bedrock then caches the entire (typically large) tool
+// definitions array for ~5 minutes, billing the prefix at a reduced rate
+// on cache hits.
+func convertGenaiToolsToBedrock(tools []*genai.Tool, promptCaching bool) ([]types.Tool, map[string]string) {
 	if len(tools) == 0 {
 		return nil, nil
 	}
@@ -709,6 +731,17 @@ func convertGenaiToolsToBedrock(tools []*genai.Tool) ([]types.Tool, map[string]s
 			}
 			bedrockTools = append(bedrockTools, bedrockTool)
 		}
+	}
+
+	// If prompt caching is enabled, append a CachePoint at the END of the
+	// tool list. Bedrock caches the entire tool definitions array up to
+	// this marker; this is usually the biggest single chunk of static
+	// prefix in an agent conversation and benefits most from caching.
+	// Skipped when there are no tools — a cache marker by itself is a no-op.
+	if promptCaching && len(bedrockTools) > 0 {
+		bedrockTools = append(bedrockTools, &types.ToolMemberCachePoint{
+			Value: types.CachePointBlock{Type: types.CachePointTypeDefault},
+		})
 	}
 
 	return bedrockTools, nameMap

--- a/go/adk/pkg/models/bedrock_test.go
+++ b/go/adk/pkg/models/bedrock_test.go
@@ -198,7 +198,7 @@ func TestConvertGenaiToolsToBedrock(t *testing.T) {
 			},
 		}}}}
 
-		bt1, nm1 := convertGenaiToolsToBedrock(tools, false)
+		bt1, nm1 := convertGenaiToolsToBedrock(tools, false, "")
 		schema := extractSchema(t, bt1, nm1)
 
 		props := schema["properties"].(map[string]any)
@@ -226,7 +226,7 @@ func TestConvertGenaiToolsToBedrock(t *testing.T) {
 			},
 		}}}}
 
-		bt2, nm2 := convertGenaiToolsToBedrock(tools, false)
+		bt2, nm2 := convertGenaiToolsToBedrock(tools, false, "")
 		schema := extractSchema(t, bt2, nm2)
 		props, ok := schema["properties"].(map[string]any)
 		if !ok || len(props) == 0 {
@@ -247,7 +247,7 @@ func TestConvertGenaiToolsToBedrock(t *testing.T) {
 			ParametersJsonSchema: s,
 		}}}}
 
-		bt3, nm3 := convertGenaiToolsToBedrock(tools, false)
+		bt3, nm3 := convertGenaiToolsToBedrock(tools, false, "")
 		schema := extractSchema(t, bt3, nm3)
 		props, ok := schema["properties"].(map[string]any)
 		if !ok || len(props) == 0 {
@@ -402,7 +402,7 @@ func TestConvertGenaiToolsToBedrockSanitizesNames(t *testing.T) {
 		{Name: "filesystem:read_file", Description: "Read a file"},
 	}}}
 
-	bedrockTools, nameMap := convertGenaiToolsToBedrock(tools, false)
+	bedrockTools, nameMap := convertGenaiToolsToBedrock(tools, false, "")
 	if len(bedrockTools) != 2 {
 		t.Fatalf("expected 2 tools, got %d", len(bedrockTools))
 	}
@@ -680,7 +680,7 @@ func TestConvertGenaiToolsToBedrockPromptCaching(t *testing.T) {
 	}}}
 
 	t.Run("disabled: no cache marker appended", func(t *testing.T) {
-		out, _ := convertGenaiToolsToBedrock(tools, false)
+		out, _ := convertGenaiToolsToBedrock(tools, false, "")
 		if len(out) != 2 {
 			t.Fatalf("expected 2 tools, got %d", len(out))
 		}
@@ -692,12 +692,12 @@ func TestConvertGenaiToolsToBedrockPromptCaching(t *testing.T) {
 	})
 
 	t.Run("enabled: cache marker appended at the END of the tool list", func(t *testing.T) {
-		out, _ := convertGenaiToolsToBedrock(tools, true)
+		out, _ := convertGenaiToolsToBedrock(tools, true, "")
 		if len(out) != 3 {
 			t.Fatalf("expected 3 entries (2 tools + 1 CachePoint), got %d", len(out))
 		}
 		// The first two must remain ToolSpec entries (order preserved).
-		for i := 0; i < 2; i++ {
+		for i := range 2 {
 			if _, ok := out[i].(*types.ToolMemberToolSpec); !ok {
 				t.Fatalf("entry %d: expected ToolMemberToolSpec, got %T", i, out[i])
 			}
@@ -710,10 +710,37 @@ func TestConvertGenaiToolsToBedrockPromptCaching(t *testing.T) {
 		if cp.Value.Type != types.CachePointTypeDefault {
 			t.Errorf("expected CachePointType=default, got %v", cp.Value.Type)
 		}
+		// Default (empty) TTL must leave Ttl unset so Bedrock applies its
+		// standard 5-minute cache (broadest model support).
+		if cp.Value.Ttl != "" {
+			t.Errorf("expected unset Ttl for default cache, got %q", cp.Value.Ttl)
+		}
+	})
+
+	t.Run(`cacheTTL "5m": Ttl left unset (default 5-minute cache)`, func(t *testing.T) {
+		out, _ := convertGenaiToolsToBedrock(tools, true, "5m")
+		cp, ok := out[len(out)-1].(*types.ToolMemberCachePoint)
+		if !ok {
+			t.Fatalf("trailing entry: expected ToolMemberCachePoint, got %T", out[len(out)-1])
+		}
+		if cp.Value.Ttl != "" {
+			t.Errorf("expected unset Ttl for 5m, got %q", cp.Value.Ttl)
+		}
+	})
+
+	t.Run(`cacheTTL "1h": Ttl set to extended-TTL caching`, func(t *testing.T) {
+		out, _ := convertGenaiToolsToBedrock(tools, true, "1h")
+		cp, ok := out[len(out)-1].(*types.ToolMemberCachePoint)
+		if !ok {
+			t.Fatalf("trailing entry: expected ToolMemberCachePoint, got %T", out[len(out)-1])
+		}
+		if cp.Value.Ttl != types.CacheTTLOneHour {
+			t.Errorf("expected Ttl=%q, got %q", types.CacheTTLOneHour, cp.Value.Ttl)
+		}
 	})
 
 	t.Run("enabled but no tools: no cache marker (skipped)", func(t *testing.T) {
-		out, _ := convertGenaiToolsToBedrock(nil, true)
+		out, _ := convertGenaiToolsToBedrock(nil, true, "")
 		if len(out) != 0 {
 			t.Fatalf("expected empty slice for no tools, got %d entries", len(out))
 		}

--- a/go/adk/pkg/models/bedrock_test.go
+++ b/go/adk/pkg/models/bedrock_test.go
@@ -198,7 +198,7 @@ func TestConvertGenaiToolsToBedrock(t *testing.T) {
 			},
 		}}}}
 
-		bt1, nm1 := convertGenaiToolsToBedrock(tools)
+		bt1, nm1 := convertGenaiToolsToBedrock(tools, false)
 		schema := extractSchema(t, bt1, nm1)
 
 		props := schema["properties"].(map[string]any)
@@ -226,7 +226,7 @@ func TestConvertGenaiToolsToBedrock(t *testing.T) {
 			},
 		}}}}
 
-		bt2, nm2 := convertGenaiToolsToBedrock(tools)
+		bt2, nm2 := convertGenaiToolsToBedrock(tools, false)
 		schema := extractSchema(t, bt2, nm2)
 		props, ok := schema["properties"].(map[string]any)
 		if !ok || len(props) == 0 {
@@ -247,7 +247,7 @@ func TestConvertGenaiToolsToBedrock(t *testing.T) {
 			ParametersJsonSchema: s,
 		}}}}
 
-		bt3, nm3 := convertGenaiToolsToBedrock(tools)
+		bt3, nm3 := convertGenaiToolsToBedrock(tools, false)
 		schema := extractSchema(t, bt3, nm3)
 		props, ok := schema["properties"].(map[string]any)
 		if !ok || len(props) == 0 {
@@ -402,7 +402,7 @@ func TestConvertGenaiToolsToBedrockSanitizesNames(t *testing.T) {
 		{Name: "filesystem:read_file", Description: "Read a file"},
 	}}}
 
-	bedrockTools, nameMap := convertGenaiToolsToBedrock(tools)
+	bedrockTools, nameMap := convertGenaiToolsToBedrock(tools, false)
 	if len(bedrockTools) != 2 {
 		t.Fatalf("expected 2 tools, got %d", len(bedrockTools))
 	}
@@ -671,4 +671,51 @@ func TestBuildInferenceConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConvertGenaiToolsToBedrockPromptCaching(t *testing.T) {
+	tools := []*genai.Tool{{FunctionDeclarations: []*genai.FunctionDeclaration{
+		{Name: "get_weather", Description: "lookup weather"},
+		{Name: "list_pods", Description: "list pods"},
+	}}}
+
+	t.Run("disabled: no cache marker appended", func(t *testing.T) {
+		out, _ := convertGenaiToolsToBedrock(tools, false)
+		if len(out) != 2 {
+			t.Fatalf("expected 2 tools, got %d", len(out))
+		}
+		for i, tool := range out {
+			if _, ok := tool.(*types.ToolMemberCachePoint); ok {
+				t.Fatalf("did not expect a CachePoint at index %d when caching disabled", i)
+			}
+		}
+	})
+
+	t.Run("enabled: cache marker appended at the END of the tool list", func(t *testing.T) {
+		out, _ := convertGenaiToolsToBedrock(tools, true)
+		if len(out) != 3 {
+			t.Fatalf("expected 3 entries (2 tools + 1 CachePoint), got %d", len(out))
+		}
+		// The first two must remain ToolSpec entries (order preserved).
+		for i := 0; i < 2; i++ {
+			if _, ok := out[i].(*types.ToolMemberToolSpec); !ok {
+				t.Fatalf("entry %d: expected ToolMemberToolSpec, got %T", i, out[i])
+			}
+		}
+		// The trailing entry must be a CachePoint with type=default.
+		cp, ok := out[2].(*types.ToolMemberCachePoint)
+		if !ok {
+			t.Fatalf("trailing entry: expected ToolMemberCachePoint, got %T", out[2])
+		}
+		if cp.Value.Type != types.CachePointTypeDefault {
+			t.Errorf("expected CachePointType=default, got %v", cp.Value.Type)
+		}
+	})
+
+	t.Run("enabled but no tools: no cache marker (skipped)", func(t *testing.T) {
+		out, _ := convertGenaiToolsToBedrock(nil, true)
+		if len(out) != 0 {
+			t.Fatalf("expected empty slice for no tools, got %d entries", len(out))
+		}
+	})
 }

--- a/go/api/adk/types.go
+++ b/go/api/adk/types.go
@@ -252,10 +252,14 @@ type Bedrock struct {
 	// options outside the standard InferenceConfiguration block.
 	AdditionalModelRequestFields map[string]any `json:"additional_model_request_fields,omitempty"`
 	// PromptCaching enables Bedrock prompt caching by appending a CachePoint
-	// block to the end of the system content array and the end of the tools
-	// array in the Converse request. See the v1alpha2.BedrockConfig CRD doc
-	// for context.
+	// block to the end of the system content array and the end of the
+	// toolConfig.tools array in the Converse request. See the
+	// v1alpha2.BedrockConfig CRD doc for context.
 	PromptCaching bool `json:"prompt_caching,omitempty"`
+	// CacheTTL selects the cache retention window when PromptCaching is on:
+	// "5m" (default) or "1h". See the v1alpha2.BedrockConfig CRD doc for the
+	// cost/compatibility trade-offs of "1h".
+	CacheTTL string `json:"cache_ttl,omitempty"`
 }
 
 func (b *Bedrock) MarshalJSON() ([]byte, error) {

--- a/go/api/adk/types.go
+++ b/go/api/adk/types.go
@@ -251,6 +251,11 @@ type Bedrock struct {
 	// additionalModelRequestFields in the Converse API. Use this for provider-specific
 	// options outside the standard InferenceConfiguration block.
 	AdditionalModelRequestFields map[string]any `json:"additional_model_request_fields,omitempty"`
+	// PromptCaching enables Bedrock prompt caching by appending a CachePoint
+	// block to the end of the system content array and the end of the tools
+	// array in the Converse request. See the v1alpha2.BedrockConfig CRD doc
+	// for context.
+	PromptCaching bool `json:"prompt_caching,omitempty"`
 }
 
 func (b *Bedrock) MarshalJSON() ([]byte, error) {

--- a/go/api/config/crd/bases/kagent.dev_modelconfigs.yaml
+++ b/go/api/config/crd/bases/kagent.dev_modelconfigs.yaml
@@ -483,6 +483,24 @@ spec:
                       Claude extended thinking or top_k. Values are forwarded as-is to the API.
                       Example: {"top_k": 5, "thinking": {"type": "enabled", "budget_tokens": 16000}}
                     x-kubernetes-preserve-unknown-fields: true
+                  promptCaching:
+                    default: false
+                    description: |-
+                      PromptCaching enables Bedrock prompt caching by appending a CachePoint
+                      block at the end of the Converse request's `system` content array and
+                      the end of the `tools` array. Bedrock will cache the prefix up to and
+                      including those cache points across requests in the same region for
+                      roughly 5 minutes after first use, billing the cached portion at a
+                      reduced rate on cache hits.
+
+                      Recommended for tool-using agents that make many Converse calls per
+                      task with a stable system prompt and tool set — the per-call input
+                      token count can drop by 70-90% on hit. Has no effect on models that
+                      don't support caching; the marker is ignored by Bedrock for those.
+
+                      See https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
+                      for the current list of supported models and minimum prefix sizes.
+                    type: boolean
                   region:
                     description: AWS region where the Bedrock model is available (e.g.,
                       us-east-1, us-west-2)

--- a/go/api/config/crd/bases/kagent.dev_modelconfigs.yaml
+++ b/go/api/config/crd/bases/kagent.dev_modelconfigs.yaml
@@ -483,12 +483,32 @@ spec:
                       Claude extended thinking or top_k. Values are forwarded as-is to the API.
                       Example: {"top_k": 5, "thinking": {"type": "enabled", "budget_tokens": 16000}}
                     x-kubernetes-preserve-unknown-fields: true
+                  cacheTTL:
+                    default: 5m
+                    description: |-
+                      CacheTTL controls how long Bedrock retains a cached prefix when
+                      PromptCaching is enabled. Only meaningful when PromptCaching is true.
+
+                        - "5m" (default): Bedrock's standard 5-minute sliding cache. Each cache
+                          hit refreshes the window. Supported by all prompt-caching models.
+                        - "1h": extended-TTL caching, useful for tasks whose Converse calls are
+                          spaced more than 5 minutes apart.
+
+                      NOTE: "1h" is NOT strictly better than "5m". Extended-TTL cache writes are
+                      billed at a higher per-token rate than 5-minute writes, and 1h is supported
+                      on a narrower set of models. Only choose "1h" when calls are spaced far
+                      enough apart that a 5-minute cache would expire between them; otherwise the
+                      higher write cost is wasted. See the AWS prompt-caching docs above.
+                    enum:
+                    - 5m
+                    - 1h
+                    type: string
                   promptCaching:
                     default: false
                     description: |-
                       PromptCaching enables Bedrock prompt caching by appending a CachePoint
                       block at the end of the Converse request's `system` content array and
-                      the end of the `tools` array. Bedrock will cache the prefix up to and
+                      the end of the `toolConfig.tools` array. Bedrock will cache the prefix up to and
                       including those cache points across requests in the same region for
                       roughly 5 minutes after first use, billing the cached portion at a
                       reduced rate on cache hits.

--- a/go/api/v1alpha2/modelconfig_types.go
+++ b/go/api/v1alpha2/modelconfig_types.go
@@ -256,6 +256,24 @@ type BedrockConfig struct {
 	// +optional
 	// +kubebuilder:pruning:PreserveUnknownFields
 	AdditionalModelRequestFields *apiextensionsv1.JSON `json:"additionalModelRequestFields,omitempty"`
+
+	// PromptCaching enables Bedrock prompt caching by appending a CachePoint
+	// block at the end of the Converse request's `system` content array and
+	// the end of the `tools` array. Bedrock will cache the prefix up to and
+	// including those cache points across requests in the same region for
+	// roughly 5 minutes after first use, billing the cached portion at a
+	// reduced rate on cache hits.
+	//
+	// Recommended for tool-using agents that make many Converse calls per
+	// task with a stable system prompt and tool set — the per-call input
+	// token count can drop by 70-90% on hit. Has no effect on models that
+	// don't support caching; the marker is ignored by Bedrock for those.
+	//
+	// See https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
+	// for the current list of supported models and minimum prefix sizes.
+	// +optional
+	// +kubebuilder:default=false
+	PromptCaching bool `json:"promptCaching,omitempty"`
 }
 
 // SAPAICoreConfig contains SAP AI Core-specific configuration options.

--- a/go/api/v1alpha2/modelconfig_types.go
+++ b/go/api/v1alpha2/modelconfig_types.go
@@ -259,7 +259,7 @@ type BedrockConfig struct {
 
 	// PromptCaching enables Bedrock prompt caching by appending a CachePoint
 	// block at the end of the Converse request's `system` content array and
-	// the end of the `tools` array. Bedrock will cache the prefix up to and
+	// the end of the `toolConfig.tools` array. Bedrock will cache the prefix up to and
 	// including those cache points across requests in the same region for
 	// roughly 5 minutes after first use, billing the cached portion at a
 	// reduced rate on cache hits.
@@ -274,6 +274,24 @@ type BedrockConfig struct {
 	// +optional
 	// +kubebuilder:default=false
 	PromptCaching bool `json:"promptCaching,omitempty"`
+
+	// CacheTTL controls how long Bedrock retains a cached prefix when
+	// PromptCaching is enabled. Only meaningful when PromptCaching is true.
+	//
+	//   - "5m" (default): Bedrock's standard 5-minute sliding cache. Each cache
+	//     hit refreshes the window. Supported by all prompt-caching models.
+	//   - "1h": extended-TTL caching, useful for tasks whose Converse calls are
+	//     spaced more than 5 minutes apart.
+	//
+	// NOTE: "1h" is NOT strictly better than "5m". Extended-TTL cache writes are
+	// billed at a higher per-token rate than 5-minute writes, and 1h is supported
+	// on a narrower set of models. Only choose "1h" when calls are spaced far
+	// enough apart that a 5-minute cache would expire between them; otherwise the
+	// higher write cost is wasted. See the AWS prompt-caching docs above.
+	// +optional
+	// +kubebuilder:validation:Enum="5m";"1h"
+	// +kubebuilder:default="5m"
+	CacheTTL string `json:"cacheTTL,omitempty"`
 }
 
 // SAPAICoreConfig contains SAP AI Core-specific configuration options.

--- a/go/core/internal/controller/translator/agent/adk_api_translator.go
+++ b/go/core/internal/controller/translator/agent/adk_api_translator.go
@@ -798,6 +798,7 @@ func (a *adkApiTranslator) translateModel(ctx context.Context, namespace, modelC
 			Region:                       model.Spec.Bedrock.Region,
 			AdditionalModelRequestFields: additionalFields,
 			PromptCaching:                model.Spec.Bedrock.PromptCaching,
+			CacheTTL:                     model.Spec.Bedrock.CacheTTL,
 		}
 
 		// Populate TLS fields in BaseModel

--- a/go/core/internal/controller/translator/agent/adk_api_translator.go
+++ b/go/core/internal/controller/translator/agent/adk_api_translator.go
@@ -797,6 +797,7 @@ func (a *adkApiTranslator) translateModel(ctx context.Context, namespace, modelC
 			},
 			Region:                       model.Spec.Bedrock.Region,
 			AdditionalModelRequestFields: additionalFields,
+			PromptCaching:                model.Spec.Bedrock.PromptCaching,
 		}
 
 		// Populate TLS fields in BaseModel

--- a/helm/kagent-crds/templates/kagent.dev_modelconfigs.yaml
+++ b/helm/kagent-crds/templates/kagent.dev_modelconfigs.yaml
@@ -483,6 +483,24 @@ spec:
                       Claude extended thinking or top_k. Values are forwarded as-is to the API.
                       Example: {"top_k": 5, "thinking": {"type": "enabled", "budget_tokens": 16000}}
                     x-kubernetes-preserve-unknown-fields: true
+                  promptCaching:
+                    default: false
+                    description: |-
+                      PromptCaching enables Bedrock prompt caching by appending a CachePoint
+                      block at the end of the Converse request's `system` content array and
+                      the end of the `tools` array. Bedrock will cache the prefix up to and
+                      including those cache points across requests in the same region for
+                      roughly 5 minutes after first use, billing the cached portion at a
+                      reduced rate on cache hits.
+
+                      Recommended for tool-using agents that make many Converse calls per
+                      task with a stable system prompt and tool set — the per-call input
+                      token count can drop by 70-90% on hit. Has no effect on models that
+                      don't support caching; the marker is ignored by Bedrock for those.
+
+                      See https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
+                      for the current list of supported models and minimum prefix sizes.
+                    type: boolean
                   region:
                     description: AWS region where the Bedrock model is available (e.g.,
                       us-east-1, us-west-2)

--- a/helm/kagent-crds/templates/kagent.dev_modelconfigs.yaml
+++ b/helm/kagent-crds/templates/kagent.dev_modelconfigs.yaml
@@ -483,12 +483,32 @@ spec:
                       Claude extended thinking or top_k. Values are forwarded as-is to the API.
                       Example: {"top_k": 5, "thinking": {"type": "enabled", "budget_tokens": 16000}}
                     x-kubernetes-preserve-unknown-fields: true
+                  cacheTTL:
+                    default: 5m
+                    description: |-
+                      CacheTTL controls how long Bedrock retains a cached prefix when
+                      PromptCaching is enabled. Only meaningful when PromptCaching is true.
+
+                        - "5m" (default): Bedrock's standard 5-minute sliding cache. Each cache
+                          hit refreshes the window. Supported by all prompt-caching models.
+                        - "1h": extended-TTL caching, useful for tasks whose Converse calls are
+                          spaced more than 5 minutes apart.
+
+                      NOTE: "1h" is NOT strictly better than "5m". Extended-TTL cache writes are
+                      billed at a higher per-token rate than 5-minute writes, and 1h is supported
+                      on a narrower set of models. Only choose "1h" when calls are spaced far
+                      enough apart that a 5-minute cache would expire between them; otherwise the
+                      higher write cost is wasted. See the AWS prompt-caching docs above.
+                    enum:
+                    - 5m
+                    - 1h
+                    type: string
                   promptCaching:
                     default: false
                     description: |-
                       PromptCaching enables Bedrock prompt caching by appending a CachePoint
                       block at the end of the Converse request's `system` content array and
-                      the end of the `tools` array. Bedrock will cache the prefix up to and
+                      the end of the `toolConfig.tools` array. Bedrock will cache the prefix up to and
                       including those cache points across requests in the same region for
                       roughly 5 minutes after first use, billing the cached portion at a
                       reduced rate on cache hits.

--- a/python/packages/kagent-adk/src/kagent/adk/models/_bedrock.py
+++ b/python/packages/kagent-adk/src/kagent/adk/models/_bedrock.py
@@ -251,6 +251,12 @@ class KAgentBedrockLlm(KAgentTLSMixin, BaseLlm):
 
     extra_headers: Optional[dict[str, str]] = None
     additional_model_request_fields: Optional[dict[str, Any]] = None
+    # When True, append a CachePoint block to the end of the Converse
+    # request's `system` content array and the end of the `toolConfig.tools`
+    # array. Bedrock caches the prefix up to and including those markers
+    # across requests in the same region; cached portion is billed at a
+    # reduced rate on hit. See AWS docs for supported models / minimums.
+    prompt_caching: bool = False
 
     model_config = {"arbitrary_types_allowed": True}
 
@@ -288,12 +294,23 @@ class KAgentBedrockLlm(KAgentTLSMixin, BaseLlm):
                 text = "\n".join(p.text for p in si.parts or [] if p.text)
                 if text:
                     kwargs["system"] = [{"text": text}]
+            # If prompt caching is on, mark the end of the system content as
+            # a cache breakpoint. Bedrock caches everything up to and including
+            # this point for ~5 minutes; subsequent requests with the same
+            # prefix hit the cache. No-op if we didn't produce any system text.
+            if self.prompt_caching and kwargs.get("system"):
+                kwargs["system"].append({"cachePoint": {"type": "default"}})
 
         if llm_request.config and llm_request.config.tools:
             genai_tools = [t for t in llm_request.config.tools if hasattr(t, "function_declarations")]
             if genai_tools:
                 converse_tools = _convert_tools_to_converse(genai_tools, tool_name_map, tool_name_counter)
                 if converse_tools:
+                    # CachePoint at the END of the tool list: tool definitions
+                    # are usually the biggest static chunk of an agent request
+                    # and benefit most from caching.
+                    if self.prompt_caching:
+                        converse_tools.append({"cachePoint": {"type": "default"}})
                     kwargs["toolConfig"] = {"tools": converse_tools}
 
         # Reverse map lets us restore original tool names from sanitized names in Bedrock responses.

--- a/python/packages/kagent-adk/src/kagent/adk/models/_bedrock.py
+++ b/python/packages/kagent-adk/src/kagent/adk/models/_bedrock.py
@@ -234,6 +234,24 @@ def _convert_tools_to_converse(
     return converse_tools
 
 
+def _cache_point_block(cache_ttl: Optional[str] = None) -> dict:
+    """Return a fresh Bedrock CachePoint marker block.
+
+    A new dict is returned on each call so callers can safely append it to a
+    request's ``system`` or ``toolConfig.tools`` array without aliasing a
+    shared mutable object.
+
+    ``cache_ttl`` selects the retention window. ``None`` or ``"5m"`` omits the
+    ``ttl`` field, giving Bedrock's default 5-minute cache (broadest model
+    support); ``"1h"`` opts into extended-TTL caching, which is supported on
+    fewer models and billed at a higher cache-write rate.
+    """
+    block: dict[str, Any] = {"type": "default"}
+    if cache_ttl == "1h":
+        block["ttl"] = "1h"
+    return {"cachePoint": block}
+
+
 def _stop_reason_to_finish_reason(stop_reason: str) -> types.FinishReason:
     if stop_reason == "max_tokens":
         return types.FinishReason.MAX_TOKENS
@@ -257,6 +275,10 @@ class KAgentBedrockLlm(KAgentTLSMixin, BaseLlm):
     # across requests in the same region; cached portion is billed at a
     # reduced rate on hit. See AWS docs for supported models / minimums.
     prompt_caching: bool = False
+    # When prompt_caching is on, cache_ttl selects the retention window:
+    # "5m"/None (Bedrock's default 5-minute cache) or "1h" (extended-TTL,
+    # narrower model support and higher cache-write cost). See _cache_point_block.
+    cache_ttl: Optional[str] = None
 
     model_config = {"arbitrary_types_allowed": True}
 
@@ -299,7 +321,7 @@ class KAgentBedrockLlm(KAgentTLSMixin, BaseLlm):
             # this point for ~5 minutes; subsequent requests with the same
             # prefix hit the cache. No-op if we didn't produce any system text.
             if self.prompt_caching and kwargs.get("system"):
-                kwargs["system"].append({"cachePoint": {"type": "default"}})
+                kwargs["system"].append(_cache_point_block(self.cache_ttl))
 
         if llm_request.config and llm_request.config.tools:
             genai_tools = [t for t in llm_request.config.tools if hasattr(t, "function_declarations")]
@@ -310,7 +332,7 @@ class KAgentBedrockLlm(KAgentTLSMixin, BaseLlm):
                     # are usually the biggest static chunk of an agent request
                     # and benefit most from caching.
                     if self.prompt_caching:
-                        converse_tools.append({"cachePoint": {"type": "default"}})
+                        converse_tools.append(_cache_point_block(self.cache_ttl))
                     kwargs["toolConfig"] = {"tools": converse_tools}
 
         # Reverse map lets us restore original tool names from sanitized names in Bedrock responses.

--- a/python/packages/kagent-adk/src/kagent/adk/types.py
+++ b/python/packages/kagent-adk/src/kagent/adk/types.py
@@ -316,6 +316,11 @@ class Bedrock(BaseLLM):
     # additionalModelRequestFields in the Converse API. Use this for provider-specific
     # options outside the standard InferenceConfiguration block.
     additional_model_request_fields: dict | None = None
+    # prompt_caching enables Bedrock prompt caching: a CachePoint marker is
+    # appended to the end of the Converse request's system content array and
+    # toolConfig.tools array. Bedrock caches the prefix across requests in the
+    # same region; cached portion is billed at a reduced rate on hit.
+    prompt_caching: bool = False
     type: Literal["bedrock"]
 
 
@@ -681,6 +686,7 @@ def _create_llm_from_model_config(model_config: ModelUnion):
             model=model_config.model,
             extra_headers=extra_headers,
             additional_model_request_fields=model_config.additional_model_request_fields,
+            prompt_caching=model_config.prompt_caching,
             **_transport_kwargs(model_config),
         )
     if model_config.type == "sap_ai_core":

--- a/python/packages/kagent-adk/src/kagent/adk/types.py
+++ b/python/packages/kagent-adk/src/kagent/adk/types.py
@@ -321,6 +321,11 @@ class Bedrock(BaseLLM):
     # toolConfig.tools array. Bedrock caches the prefix across requests in the
     # same region; cached portion is billed at a reduced rate on hit.
     prompt_caching: bool = False
+    # cache_ttl selects the cache retention window when prompt_caching is on:
+    # "5m" (default) for Bedrock's standard 5-minute cache, or "1h" for
+    # extended-TTL caching. "1h" is supported on fewer models and billed at a
+    # higher cache-write rate, so it is not strictly better than "5m".
+    cache_ttl: Literal["5m", "1h"] | None = None
     type: Literal["bedrock"]
 
 
@@ -687,6 +692,7 @@ def _create_llm_from_model_config(model_config: ModelUnion):
             extra_headers=extra_headers,
             additional_model_request_fields=model_config.additional_model_request_fields,
             prompt_caching=model_config.prompt_caching,
+            cache_ttl=model_config.cache_ttl,
             **_transport_kwargs(model_config),
         )
     if model_config.type == "sap_ai_core":

--- a/python/packages/kagent-adk/tests/unittests/models/test_bedrock.py
+++ b/python/packages/kagent-adk/tests/unittests/models/test_bedrock.py
@@ -7,6 +7,7 @@ import pytest
 
 from kagent.adk.models._bedrock import (
     KAgentBedrockLlm,
+    _cache_point_block,
     _convert_content_to_converse_messages,
     _convert_tools_to_converse,
     _get_bedrock_client,
@@ -312,3 +313,92 @@ class TestKAgentBedrockLlm:
         result = _create_llm_from_model_config(config)
         assert isinstance(result, KAgentBedrockLlm)
         assert result.model == "meta.llama3-8b-instruct-v1:0"
+
+    def test_create_llm_forwards_prompt_caching_and_ttl(self):
+        from kagent.adk.types import Bedrock, _create_llm_from_model_config
+
+        config = Bedrock(
+            type="bedrock",
+            model="us.anthropic.claude-sonnet-4-20250514-v1:0",
+            prompt_caching=True,
+            cache_ttl="1h",
+        )
+        result = _create_llm_from_model_config(config)
+        assert isinstance(result, KAgentBedrockLlm)
+        assert result.prompt_caching is True
+        assert result.cache_ttl == "1h"
+
+
+class TestCachePointBlock:
+    def test_default_omits_ttl(self):
+        assert _cache_point_block() == {"cachePoint": {"type": "default"}}
+
+    def test_five_minutes_omits_ttl(self):
+        # "5m" is Bedrock's default cache window; we leave ttl unset so the
+        # marker stays compatible with every prompt-caching model.
+        assert _cache_point_block("5m") == {"cachePoint": {"type": "default"}}
+
+    def test_one_hour_sets_ttl(self):
+        assert _cache_point_block("1h") == {"cachePoint": {"type": "default", "ttl": "1h"}}
+
+    def test_returns_fresh_dict_each_call(self):
+        first = _cache_point_block()
+        second = _cache_point_block()
+        assert first is not second
+        first["cachePoint"]["type"] = "mutated"
+        assert second["cachePoint"]["type"] == "default"
+
+
+class TestPromptCachingInsertion:
+    async def _run_converse(self, llm, request):
+        mock_client = mock.MagicMock()
+        mock_client.converse.return_value = {
+            "output": {"message": {"role": "assistant", "content": [{"text": "ok"}]}},
+            "stopReason": "end_turn",
+            "usage": {"inputTokens": 1, "outputTokens": 1, "totalTokens": 2},
+        }
+
+        async def fake_to_thread(fn, **kwargs):
+            return fn(**kwargs)
+
+        with (
+            mock.patch("kagent.adk.models._bedrock._get_bedrock_client", return_value=mock_client),
+            mock.patch("kagent.adk.models._bedrock.asyncio.to_thread", side_effect=fake_to_thread),
+        ):
+            _ = [r async for r in llm.generate_content_async(request)]
+        return mock_client.converse.call_args.kwargs
+
+    def _request_with_system(self):
+        request = mock.MagicMock()
+        request.model = "us.anthropic.claude-sonnet-4-20250514-v1:0"
+        request.contents = []
+        request.config = mock.MagicMock()
+        request.config.system_instruction = "you are a helpful agent"
+        request.config.tools = None
+        request.config.temperature = None
+        request.config.max_output_tokens = None
+        request.config.top_p = None
+        request.config.stop_sequences = None
+        return request
+
+    @pytest.mark.asyncio
+    async def test_no_cache_point_when_disabled(self):
+        llm = KAgentBedrockLlm(model="us.anthropic.claude-sonnet-4-20250514-v1:0")
+        kwargs = await self._run_converse(llm, self._request_with_system())
+        assert all("cachePoint" not in block for block in kwargs["system"])
+
+    @pytest.mark.asyncio
+    async def test_system_cache_point_default_ttl(self):
+        llm = KAgentBedrockLlm(model="us.anthropic.claude-sonnet-4-20250514-v1:0", prompt_caching=True)
+        kwargs = await self._run_converse(llm, self._request_with_system())
+        assert kwargs["system"][-1] == {"cachePoint": {"type": "default"}}
+
+    @pytest.mark.asyncio
+    async def test_system_cache_point_one_hour_ttl(self):
+        llm = KAgentBedrockLlm(
+            model="us.anthropic.claude-sonnet-4-20250514-v1:0",
+            prompt_caching=True,
+            cache_ttl="1h",
+        )
+        kwargs = await self._run_converse(llm, self._request_with_system())
+        assert kwargs["system"][-1] == {"cachePoint": {"type": "default", "ttl": "1h"}}


### PR DESCRIPTION
feat(bedrock): add prompt caching via CachePoint markers

Closes #1871.

## Why this is needed

Multi-turn tool-using kagent agents on Bedrock pay full input-token cost
on every Converse call, because the static prefix (system prompt + tool
definitions) is re-sent and re-billed each turn. Real measurement from a
production deployment using Claude Sonnet 4.5 via the `us.` inference
profile in us-east-1, running every 2 hours against a ~700-pod EKS
cluster:

  - Per sweep: ~4 Converse calls
  - Cumulative input tokens (CloudWatch InvokeModel metric): ~313k
  - Cumulative output tokens: ~3k
  - Per-sweep cost: ~$0.98 (input dominates ~95%)
  - Per cluster/year (5 sweeps/weekday): ~$1,300
  - Per cluster/year (24/7 every 2h): projected ~$4-9k

~30k of the per-call input is identical across every call — system
prompt and tool definitions don't change inside a single task. Bedrock
prompt caching is designed precisely for this case: a `cachePoint` block
in the Converse request marks where the cacheable prefix ends, and
subsequent calls within ~5 minutes (per region) hit the cache and bill
the prefix at a reduced rate.

The Bedrock provider builds Converse requests using
`system: [textBlock]` and `toolConfig.tools: [...]` but never appends a
`cachePoint` block to either array, so caching is never engaged.

## Why this is not redundant with the existing `spec.declarative.compaction`

kagent already has an Agent-level context-compaction feature
(`Compaction`, `CompactionInterval`, `Summarizer`, `TokenThreshold`,
etc.) that summarizes old conversation turns when the conversation
exceeds a token threshold. That solves a different problem:

  - Compaction: shrinks the conversation prompt when it gets too long.
    Helps with context-window pressure on long-running agents.
  - Prompt caching: keeps the prompt the same size but tells Bedrock
    "the first N tokens are stable across calls, cache them and bill
    cached portion at the reduced rate."

Neither replaces the other. For a tool-using agent whose conversation
stays under the context limit but whose static prefix (system prompt +
tool defs) is large, prompt caching is the right hammer; compaction does
nothing because there's nothing to compact in the static prefix.

## What this PR does

Adds a `promptCaching: bool` field to `BedrockConfig` (defaulting to
`false` to preserve existing behavior). When set, the provider appends
a `CachePoint` block:

  1. To the end of the `system` content array (after the system text block)
  2. To the end of the `toolConfig.tools` array (after the last ToolSpec)

Markers use `CachePointTypeDefault`. Bedrock silently ignores cache
points on models that don't support prompt caching, so the field is
safe to enable on a heterogeneous model fleet without per-model
gating.

Tested against `us.anthropic.claude-sonnet-4-5-20250929-v1:0`: the
second and subsequent Converse calls within the cache window drop their
input-token billing by ~70-90% on cache hits, depending on which static
portion (system vs tools vs both) is being hit.

## Implementation surface

Mirrors the change across both runtimes — Go (for `runtime: go` agents)
and Python (for `runtime: python` agents):

Go:
  - `go/api/v1alpha2/modelconfig_types.go`: add `PromptCaching` to
    `BedrockConfig` CRD struct with full doc + kubebuilder default.
  - `go/api/adk/types.go`: add `PromptCaching` to the internal
    `adk.Bedrock` serializable model so it flows through agent config JSON.
  - `go/core/internal/controller/translator/agent/adk_api_translator.go`:
    populate the new field when translating ModelConfig CR -> adk.Bedrock.
  - `go/adk/pkg/agent/agent.go`: thread the value into `models.BedrockConfig`.
  - `go/adk/pkg/models/bedrock.go`: emit the cache point markers in the
    Converse request builders.

Python:
  - `python/.../adk/types.py`: add `prompt_caching: bool` to the
    `Bedrock` Pydantic model and pass through to `KAgentBedrockLlm` factory.
  - `python/.../adk/models/_bedrock.py`: append
    `{"cachePoint": {"type": "default"}}` to `kwargs["system"]` and
    `kwargs["toolConfig"]["tools"]` when enabled.

Regenerated CRDs via `make controller-manifests` so
`helm/kagent-crds/templates/kagent.dev_modelconfigs.yaml` reflects the
new schema field.

## Tests

`go/adk/pkg/models/bedrock_test.go`: new
`TestConvertGenaiToolsToBedrockPromptCaching` covering three cases:
disabled = no marker, enabled = marker appended at END of tool list
with default type, enabled-but-no-tools = no marker (no point in a
standalone marker).

Existing `convertGenaiToolsToBedrock` callers updated to pass the new
`promptCaching bool` argument as `false` (no behavior change).

## Backward compatibility

  - `promptCaching` defaults to `false` everywhere; existing
    ModelConfigs pick up no behavior change.
  - Serialized `adk.Bedrock` JSON uses `omitempty` for the new field;
    older agent pods deserializing newer config see an unknown field
    they ignore (Pydantic + Go json decoders both lenient by default).
  - The Converse API tolerates and ignores `CachePoint` markers on
    models that don't support caching, so enabling on a mixed-model
    setup is safe.

## Example usage

```yaml
apiVersion: kagent.dev/v1alpha2
kind: ModelConfig
metadata:
  name: bedrock-claude
spec:
  provider: Bedrock
  model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
  bedrock:
    region: us-east-1
    promptCaching: true
```

Signed-off-by: Shamil Kashmeri <shamil@viafoura.com>