### PR TITLE
Link fixes

### DIFF
--- a/go/api/config/crd/bases/kagent.dev_agents.yaml
+++ b/go/api/config/crd/bases/kagent.dev_agents.yaml
@@ -61,7 +61,7 @@ spec:
                   controller (default 8083).
                   The A2A server URL will be served at
                   <kagent-controller-ip>:8083/api/a2a/<agent-namespace>/<agent-name>
-                  Read more about the A2A protocol here: https://github.com/google/A2A
+                  Read more about the A2A protocol here: https://github.com/a2aproject/A2A
                 properties:
                   skills:
                     items:
@@ -2397,7 +2397,7 @@ spec:
                   This follows the Gateway API pattern for cross-namespace route attachments.
                   If not specified, only Agents in the same namespace can reference this Agent as a tool.
                   This field only applies when this Agent is used as a tool by another Agent.
-                  See: https://gateway-api.sigs.k8s.io/guides/multiple-ns/#cross-namespace-routing
+                  See: https://gateway-api.sigs.k8s.io/guides/multiple-ns/#cross-namespace-route-attachment
                 properties:
                   from:
                     default: Same
@@ -7681,7 +7681,7 @@ spec:
                       controller (default 8083).
                       The A2A server URL will be served at
                       <kagent-controller-ip>:8083/api/a2a/<agent-namespace>/<agent-name>
-                      Read more about the A2A protocol here: https://github.com/google/A2A
+                      Read more about the A2A protocol here: https://github.com/a2aproject/A2A
                     properties:
                       skills:
                         items:
@@ -12986,7 +12986,7 @@ spec:
                       Allow code execution for python code blocks with this agent.
                       If true, the agent will automatically execute python code blocks in the LLM responses.
                       Code will be executed in a sandboxed environment.
