### PR TITLE
docs(api): add field descriptions for BYO agent spec

### DIFF
--- a/go/api/config/crd/bases/kagent.dev_agents.yaml
+++ b/go/api/config/crd/bases/kagent.dev_agents.yaml
@@ -2465,9 +2465,15 @@ spec:
                 - message: selector must be specified when from is Selector
                   rule: '!(self.from == ''Selector'' && !has(self.selector))'
               byo:
+                description: |-
+                  BYO configures a "bring your own" agent backed by a user-provided
+                  container image. Kagent deploys the image and expects it to serve the
+                  agent over the A2A protocol on port 8080.
+                  Required if type is BYO.
                 properties:
                   deployment:
-                    description: Trust relationship to the agent.
+                    description: Deployment configures the Kubernetes Deployment created
+                      for the BYO agent container.
                     properties:
                       affinity:
                         description: Affinity is a group of affinity scheduling rules.
@@ -3396,14 +3402,22 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
+                        description: Annotations are additional annotations added
+                          to the agent pods.
                         type: object
                       args:
+                        description: Args are the arguments passed to the container
+                          entrypoint.
                         items:
                           type: string
                         type: array
                       cmd:
+                        description: Cmd overrides the container entrypoint (the container's
+                          command).
                         type: string
                       env:
+                        description: Env are additional environment variables set
+                          on the agent container.
                         items:
                           description: EnvVar represents an environment variable present
                             in a Container.
@@ -5100,6 +5114,9 @@ spec:
                           type: object
                         type: array
                       image:
+                        description: |-
+                          Image is the container image of the BYO agent.
+                          The image is expected to serve the agent over the A2A protocol on port 8080.
                         minLength: 1
                         type: string
                       imagePullPolicy:
@@ -5107,6 +5124,9 @@ spec:
                           pull a container image
                         type: string
                       imagePullSecrets:
+                        description: |-
+                          ImagePullSecrets are references to secrets in the agent's namespace
+                          used for pulling the agent container image.
                         items:
                           description: |-
                             LocalObjectReference contains enough information to let you locate the
@@ -5127,10 +5147,14 @@ spec:
                       labels:
                         additionalProperties:
                           type: string
+                        description: Labels are additional labels added to the agent
+                          pods.
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
+                        description: NodeSelector restricts the nodes the agent pods
+                          can be scheduled on.
                         type: object
                       podSecurityContext:
                         description: |-
@@ -5369,6 +5393,8 @@ spec:
                             type: object
                         type: object
                       replicas:
+                        description: Replicas is the number of desired agent pods.
+                          Defaults to 1.
                         format: int32
                         type: integer
                       resources:
@@ -5635,10 +5661,14 @@ spec:
                           annotations:
                             additionalProperties:
                               type: string
+                            description: Annotations are additional annotations added
+                              to the created ServiceAccount.
                             type: object
                           labels:
                             additionalProperties:
                               type: string
+                            description: Labels are additional labels added to the
+                              created ServiceAccount.
                             type: object
                         type: object
                       serviceAccountName:
@@ -5648,6 +5678,7 @@ spec:
                           This field is mutually exclusive with ServiceAccountConfig.
                         type: string
                       tolerations:
+                        description: Tolerations applied to the agent pods.
                         items:
                           description: |-
                             The pod this Toleration is attached to tolerates any taint that matches
@@ -5687,6 +5718,8 @@ spec:
                           type: object
                         type: array
                       volumeMounts:
+                        description: VolumeMounts are additional volume mounts added
+                          to the agent container.
                         items:
                           description: VolumeMount describes a mounting of a Volume
                             within a container.
@@ -5750,6 +5783,8 @@ spec:
                           type: object
                         type: array
                       volumes:
+                        description: Volumes are additional volumes added to the agent
+                          pod.
                         items:
                           description: Volume represents a named volume in a pod that
                             may be accessed by any container in the pod.
