### PR TITLE
add RemoteMCPServerPlugin reconcile-phase extension point

### DIFF
--- a/go/core/internal/controller/reconciler/mcp_server_reconciler_test.go
+++ b/go/core/internal/controller/reconciler/mcp_server_reconciler_test.go
@@ -117,6 +117,7 @@ func TestReconcileKagentMCPServer_ErrorPropagation(t *testing.T) {
 				[]string{}, // No namespace restrictions for tests
 				nil,
 				false,
+				nil,
 			)
 
 			// Call ReconcileKagentMCPServer

--- a/go/core/internal/controller/reconciler/owned_resource_types_test.go
+++ b/go/core/internal/controller/reconciler/owned_resource_types_test.go
@@ -1,0 +1,69 @@
+package reconciler
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/kagent-dev/kagent/go/api/v1alpha2"
+	agenttranslator "github.com/kagent-dev/kagent/go/core/internal/controller/translator/agent"
+	pkgtranslator "github.com/kagent-dev/kagent/go/core/pkg/translator"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// stubTranslator implements agenttranslator.AdkApiTranslator; only
+// GetOwnedResourceTypes is exercised by these tests.
+type stubTranslator struct{ owned []client.Object }
+
+func (s *stubTranslator) CompileAgent(context.Context, v1alpha2.AgentObject) (*agenttranslator.AgentManifestInputs, error) {
+	return nil, nil
+}
+
+func (s *stubTranslator) BuildManifest(context.Context, v1alpha2.AgentObject, *agenttranslator.AgentManifestInputs) (*agenttranslator.AgentOutputs, error) {
+	return nil, nil
+}
+
+func (s *stubTranslator) GetOwnedResourceTypes() []client.Object { return s.owned }
+
+// stubRMSPlugin implements pkgtranslator.RemoteMCPServerPlugin.
+type stubRMSPlugin struct{ owned []client.Object }
+
+func (s *stubRMSPlugin) ProcessRemoteMCPServer(context.Context, *v1alpha2.RemoteMCPServer, *pkgtranslator.RemoteMCPServerOutputs) error {
+	return nil
+}
+
+func (s *stubRMSPlugin) GetOwnedResourceTypes() []client.Object { return s.owned }
+
+// TestGetOwnedResourceTypes_Composition verifies that the owned types are the
+// union of the agent translator's and every registered RemoteMCPServer plugin's
+// types. Deduplication is SetupOwnerIndexes' responsibility (see
+// TestDistinctByType in the utils package), so an overlapping type may
+// legitimately appear more than once here.
+func TestGetOwnedResourceTypes_Composition(t *testing.T) {
+	// ConfigMap overlaps between the translator and the plugin; Secret is
+	// plugin-only.
+	tr := &stubTranslator{owned: []client.Object{&corev1.ConfigMap{}}}
+	plugin := &stubRMSPlugin{owned: []client.Object{&corev1.ConfigMap{}, &corev1.Secret{}}}
+
+	r := NewKagentReconciler(
+		tr,
+		nil, // kube — unused by GetOwnedResourceTypes
+		nil, // dbClient — unused
+		types.NamespacedName{},
+		nil,   // watchedNamespaces
+		nil,   // sandboxBackend
+		false, // mcpEgressPlaintext
+		[]pkgtranslator.RemoteMCPServerPlugin{plugin},
+	)
+
+	counts := map[reflect.Type]int{}
+	for _, o := range r.GetOwnedResourceTypes() {
+		counts[reflect.TypeOf(o)]++
+	}
+	assert.Contains(t, counts, reflect.TypeFor[*corev1.ConfigMap](), "translator type must be present")
+	assert.Contains(t, counts, reflect.TypeFor[*corev1.Secret](), "plugin-only type must be present")
+	assert.Equal(t, 2, counts[reflect.TypeFor[*corev1.ConfigMap]()], "overlapping type appears once per owning source")
+}

