### PR TITLE
fix(mcp): handle null tools field in MCP server configs

### DIFF
--- a/go/api/adk/types.go
+++ b/go/api/adk/types.go
@@ -21,7 +21,7 @@ type StreamableHTTPConnectionParams struct {
 
 type HttpMcpServerConfig struct {
 	Params          StreamableHTTPConnectionParams `json:"params"`
-	Tools           []string                       `json:"tools"`
+	Tools           []string                       `json:"tools,omitempty"`
 	AllowedHeaders  []string                       `json:"allowed_headers,omitempty"`
 	RequireApproval []string                       `json:"require_approval,omitempty"`
 }
@@ -39,7 +39,7 @@ type SseConnectionParams struct {
 
 type SseMcpServerConfig struct {
 	Params          SseConnectionParams `json:"params"`
-	Tools           []string            `json:"tools"`
+	Tools           []string            `json:"tools,omitempty"`
 	AllowedHeaders  []string            `json:"allowed_headers,omitempty"`
 	RequireApproval []string            `json:"require_approval,omitempty"`
 }

--- a/python/packages/kagent-adk/src/kagent/adk/types.py
+++ b/python/packages/kagent-adk/src/kagent/adk/types.py
@@ -11,7 +11,7 @@ from google.adk.agents.remote_a2a_agent import AGENT_CARD_WELL_KNOWN_PATH, DEFAU
 from google.adk.models.anthropic_llm import Claude as ClaudeLLM
 from google.adk.models.google_llm import Gemini as GeminiLLM
 from google.adk.tools.mcp_tool import SseConnectionParams, StreamableHTTPConnectionParams
-from pydantic import AliasChoices, BaseModel, Field, model_validator
+from pydantic import AliasChoices, BaseModel, Field, field_validator, model_validator
 
 from kagent.adk._approval import make_approval_callback, strip_confirmation_parts_callback
 from kagent.adk._mcp_toolset import KAgentMcpToolset
@@ -148,11 +148,6 @@ def _build_tls_httpx_client_factory(
     ca_cert_path: str | None,
     disable_system_cas: bool,
 ) -> Callable[..., httpx.AsyncClient]:
-    """Returns an httpx_client_factory suitable for google-adk MCP transport
-    connection params. The factory applies the kagent TLS configuration
-    (disableVerify / caCert / disableSystemCAs) to every httpx.AsyncClient
-    the MCP session manager constructs.
-    """
     ssl_ctx = create_ssl_context(
         disable_verify=disable_verify,
         ca_cert_path=ca_cert_path,
@@ -171,7 +166,6 @@ def _build_tls_httpx_client_factory(
         if timeout is not None:
             kwargs["timeout"] = timeout
         else:
-            # Mirror google-adk's create_mcp_http_client defaults.
             kwargs["timeout"] = httpx.Timeout(30, read=300)
         if headers is not None:
             kwargs["headers"] = headers
@@ -183,29 +177,14 @@ def _build_tls_httpx_client_factory(
 
 
 class _McpTlsMixin(BaseModel):
-    """Shared TLS plumbing for HttpMcpServerConfig / SseMcpServerConfig.
-
-    The kagent controller emits TLS keys nested under `params` on the
-    wire (so the same JSON schema works for both Go and Python
-    runtimes); we lift them up at load time and install a TLS-aware
-    httpx_client_factory on the params instance at toolset construction
-    time. Lift-into-wire-config + install-into-params keeps google-adk's
-    upstream types unchanged and avoids exporting our own params
-    subclasses that would shadow the upstream names.
-    """
-
     tls_insecure_skip_verify: bool | None = None
     tls_ca_cert_path: str | None = None
     tls_disable_system_cas: bool | None = None
+    tools: list[str] = Field(default_factory=list)
 
     @model_validator(mode="before")
     @classmethod
     def _lift_tls_from_params(cls, values: Any) -> Any:
-        # The kagent controller emits TLS keys nested under `params` so
-        # the same JSON wire schema works for both Go and Python runtimes;
-        # lift them to the top level. google-adk's params types use
-        # pydantic's default extra="ignore", so the duplicate copies that
-        # remain on `params` are silently dropped at construction.
         if isinstance(values, dict) and isinstance(values.get("params"), dict):
             params = values["params"]
             for key in ("tls_insecure_skip_verify", "tls_ca_cert_path", "tls_disable_system_cas"):
@@ -213,16 +192,12 @@ class _McpTlsMixin(BaseModel):
                     values[key] = params[key]
         return values
 
-    def _apply_tls_to_params(self, params: Any) -> None:
-        """Install a TLS-aware httpx_client_factory on the params instance
-        if any TLS field is set. No-op when no TLS config was supplied so
-        the upstream google-adk default factory remains in place.
+    @field_validator("tools", mode="before")
+    @classmethod
+    def _coerce_tools(cls, v: object) -> list:
+        return v or []
 
-        Reachability: when called from the Go controller's emitted config,
-        ``deriveTLSFields`` writes all three pointer fields whenever a
-        non-empty TLS config exists, so the all-None short-circuit below
-        only triggers for Python callers constructing this config directly
-        without TLS."""
+    def _apply_tls_to_params(self, params: Any) -> None:
         if (
             self.tls_insecure_skip_verify is None
             and self.tls_ca_cert_path is None
@@ -237,28 +212,23 @@ class _McpTlsMixin(BaseModel):
         if hasattr(params, "httpx_client_factory"):
             params.httpx_client_factory = factory
         else:
-            # Older google-adk (< 1.28) lacked httpx_client_factory on
-            # SseConnectionParams. The pyproject floor forbids this in
-            # production; warn loudly for stale dev environments.
             logger.warning(
                 "TLS configuration ignored on %s: google-adk does not expose "
-                "httpx_client_factory on this params type — upgrade to ≥ 1.28.1.",
+                "httpx_client_factory on this params type — upgrade to >= 1.28.1.",
                 type(params).__name__,
             )
 
 
 class HttpMcpServerConfig(_McpTlsMixin):
     params: StreamableHTTPConnectionParams
-    tools: list[str] = Field(default_factory=list)
-    allowed_headers: list[str] | None = None  # Headers to forward from A2A request to MCP calls
-    require_approval: list[str] | None = None  # Tools requiring human approval before execution
+    allowed_headers: list[str] | None = None
+    require_approval: list[str] | None = None
 
 
 class SseMcpServerConfig(_McpTlsMixin):
     params: SseConnectionParams
-    tools: list[str] = Field(default_factory=list)
-    allowed_headers: list[str] | None = None  # Headers to forward from A2A request to MCP calls
-    require_approval: list[str] | None = None  # Tools requiring human approval before execution
+    allowed_headers: list[str] | None = None
+    require_approval: list[str] | None = None
 
 
 class RemoteAgentConfig(BaseModel):


### PR DESCRIPTION
When tools is omitted from an MCP server config, the Go side serializes it as null. This causes a pydantic ValidationError on the Python side because the field expects list[str].

Fix: add omitempty to the Go JSON tags so null is never sent, and add a field_validator in Python to coerce null to an empty list.

Fixes #1797