@@ -7673,6 +7708,10 @@ spec:
                       rule: '!(has(self.serviceAccountName) && has(self.serviceAccountConfig))'
                 type: object
               declarative:
+                description: |-
+                  Declarative configures an agent that is fully described by this resource
+                  (model, instructions, tools) and runs on one of kagent's built-in runtimes.
+                  Required if type is Declarative.
                 properties:
                   a2aConfig:
                     description: |-
@@ -8713,8 +8752,12 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
+                        description: Annotations are additional annotations added
+                          to the agent pods.
                         type: object
                       env:
+                        description: Env are additional environment variables set
+                          on the agent container.
                         items:
                           description: EnvVar represents an environment variable present
                             in a Container.
@@ -10415,6 +10458,9 @@ spec:
                           pull a container image
                         type: string
                       imagePullSecrets:
+                        description: |-
+                          ImagePullSecrets are references to secrets in the agent's namespace
+                          used for pulling the agent container image.
                         items:
                           description: |-
                             LocalObjectReference contains enough information to let you locate the
@@ -10437,10 +10483,14 @@ spec:
                       labels:
                         additionalProperties:
                           type: string
+                        description: Labels are additional labels added to the agent
+                          pods.
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
+                        description: NodeSelector restricts the nodes the agent pods
+                          can be scheduled on.
                         type: object
                       podSecurityContext:
                         description: |-
@@ -10679,6 +10729,8 @@ spec:
                             type: object
                         type: object
                       replicas:
+                        description: Replicas is the number of desired agent pods.
+                          Defaults to 1.
                         format: int32
                         type: integer
                       resources:
@@ -10945,10 +10997,14 @@ spec:
                           annotations:
                             additionalProperties:
                               type: string
+                            description: Annotations are additional annotations added
+                              to the created ServiceAccount.
                             type: object
                           labels:
                             additionalProperties:
                               type: string
+                            description: Labels are additional labels added to the
+                              created ServiceAccount.
                             type: object
                         type: object
                       serviceAccountName:
@@ -10958,6 +11014,7 @@ spec:
                           This field is mutually exclusive with ServiceAccountConfig.
                         type: string
                       tolerations:
+                        description: Tolerations applied to the agent pods.
                         items:
                           description: |-
                             The pod this Toleration is attached to tolerates any taint that matches
@@ -10997,6 +11054,8 @@ spec:
                           type: object
                         type: array
                       volumeMounts:
+                        description: VolumeMounts are additional volume mounts added
+                          to the agent container.
                         items:
                           description: VolumeMount describes a mounting of a Volume
                             within a container.
@@ -11060,6 +11119,8 @@ spec:
                           type: object
                         type: array
                       volumes:
+                        description: Volumes are additional volumes added to the agent
+                          pod.
                         items:
                           description: Volume represents a named volume in a pod that
                             may be accessed by any container in the pod.

--- a/go/api/config/crd/bases/kagent.dev_sandboxagents.yaml
+++ b/go/api/config/crd/bases/kagent.dev_sandboxagents.yaml
@@ -123,9 +123,15 @@ spec:
                 - message: selector must be specified when from is Selector
                   rule: '!(self.from == ''Selector'' && !has(self.selector))'
               byo:
+                description: |-
+                  BYO configures a "bring your own" agent backed by a user-provided
+                  container image. Kagent deploys the image and expects it to serve the
+                  agent over the A2A protocol on port 8080.
+                  Required if type is BYO.
                 properties:
                   deployment:
-                    description: Trust relationship to the agent.
+                    description: Deployment configures the Kubernetes Deployment created
+                      for the BYO agent container.
                     properties:
                       affinity:
                         description: Affinity is a group of affinity scheduling rules.
@@ -1054,14 +1060,22 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
+                        description: Annotations are additional annotations added
+                          to the agent pods.
                         type: object
                       args:
+                        description: Args are the arguments passed to the container
+                          entrypoint.
                         items:
                           type: string
                         type: array
                       cmd:
+                        description: Cmd overrides the container entrypoint (the container's
+                          command).
                         type: string
                       env:
