### PR TITLE
Fix/1945 fix for wrong validation being triggered

### DIFF
--- a/ui/src/app/models/new/page.tsx
+++ b/ui/src/app/models/new/page.tsx
@@ -555,7 +555,6 @@ function ModelPageContent() {
     const finalSelectedProvider = providers.find(p => getProviderFormKey(p.type as BackendModelProviderType) === providerKey);
 
     if (!validateForm() || !finalSelectedProvider) {
-      console.log("Validation failed:", errors);
       toast.error("Please fill in all required fields and correct any errors.");
       return;
     }

--- a/ui/src/app/models/new/page.tsx
+++ b/ui/src/app/models/new/page.tsx
@@ -428,7 +428,7 @@ function ModelPageContent() {
 
     if (!isResourceNameValid(name)) newErrors.name = "Name must be a valid RFC 1123 subdomain name";
     if (!selectedCombinedModel) newErrors.selectedCombinedModel = "Provider and Model selection is required";
-    const isOllamaNow = selectedCombinedModel?.startsWith('ollama::');
+    const isOllamaNow = selectedProvider?.type?.toLowerCase() === 'ollama';
     if (!isEditMode && !isOllamaNow && isApiKeyNeeded && !apiKey.trim()) {
       newErrors.apiKey = "API key is required for new models (except for Ollama or when you don't need an API key)";
     }
@@ -555,6 +555,7 @@ function ModelPageContent() {
     const finalSelectedProvider = providers.find(p => getProviderFormKey(p.type as BackendModelProviderType) === providerKey);
 
     if (!validateForm() || !finalSelectedProvider) {
+      console.log("Validation failed:", errors);
       toast.error("Please fill in all required fields and correct any errors.");
       return;
     }


### PR DESCRIPTION
   Title:
  fix(ui): don't require API key when creating Ollama model (#1945)

  Description:

  ## What
  Creating an Ollama model failed validation with "API key is required …",
  blocking creation even though Ollama needs no key.

  Fixes #1945

  ## Cause
  `validateForm` detected Ollama via `selectedCombinedModel.startsWith('ollama::')`,  but the combined value is built from the provider key and is actually  `"Ollama::<model>"` (capital O) — so the check never matched and the  API-key requirement fired.

  ## Fix
  Detect Ollama from the selected provider instead, case-insensitively: `selectedProvider?.type?.toLowerCase() === 'ollama'`.
  Also removed a leftover debug `console.log`.

  ## Testing
  - Ollama + empty API key → creates successfully.
  - OpenAI + empty API key → still correctly blocked.



https://github.com/user-attachments/assets/caad115e-cc17-4e46-84c2-734822c2ceee

