### PR TITLE
fix(openai): apply ReasoningEffort in applyOpenAIConfig

### DIFF
--- a/go/adk/pkg/models/openai_adk.go
+++ b/go/adk/pkg/models/openai_adk.go
@@ -189,6 +189,9 @@ func applyOpenAIConfig(params *openai.ChatCompletionNewParams, cfg *OpenAIConfig
 	if cfg.N != nil {
 		params.N = openai.Int(int64(*cfg.N))
 	}
+	if cfg.ReasoningEffort != nil {
+		params.ReasoningEffort = shared.ReasoningEffort(*cfg.ReasoningEffort)
+	}
 }
 
 func genaiContentsToOpenAIMessages(contents []*genai.Content, config *genai.GenerateContentConfig) ([]openai.ChatCompletionMessageParamUnion, string) {

--- a/go/adk/pkg/models/openai_adk_test.go
+++ b/go/adk/pkg/models/openai_adk_test.go
@@ -247,6 +247,16 @@ func TestApplyOpenAIConfig(t *testing.T) {
 			t.Errorf("MaxTokens: Valid=%v, Value=%v, want (true, 100)", params.MaxTokens.Valid(), params.MaxTokens.Value)
 		}
 	})
+
+	t.Run("config with reasoning_effort", func(t *testing.T) {
+		effort := "medium"
+		cfg := &OpenAIConfig{ReasoningEffort: &effort}
+		var params openai.ChatCompletionNewParams
+		applyOpenAIConfig(&params, cfg)
+		if params.ReasoningEffort != "medium" {
+			t.Errorf("ReasoningEffort: got %q, want %q", params.ReasoningEffort, "medium")
+		}
+	})
 }
 
 func TestGenaiContentsToOpenAIMessages_PreservesThoughtSignatureOnToolCallAndToolResult(t *testing.T) {


### PR DESCRIPTION
ReasoningEffort was set in OpenAIConfig but never forwarded to ChatCompletionNewParams, so o1 model reasoning settings were silently ignored.

This adds the missing field assignment in applyOpenAIConfig, matching the pattern used for other config fields.

Fixes: ReasoningEffort is now passed through to the OpenAI API call.