+                        description: Env are additional environment variables set
+                          on the agent container.
                         items:
                           description: EnvVar represents an environment variable present
                             in a Container.
@@ -2758,6 +2772,9 @@ spec:
                           type: object
                         type: array
                       image:
+                        description: |-
+                          Image is the container image of the BYO agent.
+                          The image is expected to serve the agent over the A2A protocol on port 8080.
                         minLength: 1
                         type: string
                       imagePullPolicy:
@@ -2765,6 +2782,9 @@ spec:
                           pull a container image
                         type: string
                       imagePullSecrets:
+                        description: |-
+                          ImagePullSecrets are references to secrets in the agent's namespace
+                          used for pulling the agent container image.
                         items:
                           description: |-
                             LocalObjectReference contains enough information to let you locate the
@@ -2785,10 +2805,14 @@ spec:
                       labels:
                         additionalProperties:
                           type: string
+                        description: Labels are additional labels added to the agent
+                          pods.
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
+                        description: NodeSelector restricts the nodes the agent pods
+                          can be scheduled on.
                         type: object
                       podSecurityContext:
                         description: |-
@@ -3027,6 +3051,8 @@ spec:
                             type: object
                         type: object
                       replicas:
+                        description: Replicas is the number of desired agent pods.
+                          Defaults to 1.
                         format: int32
                         type: integer
                       resources:
@@ -3293,10 +3319,14 @@ spec:
                           annotations:
                             additionalProperties:
                               type: string
+                            description: Annotations are additional annotations added
+                              to the created ServiceAccount.
                             type: object
                           labels:
                             additionalProperties:
                               type: string
+                            description: Labels are additional labels added to the
+                              created ServiceAccount.
                             type: object
                         type: object
                       serviceAccountName:
@@ -3306,6 +3336,7 @@ spec:
                           This field is mutually exclusive with ServiceAccountConfig.
                         type: string
                       tolerations:
+                        description: Tolerations applied to the agent pods.
                         items:
                           description: |-
                             The pod this Toleration is attached to tolerates any taint that matches
@@ -3345,6 +3376,8 @@ spec:
                           type: object
                         type: array
                       volumeMounts:
+                        description: VolumeMounts are additional volume mounts added
+                          to the agent container.
                         items:
                           description: VolumeMount describes a mounting of a Volume
                             within a container.
@@ -3408,6 +3441,8 @@ spec:
                           type: object
                         type: array
                       volumes:
+                        description: Volumes are additional volumes added to the agent
+                          pod.
                         items:
                           description: Volume represents a named volume in a pod that
                             may be accessed by any container in the pod.
@@ -5331,6 +5366,10 @@ spec:
                       rule: '!(has(self.serviceAccountName) && has(self.serviceAccountConfig))'
                 type: object
               declarative:
+                description: |-
+                  Declarative configures an agent that is fully described by this resource
+                  (model, instructions, tools) and runs on one of kagent's built-in runtimes.
+                  Required if type is Declarative.
                 properties:
                   a2aConfig:
                     description: |-
@@ -6371,8 +6410,12 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
+                        description: Annotations are additional annotations added
+                          to the agent pods.
                         type: object
                       env:
+                        description: Env are additional environment variables set
+                          on the agent container.
                         items:
                           description: EnvVar represents an environment variable present
                             in a Container.
@@ -8073,6 +8116,9 @@ spec:
                           pull a container image
                         type: string
                       imagePullSecrets:
+                        description: |-
+                          ImagePullSecrets are references to secrets in the agent's namespace
+                          used for pulling the agent container image.
                         items:
                           description: |-
                             LocalObjectReference contains enough information to let you locate the
@@ -8095,10 +8141,14 @@ spec:
                       labels:
                         additionalProperties:
                           type: string
+                        description: Labels are additional labels added to the agent
+                          pods.
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
+                        description: NodeSelector restricts the nodes the agent pods
+                          can be scheduled on.
                         type: object
                       podSecurityContext:
                         description: |-
