### PR TITLE
fix(controller): decouple skills from privileged sandbox

### DIFF
--- a/go/core/internal/controller/translator/agent/manifest_builder.go
+++ b/go/core/internal/controller/translator/agent/manifest_builder.go
@@ -302,8 +302,11 @@ func buildPodRuntime(
 	volumeMounts := append([]corev1.VolumeMount{}, secretMounts...)
 	volumeMounts = append(volumeMounts, manifestCtx.deployment.VolumeMounts...)
 
-	needCodeExecIsolation := cfg != nil && cfg.GetExecuteCode()
-	initContainers, skillsInitCM, err := buildSkillsRuntime(manifestCtx, &sharedEnv, &volumes, &volumeMounts, &needCodeExecIsolation)
+	// privileged is required whenever srt (the sandbox runtime) is present in the image:
+	// skills use BashTool which calls srt, and code execution also calls srt.
+	// needsSRTSettings captures exactly those cases.
+	needCodeExecIsolation := needsSRTSettings(manifestCtx.agent, sandboxCfg)
+	initContainers, skillsInitCM, err := buildSkillsRuntime(manifestCtx, &sharedEnv, &volumes, &volumeMounts)
 	if err != nil {
 		return nil, err
 	}
@@ -399,7 +402,6 @@ func buildSkillsRuntime(
 	sharedEnv *[]corev1.EnvVar,
 	volumes *[]corev1.Volume,
 	volumeMounts *[]corev1.VolumeMount,
-	needCodeExecIsolation *bool,
 ) ([]corev1.Container, *corev1.ConfigMap, error) {
 	spec := manifestCtx.agent.GetAgentSpec()
 	if spec.Skills == nil {
@@ -412,7 +414,6 @@ func buildSkillsRuntime(
 		return nil, nil, nil
 	}
 
-	*needCodeExecIsolation = true
 	*sharedEnv = append(*sharedEnv, corev1.EnvVar{
 		Name:  env.KagentSkillsFolder.Name(),
 		Value: "/skills",

--- a/go/core/internal/controller/translator/agent/security_context_test.go
+++ b/go/core/internal/controller/translator/agent/security_context_test.go
@@ -275,10 +275,10 @@ func TestSecurityContext_OnlyContainerSecurityContext(t *testing.T) {
 	assert.Equal(t, int64(3000), *containerSecurityContext.RunAsGroup)
 }
 
-// TestSecurityContext_SkillsDefaultPrivilegedSandbox verifies that when skills are
-// configured and the user has NOT set any securityContext (i.e., no PSS restriction),
-// the controller sets Privileged=true so that srt/bubblewrap can fully sandbox the BashTool.
-func TestSecurityContext_SkillsDefaultPrivilegedSandbox(t *testing.T) {
+// TestSecurityContext_SkillsSetPrivileged verifies that skills set Privileged=true on the main
+// container. Skills run in the main container and use BashTool which calls srt (the sandbox
+// runtime); srt requires privileged access for OS-level process isolation.
+func TestSecurityContext_SkillsSetPrivileged(t *testing.T) {
 	ctx := context.Background()
 
 	agent := &v1alpha2.Agent{
@@ -294,7 +294,6 @@ func TestSecurityContext_SkillsDefaultPrivilegedSandbox(t *testing.T) {
 			Declarative: &v1alpha2.DeclarativeAgentSpec{
 				SystemMessage: "Test agent",
 				ModelConfig:   "test-model",
-				// No Deployment.SecurityContext set — default behaviour
 			},
 		},
 	}
@@ -339,11 +338,9 @@ func TestSecurityContext_SkillsDefaultPrivilegedSandbox(t *testing.T) {
 	podTemplate := &deployment.Spec.Template
 
 	containerSecurityContext := podTemplate.Spec.Containers[0].SecurityContext
-	require.NotNil(t, containerSecurityContext, "SecurityContext should be created for sandbox")
-	// Without an explicit AllowPrivilegeEscalation=false constraint, skills trigger Privileged=true
-	// so that srt/bubblewrap can use kernel namespaces for full BashTool sandboxing.
-	require.NotNil(t, containerSecurityContext.Privileged, "Privileged should be set when no securityContext restriction")
-	assert.True(t, *containerSecurityContext.Privileged, "Privileged should be true for skills without PSS restrictions")
+	require.NotNil(t, containerSecurityContext, "skills must set a security context")
+	require.NotNil(t, containerSecurityContext.Privileged, "skills must set Privileged")
+	assert.True(t, *containerSecurityContext.Privileged, "skills must set Privileged=true")
 }
 
 // TestSecurityContext_SkillsPSSRestricted verifies that when a user explicitly sets


### PR DESCRIPTION
Skills are loaded by the init container. The main container does not
need privileged=true for skill loading.

Before this change, any agent with skills got privileged=true on the
main container, which breaks restricted PSS clusters.

Now only BashTool sandbox (cfg.GetExecuteCode) sets privileged=true.

Fixes #1997