### PR TITLE
fix: ignore local cache directories in go docker context

### DIFF
--- a/go/.dockerignore
+++ b/go/.dockerignore
@@ -1,6 +1,8 @@
 # Build artifacts
 ./bin/
 bin/
+.cache/
+**/.cache/
 
 # Test files
 *_test.go


### PR DESCRIPTION
## Summary
- Ignore local .cache directories in the Go Docker build context
- Prevent agent/tool-created Go caches from invalidating Docker COPY layers

## Verification
- Ran `make build-controller DOCKER_BUILD_ARGS='--progress=plain --platform linux/amd64 --output type=cacheonly'` twice
- Confirmed the second run reused cached Dockerfile layers, including the Go compile step