### PR TITLE
feat(api): add workingDir to BYO agent deployment spec

### DIFF
--- a/go/api/config/crd/bases/kagent.dev_agents.yaml
+++ b/go/api/config/crd/bases/kagent.dev_agents.yaml
@@ -7701,6 +7701,10 @@ spec:
                           - name
                           type: object
                         type: array
+                      workingDir:
+                        description: workingDir sets the container working directory.
+                          Defaults to the image WORKDIR when omitted.
+                        type: string
                     type: object
                     x-kubernetes-validations:
                     - message: serviceAccountName and serviceAccountConfig are mutually

--- a/go/api/config/crd/bases/kagent.dev_sandboxagents.yaml
+++ b/go/api/config/crd/bases/kagent.dev_sandboxagents.yaml
@@ -5359,6 +5359,10 @@ spec:
                           - name
                           type: object
                         type: array
+                      workingDir:
+                        description: workingDir sets the container working directory.
+                          Defaults to the image WORKDIR when omitted.
+                        type: string
                     type: object
                     x-kubernetes-validations:
                     - message: serviceAccountName and serviceAccountConfig are mutually

--- a/go/api/v1alpha2/agent_types.go
+++ b/go/api/v1alpha2/agent_types.go
@@ -358,6 +358,9 @@ type ByoDeploymentSpec struct {
 	// Args are the arguments passed to the container entrypoint.
 	// +optional
 	Args []string `json:"args,omitempty"`
+	// workingDir sets the container working directory. Defaults to the image WORKDIR when omitted.
+	// +optional
+	WorkingDir *string `json:"workingDir,omitempty"`
 
 	SharedDeploymentSpec `json:",inline"`
 }

--- a/go/api/v1alpha2/zz_generated.deepcopy.go
+++ b/go/api/v1alpha2/zz_generated.deepcopy.go
@@ -727,6 +727,11 @@ func (in *ByoDeploymentSpec) DeepCopyInto(out *ByoDeploymentSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.WorkingDir != nil {
+		in, out := &in.WorkingDir, &out.WorkingDir
+		*out = new(string)
+		**out = **in
+	}
 	in.SharedDeploymentSpec.DeepCopyInto(&out.SharedDeploymentSpec)
 }
 

--- a/go/core/internal/controller/translator/agent/deployments.go
+++ b/go/core/internal/controller/translator/agent/deployments.go
@@ -27,6 +27,7 @@ type resolvedDeployment struct {
 	Image           string
 	Cmd             string // empty → no explicit command
 	Args            []string
+	WorkingDir      *string
 	Port            int32 // container port and Service port
 	ImagePullPolicy corev1.PullPolicy
 
@@ -268,6 +269,7 @@ func resolveByoDeployment(agent v1alpha2.AgentObject) (*resolvedDeployment, erro
 		Image:                image,
 		Cmd:                  cmd,
 		Args:                 args,
+		WorkingDir:           spec.WorkingDir,
 		Port:                 port,
 		ImagePullPolicy:      imagePullPolicy,
 		Replicas:             replicas,

--- a/go/core/internal/controller/translator/agent/manifest_builder.go
+++ b/go/core/internal/controller/translator/agent/manifest_builder.go
@@ -492,6 +492,11 @@ func buildPodTemplate(
 		cmd = []string{dep.Cmd}
 	}
 
+	var workingDir string
+	if dep.WorkingDir != nil {
+		workingDir = *dep.WorkingDir
+	}
+
 	return corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:      manifestCtx.podLabels(),
@@ -508,6 +513,7 @@ func buildPodTemplate(
 				ImagePullPolicy: dep.ImagePullPolicy,
 				Command:         cmd,
 				Args:            dep.Args,
+				WorkingDir:      workingDir,
 				Ports:           []corev1.ContainerPort{{Name: "http", ContainerPort: dep.Port}},
 				Resources:       dep.Resources,
 				Env:             runtimeInputs.envVars,

--- a/helm/kagent-crds/templates/kagent.dev_agents.yaml
+++ b/helm/kagent-crds/templates/kagent.dev_agents.yaml
@@ -7701,6 +7701,10 @@ spec:
                           - name
                           type: object
                         type: array
+                      workingDir:
+                        description: workingDir sets the container working directory.
+                          Defaults to the image WORKDIR when omitted.
+                        type: string
                     type: object
                     x-kubernetes-validations:
                     - message: serviceAccountName and serviceAccountConfig are mutually

--- a/helm/kagent-crds/templates/kagent.dev_sandboxagents.yaml
+++ b/helm/kagent-crds/templates/kagent.dev_sandboxagents.yaml
@@ -5359,6 +5359,10 @@ spec:
                           - name
                           type: object
                         type: array
+                      workingDir:
+                        description: workingDir sets the container working directory.
+                          Defaults to the image WORKDIR when omitted.
+                        type: string
                     type: object
                     x-kubernetes-validations:
                     - message: serviceAccountName and serviceAccountConfig are mutually


### PR DESCRIPTION
Closes #1932

Add `workingDir` as an optional string field on `ByoDeploymentSpec`. Maps directly to `container.workingDir` in the generated Deployment.

```yaml
spec:
  type: BYO
  byo:
    deployment:
      image: oven/bun:1.2-alpine
      workingDir: /app
```

Changes:
- `ByoDeploymentSpec.WorkingDir *string` in `agent_types.go`
- `resolvedDeployment.WorkingDir` populated in `resolveByoDeployment`
- `container.WorkingDir` set in `manifest_builder.go`
- CRD and Helm chart updated via `make generate && make manifests`