### PR TITLE
fix(translator): forward Anthropic config fields to model config

### DIFF
--- a/go/core/internal/controller/translator/agent/adk_api_translator.go
+++ b/go/core/internal/controller/translator/agent/adk_api_translator.go
@@ -434,7 +434,16 @@ func (a *adkApiTranslator) translateModel(ctx context.Context, namespace, modelC
 		anthropic.APIKeyPassthrough = model.Spec.APIKeyPassthrough
 
 		if model.Spec.Anthropic != nil {
-			anthropic.BaseUrl = model.Spec.Anthropic.BaseURL
+			spec := model.Spec.Anthropic
+			anthropic.BaseUrl = spec.BaseURL
+			anthropic.Temperature = utils.ParseStringToFloat64(spec.Temperature)
+			anthropic.TopP = utils.ParseStringToFloat64(spec.TopP)
+			if spec.MaxTokens > 0 {
+				anthropic.MaxTokens = &spec.MaxTokens
+			}
+			if spec.TopK > 0 {
+				anthropic.TopK = &spec.TopK
+			}
 		}
 		return anthropic, modelDeploymentData, secretHashBytes, nil
 	case v1alpha2.ModelProviderAzureOpenAI:

--- a/go/core/internal/controller/translator/agent/testdata/outputs/anthropic_agent.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/anthropic_agent.json
@@ -22,7 +22,11 @@
     "description": "",
     "instruction": "You are Claude, an AI assistant created by Anthropic.",
     "model": {
+      "max_tokens": 4096,
       "model": "claude-3-sonnet-20240229",
+      "temperature": 0.3,
+      "top_k": 40,
+      "top_p": 0.9,
       "type": "anthropic"
     },
     "stream": false
@@ -54,7 +58,7 @@
       },
       "stringData": {
         "agent-card.json": "{\"name\":\"anthropic_agent\",\"description\":\"\",\"url\":\"http://anthropic-agent.test:8080\",\"version\":\"\",\"capabilities\":{\"streaming\":true,\"pushNotifications\":false,\"stateTransitionHistory\":true},\"defaultInputModes\":[\"text\"],\"defaultOutputModes\":[\"text\"],\"skills\":[],\"preferredTransport\":\"JSONRPC\"}",
-        "config.json": "{\"model\":{\"type\":\"anthropic\",\"model\":\"claude-3-sonnet-20240229\"},\"description\":\"\",\"instruction\":\"You are Claude, an AI assistant created by Anthropic.\",\"stream\":false}"
+        "config.json": "{\"model\":{\"type\":\"anthropic\",\"model\":\"claude-3-sonnet-20240229\",\"max_tokens\":4096,\"temperature\":0.3,\"top_p\":0.9,\"top_k\":40},\"description\":\"\",\"instruction\":\"You are Claude, an AI assistant created by Anthropic.\",\"stream\":false}"
       }
     },
     {
@@ -123,7 +127,7 @@
         "template": {
           "metadata": {
             "annotations": {
-              "kagent.dev/config-hash": "12361184581110359614"
+              "kagent.dev/config-hash": "11498376381486429584"
             },
             "labels": {
               "app": "kagent",


### PR DESCRIPTION
MaxTokens, Temperature, TopP, and TopK were defined in AnthropicConfig but never copied to the adk.Anthropic struct during translation, so they had no effect at runtime.

This applies them the same way OpenAI does in the same function.