--- a/go/core/internal/controller/reconciler/owned_resource_types_test.go
+++ b/go/core/internal/controller/reconciler/owned_resource_types_test.go
@@ -9,6 +9,7 @@ import (
 	agenttranslator "github.com/kagent-dev/kagent/go/core/internal/controller/translator/agent"
 	pkgtranslator "github.com/kagent-dev/kagent/go/core/pkg/translator"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -66,4 +67,30 @@ func TestGetOwnedResourceTypes_Composition(t *testing.T) {
 	assert.Contains(t, counts, reflect.TypeFor[*corev1.ConfigMap](), "translator type must be present")
 	assert.Contains(t, counts, reflect.TypeFor[*corev1.Secret](), "plugin-only type must be present")
 	assert.Equal(t, 2, counts[reflect.TypeFor[*corev1.ConfigMap]()], "overlapping type appears once per owning source")
+}
+
+// manifestRMSPlugin appends a fixed set of objects to outputs.Manifest.
+type manifestRMSPlugin struct{ manifest []client.Object }
+
+func (p *manifestRMSPlugin) ProcessRemoteMCPServer(_ context.Context, _ *v1alpha2.RemoteMCPServer, outputs *pkgtranslator.RemoteMCPServerOutputs) error {
+	outputs.Manifest = append(outputs.Manifest, p.manifest...)
+	return nil
+}
+
+func (p *manifestRMSPlugin) GetOwnedResourceTypes() []client.Object { return nil }
+
+// TestReconcileRemoteMCPServerPlugins_NilManifestObject ensures a plugin that
+// appends a nil object fails the reconcile with a clear error instead of
+// panicking in SetControllerReference.
+func TestReconcileRemoteMCPServerPlugins_NilManifestObject(t *testing.T) {
+	r := &kagentReconciler{
+		remoteMCPServerPlugins: []pkgtranslator.RemoteMCPServerPlugin{
+			&manifestRMSPlugin{manifest: []client.Object{nil}},
+		},
+	}
+	server := &v1alpha2.RemoteMCPServer{}
+
+	err := r.reconcileRemoteMCPServerPlugins(context.Background(), server)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil object")
 }

--- a/go/core/internal/controller/reconciler/reconciler.go
+++ b/go/core/internal/controller/reconciler/reconciler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kagent-dev/kagent/go/core/internal/controller/translator"
 	"github.com/kagent-dev/kagent/go/core/pkg/egress"
 	"github.com/kagent-dev/kagent/go/core/pkg/sandboxbackend"
+	pkgtranslator "github.com/kagent-dev/kagent/go/core/pkg/translator"
 	"github.com/kagent-dev/kmcp/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -101,6 +102,11 @@ type kagentReconciler struct {
 	// uses s.Spec.URL verbatim. Mirrors the agent translator's config-phase
 	// egress rewrite.
 	mcpEgressPlaintext bool
+
+	// remoteMCPServerPlugins are reconcile-phase extensions invoked on each
+	// RemoteMCPServer reconcile. Their returned objects are owned by the RMS
+	// and reconciled (apply + prune).
+	remoteMCPServerPlugins []pkgtranslator.RemoteMCPServerPlugin
 }
 
 func NewKagentReconciler(
@@ -111,15 +117,17 @@ func NewKagentReconciler(
 	watchedNamespaces []string,
 	sandboxBackend sandboxbackend.Backend,
 	mcpEgressPlaintext bool,
+	remoteMCPServerPlugins []pkgtranslator.RemoteMCPServerPlugin,
 ) KagentReconciler {
 	return &kagentReconciler{
-		adkTranslator:      adkTranslator,
-		kube:               kube,
-		dbClient:           dbClient,
-		defaultModelConfig: defaultModelConfig,
-		watchedNamespaces:  watchedNamespaces,
-		sandboxBackend:     sandboxBackend,
-		mcpEgressPlaintext: mcpEgressPlaintext,
+		adkTranslator:          adkTranslator,
+		kube:                   kube,
+		dbClient:               dbClient,
+		defaultModelConfig:     defaultModelConfig,
+		watchedNamespaces:      watchedNamespaces,
+		sandboxBackend:         sandboxBackend,
+		mcpEgressPlaintext:     mcpEgressPlaintext,
+		remoteMCPServerPlugins: remoteMCPServerPlugins,
 	}
 }
 
@@ -613,6 +621,15 @@ func (a *kagentReconciler) ReconcileKagentRemoteMCPServer(ctx context.Context, r
 		return fmt.Errorf("failed to get remote mcp server %s: %w", serverRef, err)
 	}
 
+	// Author any extension-owned resources for this RMS before tool discovery,
+	// so the discovery dial can traverse them.
+	// A plugin failure is retried (returned at the end) but does not block
+	// discovery or the status update below.
+	pluginErr := a.reconcileRemoteMCPServerPlugins(ctx, server)
+	if pluginErr != nil {
+		l.Error(pluginErr, "failed to reconcile remote mcp server plugins")
+	}
+
 	dbServer := &database.ToolServer{
 		Name:        serverRef,
 		Description: server.Spec.Description,
@@ -662,7 +679,9 @@ func (a *kagentReconciler) ReconcileKagentRemoteMCPServer(ctx context.Context, r
 		return fmt.Errorf("failed to reconcile remote mcp server status %s: %w", req.NamespacedName, err)
 	}
 
-	return nil
+	// Surface a plugin failure so the controller requeues; status was still
+	// updated above from the discovery result.
+	return pluginErr
 }
 
 // computeRemoteMCPServerSecretHash returns a hash over the TLS Secret
@@ -909,14 +928,60 @@ func (a *kagentReconciler) validateRuntimeFeatures(agent v1alpha2.AgentObject) s
 		strings.Join(unsupported, ", "))
 }
 
