### PR TITLE
chore: bump kagent tools to 0.2.1

### DIFF
--- a/helm/kagent/Chart-template.yaml
+++ b/helm/kagent/Chart-template.yaml
@@ -9,7 +9,7 @@ dependencies:
     repository: oci://ghcr.io/kagent-dev/kmcp/helm
     condition: kmcp.enabled
   - name: kagent-tools
-    version: 0.1.3
+    version: 0.2.1
     repository: oci://ghcr.io/kagent-dev/tools/helm
     condition: kagent-tools.enabled
   - name: grafana-mcp


### PR DESCRIPTION
- Bump kagent tools to `0.2.1` which includes a change that mounts an empty `tmp` volume to the tools container to enable write operations to be unimpeded by pod's securityContext.readOnlyRootFileSystem set to be true.