@@ -8337,6 +8387,8 @@ spec:
                             type: object
                         type: object
                       replicas:
+                        description: Replicas is the number of desired agent pods.
+                          Defaults to 1.
                         format: int32
                         type: integer
                       resources:
@@ -8603,10 +8655,14 @@ spec:
                           annotations:
                             additionalProperties:
                               type: string
+                            description: Annotations are additional annotations added
+                              to the created ServiceAccount.
                             type: object
                           labels:
                             additionalProperties:
                               type: string
+                            description: Labels are additional labels added to the
+                              created ServiceAccount.
                             type: object
                         type: object
                       serviceAccountName:
@@ -8616,6 +8672,7 @@ spec:
                           This field is mutually exclusive with ServiceAccountConfig.
                         type: string
                       tolerations:
+                        description: Tolerations applied to the agent pods.
                         items:
                           description: |-
                             The pod this Toleration is attached to tolerates any taint that matches
@@ -8655,6 +8712,8 @@ spec:
                           type: object
                         type: array
                       volumeMounts:
+                        description: VolumeMounts are additional volume mounts added
+                          to the agent container.
                         items:
                           description: VolumeMount describes a mounting of a Volume
                             within a container.
@@ -8718,6 +8777,8 @@ spec:
                           type: object
                         type: array
                       volumes:
+                        description: Volumes are additional volumes added to the agent
+                          pod.
                         items:
                           description: Volume represents a named volume in a pod that
                             may be accessed by any container in the pod.

