### PR TITLE
fix: remove optional label from agent description field

### DIFF
--- a/ui/src/app/agents/new/page.tsx
+++ b/ui/src/app/agents/new/page.tsx
@@ -822,7 +822,7 @@ function AgentPageContent({ isEditMode, agentName, agentNamespace }: AgentPageCo
               )}
 
               <FieldRoot>
-                <FieldLabel htmlFor="agent-desc">Description (optional)</FieldLabel>
+                <FieldLabel htmlFor="agent-desc">Description</FieldLabel>
                 <FieldHint>Internal note only; not sent to the model as instructions.</FieldHint>
                 <Textarea
                   id="agent-desc"


### PR DESCRIPTION
Fixes a mismatch on the create agent form: the description field was labeled optional but validation still required it.

Closes #2012 