### PR TITLE
fix(agentharness): fallback to conditions when AgentHarness phase=UNSPECIFIED

### DIFF
--- a/go/core/pkg/sandboxbackend/openshell/translate.go
+++ b/go/core/pkg/sandboxbackend/openshell/translate.go
@@ -78,6 +78,14 @@ func phaseToCondition(sb *openshellv1.Sandbox) (metav1.ConditionStatus, string, 
 	case openshellv1.SandboxPhase_SANDBOX_PHASE_DELETING:
 		return metav1.ConditionFalse, "SandboxDeleting", msg
 	case openshellv1.SandboxPhase_SANDBOX_PHASE_UNKNOWN, openshellv1.SandboxPhase_SANDBOX_PHASE_UNSPECIFIED:
+		// Gateway may omit the phase field (NVIDIA/OpenShell#1710).
+		// Fall back to status.conditions so an older gateway does not
+		// permanently block AgentHarness readiness.
+		for _, c := range sb.GetStatus().GetConditions() {
+			if c.GetType() == "Ready" && c.GetStatus() == "True" {
+				return metav1.ConditionTrue, "SandboxReady", msg
+			}
+		}
 		return metav1.ConditionUnknown, "SandboxPhaseUnknown", msg
 	default:
 		return metav1.ConditionUnknown, "SandboxPhaseUnrecognized", fmt.Sprintf("unrecognized phase %s", sb.GetPhase())


### PR DESCRIPTION
Fixes #1958

## Problem

When the openclaw backend returns `phase=UNSPECIFIED` for a sandbox, the `AgentHarness` controller never surfaces `Ready=True` — the harness is stuck indefinitely even though the sandbox is healthy.

## Root Cause

`translate.go` maps the OpenShell `phase` field directly to the `AgentHarness` ready state. When openclaw reports `phase=UNSPECIFIED` (which it does in some versions), there is no fallback — the controller sees no usable phase and never marks the harness ready.

## Fix

Add a fallback in `translate.go`: if `phase=UNSPECIFIED`, check `status.conditions` for a `Ready=True` condition and use that to determine readiness instead.

```go
// Before: phase=UNSPECIFIED → never ready
// After:  phase=UNSPECIFIED → fall back to status.conditions[Ready=True]
```

## Testing

Validated on a local kind cluster — `AgentHarness` reaches `Ready=True` with this fix applied against an openclaw backend that reports `phase=UNSPECIFIED`.