### PR TITLE
fix(adk): write materialized secret files with 0600 permissions

### DIFF
--- a/go/adk/pkg/config/config_loader_test.go
+++ b/go/adk/pkg/config/config_loader_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -109,6 +110,18 @@ func TestMaterializeFromEnv(t *testing.T) {
 	}
 	if string(srtData) != `{"skills":[]}` {
 		t.Fatalf("srt settings = %q", string(srtData))
+	}
+
+	if runtime.GOOS != "windows" {
+		for _, name := range []string{"config.json", "agent-card.json", srtSettingsFile} {
+			fi, err := os.Stat(filepath.Join(tmpDir, name))
+			if err != nil {
+				t.Fatalf("stat %s: %v", name, err)
+			}
+			if perm := fi.Mode().Perm(); perm != 0o600 {
+				t.Errorf("%s permissions = %o, want 0600", name, perm)
+			}
+		}
 	}
 }
 

--- a/go/adk/pkg/config/config_materialize.go
+++ b/go/adk/pkg/config/config_materialize.go
@@ -43,8 +43,11 @@ func materializeEnvToFile(envKey, path string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("create directory for %s: %w", path, err)
 	}
-	if err := os.WriteFile(path, []byte(value), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(value), 0o600); err != nil {
 		return fmt.Errorf("write %s: %w", path, err)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		return fmt.Errorf("chmod %s: %w", path, err)
 	}
 	return nil
 }


### PR DESCRIPTION
- `config.json` contains model API keys (e.g. OpenAI `api_key`)
- `kagent-token` is a k8s service account token injected via `KAGENT_TOKEN` in substrate mode
- Both were written with `0644` (world-readable), changed to `0600` (owner-only)
- Added a permission assertion to `TestMaterializeFromEnv` to catch regressions