--- a/go/api/v1alpha2/agent_types.go
+++ b/go/api/v1alpha2/agent_types.go
@@ -57,8 +57,15 @@ type AgentSpec struct {
 	// +optional
 	Type AgentType `json:"type,omitempty"`
 
+	// BYO configures a "bring your own" agent backed by a user-provided
+	// container image. Kagent deploys the image and expects it to serve the
+	// agent over the A2A protocol on port 8080.
+	// Required if type is BYO.
 	// +optional
 	BYO *BYOAgentSpec `json:"byo,omitempty"`
+	// Declarative configures an agent that is fully described by this resource
+	// (model, instructions, tools) and runs on one of kagent's built-in runtimes.
+	// Required if type is Declarative.
 	// +optional
 	Declarative *DeclarativeAgentSpec `json:"declarative,omitempty"`
 
@@ -334,17 +341,21 @@ type DeclarativeDeploymentSpec struct {
 }
 
 type BYOAgentSpec struct {
-	// Trust relationship to the agent.
+	// Deployment configures the Kubernetes Deployment created for the BYO agent container.
 	// +optional
 	Deployment *ByoDeploymentSpec `json:"deployment,omitempty"`
 }
 
 type ByoDeploymentSpec struct {
+	// Image is the container image of the BYO agent.
+	// The image is expected to serve the agent over the A2A protocol on port 8080.
 	// +kubebuilder:validation:MinLength=1
 	// +optional
 	Image string `json:"image,omitempty"`
+	// Cmd overrides the container entrypoint (the container's command).
 	// +optional
 	Cmd *string `json:"cmd,omitempty"`
+	// Args are the arguments passed to the container entrypoint.
 	// +optional
 	Args []string `json:"args,omitempty"`
 
@@ -353,28 +364,38 @@ type ByoDeploymentSpec struct {
 
 // +kubebuilder:validation:XValidation:message="serviceAccountName and serviceAccountConfig are mutually exclusive",rule="!(has(self.serviceAccountName) && has(self.serviceAccountConfig))"
 type SharedDeploymentSpec struct {
+	// Replicas is the number of desired agent pods. Defaults to 1.
 	// +optional
 	Replicas *int32 `json:"replicas,omitempty"`
+	// ImagePullSecrets are references to secrets in the agent's namespace
+	// used for pulling the agent container image.
 	// +optional
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
+	// Volumes are additional volumes added to the agent pod.
 	// +optional
 	Volumes []corev1.Volume `json:"volumes,omitempty"`
+	// VolumeMounts are additional volume mounts added to the agent container.
 	// +optional
 	VolumeMounts []corev1.VolumeMount `json:"volumeMounts,omitempty"`
+	// Labels are additional labels added to the agent pods.
 	// +optional
 	Labels map[string]string `json:"labels,omitempty"`
+	// Annotations are additional annotations added to the agent pods.
 	// +optional
 	Annotations map[string]string `json:"annotations,omitempty"`
+	// Env are additional environment variables set on the agent container.
 	// +optional
 	Env []corev1.EnvVar `json:"env,omitempty"`
 	// +optional
 	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 	// +optional
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
+	// Tolerations applied to the agent pods.
 	// +optional
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 	// +optional
 	Affinity *corev1.Affinity `json:"affinity,omitempty"`
+	// NodeSelector restricts the nodes the agent pods can be scheduled on.
 	// +optional
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 	// +optional
@@ -399,8 +420,10 @@ type SharedDeploymentSpec struct {
 }
 
 type ServiceAccountConfig struct {
+	// Labels are additional labels added to the created ServiceAccount.
 	// +optional
 	Labels map[string]string `json:"labels,omitempty"`
+	// Annotations are additional annotations added to the created ServiceAccount.
 	// +optional
 	Annotations map[string]string `json:"annotations,omitempty"`
 }

--- a/helm/kagent-crds/templates/kagent.dev_agents.yaml
+++ b/helm/kagent-crds/templates/kagent.dev_agents.yaml
@@ -2465,9 +2465,15 @@ spec:
                 - message: selector must be specified when from is Selector
                   rule: '!(self.from == ''Selector'' && !has(self.selector))'
               byo:
+                description: |-
+                  BYO configures a "bring your own" agent backed by a user-provided
+                  container image. Kagent deploys the image and expects it to serve the
+                  agent over the A2A protocol on port 8080.
+                  Required if type is BYO.
                 properties:
                   deployment:
-                    description: Trust relationship to the agent.
+                    description: Deployment configures the Kubernetes Deployment created
+                      for the BYO agent container.
                     properties:
                       affinity:
                         description: Affinity is a group of affinity scheduling rules.
@@ -3396,14 +3402,22 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
+                        description: Annotations are additional annotations added
+                          to the agent pods.
                         type: object
                       args:
+                        description: Args are the arguments passed to the container
+                          entrypoint.
                         items:
                           type: string
                         type: array
                       cmd:
+                        description: Cmd overrides the container entrypoint (the container's
+                          command).
                         type: string
                       env:
+                        description: Env are additional environment variables set
+                          on the agent container.
                         items:
                           description: EnvVar represents an environment variable present
                             in a Container.
@@ -5100,6 +5114,9 @@ spec:
                           type: object
                         type: array
                       image:
+                        description: |-
+                          Image is the container image of the BYO agent.
+                          The image is expected to serve the agent over the A2A protocol on port 8080.
                         minLength: 1
                         type: string
                       imagePullPolicy:
@@ -5107,6 +5124,9 @@ spec:
                           pull a container image
                         type: string
                       imagePullSecrets:
+                        description: |-
+                          ImagePullSecrets are references to secrets in the agent's namespace
+                          used for pulling the agent container image.
                         items:
                           description: |-
                             LocalObjectReference contains enough information to let you locate the
@@ -5127,10 +5147,14 @@ spec:
                       labels:
                         additionalProperties:
                           type: string
+                        description: Labels are additional labels added to the agent
+                          pods.
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
+                        description: NodeSelector restricts the nodes the agent pods
+                          can be scheduled on.
                         type: object
                       podSecurityContext:
                         description: |-
@@ -5369,6 +5393,8 @@ spec:
                             type: object
                         type: object
                       replicas:
+                        description: Replicas is the number of desired agent pods.
+                          Defaults to 1.
                         format: int32
                         type: integer
                       resources:
@@ -5635,10 +5661,14 @@ spec:
                           annotations:
                             additionalProperties:
                               type: string
+                            description: Annotations are additional annotations added
+                              to the created ServiceAccount.
                             type: object
                           labels:
                             additionalProperties:
                               type: string
+                            description: Labels are additional labels added to the
+                              created ServiceAccount.
                             type: object
                         type: object
                       serviceAccountName:
@@ -5648,6 +5678,7 @@ spec:
                           This field is mutually exclusive with ServiceAccountConfig.
                         type: string
                       tolerations:
+                        description: Tolerations applied to the agent pods.
                         items:
                           description: |-
                             The pod this Toleration is attached to tolerates any taint that matches
@@ -5687,6 +5718,8 @@ spec:
                           type: object
                         type: array
                       volumeMounts:
+                        description: VolumeMounts are additional volume mounts added
+                          to the agent container.
                         items:
                           description: VolumeMount describes a mounting of a Volume
                             within a container.
@@ -5750,6 +5783,8 @@ spec:
                           type: object
                         type: array
                       volumes:
+                        description: Volumes are additional volumes added to the agent
+                          pod.
                         items:
                           description: Volume represents a named volume in a pod that
                             may be accessed by any container in the pod.
@@ -7673,6 +7708,10 @@ spec:
                       rule: '!(has(self.serviceAccountName) && has(self.serviceAccountConfig))'
                 type: object
               declarative:
+                description: |-
+                  Declarative configures an agent that is fully described by this resource
+                  (model, instructions, tools) and runs on one of kagent's built-in runtimes.
+                  Required if type is Declarative.
                 properties:
                   a2aConfig:
                     description: |-
@@ -8713,8 +8752,12 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
+                        description: Annotations are additional annotations added
+                          to the agent pods.
                         type: object
                       env:
+                        description: Env are additional environment variables set
+                          on the agent container.
                         items:
                           description: EnvVar represents an environment variable present
                             in a Container.
@@ -10415,6 +10458,9 @@ spec:
                           pull a container image
                         type: string
                       imagePullSecrets:
+                        description: |-
+                          ImagePullSecrets are references to secrets in the agent's namespace
+                          used for pulling the agent container image.
                         items:
                           description: |-
                             LocalObjectReference contains enough information to let you locate the
@@ -10437,10 +10483,14 @@ spec:
                       labels:
                         additionalProperties:
                           type: string
+                        description: Labels are additional labels added to the agent
+                          pods.
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
+                        description: NodeSelector restricts the nodes the agent pods
+                          can be scheduled on.
                         type: object
                       podSecurityContext:
                         description: |-
@@ -10679,6 +10729,8 @@ spec:
                             type: object
                         type: object
                       replicas:
+                        description: Replicas is the number of desired agent pods.
+                          Defaults to 1.
                         format: int32
                         type: integer
                       resources:
@@ -10945,10 +10997,14 @@ spec:
                           annotations:
                             additionalProperties:
                               type: string
+                            description: Annotations are additional annotations added
+                              to the created ServiceAccount.
                             type: object
                           labels:
                             additionalProperties:
                               type: string
+                            description: Labels are additional labels added to the
+                              created ServiceAccount.
                             type: object
                         type: object
                       serviceAccountName:
@@ -10958,6 +11014,7 @@ spec:
                           This field is mutually exclusive with ServiceAccountConfig.
                         type: string
                       tolerations:
+                        description: Tolerations applied to the agent pods.
                         items:
                           description: |-
                             The pod this Toleration is attached to tolerates any taint that matches
@@ -10997,6 +11054,8 @@ spec:
                           type: object
                         type: array
                       volumeMounts:
+                        description: VolumeMounts are additional volume mounts added
+                          to the agent container.
                         items:
                           description: VolumeMount describes a mounting of a Volume
                             within a container.
@@ -11060,6 +11119,8 @@ spec:
                           type: object
                         type: array
                       volumes:
+                        description: Volumes are additional volumes added to the agent
+                          pod.
                         items:
                           description: Volume represents a named volume in a pod that
                             may be accessed by any container in the pod.

--- a/helm/kagent-crds/templates/kagent.dev_sandboxagents.yaml
+++ b/helm/kagent-crds/templates/kagent.dev_sandboxagents.yaml
@@ -123,9 +123,15 @@ spec:
                 - message: selector must be specified when from is Selector
                   rule: '!(self.from == ''Selector'' && !has(self.selector))'
               byo:
+                description: |-
+                  BYO configures a "bring your own" agent backed by a user-provided
+                  container image. Kagent deploys the image and expects it to serve the
+                  agent over the A2A protocol on port 8080.
+                  Required if type is BYO.
                 properties:
                   deployment:
-                    description: Trust relationship to the agent.
+                    description: Deployment configures the Kubernetes Deployment created
+                      for the BYO agent container.
                     properties:
                       affinity:
                         description: Affinity is a group of affinity scheduling rules.
@@ -1054,14 +1060,22 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
+                        description: Annotations are additional annotations added
+                          to the agent pods.
                         type: object
                       args:
+                        description: Args are the arguments passed to the container
+                          entrypoint.
                         items:
                           type: string
                         type: array
                       cmd:
+                        description: Cmd overrides the container entrypoint (the container's
+                          command).
                         type: string
                       env:
+                        description: Env are additional environment variables set
+                          on the agent container.
                         items:
                           description: EnvVar represents an environment variable present
                             in a Container.
@@ -2758,6 +2772,9 @@ spec:
                           type: object
                         type: array
                       image:
+                        description: |-
+                          Image is the container image of the BYO agent.
+                          The image is expected to serve the agent over the A2A protocol on port 8080.
                         minLength: 1
                         type: string
                       imagePullPolicy:
@@ -2765,6 +2782,9 @@ spec:
                           pull a container image
                         type: string
                       imagePullSecrets:
+                        description: |-
+                          ImagePullSecrets are references to secrets in the agent's namespace
+                          used for pulling the agent container image.
                         items:
                           description: |-
                             LocalObjectReference contains enough information to let you locate the
@@ -2785,10 +2805,14 @@ spec:
                       labels:
                         additionalProperties:
                           type: string
+                        description: Labels are additional labels added to the agent
+                          pods.
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
+                        description: NodeSelector restricts the nodes the agent pods
+                          can be scheduled on.
                         type: object
                       podSecurityContext:
                         description: |-
@@ -3027,6 +3051,8 @@ spec:
                             type: object
                         type: object
                       replicas:
+                        description: Replicas is the number of desired agent pods.
+                          Defaults to 1.
                         format: int32
                         type: integer
                       resources:
@@ -3293,10 +3319,14 @@ spec:
                           annotations:
                             additionalProperties:
                               type: string
+                            description: Annotations are additional annotations added
+                              to the created ServiceAccount.
                             type: object
                           labels:
                             additionalProperties:
                               type: string
+                            description: Labels are additional labels added to the
+                              created ServiceAccount.
                             type: object
                         type: object
                       serviceAccountName:
@@ -3306,6 +3336,7 @@ spec:
                           This field is mutually exclusive with ServiceAccountConfig.
                         type: string
                       tolerations:
+                        description: Tolerations applied to the agent pods.
                         items:
                           description: |-
                             The pod this Toleration is attached to tolerates any taint that matches
@@ -3345,6 +3376,8 @@ spec:
                           type: object
                         type: array
                       volumeMounts:
+                        description: VolumeMounts are additional volume mounts added
+                          to the agent container.
                         items:
                           description: VolumeMount describes a mounting of a Volume
                             within a container.
@@ -3408,6 +3441,8 @@ spec:
                           type: object
                         type: array
                       volumes:
+                        description: Volumes are additional volumes added to the agent
+                          pod.
                         items:
                           description: Volume represents a named volume in a pod that
                             may be accessed by any container in the pod.
@@ -5331,6 +5366,10 @@ spec:
                       rule: '!(has(self.serviceAccountName) && has(self.serviceAccountConfig))'
                 type: object
               declarative:
+                description: |-
+                  Declarative configures an agent that is fully described by this resource
+                  (model, instructions, tools) and runs on one of kagent's built-in runtimes.
+                  Required if type is Declarative.
                 properties:
                   a2aConfig:
                     description: |-
@@ -6371,8 +6410,12 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
+                        description: Annotations are additional annotations added
+                          to the agent pods.
                         type: object
                       env:
+                        description: Env are additional environment variables set
+                          on the agent container.
                         items:
                           description: EnvVar represents an environment variable present
                             in a Container.
@@ -8073,6 +8116,9 @@ spec:
                           pull a container image
                         type: string
                       imagePullSecrets:
+                        description: |-
+                          ImagePullSecrets are references to secrets in the agent's namespace
+                          used for pulling the agent container image.
                         items:
                           description: |-
                             LocalObjectReference contains enough information to let you locate the
@@ -8095,10 +8141,14 @@ spec:
                       labels:
                         additionalProperties:
                           type: string
+                        description: Labels are additional labels added to the agent
+                          pods.
                         type: object
                       nodeSelector:
                         additionalProperties:
                           type: string
+                        description: NodeSelector restricts the nodes the agent pods
+                          can be scheduled on.
                         type: object
                       podSecurityContext:
                         description: |-
@@ -8337,6 +8387,8 @@ spec:
                             type: object
                         type: object
                       replicas:
+                        description: Replicas is the number of desired agent pods.
+                          Defaults to 1.
                         format: int32
                         type: integer
                       resources:
@@ -8603,10 +8655,14 @@ spec:
                           annotations:
                             additionalProperties:
                               type: string
+                            description: Annotations are additional annotations added
+                              to the created ServiceAccount.
                             type: object
                           labels:
                             additionalProperties:
                               type: string
+                            description: Labels are additional labels added to the
+                              created ServiceAccount.
                             type: object
                         type: object
                       serviceAccountName:
@@ -8616,6 +8672,7 @@ spec:
                           This field is mutually exclusive with ServiceAccountConfig.
                         type: string
                       tolerations:
+                        description: Tolerations applied to the agent pods.
                         items:
                           description: |-
                             The pod this Toleration is attached to tolerates any taint that matches
@@ -8655,6 +8712,8 @@ spec:
                           type: object
                         type: array
                       volumeMounts:
+                        description: VolumeMounts are additional volume mounts added
+                          to the agent container.
                         items:
                           description: VolumeMount describes a mounting of a Volume
                             within a container.
@@ -8718,6 +8777,8 @@ spec:
                           type: object
                         type: array
                       volumes:
+                        description: Volumes are additional volumes added to the agent
+                          pod.
                         items:
                           description: Volume represents a named volume in a pod that
                             may be accessed by any container in the pod.


### PR DESCRIPTION
This PR adds doc comments in `go/api/v1alpha2/agent_types.go` and regenerates the CRD manifests (`make controller-manifests`):

- `AgentSpec.BYO` / `AgentSpec.Declarative` — describe the two agent types; for BYO, state the convention that the image must serve the agent over A2A on port 8080 (verified in `resolveByoDeployment`, this was previously documented nowhere in the CRD)
- `BYOAgentSpec.Deployment` — replace the "Trust relationship to the agent." comment, which didn't seemto belong there.
- `ByoDeploymentSpec` — `image`, `cmd`, `args`
- `SharedDeploymentSpec` — `replicas`, `imagePullSecrets`, `volumes`, `volumeMounts`, `labels`, `annotations`, `env`, `tolerations`, `nodeSelector`
- `ServiceAccountConfig` — `labels`, `annotations`

Since `SharedDeploymentSpec` is embedded in `DeclarativeDeploymentSpec` as well, the same comments also fill the identical gaps under `spec.declarative.deployment.*`, and the SandboxAgent CRD picks them up too.