-// GetOwnedResourceTypes returns all the resource types that may be owned by
-// controllers that are reconciled herein. At present only the agents controller
-// owns resources so this simply wraps a call to the ADK translator as that is
-// responsible for creating the manifests for an agent. If in future other
-// controllers start owning resources then this method should be updated to
-// return the distinct union of all owned resource types.
+// GetOwnedResourceTypes returns the resource types that may be owned by
+// controllers reconciled herein: the agent manifests (from the ADK translator)
+// plus any types authored by registered RemoteMCPServer plugins. The result is
+// what app.Start passes to SetupOwnerIndexes, so the owner index FindOwnedObjects
+// relies on (for pruning) is registered for every owned type, including
+// extension-authored ones. The same type may appear more than once when several
+// sources own it; SetupOwnerIndexes skips the duplicates.
 func (r *kagentReconciler) GetOwnedResourceTypes() []client.Object {
-	return r.adkTranslator.GetOwnedResourceTypes()
+	owned := r.adkTranslator.GetOwnedResourceTypes()
+	for _, plugin := range r.remoteMCPServerPlugins {
+		owned = append(owned, plugin.GetOwnedResourceTypes()...)
+	}
+	return owned
+}
+
+// reconcileRemoteMCPServerPlugins runs the registered RemoteMCPServer plugins
+// and reconciles the objects they return: each is owned by the RMS — so K8s GC
+// removes it on RMS delete and the owner index finds it — applied, and any
+// previously-owned objects the plugins no longer return are pruned. A no-op
+// when no plugins are registered.
+func (a *kagentReconciler) reconcileRemoteMCPServerPlugins(ctx context.Context, server *v1alpha2.RemoteMCPServer) error {
+	if len(a.remoteMCPServerPlugins) == 0 {
+		return nil
+	}
+
+	outputs := &pkgtranslator.RemoteMCPServerOutputs{}
+	var ownedTypes []client.Object
+	for _, plugin := range a.remoteMCPServerPlugins {
+		if err := plugin.ProcessRemoteMCPServer(ctx, server, outputs); err != nil {
+			return fmt.Errorf("remote mcp server plugin: %w", err)
+		}
+		ownedTypes = append(ownedTypes, plugin.GetOwnedResourceTypes()...)
+	}
+
+	// Own every returned object to the RMS so it is garbage-collected on RMS
+	// delete and found by the owner index for pruning. This also rejects
+	// cross-namespace objects (SetControllerReference requires same namespace).
+	for _, obj := range outputs.Manifest {
+		if err := controllerutil.SetControllerReference(server, obj, a.kube.Scheme()); err != nil {
+			return fmt.Errorf("set controller reference on %s %s/%s: %w",
+				obj.GetObjectKind().GroupVersionKind().Kind, obj.GetNamespace(), obj.GetName(), err)
+		}
+	}
+
+	ownedObjects, err := reconcilerutils.FindOwnedObjects(ctx, a.kube, server.GetUID(), server.GetNamespace(), ownedTypes)
+	if err != nil {
+		return fmt.Errorf("find owned objects: %w", err)
+	}
+
+	if err := a.reconcileDesiredObjects(ctx, server, outputs.Manifest, ownedObjects); err != nil {
+		return fmt.Errorf("reconcile plugin objects: %w", err)
+	}
+
+	return nil
 }
 
 // Function initially copied from https://github.com/open-telemetry/opentelemetry-operator/blob/e6d96f006f05cff0bc3808da1af69b6b636fbe88/internal/controllers/common.go#L141-L192

