### PR TITLE
fix(controller): disable standalone SSE for STREAMABLE_HTTP remote mcp servers

### DIFF
--- a/go/core/internal/controller/reconciler/reconciler.go
+++ b/go/core/internal/controller/reconciler/reconciler.go
@@ -1127,8 +1127,9 @@ func (a *kagentReconciler) createMcpTransport(ctx context.Context, s *v1alpha2.R
 		}, nil
 	default:
 		return &mcp.StreamableClientTransport{
-			Endpoint:   endpoint,
-			HTTPClient: httpClient,
+			Endpoint:             endpoint,
+			HTTPClient:           httpClient,
+			DisableStandaloneSSE: true,
 		}, nil
 	}
 }
@@ -1187,7 +1188,11 @@ func (a *kagentReconciler) buildRemoteMCPServerTLSConfig(ctx context.Context, s 
 // so we need to create a custom HTTP client that adds headers to all
 // requests. When tlsConfig is non-nil it's installed on a cloned
 // transport so tool discovery honors RemoteMCPServer.spec.tls.
-func newHTTPClient(headers map[string]string, timeout time.Duration, tlsConfig *tls.Config) *http.Client {
+func newHTTPClient(
+	headers map[string]string,
+	timeout time.Duration,
+	tlsConfig *tls.Config,
+) *http.Client {
 	var base = http.DefaultTransport
 	if tlsConfig != nil {
 		// Clone the default transport to preserve its dial/keepalive

--- a/go/core/test/e2e/remotemcpserver_tls_test.go
+++ b/go/core/test/e2e/remotemcpserver_tls_test.go
@@ -26,6 +26,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"io"
 	"math/big"
 	"net"
 	"net/http"
@@ -542,6 +543,76 @@ func TestE2E_API_ToolServerCompanionSecrets(t *testing.T) {
 	assert.Equal(t, "RemoteMCPServer", or.Kind)
 	assert.Equal(t, rmsName, or.Name)
 	assert.Equal(t, v1alpha2.GroupVersion.Identifier(), or.APIVersion)
+}
+
+// TestE2E_RemoteMCPServer_STREAMABLE_HTTP_WITH_STANDALONE_SSE reproduces
+// github.com/kagent-dev/kagent/issues/1955: a Streamable HTTP server that
+// holds the GET (standalone SSE) channel open without responding causes the
+// reconciler's tool discovery to fail when http.Client.Timeout fires and
+// marks the connection failed before tools/list can complete.
+func TestE2E_RemoteMCPServer_STREAMABLE_HTTP_WITH_STANDALONE_SSE(t *testing.T) {
+	cli := setupK8sClient(t, false)
+	mcp := setupMockMCP(t, false, mockmcp.Options{})
+
+	// mockmcp.Start() returns the bind address (e.g. http://[::]:PORT) which
+	// is not dialable from the proxy process itself. Extract the port and
+	// forward to 127.0.0.1 so the proxy can reach mockmcp locally.
+	_, mcpPort, err := net.SplitHostPort(mcp.server.Addr().String())
+	require.NoError(t, err)
+	localMCPURL := "http://127.0.0.1:" + mcpPort + mockmcp.MCPPath
+
+	// Start a server that accepts GET but never responds — simulating a
+	// spec-compliant MCP server that holds the standalone SSE channel open
+	// without sending events. POST requests are forwarded to mockmcp so
+	// initialize/tools-list work normally.
+	ln, err := net.Listen("tcp", ":0")
+	require.NoError(t, err)
+	hangingServer := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodGet {
+				// Block without writing anything back. client.Do in connectSSE
+				// blocks here until http.Client.Timeout fires, marking the
+				// connection failed and causing tools/list to fail.
+				<-r.Context().Done()
+				return
+			}
+			proxyReq, err := http.NewRequestWithContext(r.Context(), r.Method, localMCPURL, r.Body)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadGateway)
+				return
+			}
+			proxyReq.Header = r.Header.Clone()
+			resp, err := http.DefaultTransport.RoundTrip(proxyReq)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadGateway)
+				return
+			}
+			defer resp.Body.Close()
+			for k, vs := range resp.Header {
+				for _, v := range vs {
+					w.Header().Add(k, v)
+				}
+			}
+			w.WriteHeader(resp.StatusCode)
+			io.Copy(w, resp.Body)
+		}),
+	}
+	go hangingServer.Serve(ln)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = hangingServer.Shutdown(ctx)
+	})
+
+	timeout := metav1.Duration{Duration: 5 * time.Second}
+	rms := createRMS(t, cli, v1alpha2.RemoteMCPServerSpec{
+		URL:      buildK8sURL("http://" + ln.Addr().String()),
+		Protocol: v1alpha2.RemoteMCPServerProtocolStreamableHttp,
+		Timeout:  &timeout,
+	})
+
+	assert.NotEmpty(t, rms.Status.DiscoveredTools,
+		"tool discovery must succeed even when the server holds the GET SSE channel open")
 }
 
 // recordedPaths is a small helper for assertion failure messages — turns


### PR DESCRIPTION
- Fixes issue #1955 by disabling SSE for `STREAMABLE_HTTP` remote mcp servers.  The reconciler's createMcpTransport was passing an HTTP client with Timeout: spec.timeout (default 30s) to StreamableClientTransport. After initialize completes, the SDK synchronously opens a GET request for the standalone SSE channel before returning from Connect. A spec-compliant server holds this connection open indefinitely, causing client.Do to block until http.Client.Timeout fires at which point the connection is marked failed and tools/list cannot complete. Since we currently do not implement notification handlers in the reconciler as the primary function is to perform tool discovery. disabling standalone SSE on the transport used for tool discovery fixes the issue and is safe as the SSE stream provides no value in this code path.