-                      due to a bug in adk (https://github.com/google/adk-python/issues/3921), this field is ignored for now.
+                      due to a bug in adk (https://github.com/google/adk-python/issues/3921 ), this field is ignored for now.
                     type: boolean
                   memory:
                     description: Memory configuration for the agent.

--- a/go/api/config/crd/bases/kagent.dev_remotemcpservers.yaml
+++ b/go/api/config/crd/bases/kagent.dev_remotemcpservers.yaml
@@ -58,7 +58,7 @@ spec:
                   AllowedNamespaces defines which namespaces are allowed to reference this RemoteMCPServer.
                   This follows the Gateway API pattern for cross-namespace route attachments.
                   If not specified, only Agents in the same namespace can reference this RemoteMCPServer.
-                  See: https://gateway-api.sigs.k8s.io/guides/multiple-ns/#cross-namespace-routing
+                  See: https://gateway-api.sigs.k8s.io/guides/multiple-ns/#cross-namespace-route-attachment
                 properties:
                   from:
                     default: Same

--- a/go/api/config/crd/bases/kagent.dev_sandboxagents.yaml
+++ b/go/api/config/crd/bases/kagent.dev_sandboxagents.yaml
@@ -55,7 +55,7 @@ spec:
                   This follows the Gateway API pattern for cross-namespace route attachments.
                   If not specified, only Agents in the same namespace can reference this Agent as a tool.
                   This field only applies when this Agent is used as a tool by another Agent.
-                  See: https://gateway-api.sigs.k8s.io/guides/multiple-ns/#cross-namespace-routing
+                  See: https://gateway-api.sigs.k8s.io/guides/multiple-ns/#cross-namespace-route-attachment
                 properties:
                   from:
                     default: Same
@@ -5339,7 +5339,7 @@ spec:
                       controller (default 8083).
                       The A2A server URL will be served at
                       <kagent-controller-ip>:8083/api/a2a/<agent-namespace>/<agent-name>
-                      Read more about the A2A protocol here: https://github.com/google/A2A
+                      Read more about the A2A protocol here: https://github.com/a2aproject/A2A
                     properties:
                       skills:
                         items:
@@ -10644,7 +10644,7 @@ spec:
                       Allow code execution for python code blocks with this agent.
                       If true, the agent will automatically execute python code blocks in the LLM responses.
                       Code will be executed in a sandboxed environment.
-                      due to a bug in adk (https://github.com/google/adk-python/issues/3921), this field is ignored for now.
+                      due to a bug in adk (https://github.com/google/adk-python/issues/3921 ), this field is ignored for now.
                     type: boolean
                   memory:
                     description: Memory configuration for the agent.

--- a/go/api/v1alpha1/agent_types.go
+++ b/go/api/v1alpha1/agent_types.go
@@ -53,7 +53,7 @@ type AgentSpec struct {
 	// controller (default 8083).
 	// The A2A server URL will be served at
 	// <kagent-controller-ip>:8083/api/a2a/<agent-namespace>/<agent-name>
-	// Read more about the A2A protocol here: https://github.com/google/A2A
+	// Read more about the A2A protocol here: https://github.com/a2aproject/A2A
 	// +optional
 	A2AConfig *A2AConfig `json:"a2aConfig,omitempty"`
 	// +optional

--- a/go/api/v1alpha2/agent_types.go
+++ b/go/api/v1alpha2/agent_types.go
@@ -80,7 +80,7 @@ type AgentSpec struct {
 	// This follows the Gateway API pattern for cross-namespace route attachments.
 	// If not specified, only Agents in the same namespace can reference this Agent as a tool.
 	// This field only applies when this Agent is used as a tool by another Agent.
-	// See: https://gateway-api.sigs.k8s.io/guides/multiple-ns/#cross-namespace-routing
+	// See: https://gateway-api.sigs.k8s.io/guides/multiple-ns/#cross-namespace-route-attachment
 	// +optional
 	AllowedNamespaces *AllowedNamespaces `json:"allowedNamespaces,omitempty"`
 }
@@ -201,7 +201,7 @@ type DeclarativeAgentSpec struct {
 	// controller (default 8083).
 	// The A2A server URL will be served at
 	// <kagent-controller-ip>:8083/api/a2a/<agent-namespace>/<agent-name>
-	// Read more about the A2A protocol here: https://github.com/google/A2A
+	// Read more about the A2A protocol here: https://github.com/a2aproject/A2A
 	// +optional
 	A2AConfig *A2AConfig `json:"a2aConfig,omitempty"`
 
@@ -212,7 +212,7 @@ type DeclarativeAgentSpec struct {
 	// If true, the agent will automatically execute python code blocks in the LLM responses.
 	// Code will be executed in a sandboxed environment.
 	// +optional
-	// due to a bug in adk (https://github.com/google/adk-python/issues/3921), this field is ignored for now.
+	// due to a bug in adk (https://github.com/google/adk-python/issues/3921 ), this field is ignored for now.
 	ExecuteCodeBlocks *bool `json:"executeCodeBlocks,omitempty"`
 
 	// Memory configuration for the agent.

--- a/go/api/v1alpha2/common_types.go
+++ b/go/api/v1alpha2/common_types.go
@@ -31,7 +31,7 @@ import (
 
 // FromNamespaces specifies namespace from which references to this resource are allowed.
 // This follows the same pattern as Gateway API's cross-namespace route attachment.
-// See: https://gateway-api.sigs.k8s.io/guides/multiple-ns/#cross-namespace-routing
+// See: https://gateway-api.sigs.k8s.io/guides/multiple-ns/#cross-namespace-route-attachment
 // +kubebuilder:validation:Enum=All;Same;Selector
 type FromNamespaces string
 

--- a/go/api/v1alpha2/remotemcpserver_types.go
+++ b/go/api/v1alpha2/remotemcpserver_types.go
@@ -60,7 +60,7 @@ type RemoteMCPServerSpec struct {
 	// AllowedNamespaces defines which namespaces are allowed to reference this RemoteMCPServer.
 	// This follows the Gateway API pattern for cross-namespace route attachments.
 	// If not specified, only Agents in the same namespace can reference this RemoteMCPServer.
-	// See: https://gateway-api.sigs.k8s.io/guides/multiple-ns/#cross-namespace-routing
+	// See: https://gateway-api.sigs.k8s.io/guides/multiple-ns/#cross-namespace-route-attachment
 	// +optional
 	AllowedNamespaces *AllowedNamespaces `json:"allowedNamespaces,omitempty"`
 }

--- a/helm/kagent-crds/templates/kagent.dev_agents.yaml
+++ b/helm/kagent-crds/templates/kagent.dev_agents.yaml
@@ -61,7 +61,7 @@ spec:
                   controller (default 8083).
                   The A2A server URL will be served at
                   <kagent-controller-ip>:8083/api/a2a/<agent-namespace>/<agent-name>
-                  Read more about the A2A protocol here: https://github.com/google/A2A
+                  Read more about the A2A protocol here: https://github.com/a2aproject/A2A
                 properties:
                   skills:
                     items:
@@ -2397,7 +2397,7 @@ spec:
                   This follows the Gateway API pattern for cross-namespace route attachments.
                   If not specified, only Agents in the same namespace can reference this Agent as a tool.
                   This field only applies when this Agent is used as a tool by another Agent.
-                  See: https://gateway-api.sigs.k8s.io/guides/multiple-ns/#cross-namespace-routing
+                  See: https://gateway-api.sigs.k8s.io/guides/multiple-ns/#cross-namespace-route-attachment
                 properties:
                   from:
                     default: Same
@@ -7681,7 +7681,7 @@ spec:
                       controller (default 8083).
                       The A2A server URL will be served at
                       <kagent-controller-ip>:8083/api/a2a/<agent-namespace>/<agent-name>
-                      Read more about the A2A protocol here: https://github.com/google/A2A
+                      Read more about the A2A protocol here: https://github.com/a2aproject/A2A
                     properties:
                       skills:
                         items:
@@ -12986,7 +12986,7 @@ spec:
                       Allow code execution for python code blocks with this agent.
                       If true, the agent will automatically execute python code blocks in the LLM responses.
                       Code will be executed in a sandboxed environment.
-                      due to a bug in adk (https://github.com/google/adk-python/issues/3921), this field is ignored for now.
+                      due to a bug in adk (https://github.com/google/adk-python/issues/3921 ), this field is ignored for now.
                     type: boolean
                   memory:
                     description: Memory configuration for the agent.

--- a/helm/kagent-crds/templates/kagent.dev_remotemcpservers.yaml
+++ b/helm/kagent-crds/templates/kagent.dev_remotemcpservers.yaml
@@ -58,7 +58,7 @@ spec:
                   AllowedNamespaces defines which namespaces are allowed to reference this RemoteMCPServer.
                   This follows the Gateway API pattern for cross-namespace route attachments.
                   If not specified, only Agents in the same namespace can reference this RemoteMCPServer.
-                  See: https://gateway-api.sigs.k8s.io/guides/multiple-ns/#cross-namespace-routing
+                  See: https://gateway-api.sigs.k8s.io/guides/multiple-ns/#cross-namespace-route-attachment
                 properties:
                   from:
                     default: Same

--- a/helm/kagent-crds/templates/kagent.dev_sandboxagents.yaml
+++ b/helm/kagent-crds/templates/kagent.dev_sandboxagents.yaml
@@ -55,7 +55,7 @@ spec:
                   This follows the Gateway API pattern for cross-namespace route attachments.
                   If not specified, only Agents in the same namespace can reference this Agent as a tool.
                   This field only applies when this Agent is used as a tool by another Agent.
-                  See: https://gateway-api.sigs.k8s.io/guides/multiple-ns/#cross-namespace-routing
+                  See: https://gateway-api.sigs.k8s.io/guides/multiple-ns/#cross-namespace-route-attachment
                 properties:
                   from:
                     default: Same
@@ -5339,7 +5339,7 @@ spec:
                       controller (default 8083).
                       The A2A server URL will be served at
                       <kagent-controller-ip>:8083/api/a2a/<agent-namespace>/<agent-name>
-                      Read more about the A2A protocol here: https://github.com/google/A2A
+                      Read more about the A2A protocol here: https://github.com/a2aproject/A2A
                     properties:
                       skills:
                         items:
@@ -10644,7 +10644,7 @@ spec:
                       Allow code execution for python code blocks with this agent.
                       If true, the agent will automatically execute python code blocks in the LLM responses.
                       Code will be executed in a sandboxed environment.
-                      due to a bug in adk (https://github.com/google/adk-python/issues/3921), this field is ignored for now.
+                      due to a bug in adk (https://github.com/google/adk-python/issues/3921 ), this field is ignored for now.
                     type: boolean
                   memory:
                     description: Memory configuration for the agent.


### PR DESCRIPTION
## fix: update stale and broken URLs in Go API type comments

Three sets of comment URLs in the API type definitions were either redirecting or pointing to renamed anchors, causing failures in downstream docs link checking.

## Changes

- **`github.com/google/A2A` → `github.com/a2aproject/A2A`** (`v1alpha1` and `v1alpha2` `agent_types.go`): The A2A project moved to a new GitHub org. Updated the link in the `a2aConfig` field description.

- **`#cross-namespace-routing` → `#cross-namespace-route-attachment`** (`agent_types.go`, `remotemcpserver_types.go`, `common_types.go`): The Gateway API docs renamed this anchor. The old fragment no longer exists on the `guides/multiple-ns/` page.

- **`adk-python/issues/3921)`** (`agent_types.go`): Added a space before the closing parenthesis so URL parsers don't include it as part of the link.

These comments flow into the auto-generated API reference docs via `crd-ref-docs`, so fixing them here eliminates the link checker warnings in downstream doc sites.