--- a/go/core/internal/controller/reconciler/reconciler.go
+++ b/go/core/internal/controller/reconciler/reconciler.go
@@ -966,6 +966,9 @@ func (a *kagentReconciler) reconcileRemoteMCPServerPlugins(ctx context.Context, 
 	// delete and found by the owner index for pruning. This also rejects
 	// cross-namespace objects (SetControllerReference requires same namespace).
 	for _, obj := range outputs.Manifest {
+		if obj == nil {
+			return fmt.Errorf("remote mcp server plugin returned a nil object in outputs.Manifest")
+		}
 		if err := controllerutil.SetControllerReference(server, obj, a.kube.Scheme()); err != nil {
 			return fmt.Errorf("set controller reference on %s %s/%s: %w",
 				obj.GetObjectKind().GroupVersionKind().Kind, obj.GetNamespace(), obj.GetName(), err)

--- a/go/core/internal/controller/reconciler/utils/reconciler_utils.go
+++ b/go/core/internal/controller/reconciler/utils/reconciler_utils.go
@@ -158,6 +158,20 @@ func distinctByType(objs []client.Object) []client.Object {
 	return out
 }
 
+// ownerIndexValue is the owner-index key function: it maps an owned object to
+// its controller-owner UID, or nil when there is no controller owner. The key
+// is the owner UID (unique cluster-wide), so FindOwnedObjects matches an owner's
+// children by UID alone — no need to filter on the owner's Kind. Objects owned
+// by an unrelated controller are still indexed but never match our queries,
+// since their owner UID differs.
+func ownerIndexValue(rawObj client.Object) []string {
+	owner := metav1.GetControllerOf(rawObj)
+	if owner == nil {
+		return nil
+	}
+	return []string{string(owner.UID)}
+}
+
 // SetupOwnerIndexes sets up caching and indexing of owned resources.
 //
 // ownedTypes may contain the same Go type more than once (e.g. a type owned by
@@ -177,21 +191,7 @@ func SetupOwnerIndexes(mgr ctrl.Manager, ownedTypes []client.Object) error {
 			return err
 		}
 
-		if err := mgr.GetFieldIndexer().IndexField(context.Background(), resource, ownerIndexKey, func(rawObj client.Object) []string {
-			owner := metav1.GetControllerOf(rawObj)
-			if owner == nil {
-				return nil
-			}
-
-			// This is an optimisation to avoid indexing every owned object,
-			// only those owned by Agent or SandboxAgent will be indexed. It may need to be
-			// adjusted in future if other controllers start owning resources.
-			if owner.Kind != "Agent" && owner.Kind != "SandboxAgent" {
-				return nil
-			}
-
-			return []string{string(owner.UID)}
-		}); err != nil {
+		if err := mgr.GetFieldIndexer().IndexField(context.Background(), resource, ownerIndexKey, ownerIndexValue); err != nil {
 			return err
 		}
 	}

--- a/go/core/internal/controller/reconciler/utils/reconciler_utils.go
+++ b/go/core/internal/controller/reconciler/utils/reconciler_utils.go
@@ -139,9 +139,33 @@ func DeepEqual(val1, val2 any) bool {
 	return reflect.DeepEqual(val1, val2)
 }
 
+// distinctByType returns objs with duplicate Go types removed, preserving first
+// occurrence order. Objects with a nil reflect type are dropped.
+func distinctByType(objs []client.Object) []client.Object {
+	seen := make(map[reflect.Type]struct{}, len(objs))
+	out := make([]client.Object, 0, len(objs))
+	for _, obj := range objs {
+		t := reflect.TypeOf(obj)
+		if t == nil {
+			continue
+		}
+		if _, ok := seen[t]; ok {
+			continue
+		}
+		seen[t] = struct{}{}
+		out = append(out, obj)
+	}
+	return out
+}
+
 // SetupOwnerIndexes sets up caching and indexing of owned resources.
+//
+// ownedTypes may contain the same Go type more than once (e.g. a type owned by
+// both the agent translator and a RemoteMCPServer plugin); duplicates are
+// skipped because IndexField errors if the same field key is registered twice
+// on one type. Callers therefore need not pre-deduplicate.
 func SetupOwnerIndexes(mgr ctrl.Manager, ownedTypes []client.Object) error {
-	for _, resource := range ownedTypes {
+	for _, resource := range distinctByType(ownedTypes) {
 		gvk, err := apiutil.GVKForObject(resource, mgr.GetScheme())
 		if err != nil {
 			return err

--- a/go/core/internal/controller/reconciler/utils/reconciler_utils_test.go
+++ b/go/core/internal/controller/reconciler/utils/reconciler_utils_test.go
@@ -1,0 +1,47 @@
+package utils
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TestDistinctByType is the dedup that lets SetupOwnerIndexes accept the same
+// type from several owners (e.g. a type owned by both the agent translator and
+// a RemoteMCPServer plugin) without IndexField erroring on a duplicate field
+// registration.
+func TestDistinctByType(t *testing.T) {
+	t.Run("removes duplicate types, keeps first-occurrence order", func(t *testing.T) {
+		in := []client.Object{
+			&corev1.ConfigMap{}, // translator
+			&corev1.ConfigMap{}, // plugin (overlap)
+			&corev1.Secret{},    // plugin-only
+		}
+		got := distinctByType(in)
+
+		require.Len(t, got, 2, "duplicate ConfigMap must collapse to one entry")
+		assert.IsType(t, &corev1.ConfigMap{}, got[0], "first occurrence order preserved")
+		assert.IsType(t, &corev1.Secret{}, got[1])
+
+		counts := map[reflect.Type]int{}
+		for _, o := range got {
+			counts[reflect.TypeOf(o)]++
+		}
+		assert.Equal(t, 1, counts[reflect.TypeFor[*corev1.ConfigMap]()])
+		assert.Equal(t, 1, counts[reflect.TypeFor[*corev1.Secret]()])
+	})
+
+	t.Run("nil-typed entries are dropped", func(t *testing.T) {
+		got := distinctByType([]client.Object{nil, &corev1.Secret{}, nil})
+		require.Len(t, got, 1)
+		assert.IsType(t, &corev1.Secret{}, got[0])
+	})
+
+	t.Run("empty input yields empty output", func(t *testing.T) {
+		assert.Empty(t, distinctByType(nil))
+	})
+}

--- a/go/core/internal/controller/reconciler/utils/reconciler_utils_test.go
+++ b/go/core/internal/controller/reconciler/utils/reconciler_utils_test.go
@@ -7,8 +7,44 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// TestOwnerIndexValue covers the owner-index key function used by
+// SetupOwnerIndexes. It maps an owned object to its controller-owner UID
+// (regardless of owner Kind), or nil when there is no controller owner.
+func TestOwnerIndexValue(t *testing.T) {
+	controller := true
+	withController := func(kind string, uid types.UID) client.Object {
+		return &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{{
+					Kind:       kind,
+					UID:        uid,
+					Name:       "owner",
+					Controller: &controller,
+				}},
+			},
+		}
+	}
+
+	cases := []struct {
+		name string
+		obj  client.Object
+		want []string
+	}{
+		{"controller owner maps to its UID", withController("RemoteMCPServer", "uid-r"), []string{"uid-r"}},
+		{"owner Kind is irrelevant — any controller owner is indexed", withController("Agent", "uid-a"), []string{"uid-a"}},
+		{"no controller owner is not indexed", &corev1.ConfigMap{}, nil},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, ownerIndexValue(c.obj))
+		})
+	}
+}
 
 // TestDistinctByType is the dedup that lets SetupOwnerIndexes accept the same
 // type from several owners (e.g. a type owned by both the agent translator and

--- a/go/core/pkg/app/app.go
+++ b/go/core/pkg/app/app.go
@@ -319,11 +319,12 @@ type BootstrapConfig struct {
 type CtrlManagerConfigFunc func(manager.Manager) error
 
 type ExtensionConfig struct {
-	Authenticator    auth.AuthProvider
-	Authorizer       auth.Authorizer
-	AgentPlugins     []agent_translator.TranslatorPlugin
-	MCPServerPlugins []translator.MCPTranslatorPlugin
-	SandboxBackend   sandboxbackend.Backend
+	Authenticator          auth.AuthProvider
+	Authorizer             auth.Authorizer
+	AgentPlugins           []agent_translator.TranslatorPlugin
+	MCPServerPlugins       []translator.MCPTranslatorPlugin
+	RemoteMCPServerPlugins []translator.RemoteMCPServerPlugin
+	SandboxBackend         sandboxbackend.Backend
 }
 
 type GetExtensionConfig func(bootstrap BootstrapConfig) (*ExtensionConfig, error)
@@ -560,6 +561,7 @@ func Start(getExtensionConfig GetExtensionConfig, migrationRunner MigrationRunne
 		watchNamespacesList,
 		extensionCfg.SandboxBackend,
 		cfg.MCPEgressPlaintext,
+		extensionCfg.RemoteMCPServerPlugins,
 	)
 
 	if err := (&controller.ServiceController{

--- a/go/core/pkg/translator/remote_mcp_server_plugin_types.go
+++ b/go/core/pkg/translator/remote_mcp_server_plugin_types.go
@@ -1,0 +1,41 @@
+package translator
+
+import (
+	"context"
+
+	"github.com/kagent-dev/kagent/go/api/v1alpha2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// RemoteMCPServerOutputs collects the resources a RemoteMCPServerPlugin wants
+// reconciled for a RemoteMCPServer. The reconciler applies these objects and
+// prunes any previously-owned objects (of the plugin's GetOwnedResourceTypes)
+// that the plugin no longer returns, keying ownership on the RemoteMCPServer.
+type RemoteMCPServerOutputs struct {
+	// Manifest is the set of objects the plugin wants to exist for this
+	// RemoteMCPServer. The reconciler sets the controller reference to the
+	// RemoteMCPServer on each, so the objects must live in the RMS's own
+	// namespace and are garbage-collected when the RMS is deleted.
+	Manifest []client.Object
+}
+
+// RemoteMCPServerPlugin is a reconcile-phase extension point that runs during
+// the RemoteMCPServer reconcile. It lets an extension author resources for a
+// RemoteMCPServer without standing up a second controller that watches the
+// same RemoteMCPServer.
+//
+// It mirrors the agent-side TranslatorPlugin: the plugin appends desired
+// objects to outputs.Manifest, the reconciler owns them to the RMS and
+// reconciles them (apply + prune of its GetOwnedResourceTypes). A plugin error
+// fails only the RemoteMCPServer reconcile (which is retried); it never affects
+// agent translation. Registered plugins are invoked unconditionally — any
+// feature gating is the plugin's decision.
+type RemoteMCPServerPlugin interface {
+	// ProcessRemoteMCPServer is called on each reconcile of server. The plugin
+	// appends the objects it wants to exist to outputs.Manifest.
+	ProcessRemoteMCPServer(ctx context.Context, server *v1alpha2.RemoteMCPServer, outputs *RemoteMCPServerOutputs) error
+	// GetOwnedResourceTypes returns the object types this plugin may author, so
+	// the reconciler can set up owner indexes and prune stale objects. Mirrors
+	// TranslatorPlugin.GetOwnedResourceTypes.
+	GetOwnedResourceTypes() []client.Object
+}


### PR DESCRIPTION
# Description

Adds a reconcile-phase extension point, `RemoteMCPServerPlugin`, so an extension can author Kubernetes resources for a `RemoteMCPServer` without standing up a second controller that watches the same resource. It mirrors the existing agent-side `TranslatorPlugin`: the plugin appends desired objects to an outputs struct, and the `RemoteMCPServer` reconciler owns them to the RMS and reconciles them (apply + prune).

```go
// translator.RemoteMCPServerPlugin
type RemoteMCPServerPlugin interface {
    // Called on each reconcile of server; the plugin appends the objects it
    // wants to exist to outputs.Manifest.
    ProcessRemoteMCPServer(ctx context.Context, server *v1alpha2.RemoteMCPServer, outputs *RemoteMCPServerOutputs) error
    // The object types this plugin may author, so the reconciler can set up
    // owner indexes and prune stale objects.
    GetOwnedResourceTypes() []client.Object
}
```

Plugins are registered through the existing extension-config seam (`ExtensionConfig.RemoteMCPServerPlugins`), alongside `AgentPlugins` and `MCPServerPlugins`. With no plugin registered the behavior is unchanged — this is plumbing for out-of-tree extensions.

## Reconcile flow

On each `RemoteMCPServer` reconcile, registered plugins run **before** tool discovery so any resources they author (routing, etc.) exist before the discovery dial traverses them. For every object a plugin returns, the reconciler:

- validates the object is non-nil (a plugin returning `nil` fails the reconcile with a clear error rather than panicking in `SetControllerReference`);
- sets the controller reference to the `RemoteMCPServer` (so it is garbage-collected on RMS delete and found by the owner index for pruning — this also rejects cross-namespace objects, since `SetControllerReference` requires same namespace);
- applies it and prunes any previously-owned object of the plugin's `GetOwnedResourceTypes()` that the plugin no longer returns.

Things to note:

- `RemoteMCPServerPlugin` / `RemoteMCPServerOutputs` live in `core/pkg/translator` next to the agent-side `TranslatorPlugin`, so both extension surfaces sit in one place and share the same shape (`Manifest []client.Object` + `GetOwnedResourceTypes()`).
- Registered plugins are invoked **unconditionally** — any feature gating is the plugin's own decision, matching how `AgentPlugins` work.
- A plugin failure fails **only** the `RemoteMCPServer` reconcile (logged, then returned so the controller requeues); it does not block tool discovery or the status update, and it never affects agent translation. The status is still updated from the discovery result before the plugin error is surfaced.
- `NewKagentReconciler` takes the registered plugins; `app.Start` threads `ExtensionConfig.RemoteMCPServerPlugins` through. `GetOwnedResourceTypes()` returns the union of the agent translator's owned types and every registered plugin's owned types, so the owner index `FindOwnedObjects` relies on (for pruning) is registered for extension-authored types too.
- Owned-type **deduplication moved to `SetupOwnerIndexes`** (the indexer layer that actually has the constraint). A type owned by more than one source — e.g. the agent translator and a plugin both owning `ConfigMap` — would otherwise make `IndexField` error on a duplicate field registration. `SetupOwnerIndexes` now skips duplicate Go types via a small `distinctByType` helper, so callers need not pre-deduplicate and `GetOwnedResourceTypes` is a plain union.
- The owner-index key function (`ownerIndexValue`) now keys on the controller-owner **UID** for any owner, dropping the prior `Agent`/`SandboxAgent` Kind allow-list. The allow-list was an index-size optimization, but it silently excluded `RemoteMCPServer`-owned objects — so `FindOwnedObjects` never returned them and the prune step above no-op'd (stale objects leaking). Keying on UID alone is correct because UIDs are unique cluster-wide: an owner's children match by UID regardless of Kind, and foreign-owned objects of the same type are indexed but never match our queries. This removes the per-kind list (and its drift risk) entirely.

# Out of scope

- Any concrete plugin implementation — this PR is the interface and reconcile wiring only.
- Plugin support for resources outside the `RemoteMCPServer`'s own namespace (controller-ref ownership requires same namespace by construction).
- Ordering/dependencies between multiple registered plugins (they run in registration order; no inter-plugin contract).