### PR TITLE
feat(adk): Go runtime conversation-history compaction

### DIFF
--- a/go/adk/cmd/main.go
+++ b/go/adk/cmd/main.go
@@ -178,10 +178,17 @@ func main() {
 		logger.Info("Memory service enabled", "appName", appName)
 	}
 
-	runnerConfig, subagentSessionIDs, err := runnerpkg.CreateRunnerConfig(ctx, agentConfig, sessionService, appName, memoryService)
+	runnerConfig, subagentSessionIDs, compactionCfg, err := runnerpkg.CreateRunnerConfig(ctx, agentConfig, sessionService, appName, memoryService)
 	if err != nil {
 		logger.Error(err, "Failed to create Google ADK Runner config")
 		os.Exit(1)
+	}
+	if compactionCfg != nil {
+		logger.Info("Compaction enabled",
+			"interval", compactionCfg.CompactionInterval,
+			"overlap", compactionCfg.OverlapSize,
+			"tokenThreshold", compactionCfg.TokenThreshold,
+		)
 	}
 
 	stream := agentConfig.GetStream()
@@ -192,6 +199,7 @@ func main() {
 		Stream:             stream,
 		AppName:            appName,
 		Logger:             logger,
+		CompactionConfig:   compactionCfg,
 	})
 
 	// Build the agent card.

--- a/go/adk/pkg/a2a/executor.go
+++ b/go/adk/pkg/a2a/executor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/a2aproject/a2a-go/a2asrv/eventqueue"
 	"github.com/go-logr/logr"
 	"github.com/kagent-dev/kagent/go/adk/pkg/auth"
+	"github.com/kagent-dev/kagent/go/adk/pkg/compaction"
 	"github.com/kagent-dev/kagent/go/adk/pkg/models"
 	"github.com/kagent-dev/kagent/go/adk/pkg/session"
 	"github.com/kagent-dev/kagent/go/adk/pkg/skills"
@@ -37,6 +38,7 @@ type KAgentExecutorConfig struct {
 	AppName            string
 	SkillsDirectory    string
 	Logger             logr.Logger
+	CompactionConfig   *compaction.Config
 }
 
 // KAgentExecutor implements a2asrv.AgentExecutor
@@ -48,6 +50,7 @@ type KAgentExecutor struct {
 	appName            string
 	skillsDirectory    string
 	logger             logr.Logger
+	compactor          *compaction.Compactor
 }
 
 var _ a2asrv.AgentExecutor = (*KAgentExecutor)(nil)
@@ -69,6 +72,7 @@ func NewKAgentExecutor(cfg KAgentExecutorConfig) *KAgentExecutor {
 		appName:            cfg.AppName,
 		skillsDirectory:    skillsDir,
 		logger:             cfg.Logger.WithName("kagent-executor"),
+		compactor:          compaction.New(cfg.CompactionConfig, cfg.Logger),
 	}
 }
 
@@ -355,7 +359,19 @@ func (e *KAgentExecutor) Execute(ctx context.Context, reqCtx *a2asrv.RequestCont
 		}
 	}
 
