### PR TITLE
fix: duplicate error message in responses and panic risk in OTEL env vars

### DIFF
--- a/go/core/internal/controller/translator/agent/adk_api_translator.go
+++ b/go/core/internal/controller/translator/agent/adk_api_translator.go
@@ -1215,27 +1215,20 @@ func mergeDeploymentData(dst, src *modelDeploymentData) {
 }
 
 func collectOtelEnvFromProcess() []corev1.EnvVar {
-	envVars := slices.Collect(utils.Map(
-		utils.Filter(
-			slices.Values(os.Environ()),
-			func(envVar string) bool {
-				return strings.HasPrefix(envVar, "OTEL_")
-			},
-		),
-		func(envVar string) corev1.EnvVar {
-			parts := strings.SplitN(envVar, "=", 2)
-			return corev1.EnvVar{
-				Name:  parts[0],
-				Value: parts[1],
-			}
-		},
-	))
-
-	// Sort by environment variable name
+	var envVars []corev1.EnvVar
+	for _, envVar := range os.Environ() {
+		if !strings.HasPrefix(envVar, "OTEL_") {
+			continue
+		}
+		name, value, found := strings.Cut(envVar, "=")
+		if !found {
+			continue
+		}
+		envVars = append(envVars, corev1.EnvVar{Name: name, Value: value})
+	}
 	slices.SortFunc(envVars, func(a, b corev1.EnvVar) int {
 		return strings.Compare(a.Name, b.Name)
 	})
-
 	return envVars
 }
 

--- a/go/core/internal/httpserver/middleware_error.go
+++ b/go/core/internal/httpserver/middleware_error.go
@@ -58,22 +58,26 @@ func (w *errorResponseWriter) RespondWithError(err error) {
 		err = errors.New("unknown error")
 	}
 
+	var underlying error
 	if apiErr, ok := err.(*apierrors.APIError); ok {
 		statusCode = apiErr.Code
 		message = apiErr.Message
-
-		if apiErr.Err != nil {
-			err = apiErr.Err
-		}
+		underlying = apiErr.Err
+	} else {
+		underlying = err
 	}
 
-	if !errors.Is(err, pgx.ErrNoRows) {
-		log.Error(err, message)
+	if underlying != nil && !errors.Is(underlying, pgx.ErrNoRows) {
+		log.Error(underlying, message)
 	} else {
 		log.Info(message)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
-	json.NewEncoder(w).Encode(map[string]string{"error": message + ": " + err.Error()}) //nolint:errcheck
+	errMsg := message
+	if underlying != nil {
+		errMsg = message + ": " + underlying.Error()
+	}
+	json.NewEncoder(w).Encode(map[string]string{"error": errMsg}) //nolint:errcheck
 }


### PR DESCRIPTION
2 bugs fixed in one commit.

`RespondWithError` was producing `"message: message"` when `APIError.Err` is nil. 
Track the underlying error separately and omit the suffix when nil.

`collectOtelEnvFromProcess` accessed `parts[1]` without a bounds check. 
Replaced with `strings.Cut`, consistent with the rest of the codebase.