-	// 11. Emit final event.
+	// 11. Post-invocation compaction (best-effort; never fails the request).
+	if e.compactor != nil && e.sessionService != nil && runErr == nil {
+		liveSess, sessErr := e.sessionService.GetSession(ctx, e.appName, userID, sessionID)
+		if sessErr != nil {
+			e.logger.V(1).Info("Compaction skipped: could not fetch session", "error", sessErr)
+		} else if liveSess != nil {
+			if compactErr := e.compactor.MaybeCompact(ctx, liveSess, e.sessionService, 0); compactErr != nil {
+				e.logger.Error(compactErr, "compaction failed (continuing)")
+			}
+		}
+	}
+
+	// 12. Emit final event.
 	finalMeta := maps.Clone(baseMeta)
 	if invocationID != "" {
 		finalMeta[adka2a.ToA2AMetaKey("invocation_id")] = invocationID

--- a/go/adk/pkg/compaction/compaction.go
+++ b/go/adk/pkg/compaction/compaction.go
@@ -3,6 +3,7 @@ package compaction
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -14,8 +15,9 @@ import (
 )
 
 const (
-	compactionAuthor     = "compaction"
-	noInvocationSentinel = "\x00no_invocation"
+	compactionAuthor         = "compaction"
+	compactionInvocationBase = "compaction_"
+	noInvocationSentinel     = "\x00no_invocation"
 
 	defaultCompactionInterval = 5
 	defaultOverlapSize        = 2
@@ -82,7 +84,8 @@ func (c *Compactor) MaybeCompact(
 	}
 
 	// Sliding window: count new invocations since the last compaction watermark.
-	invocations := groupByInvocation(allEvents)
+	nonMarkers := filterCompactionMarkers(allEvents)
+	invocations := groupByInvocation(nonMarkers)
 	watermark := findWatermark(allEvents)
 
 	window, ok := decideSlidingWindow(invocations, watermark, c.cfg)
@@ -140,9 +143,9 @@ func (c *Compactor) compactTokenThreshold(
 	allEvents []*adksession.Event,
 	log logr.Logger,
 ) error {
-	windowEvents := allEvents
-	if c.cfg.EventRetentionSize > 0 && len(allEvents) > c.cfg.EventRetentionSize {
-		windowEvents = allEvents[:len(allEvents)-c.cfg.EventRetentionSize]
+	windowEvents := filterCompactionMarkers(allEvents)
+	if c.cfg.EventRetentionSize > 0 && len(windowEvents) > c.cfg.EventRetentionSize {
+		windowEvents = windowEvents[:len(windowEvents)-c.cfg.EventRetentionSize]
 	}
 
 	windowEvents = longestSelfContainedPrefix(windowEvents)
@@ -215,16 +218,99 @@ func (c *Compactor) summarize(ctx context.Context, events []*adksession.Event) (
 	}, nil
 }
 
+// BuildCompactedEventList returns a new event list with compacted ranges
+// replaced by synthetic summary events. Compaction marker events are always
+// removed from the output. Subsumed compactions are silently dropped.
+//
+// Called by compactingService.Get before the runner sees the session, so
+// buildContentsDefault never processes marker events.
+func BuildCompactedEventList(agentName string, events []*adksession.Event) []*adksession.Event {
+	type compactionRange struct {
+		startNano, endNano int64
+		content            *genai.Content
+		markerEv           *adksession.Event
+	}
+
+	var ranges []compactionRange
+	for _, ev := range events {
+		if !isCompactionMarker(ev) {
+			continue
+		}
+		parsed, ok := parseCompactionInvocationID(ev.InvocationID)
+		if !ok {
+			continue
+		}
+		ranges = append(ranges, compactionRange{
+			startNano: parsed[0],
+			endNano:   parsed[1],
+			content:   ev.Content,
+			markerEv:  ev,
+		})
+	}
+	if len(ranges) == 0 {
+		return events
+	}
+
+	// Remove subsumed ranges.
+	active := make([]compactionRange, 0, len(ranges))
+	for _, r := range ranges {
+		subsumed := false
+		for _, r2 := range ranges {
+			if r2.markerEv == r.markerEv {
+				continue
+			}
+			if r2.startNano <= r.startNano && r2.endNano >= r.endNano {
+				subsumed = true
+				break
+			}
+		}
+		if !subsumed {
+			active = append(active, r)
+		}
+	}
+
+	// Sort by start time (insertion sort; range count is typically small).
+	for i := 1; i < len(active); i++ {
+		for j := i; j > 0 && active[j].startNano < active[j-1].startNano; j-- {
+			active[j], active[j-1] = active[j-1], active[j]
+		}
+	}
+
+	injected := make([]bool, len(active))
+	result := make([]*adksession.Event, 0, len(events))
+	for _, ev := range events {
+		if isCompactionMarker(ev) {
+			continue
+		}
+		nano := ev.Timestamp.UnixNano()
+		inRange := -1
+		for i, r := range active {
+			if nano >= r.startNano && nano <= r.endNano {
+				inRange = i
+				break
+			}
+		}
+		if inRange >= 0 {
+			if !injected[inRange] && active[inRange].content != nil {
+				summaryEv := adksession.NewEvent(fmt.Sprintf("compacted_%d", active[inRange].startNano))
+				summaryEv.Author = agentName
+				summaryEv.Timestamp = time.Unix(0, active[inRange].startNano).UTC()
+				summaryEv.Content = active[inRange].content
+				result = append(result, summaryEv)
+				injected[inRange] = true
+			}
+			continue
+		}
+		result = append(result, ev)
+	}
+	return result
+}
+
 // decideSlidingWindow returns the invocation groups to compact based on a
 // watermark-based count of new invocations. Returns (nil, false) when the
 // trigger condition is not met.
-//
-// Watermark = EndTimestamp of the most recent compaction event (zero if none).
-// New invocations = those with max event timestamp strictly after the watermark.
-// Trigger when len(new) >= CompactionInterval.
-// Window = invocations[max(0, firstNewIdx-OverlapSize) : len-OverlapSize].
 func decideSlidingWindow(invocations []invocationGroup, watermark time.Time, cfg *Config) ([]invocationGroup, bool) {
-	firstNewIdx := len(invocations) // sentinel: no new invocations found
+	firstNewIdx := len(invocations)
 	for i, inv := range invocations {
 		if watermark.IsZero() || maxTimestamp(inv.events).After(watermark) {
 			firstNewIdx = i
@@ -236,12 +322,10 @@ func decideSlidingWindow(invocations []invocationGroup, watermark time.Time, cfg
 		return nil, false
 	}
 
-	// Reach back OverlapSize into already-compacted invocations for context.
 	windowStart := firstNewIdx - cfg.OverlapSize
 	if windowStart < 0 {
 		windowStart = 0
 	}
-	// Keep last OverlapSize new invocations as a recent-context tail.
 	windowEnd := len(invocations) - cfg.OverlapSize
 	if windowEnd <= windowStart {
 		return nil, false
@@ -249,37 +333,63 @@ func decideSlidingWindow(invocations []invocationGroup, watermark time.Time, cfg
 	return invocations[windowStart:windowEnd], true
 }
 
-// findWatermark returns the latest EndTimestamp seen in any compaction event,
-// or zero time when no compaction event exists.
+// findWatermark returns the latest end timestamp encoded in any compaction
+// marker event's InvocationID, or zero time when no marker exists.
 func findWatermark(events []*adksession.Event) time.Time {
 	var watermark time.Time
 	for _, ev := range events {
-		if ev.Actions.Compaction != nil {
-			if ts := ev.Actions.Compaction.EndTimestamp; ts.After(watermark) {
-				watermark = ts
-			}
+		if !isCompactionMarker(ev) {
+			continue
+		}
+		parsed, ok := parseCompactionInvocationID(ev.InvocationID)
+		if !ok {
+			continue
+		}
+		if end := time.Unix(0, parsed[1]).UTC(); end.After(watermark) {
+			watermark = end
 		}
 	}
 	return watermark
 }
 
-// buildCompactionEvent creates an event that marks a compacted range.
-// The event carries the summary in Actions.Compaction; its Content is nil.
-func buildCompactionEvent(ctx context.Context, content *genai.Content, startTS, endTS time.Time) *adksession.Event {
-	invID := "compaction_" + startTS.UTC().Format("20060102T150405Z")
-	e := adksession.NewEventWithContext(ctx, invID)
-	e.Author = compactionAuthor
-	e.Actions.Compaction = &adksession.EventCompaction{
-		StartTimestamp:   startTS,
-		EndTimestamp:     endTS,
-		CompactedContent: content,
+// buildCompactionEvent creates a compaction marker event.
+// Summary is stored as Content. Start and end timestamps are encoded in
+// InvocationID as "compaction_<startNano>_<endNano>".
+// buildContentsDefault never sees this event: compactingService.Get applies
+// BuildCompactedEventList before the runner loads the session.
+func buildCompactionEvent(_ context.Context, content *genai.Content, startTS, endTS time.Time) *adksession.Event {
+	invID := fmt.Sprintf("%s%d_%d", compactionInvocationBase, startTS.UnixNano(), endTS.UnixNano())
+	ev := adksession.NewEvent(invID)
+	ev.Author = compactionAuthor
+	ev.Timestamp = endTS
+	ev.Content = content
+	return ev
+}
+
+// isCompactionMarker reports whether ev is a compaction marker event.
+func isCompactionMarker(ev *adksession.Event) bool {
+	return ev.Author == compactionAuthor &&
+		strings.HasPrefix(ev.InvocationID, compactionInvocationBase)
+}
+
+// parseCompactionInvocationID parses "compaction_<startNano>_<endNano>"
+// and returns [startNano, endNano].
+func parseCompactionInvocationID(invID string) ([2]int64, bool) {
+	rest := strings.TrimPrefix(invID, compactionInvocationBase)
+	idx := strings.LastIndex(rest, "_")
+	if idx < 0 {
+		return [2]int64{}, false
 	}
-	return e
+	startNano, err1 := strconv.ParseInt(rest[:idx], 10, 64)
+	endNano, err2 := strconv.ParseInt(rest[idx+1:], 10, 64)
+	if err1 != nil || err2 != nil {
+		return [2]int64{}, false
+	}
+	return [2]int64{startNano, endNano}, true
 }
 
 // longestSelfContainedPrefix returns the longest prefix of events that ends
 // at a point where no function call is open and no tool confirmation is pending.
-// This prevents compacting through an in-flight tool exchange.
 func longestSelfContainedPrefix(events []*adksession.Event) []*adksession.Event {
 	openCalls := map[string]bool{}
 	safeIdx := 0
@@ -327,6 +437,17 @@ func groupByInvocation(events []*adksession.Event) []invocationGroup {
 		}
 	}
 	return groups
+}
+
+// filterCompactionMarkers returns events with compaction markers removed.
+func filterCompactionMarkers(events []*adksession.Event) []*adksession.Event {
+	out := make([]*adksession.Event, 0, len(events))
+	for _, ev := range events {
+		if !isCompactionMarker(ev) {
+			out = append(out, ev)
+		}
+	}
+	return out
 }
 
 func maxTimestamp(events []*adksession.Event) time.Time {
@@ -413,8 +534,7 @@ func FromAgentConfig(agentCfg *adkapiconfig.AgentConfig) (*Config, error) {
 }
 
 // SummarizerModelName returns the model name configured for summarization,
-// or "" when none is set. Used by adapter.go to decide whether to build a
-// dedicated summarizer LLM or fall back to the agent's own model.
+// or "" when none is set.
 func SummarizerModelName(agentCfg *adkapiconfig.AgentConfig) string {
 	if agentCfg == nil || agentCfg.ContextConfig == nil || agentCfg.ContextConfig.Compaction == nil {
 		return ""

--- a/go/adk/pkg/compaction/compaction.go
+++ b/go/adk/pkg/compaction/compaction.go
@@ -1,0 +1,431 @@
+package compaction
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	adkapiconfig "github.com/kagent-dev/kagent/go/api/adk"
+	"google.golang.org/adk/model"
+	adksession "google.golang.org/adk/session"
+	"google.golang.org/genai"
+)
+
+const (
+	compactionAuthor     = "compaction"
+	noInvocationSentinel = "\x00no_invocation"
+
+	defaultCompactionInterval = 5
+	defaultOverlapSize        = 2
+
+	defaultSummaryPrompt = `You are a conversation compactor. Summarise the following agent conversation history concisely, preserving all key facts, decisions, tool calls, and outcomes. The summary will replace these events in the agent context window.
+
+Conversation history:
+{{events}}
+
+Provide a concise summary:`
+)
+
+// Config holds compaction settings for an agent.
+type Config struct {
+	CompactionInterval int
+	OverlapSize        int
+	TokenThreshold     int
+	EventRetentionSize int
+	SummarizerLLM      model.LLM
+	PromptTemplate     string
+}
+
+// Compactor performs post-invocation event history compaction on a session.
+// A nil Compactor is valid; all methods are no-ops.
+type Compactor struct {
+	cfg    *Config
+	logger logr.Logger
+}
+
+// New returns a Compactor for cfg, or nil when cfg is nil.
+func New(cfg *Config, logger logr.Logger) *Compactor {
+	if cfg == nil {
+		return nil
+	}
+	return &Compactor{cfg: cfg, logger: logger.WithName("compaction")}
+}
+
+// MaybeCompact checks whether compaction should run after the latest
+// invocation and performs it if triggered. Safe to call after every agent run.
+func (c *Compactor) MaybeCompact(
+	ctx context.Context,
+	sess adksession.Session,
+	sessionSvc adksession.Service,
+	lastTokens int,
+) error {
+	if c == nil {
+		return nil
+	}
+	log := c.logger.WithValues("sessionID", sess.ID())
+
+	allEvents := collectEvents(sess)
+
+	// Token threshold takes precedence.
+	if c.cfg.TokenThreshold > 0 {
+		tokens := lastTokens
+		if tokens == 0 {
+			tokens = estimateTokens(allEvents)
+		}
+		if tokens >= c.cfg.TokenThreshold {
+			log.V(1).Info("Compaction triggered by token threshold",
+				"tokens", tokens, "threshold", c.cfg.TokenThreshold)
+			return c.compactTokenThreshold(ctx, sess, sessionSvc, allEvents, log)
+		}
+	}
+
+	// Sliding window: count new invocations since the last compaction watermark.
+	invocations := groupByInvocation(allEvents)
+	watermark := findWatermark(allEvents)
+
+	window, ok := decideSlidingWindow(invocations, watermark, c.cfg)
+	if !ok {
+		return nil
+	}
+	log.V(1).Info("Compaction triggered by interval",
+		"watermark", watermark, "windowGroups", len(window))
+	return c.compact(ctx, sess, sessionSvc, window, log)
+}
+
+func (c *Compactor) compact(
+	ctx context.Context,
+	sess adksession.Session,
+	sessionSvc adksession.Service,
+	window []invocationGroup,
+	log logr.Logger,
+) error {
+	var windowEvents []*adksession.Event
+	for _, inv := range window {
+		windowEvents = append(windowEvents, inv.events...)
+	}
+
+	// Never compact through an open function call or unresolved HITL confirmation.
+	windowEvents = longestSelfContainedPrefix(windowEvents)
+	if len(windowEvents) == 0 {
+		return nil
+	}
+
+	startTS := windowEvents[0].Timestamp
+	endTS := windowEvents[len(windowEvents)-1].Timestamp
+
+	summaryContent, err := c.summarize(ctx, windowEvents)
+	if err != nil {
+		log.Error(err, "Failed to summarize; skipping compaction")
+		return nil
+	}
+	if summaryContent == nil {
+		return nil
+	}
+
+	compactionEvent := buildCompactionEvent(ctx, summaryContent, startTS, endTS)
+	if err := sessionSvc.AppendEvent(ctx, sess, compactionEvent); err != nil {
+		return fmt.Errorf("compaction: append event: %w", err)
+	}
+	log.Info("Compaction complete",
+		"start", startTS, "end", endTS, "windowLen", len(windowEvents))
+	return nil
+}
+
+func (c *Compactor) compactTokenThreshold(
+	ctx context.Context,
+	sess adksession.Session,
+	sessionSvc adksession.Service,
+	allEvents []*adksession.Event,
+	log logr.Logger,
+) error {
+	windowEvents := allEvents
+	if c.cfg.EventRetentionSize > 0 && len(allEvents) > c.cfg.EventRetentionSize {
+		windowEvents = allEvents[:len(allEvents)-c.cfg.EventRetentionSize]
+	}
+
+	windowEvents = longestSelfContainedPrefix(windowEvents)
+	if len(windowEvents) == 0 {
+		return nil
+	}
+
+	startTS := windowEvents[0].Timestamp
+	endTS := windowEvents[len(windowEvents)-1].Timestamp
+
+	summaryContent, err := c.summarize(ctx, windowEvents)
+	if err != nil {
+		log.Error(err, "Failed to summarize; skipping token compaction")
+		return nil
+	}
+	if summaryContent == nil {
+		return nil
+	}
+
+	compactionEvent := buildCompactionEvent(ctx, summaryContent, startTS, endTS)
+	if err := sessionSvc.AppendEvent(ctx, sess, compactionEvent); err != nil {
+		return fmt.Errorf("compaction: append event: %w", err)
+	}
+	log.Info("Token compaction complete",
+		"start", startTS, "end", endTS, "windowLen", len(windowEvents))
+	return nil
+}
+
+func (c *Compactor) summarize(ctx context.Context, events []*adksession.Event) (*genai.Content, error) {
+	text := serializeEvents(events)
+	if text == "" {
+		return nil, nil
+	}
+
+	if c.cfg.SummarizerLLM == nil {
+		return &genai.Content{
+			Role:  "model",
+			Parts: []*genai.Part{{Text: "[Compacted history]\n" + text}},
+		}, nil
+	}
+
+	prompt := strings.ReplaceAll(c.cfg.PromptTemplate, "{{events}}", text)
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{
+			{Role: "user", Parts: []*genai.Part{{Text: prompt}}},
+		},
+		// No SystemInstruction: avoids Anthropic 400 on null system prompt.
+	}
+
+	var parts []string
+	for resp, err := range c.cfg.SummarizerLLM.GenerateContent(ctx, req, false) {
+		if err != nil {
+			return nil, fmt.Errorf("summarizer: %w", err)
+		}
+		if resp != nil && resp.Content != nil {
+			for _, p := range resp.Content.Parts {
+				if p != nil && p.Text != "" {
+					parts = append(parts, p.Text)
+				}
+			}
+		}
+	}
+
+	if len(parts) == 0 {
+		return nil, fmt.Errorf("summarizer: empty response")
+	}
+	return &genai.Content{
+		Role:  "model",
+		Parts: []*genai.Part{{Text: strings.Join(parts, "")}},
+	}, nil
+}
+
+// decideSlidingWindow returns the invocation groups to compact based on a
+// watermark-based count of new invocations. Returns (nil, false) when the
+// trigger condition is not met.
+//
+// Watermark = EndTimestamp of the most recent compaction event (zero if none).
+// New invocations = those with max event timestamp strictly after the watermark.
+// Trigger when len(new) >= CompactionInterval.
+// Window = invocations[max(0, firstNewIdx-OverlapSize) : len-OverlapSize].
+func decideSlidingWindow(invocations []invocationGroup, watermark time.Time, cfg *Config) ([]invocationGroup, bool) {
+	firstNewIdx := len(invocations) // sentinel: no new invocations found
+	for i, inv := range invocations {
+		if watermark.IsZero() || maxTimestamp(inv.events).After(watermark) {
+			firstNewIdx = i
+			break
+		}
+	}
+	newCount := len(invocations) - firstNewIdx
+	if newCount < cfg.CompactionInterval {
+		return nil, false
+	}
+
+	// Reach back OverlapSize into already-compacted invocations for context.
+	windowStart := firstNewIdx - cfg.OverlapSize
+	if windowStart < 0 {
+		windowStart = 0
+	}
+	// Keep last OverlapSize new invocations as a recent-context tail.
+	windowEnd := len(invocations) - cfg.OverlapSize
+	if windowEnd <= windowStart {
+		return nil, false
+	}
+	return invocations[windowStart:windowEnd], true
+}
+
+// findWatermark returns the latest EndTimestamp seen in any compaction event,
+// or zero time when no compaction event exists.
+func findWatermark(events []*adksession.Event) time.Time {
+	var watermark time.Time
+	for _, ev := range events {
+		if ev.Actions.Compaction != nil {
+			if ts := ev.Actions.Compaction.EndTimestamp; ts.After(watermark) {
+				watermark = ts
+			}
+		}
+	}
+	return watermark
+}
+
+// buildCompactionEvent creates an event that marks a compacted range.
+// The event carries the summary in Actions.Compaction; its Content is nil.
+func buildCompactionEvent(ctx context.Context, content *genai.Content, startTS, endTS time.Time) *adksession.Event {
+	invID := "compaction_" + startTS.UTC().Format("20060102T150405Z")
+	e := adksession.NewEventWithContext(ctx, invID)
+	e.Author = compactionAuthor
+	e.Actions.Compaction = &adksession.EventCompaction{
+		StartTimestamp:   startTS,
+		EndTimestamp:     endTS,
+		CompactedContent: content,
+	}
+	return e
+}
+
+// longestSelfContainedPrefix returns the longest prefix of events that ends
+// at a point where no function call is open and no tool confirmation is pending.
+// This prevents compacting through an in-flight tool exchange.
+func longestSelfContainedPrefix(events []*adksession.Event) []*adksession.Event {
+	openCalls := map[string]bool{}
+	safeIdx := 0
+
+	for i, ev := range events {
+		if ev.Content != nil {
+			for _, p := range ev.Content.Parts {
+				if p.FunctionCall != nil {
+					openCalls[p.FunctionCall.ID] = true
+				}
+				if p.FunctionResponse != nil {
+					delete(openCalls, p.FunctionResponse.ID)
+				}
+			}
+		}
+		if len(openCalls) == 0 && len(ev.Actions.RequestedToolConfirmations) == 0 {
+			safeIdx = i + 1
+		}
+	}
+	return events[:safeIdx]
+}
+
+type invocationGroup struct {
+	invocationID string
+	events       []*adksession.Event
+}
+
+func groupByInvocation(events []*adksession.Event) []invocationGroup {
+	var groups []invocationGroup
+	index := map[string]int{}
+
+	for _, e := range events {
+		id := e.InvocationID
+		if id == "" {
+			id = noInvocationSentinel
+		}
+		if i, ok := index[id]; ok {
+			groups[i].events = append(groups[i].events, e)
+		} else {
+			index[id] = len(groups)
+			groups = append(groups, invocationGroup{
+				invocationID: id,
+				events:       []*adksession.Event{e},
+			})
+		}
+	}
+	return groups
+}
+
+func maxTimestamp(events []*adksession.Event) time.Time {
+	var t time.Time
+	for _, e := range events {
+		if e.Timestamp.After(t) {
+			t = e.Timestamp
+		}
+	}
+	return t
+}
+
+func collectEvents(sess adksession.Session) []*adksession.Event {
+	var out []*adksession.Event
+	for e := range sess.Events().All() {
+		out = append(out, e)
+	}
+	return out
+}
+
+func serializeEvents(events []*adksession.Event) string {
+	var sb strings.Builder
+	for _, e := range events {
+		if e.Content == nil {
+			continue
+		}
+		role := e.Author
+		if role == "" {
+			role = e.Content.Role
+		}
+		for _, p := range e.Content.Parts {
+			if p == nil {
+				continue
+			}
+			switch {
+			case p.Text != "":
+				fmt.Fprintf(&sb, "[%s]: %s\n", role, p.Text)
+			case p.FunctionCall != nil:
+				fmt.Fprintf(&sb, "[%s] called tool %q\n", role, p.FunctionCall.Name)
+			case p.FunctionResponse != nil:
+				fmt.Fprintf(&sb, "[tool %s response]\n", p.FunctionResponse.Name)
+			}
+		}
+	}
+	return sb.String()
+}
+
+func estimateTokens(events []*adksession.Event) int {
+	return len(serializeEvents(events)) / 4
+}
+
+// FromAgentConfig builds a Config from the kagent AgentConfig.
+// Returns nil when compaction is not configured.
+// SummarizerLLM must be wired separately (adapter.go buildCompactionConfig).
+func FromAgentConfig(agentCfg *adkapiconfig.AgentConfig) (*Config, error) {
+	if agentCfg == nil || agentCfg.ContextConfig == nil || agentCfg.ContextConfig.Compaction == nil {
+		return nil, nil
+	}
+	comp := agentCfg.ContextConfig.Compaction
+
+	cfg := &Config{
+		CompactionInterval: defaultCompactionInterval,
+		OverlapSize:        defaultOverlapSize,
+		PromptTemplate:     defaultSummaryPrompt,
+	}
+
+	if comp.CompactionInterval != nil && *comp.CompactionInterval > 0 {
+		cfg.CompactionInterval = *comp.CompactionInterval
+	}
+	if comp.OverlapSize != nil && *comp.OverlapSize >= 0 {
+		cfg.OverlapSize = *comp.OverlapSize
+	}
+	if comp.TokenThreshold != nil {
+		cfg.TokenThreshold = *comp.TokenThreshold
+	}
+	if comp.EventRetentionSize != nil {
+		cfg.EventRetentionSize = *comp.EventRetentionSize
+	}
+	if comp.PromptTemplate != "" {
+		cfg.PromptTemplate = comp.PromptTemplate
+	}
+
+	return cfg, nil
+}
+
+// SummarizerModelName returns the model name configured for summarization,
+// or "" when none is set. Used by adapter.go to decide whether to build a
+// dedicated summarizer LLM or fall back to the agent's own model.
+func SummarizerModelName(agentCfg *adkapiconfig.AgentConfig) string {
+	if agentCfg == nil || agentCfg.ContextConfig == nil || agentCfg.ContextConfig.Compaction == nil {
+		return ""
+	}
+	comp := agentCfg.ContextConfig.Compaction
+	if comp.SummarizerModel == nil {
+		return ""
+	}
+	type namer interface{ GetModelName() string }
+	if n, ok := comp.SummarizerModel.(namer); ok {
+		return n.GetModelName()
+	}
+	return "configured"
+}

--- a/go/adk/pkg/compaction/compaction_test.go
+++ b/go/adk/pkg/compaction/compaction_test.go
@@ -1,6 +1,7 @@
 package compaction
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -20,6 +21,13 @@ var (
 	t5 = t0.Add(5 * time.Second)
 	t6 = t0.Add(6 * time.Second)
 )
+
+func makeCompactionMarkerEvent(startTS, endTS time.Time, summaryText string) *adksession.Event {
+	return buildCompactionEvent(context.Background(), &genai.Content{
+		Role:  "model",
+		Parts: []*genai.Part{{Text: summaryText}},
+	}, startTS, endTS)
+}
 
 func makeEvent(ts time.Time, invocationID string) *adksession.Event {
 	return &adksession.Event{
@@ -85,19 +93,13 @@ func TestFindWatermark_None(t *testing.T) {
 }
 
 func TestFindWatermark_Single(t *testing.T) {
-	ev := makeEvent(t5, "comp1")
-	ev.Actions.Compaction = &adksession.EventCompaction{
-		StartTimestamp: t0,
-		EndTimestamp:   t3,
-	}
-	require.Equal(t, t3, findWatermark([]*adksession.Event{makeEvent(t0, "inv1"), ev}))
+	marker := makeCompactionMarkerEvent(t0, t3, "summary")
+	require.Equal(t, t3, findWatermark([]*adksession.Event{makeEvent(t0, "inv1"), marker}))
 }
 
 func TestFindWatermark_MultiplePicksLatest(t *testing.T) {
-	c1 := makeEvent(t4, "comp1")
-	c1.Actions.Compaction = &adksession.EventCompaction{EndTimestamp: t2}
-	c2 := makeEvent(t5, "comp2")
-	c2.Actions.Compaction = &adksession.EventCompaction{EndTimestamp: t3}
+	c1 := makeCompactionMarkerEvent(t0, t2, "summary1")
+	c2 := makeCompactionMarkerEvent(t0, t3, "summary2")
 	require.Equal(t, t3, findWatermark([]*adksession.Event{makeEvent(t0, "inv1"), c1, c2}))
 }
 

--- a/go/adk/pkg/compaction/compaction_test.go
+++ b/go/adk/pkg/compaction/compaction_test.go
@@ -1,0 +1,282 @@
+package compaction
+
+import (
+	"testing"
+	"time"
+
+	adkapiconfig "github.com/kagent-dev/kagent/go/api/adk"
+	"github.com/stretchr/testify/require"
+	adksession "google.golang.org/adk/session"
+	"google.golang.org/adk/tool/toolconfirmation"
+	"google.golang.org/genai"
+)
+
+var (
+	t0 = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 = t0.Add(time.Second)
+	t2 = t0.Add(2 * time.Second)
+	t3 = t0.Add(3 * time.Second)
+	t4 = t0.Add(4 * time.Second)
+	t5 = t0.Add(5 * time.Second)
+	t6 = t0.Add(6 * time.Second)
+)
+
+func makeEvent(ts time.Time, invocationID string) *adksession.Event {
+	return &adksession.Event{
+		ID:           "ev-" + ts.Format("150405.000"),
+		Timestamp:    ts,
+		InvocationID: invocationID,
+	}
+}
+
+func makeTextEvent(ts time.Time, invocationID, author, text string) *adksession.Event {
+	ev := makeEvent(ts, invocationID)
+	ev.Author = author
+	ev.LLMResponse.Content = &genai.Content{
+		Role:  "model",
+		Parts: []*genai.Part{{Text: text}},
+	}
+	return ev
+}
+
+func makeFuncCallEvent(ts time.Time, invocationID, callID, funcName string) *adksession.Event {
+	ev := makeEvent(ts, invocationID)
+	ev.LLMResponse.Content = &genai.Content{
+		Role:  "model",
+		Parts: []*genai.Part{{FunctionCall: &genai.FunctionCall{ID: callID, Name: funcName}}},
+	}
+	return ev
+}
+
+func makeFuncRespEvent(ts time.Time, invocationID, callID, funcName string) *adksession.Event {
+	ev := makeEvent(ts, invocationID)
+	ev.LLMResponse.Content = &genai.Content{
+		Role:  "user",
+		Parts: []*genai.Part{{FunctionResponse: &genai.FunctionResponse{ID: callID, Name: funcName}}},
+	}
+	return ev
+}
+
+// ---------------------------------------------------------------------------
+// groupByInvocation
+// ---------------------------------------------------------------------------
+
+func TestGroupByInvocation(t *testing.T) {
+	events := []*adksession.Event{
+		makeEvent(t0, "inv1"),
+		makeEvent(t1, "inv1"),
+		makeEvent(t2, "inv2"),
+		makeEvent(t3, ""),
+	}
+	groups := groupByInvocation(events)
+	require.Len(t, groups, 3)
+	require.Equal(t, "inv1", groups[0].invocationID)
+	require.Len(t, groups[0].events, 2)
+	require.Equal(t, "inv2", groups[1].invocationID)
+	require.Equal(t, noInvocationSentinel, groups[2].invocationID)
+}
+
+// ---------------------------------------------------------------------------
+// findWatermark
+// ---------------------------------------------------------------------------
+
+func TestFindWatermark_None(t *testing.T) {
+	require.True(t, findWatermark([]*adksession.Event{makeEvent(t0, "inv1")}).IsZero())
+}
+
+func TestFindWatermark_Single(t *testing.T) {
+	ev := makeEvent(t5, "comp1")
+	ev.Actions.Compaction = &adksession.EventCompaction{
+		StartTimestamp: t0,
+		EndTimestamp:   t3,
+	}
+	require.Equal(t, t3, findWatermark([]*adksession.Event{makeEvent(t0, "inv1"), ev}))
+}
+
+func TestFindWatermark_MultiplePicksLatest(t *testing.T) {
+	c1 := makeEvent(t4, "comp1")
+	c1.Actions.Compaction = &adksession.EventCompaction{EndTimestamp: t2}
+	c2 := makeEvent(t5, "comp2")
+	c2.Actions.Compaction = &adksession.EventCompaction{EndTimestamp: t3}
+	require.Equal(t, t3, findWatermark([]*adksession.Event{makeEvent(t0, "inv1"), c1, c2}))
+}
+
+// ---------------------------------------------------------------------------
+// decideSlidingWindow
+// ---------------------------------------------------------------------------
+
+func TestDecideSlidingWindow_EmptyNoFire(t *testing.T) {
+	cfg := &Config{CompactionInterval: 5, OverlapSize: 2}
+	_, ok := decideSlidingWindow(nil, time.Time{}, cfg)
+	require.False(t, ok)
+}
+
+func TestDecideSlidingWindow_InsufficientNewInvocations(t *testing.T) {
+	inv := []invocationGroup{
+		{invocationID: "inv1", events: []*adksession.Event{makeEvent(t0, "inv1")}},
+		{invocationID: "inv2", events: []*adksession.Event{makeEvent(t1, "inv2")}},
+		{invocationID: "inv3", events: []*adksession.Event{makeEvent(t2, "inv3")}},
+	}
+	_, ok := decideSlidingWindow(inv, time.Time{}, &Config{CompactionInterval: 5, OverlapSize: 2})
+	require.False(t, ok)
+}
+
+func TestDecideSlidingWindow_ExactThreshold(t *testing.T) {
+	inv := []invocationGroup{
+		{invocationID: "inv1", events: []*adksession.Event{makeEvent(t0, "inv1")}},
+		{invocationID: "inv2", events: []*adksession.Event{makeEvent(t1, "inv2")}},
+		{invocationID: "inv3", events: []*adksession.Event{makeEvent(t2, "inv3")}},
+		{invocationID: "inv4", events: []*adksession.Event{makeEvent(t3, "inv4")}},
+		{invocationID: "inv5", events: []*adksession.Event{makeEvent(t4, "inv5")}},
+	}
+	// interval=5, overlap=2 → window = inv[0:3]
+	window, ok := decideSlidingWindow(inv, time.Time{}, &Config{CompactionInterval: 5, OverlapSize: 2})
+	require.True(t, ok)
+	require.Len(t, window, 3)
+	require.Equal(t, "inv1", window[0].invocationID)
+	require.Equal(t, "inv3", window[2].invocationID)
+}
+
+func TestDecideSlidingWindow_WatermarkPreventsEarlyFire(t *testing.T) {
+	inv := []invocationGroup{
+		{invocationID: "inv1", events: []*adksession.Event{makeEvent(t0, "inv1")}},
+		{invocationID: "inv2", events: []*adksession.Event{makeEvent(t1, "inv2")}},
+		{invocationID: "inv3", events: []*adksession.Event{makeEvent(t2, "inv3")}},
+		{invocationID: "inv4", events: []*adksession.Event{makeEvent(t3, "inv4")}},
+		{invocationID: "inv5", events: []*adksession.Event{makeEvent(t4, "inv5")}},
+	}
+	// watermark = t1 → inv1 and inv2 are "old" (timestamp <= watermark).
+	// inv3, inv4, inv5 are new (3 < 5) → no fire.
+	_, ok := decideSlidingWindow(inv, t1, &Config{CompactionInterval: 5, OverlapSize: 2})
+	require.False(t, ok)
+}
+
+func TestDecideSlidingWindow_WatermarkTriggersWithSix(t *testing.T) {
+	// 6 invocations, watermark covers inv1 (t0).
+	// inv2-inv6 are new (5 >= interval 5) → fire.
+	// windowStart = max(0, firstNewIdx-overlap) = max(0,1-2) = 0
+	// windowEnd = 6-2 = 4 → inv[0:4]
+	inv := make([]invocationGroup, 6)
+	for i := range inv {
+		ts := t0.Add(time.Duration(i) * time.Second)
+		id := "inv" + string(rune('1'+i))
+		inv[i] = invocationGroup{invocationID: id, events: []*adksession.Event{makeEvent(ts, id)}}
+	}
+	window, ok := decideSlidingWindow(inv, t0, &Config{CompactionInterval: 5, OverlapSize: 2})
+	require.True(t, ok)
+	require.Len(t, window, 4) // inv[0:4]
+}
+
+// ---------------------------------------------------------------------------
+// longestSelfContainedPrefix
+// ---------------------------------------------------------------------------
+
+func TestLongestSelfContainedPrefix_Empty(t *testing.T) {
+	require.Empty(t, longestSelfContainedPrefix(nil))
+}
+
+func TestLongestSelfContainedPrefix_NoOpenCalls(t *testing.T) {
+	events := []*adksession.Event{
+		makeTextEvent(t0, "inv1", "agent", "hello"),
+		makeTextEvent(t1, "inv1", "user", "world"),
+	}
+	require.Len(t, longestSelfContainedPrefix(events), 2)
+}
+
+func TestLongestSelfContainedPrefix_OpenFunctionCallBlocks(t *testing.T) {
+	events := []*adksession.Event{
+		makeTextEvent(t0, "inv1", "agent", "before"),
+		makeFuncCallEvent(t1, "inv1", "call-1", "my_tool"),
+	}
+	// Safe boundary is after the text event only.
+	require.Len(t, longestSelfContainedPrefix(events), 1)
+}
+
+func TestLongestSelfContainedPrefix_ResolvedCallCompactable(t *testing.T) {
+	events := []*adksession.Event{
+		makeFuncCallEvent(t0, "inv1", "call-1", "my_tool"),
+		makeFuncRespEvent(t1, "inv1", "call-1", "my_tool"),
+		makeTextEvent(t2, "inv1", "agent", "done"),
+	}
+	require.Len(t, longestSelfContainedPrefix(events), 3)
+}
+
+func TestLongestSelfContainedPrefix_HITLConfirmationBlocks(t *testing.T) {
+	hitlEvent := makeTextEvent(t1, "inv1", "agent", "confirm?")
+	hitlEvent.Actions.RequestedToolConfirmations = map[string]toolconfirmation.ToolConfirmation{
+		"call-1": {},
+	}
+	events := []*adksession.Event{
+		makeTextEvent(t0, "inv1", "agent", "before"),
+		hitlEvent,
+	}
+	require.Len(t, longestSelfContainedPrefix(events), 1)
+}
+
+func TestLongestSelfContainedPrefix_OpenCallAtStartBlocksAll(t *testing.T) {
+	events := []*adksession.Event{
+		makeFuncCallEvent(t0, "inv1", "call-1", "my_tool"),
+		makeTextEvent(t1, "inv1", "agent", "waiting"),
+	}
+	require.Empty(t, longestSelfContainedPrefix(events))
+}
+
+// ---------------------------------------------------------------------------
+// FromAgentConfig
+// ---------------------------------------------------------------------------
+
+func TestFromAgentConfig_Nil(t *testing.T) {
+	cfg, err := FromAgentConfig(nil)
+	require.NoError(t, err)
+	require.Nil(t, cfg)
+}
+
+func TestFromAgentConfig_NoCompaction(t *testing.T) {
+	cfg, err := FromAgentConfig(&adkapiconfig.AgentConfig{})
+	require.NoError(t, err)
+	require.Nil(t, cfg)
+}
+
+func TestFromAgentConfig_Defaults(t *testing.T) {
+	interval := 0
+	agentCfg := &adkapiconfig.AgentConfig{
+		ContextConfig: &adkapiconfig.AgentContextConfig{
+			Compaction: &adkapiconfig.AgentCompressionConfig{
+				CompactionInterval: &interval, // zero → use default
+			},
+		},
+	}
+	cfg, err := FromAgentConfig(agentCfg)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	require.Equal(t, defaultCompactionInterval, cfg.CompactionInterval)
+	require.Equal(t, defaultOverlapSize, cfg.OverlapSize)
+	require.Equal(t, defaultSummaryPrompt, cfg.PromptTemplate)
+}
+
+func TestFromAgentConfig_CustomValues(t *testing.T) {
+	interval := 10
+	overlap := 3
+	threshold := 50000
+	retention := 20
+	prompt := "custom: {{events}}"
+	agentCfg := &adkapiconfig.AgentConfig{
+		ContextConfig: &adkapiconfig.AgentContextConfig{
+			Compaction: &adkapiconfig.AgentCompressionConfig{
+				CompactionInterval: &interval,
+				OverlapSize:        &overlap,
+				TokenThreshold:     &threshold,
+				EventRetentionSize: &retention,
+				PromptTemplate:     prompt,
+			},
+		},
+	}
+	cfg, err := FromAgentConfig(agentCfg)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	require.Equal(t, 10, cfg.CompactionInterval)
+	require.Equal(t, 3, cfg.OverlapSize)
+	require.Equal(t, 50000, cfg.TokenThreshold)
+	require.Equal(t, 20, cfg.EventRetentionSize)
+	require.Equal(t, prompt, cfg.PromptTemplate)
+}

--- a/go/adk/pkg/compaction/session_wrapper.go
+++ b/go/adk/pkg/compaction/session_wrapper.go
@@ -1,0 +1,89 @@
+package compaction
+
+import (
+	"context"
+	"iter"
+
+	adksession "google.golang.org/adk/session"
+)
+
+// NewCompactingService wraps real so that Get returns a compacted view of
+// the session: compaction marker events are removed and replaced by synthetic
+// summary events. All other Service methods delegate unchanged.
+//
+// AppendEvent unwraps *compactedSession before delegating so that storage
+// implementations that type-assert the session (e.g. in-memory service) still
+// receive the concrete type they expect.
+func NewCompactingService(real adksession.Service, agentName string) adksession.Service {
+	return &compactingService{real: real, agentName: agentName}
+}
+
+type compactingService struct {
+	real      adksession.Service
+	agentName string
+}
+
+func (s *compactingService) Create(ctx context.Context, req *adksession.CreateRequest) (*adksession.CreateResponse, error) {
+	return s.real.Create(ctx, req)
+}
+
+func (s *compactingService) Get(ctx context.Context, req *adksession.GetRequest) (*adksession.GetResponse, error) {
+	resp, err := s.real.Get(ctx, req)
+	if err != nil || resp == nil || resp.Session == nil {
+		return resp, err
+	}
+	events := collectEvents(resp.Session)
+	compacted := BuildCompactedEventList(s.agentName, events)
+	return &adksession.GetResponse{
+		Session: &compactedSession{
+			Session:   resp.Session,
+			compacted: eventSlice(compacted),
+		},
+	}, nil
+}
+
+func (s *compactingService) List(ctx context.Context, req *adksession.ListRequest) (*adksession.ListResponse, error) {
+	return s.real.List(ctx, req)
+}
+
+func (s *compactingService) Delete(ctx context.Context, req *adksession.DeleteRequest) error {
+	return s.real.Delete(ctx, req)
+}
+
+// AppendEvent unwraps *compactedSession to its underlying Session before
+// delegating. The in-memory service does a concrete type assertion on the
+// Session parameter; passing the wrapper would cause that assertion to fail.
+func (s *compactingService) AppendEvent(ctx context.Context, sess adksession.Session, event *adksession.Event) error {
+	if cs, ok := sess.(*compactedSession); ok {
+		return s.real.AppendEvent(ctx, cs.Session, event)
+	}
+	return s.real.AppendEvent(ctx, sess, event)
+}
+
+// compactedSession wraps a real Session and overrides Events() to return the
+// compacted event list. All other Session methods delegate to the real session.
+type compactedSession struct {
+	adksession.Session
+	compacted eventSlice
+}
+
+func (s *compactedSession) Events() adksession.Events {
+	return s.compacted
+}
+
+// eventSlice implements adksession.Events over a plain slice.
+type eventSlice []*adksession.Event
+
+func (e eventSlice) All() iter.Seq[*adksession.Event] {
+	return func(yield func(*adksession.Event) bool) {
+		for _, ev := range e {
+			if !yield(ev) {
+				return
+			}
+		}
+	}
+}
+
+func (e eventSlice) Len() int { return len(e) }
+
+func (e eventSlice) At(i int) *adksession.Event { return e[i] }

--- a/go/adk/pkg/runner/adapter.go
+++ b/go/adk/pkg/runner/adapter.go
@@ -84,19 +84,27 @@ func CreateRunnerConfig(
 		}
 	}
 
+	compactionCfg, err := buildCompactionConfig(ctx, agentConfig, log)
+	if err != nil {
+		return runner.Config{}, nil, nil, fmt.Errorf("failed to build compaction config: %w", err)
+	}
+
+	// Wrap the session service so the runner receives a compacted event view.
+	// The executor's raw KAgentSessionService is kept unwrapped so MaybeCompact
+	// can read and write real marker events.
+	runnerSessionService := adkSessionService
+	if compactionCfg != nil {
+		runnerSessionService = compaction.NewCompactingService(adkSessionService, agentNameFromAppName(appName))
+	}
+
 	cfg := runner.Config{
 		AppName:        appName,
 		Agent:          adkAgent,
-		SessionService: adkSessionService,
+		SessionService: runnerSessionService,
 		MemoryService:  runnerMemory,
 		PluginConfig: runner.PluginConfig{
 			Plugins: adkPlugins,
 		},
-	}
-
-	compactionCfg, err := buildCompactionConfig(ctx, agentConfig, log)
-	if err != nil {
-		return runner.Config{}, nil, nil, fmt.Errorf("failed to build compaction config: %w", err)
 	}
 
 	return cfg, subagentSessionIDs, compactionCfg, nil

--- a/go/adk/pkg/runner/adapter.go
+++ b/go/adk/pkg/runner/adapter.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/kagent-dev/kagent/go/adk/pkg/agent"
+	"github.com/kagent-dev/kagent/go/adk/pkg/compaction"
 	kagentmemory "github.com/kagent-dev/kagent/go/adk/pkg/memory"
 	"github.com/kagent-dev/kagent/go/adk/pkg/session"
 	"github.com/kagent-dev/kagent/go/adk/pkg/sts"
@@ -26,34 +27,34 @@ func agentNameFromAppName(appName string) string {
 	return appName
 }
 
-// CreateRunnerConfig builds a runner.Config and subagent session IDs for A2A
-// stamping (from remote agent wiring in the agent builder).
+// CreateRunnerConfig builds a runner.Config, subagent session IDs, and
+// compaction config for the executor.
 func CreateRunnerConfig(
 	ctx context.Context,
 	agentConfig *adk.AgentConfig,
 	sessionService *session.KAgentSessionService,
 	appName string,
 	memoryService *kagentmemory.KagentMemoryService,
-) (runner.Config, map[string]string, error) {
+) (runner.Config, map[string]string, *compaction.Config, error) {
 	log := logr.FromContextOrDiscard(ctx)
 
 	var extraTools []adktool.Tool
 	if memoryService != nil {
 		saveTool, err := kagentmemory.NewSaveMemoryTool(memoryService)
 		if err != nil {
-			return runner.Config{}, nil, fmt.Errorf("failed to create save_memory tool: %w", err)
+			return runner.Config{}, nil, nil, fmt.Errorf("failed to create save_memory tool: %w", err)
 		}
 		extraTools = append(extraTools, saveTool)
 	}
 
 	stsPlugin, err := buildTokenPropagationPlugin(ctx, log)
 	if err != nil {
-		return runner.Config{}, nil, err
+		return runner.Config{}, nil, nil, err
 	}
 
 	adkAgent, subagentSessionIDs, err := agent.CreateGoogleADKAgentWithSubagentSessionIDs(ctx, agentConfig, agentNameFromAppName(appName), stsPlugin, extraTools...)
 	if err != nil {
-		return runner.Config{}, nil, fmt.Errorf("failed to create agent: %w", err)
+		return runner.Config{}, nil, nil, fmt.Errorf("failed to create agent: %w", err)
 	}
 
 	var adkSessionService adksession.Service
@@ -76,7 +77,7 @@ func CreateRunnerConfig(
 	if stsPlugin != nil {
 		p, err := stsPlugin.ADKPlugin()
 		if err != nil {
-			return runner.Config{}, nil, fmt.Errorf("failed to create STS ADK plugin: %w", err)
+			return runner.Config{}, nil, nil, fmt.Errorf("failed to create STS ADK plugin: %w", err)
 		}
 		if p != nil {
 			adkPlugins = append(adkPlugins, p)
@@ -93,7 +94,43 @@ func CreateRunnerConfig(
 		},
 	}
 
-	return cfg, subagentSessionIDs, nil
+	compactionCfg, err := buildCompactionConfig(ctx, agentConfig, log)
+	if err != nil {
+		return runner.Config{}, nil, nil, fmt.Errorf("failed to build compaction config: %w", err)
+	}
+
+	return cfg, subagentSessionIDs, compactionCfg, nil
+}
+
+// buildCompactionConfig builds a *compaction.Config from the agent config,
+// wiring the summarizer LLM if one is configured.
+func buildCompactionConfig(ctx context.Context, agentConfig *adk.AgentConfig, log logr.Logger) (*compaction.Config, error) {
+	cfg, err := compaction.FromAgentConfig(agentConfig)
+	if err != nil || cfg == nil {
+		return cfg, err
+	}
+
+	summarizerModelName := compaction.SummarizerModelName(agentConfig)
+	if summarizerModelName != "" {
+		// SummarizerModel is configured as a full Model spec in the agent config.
+		if agentConfig.ContextConfig != nil && agentConfig.ContextConfig.Compaction != nil &&
+			agentConfig.ContextConfig.Compaction.SummarizerModel != nil {
+			summarizerLLM, err := agent.CreateLLM(ctx, agentConfig.ContextConfig.Compaction.SummarizerModel, log)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create summarizer LLM: %w", err)
+			}
+			cfg.SummarizerLLM = summarizerLLM
+		}
+	} else if agentConfig.Model != nil {
+		// Fall back to the agent's own model for summarization.
+		summarizerLLM, err := agent.CreateLLM(ctx, agentConfig.Model, log)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create summarizer LLM from agent model: %w", err)
+		}
+		cfg.SummarizerLLM = summarizerLLM
+	}
+
+	return cfg, nil
 }
 
 func buildTokenPropagationPlugin(ctx context.Context, log logr.Logger) (*sts.TokenPropagationPlugin, error) {

--- a/go/adk/pkg/session/local_session.go
+++ b/go/adk/pkg/session/local_session.go
@@ -63,6 +63,17 @@ func (s *localSession) appendEvent(event *adksession.Event) error {
 	return nil
 }
 
+// ReplaceEvents atomically replaces the in-memory event slice.
+// Used by the compactor when it needs to trim the in-memory cache after
+// persisting a compaction marker via AppendEvent.
+func (s *localSession) ReplaceEvents(newEvents []*adksession.Event) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	snap := make([]*adksession.Event, len(newEvents))
+	copy(snap, newEvents)
+	s.events = snap
+}
+
 // events implements adksession.Events.
 type events []*adksession.Event
 

--- a/go/adk/pkg/session/local_session.go
+++ b/go/adk/pkg/session/local_session.go
@@ -63,17 +63,6 @@ func (s *localSession) appendEvent(event *adksession.Event) error {
 	return nil
 }
 
-// ReplaceEvents atomically replaces the in-memory event slice.
-// Used by the compactor when it needs to trim the in-memory cache after
-// persisting a compaction marker via AppendEvent.
-func (s *localSession) ReplaceEvents(newEvents []*adksession.Event) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	snap := make([]*adksession.Event, len(newEvents))
-	copy(snap, newEvents)
-	s.events = snap
-}
-
 // events implements adksession.Events.
 type events []*adksession.Event
 

--- a/go/core/internal/controller/reconciler/reconciler.go
+++ b/go/core/internal/controller/reconciler/reconciler.go
@@ -908,10 +908,7 @@ func (a *kagentReconciler) validateRuntimeFeatures(agent v1alpha2.AgentObject) s
 	}
 
 	// Memory: ✅ Supported in Go as of PR #1444
-	// Context compression: Not yet implemented in Go runtime
-	if decl.Context != nil && decl.Context.Compaction != nil {
-		unsupported = append(unsupported, "context compression/compaction (not implemented in Go runtime)")
-	}
+	// Context compression: ✅ Supported in Go runtime via compaction package.
 
 	if len(unsupported) == 0 {
 		return ""

--- a/go/go.mod
+++ b/go/go.mod
@@ -451,3 +451,5 @@ require (
 tool sigs.k8s.io/kube-api-linter/cmd/golangci-lint-kube-api-linter
 
 replace github.com/agent-substrate/substrate => github.com/kagent-dev/substrate v0.0.6
+
+replace google.golang.org/adk => github.com/QuentinBisson/adk-go v0.0.0-20260615220632-534ff82e2630

--- a/go/go.mod
+++ b/go/go.mod
@@ -47,7 +47,7 @@ require (
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.28.0
 	golang.org/x/text v0.37.0
-	google.golang.org/adk v1.2.0
+	google.golang.org/adk v1.4.0
 	google.golang.org/genai v1.57.0
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 	gopkg.in/yaml.v3 v3.0.1
@@ -451,5 +451,3 @@ require (
 tool sigs.k8s.io/kube-api-linter/cmd/golangci-lint-kube-api-linter
 
 replace github.com/agent-substrate/substrate => github.com/kagent-dev/substrate v0.0.6
-
-replace google.golang.org/adk => github.com/QuentinBisson/adk-go v0.0.0-20260615220632-534ff82e2630

--- a/go/go.sum
+++ b/go/go.sum
@@ -62,8 +62,6 @@ github.com/MirrexOne/unqueryvet v1.5.4 h1:38QOxShO7JmMWT+eCdDMbcUgGCOeJphVkzzRgy
 github.com/MirrexOne/unqueryvet v1.5.4/go.mod h1:fs9Zq6eh1LRIhsDIsxf9PONVUjYdFHdtkHIgZdJnyPU=
 github.com/OpenPeeDeeP/depguard/v2 v2.2.1 h1:vckeWVESWp6Qog7UZSARNqfu/cZqvki8zsuj3piCMx4=
 github.com/OpenPeeDeeP/depguard/v2 v2.2.1/go.mod h1:q4DKzC4UcVaAvcfd41CZh0PWpGgzrVxUYBlgKNGquUo=
-github.com/QuentinBisson/adk-go v0.0.0-20260615220632-534ff82e2630 h1:VNJhA5EPiVsPh8Pk3WA8xnX0dtOKX1utwbSBWzHbMYw=
-github.com/QuentinBisson/adk-go v0.0.0-20260615220632-534ff82e2630/go.mod h1:kmzzFxl787QWuKxdab74upPCeoM6u8BDSmQa/VvmQ7w=
 github.com/a2aproject/a2a-go v0.3.15 h1:h5YpCiPq3jxQ5rIns7oDjPag3ivP8u817AzdA4F+NiI=
 github.com/a2aproject/a2a-go v0.3.15/go.mod h1:I7Cm+a1oL+UT6zMoP+roaRE5vdfUa1iQGVN8aSOuZ0I=
 github.com/a2aproject/a2a-go/v2 v2.3.1 h1:QWMdOX2UsJ8BJmjs952eo1FRyGsOVl0gFCKeM76AgGE=
@@ -1047,6 +1045,8 @@ gomodules.xyz/jsonpatch/v2 v2.5.0 h1:JELs8RLM12qJGXU4u/TO3V25KW8GreMKl9pdkk14RM0
 gomodules.xyz/jsonpatch/v2 v2.5.0/go.mod h1:AH3dM2RI6uoBZxn3LVrfvJ3E0/9dG4cSrbuBJT4moAY=
 gonum.org/v1/gonum v0.17.0 h1:VbpOemQlsSMrYmn7T2OUvQ4dqxQXU+ouZFQsZOx50z4=
 gonum.org/v1/gonum v0.17.0/go.mod h1:El3tOrEuMpv2UdMrbNlKEh9vd86bmQ6vqIcDwxEOc1E=
+google.golang.org/adk v1.4.0 h1:Qi4KB9YKD00/I5K9v3QsZ9ng5YiZQ7MfMgM8BZjNcsM=
+google.golang.org/adk v1.4.0/go.mod h1:R8tNFnI/eiBXHn7zJPJtqdiK/WXC+tVkyuZsXyNZXN4=
 google.golang.org/api v0.279.0 h1:hsx2M2OaRcaKtVYK6vXEUnQvdjnend7ZYES+lYaot74=
 google.golang.org/api v0.279.0/go.mod h1:B9TqLBwJqVjp1mtt7WeoQwWRwvu/400y5lETOql+giQ=
 google.golang.org/genai v1.57.0 h1:qTyG2ynz5dQy2jF4CvZdLHHVslhR0heMue+zM1a4GNM=

--- a/go/go.sum
+++ b/go/go.sum
@@ -62,6 +62,8 @@ github.com/MirrexOne/unqueryvet v1.5.4 h1:38QOxShO7JmMWT+eCdDMbcUgGCOeJphVkzzRgy
 github.com/MirrexOne/unqueryvet v1.5.4/go.mod h1:fs9Zq6eh1LRIhsDIsxf9PONVUjYdFHdtkHIgZdJnyPU=
 github.com/OpenPeeDeeP/depguard/v2 v2.2.1 h1:vckeWVESWp6Qog7UZSARNqfu/cZqvki8zsuj3piCMx4=
 github.com/OpenPeeDeeP/depguard/v2 v2.2.1/go.mod h1:q4DKzC4UcVaAvcfd41CZh0PWpGgzrVxUYBlgKNGquUo=
+github.com/QuentinBisson/adk-go v0.0.0-20260615220632-534ff82e2630 h1:VNJhA5EPiVsPh8Pk3WA8xnX0dtOKX1utwbSBWzHbMYw=
+github.com/QuentinBisson/adk-go v0.0.0-20260615220632-534ff82e2630/go.mod h1:kmzzFxl787QWuKxdab74upPCeoM6u8BDSmQa/VvmQ7w=
 github.com/a2aproject/a2a-go v0.3.15 h1:h5YpCiPq3jxQ5rIns7oDjPag3ivP8u817AzdA4F+NiI=
 github.com/a2aproject/a2a-go v0.3.15/go.mod h1:I7Cm+a1oL+UT6zMoP+roaRE5vdfUa1iQGVN8aSOuZ0I=
 github.com/a2aproject/a2a-go/v2 v2.3.1 h1:QWMdOX2UsJ8BJmjs952eo1FRyGsOVl0gFCKeM76AgGE=
@@ -1045,8 +1047,6 @@ gomodules.xyz/jsonpatch/v2 v2.5.0 h1:JELs8RLM12qJGXU4u/TO3V25KW8GreMKl9pdkk14RM0
 gomodules.xyz/jsonpatch/v2 v2.5.0/go.mod h1:AH3dM2RI6uoBZxn3LVrfvJ3E0/9dG4cSrbuBJT4moAY=
 gonum.org/v1/gonum v0.17.0 h1:VbpOemQlsSMrYmn7T2OUvQ4dqxQXU+ouZFQsZOx50z4=
 gonum.org/v1/gonum v0.17.0/go.mod h1:El3tOrEuMpv2UdMrbNlKEh9vd86bmQ6vqIcDwxEOc1E=
-google.golang.org/adk v1.2.0 h1:MfQD1/GqPfIsFNBcozNykkjdqNIdCrPH/SNqKPZF/yM=
-google.golang.org/adk v1.2.0/go.mod h1:6QY5jQI7awU4WYtJqvyIkJQheCvqsGWweU6BX63USEc=
 google.golang.org/api v0.279.0 h1:hsx2M2OaRcaKtVYK6vXEUnQvdjnend7ZYES+lYaot74=
 google.golang.org/api v0.279.0/go.mod h1:B9TqLBwJqVjp1mtt7WeoQwWRwvu/400y5lETOql+giQ=
 google.golang.org/genai v1.57.0 h1:qTyG2ynz5dQy2jF4CvZdLHHVslhR0heMue+zM1a4GNM=


### PR DESCRIPTION
## What

Implement conversation-history compaction for the Go ADK runtime, bringing it to functional parity with the Python runtime's `spec.declarative.context.compaction` feature.

The Go runtime previously silently dropped the `contextConfig.compaction` field and raised `UnsupportedFeatures` on `runtime: go` declarative agents. This PR fixes that.

## Approach

The compaction algorithm is ported from adk-python and runs entirely within the kagent `adk/pkg/compaction` package — no fork of `google.golang.org/adk` is required.

Because `google.golang.org/adk` v1.4.0 has no compaction event types, compaction markers are encoded in existing `Event` fields:

- `Author = "compaction"`
- `InvocationID = "compaction_<startNano>_<endNano>"`
- `Content` holds the LLM-generated summary

A `compactingService` wrapper (`session_wrapper.go`) intercepts `Get` to replace the raw marker events with synthetic summary events before the runner sees them. The underlying storage keeps the markers intact so `MaybeCompact` can parse the watermark on subsequent invocations.

## Algorithm

Mirrors adk-python's invocation-based sliding window:

1. Group events by `InvocationID`; parse the watermark from the most recent compaction marker's `InvocationID`
2. Count invocations whose latest timestamp is after the watermark; fire when `≥ compactionInterval`
3. Window start = `max(0, firstNewIdx - overlapSize)` (overlap reaches back into already-compacted invocations)
4. Trim to the longest self-contained prefix — never compacts through an open function call or unresolved HITL confirmation

Supports both sliding-window and token-threshold modes. All model adapters (Anthropic, OpenAI, Bedrock, Ollama) are reused for summarization via the existing `CreateLLM` path.

## Files changed

| File | Change |
|---|---|
| `go/adk/pkg/compaction/compaction.go` | Rewritten: InvocationID-based marker encoding, `BuildCompactedEventList`, watermark parsing, `filterCompactionMarkers`, `MaybeCompact` |
| `go/adk/pkg/compaction/session_wrapper.go` | New: `compactingService` + `compactedSession` wrapper; applies compacted view on `Get`, unwraps on `AppendEvent` |
| `go/adk/pkg/compaction/compaction_test.go` | Updated: removed fork-type helpers, added `makeCompactionMarkerEvent` using the new encoding |
| `go/adk/pkg/runner/adapter.go` | Wraps session service with `NewCompactingService` when compaction is configured |
| `go/adk/pkg/session/local_session.go` | Remove `ReplaceEvents` (no callers) |
| `go/core/internal/controller/reconciler/reconciler.go` | Remove `UnsupportedFeatures` guard for `context.compaction` on `runtime: go` |
| `go/go.mod` / `go/go.sum` | Upgrade `google.golang.org/adk` to v1.4.0; no replace directive |

## Closes

kagent-dev/kagent#1173