### PR TITLE
feat(helm): gate OpenShift UI Route behind ui.route.enabled

### DIFF
--- a/helm/kagent/templates/openshift-route.yaml
+++ b/helm/kagent/templates/openshift-route.yaml
@@ -1,6 +1,6 @@
 ---
-#if route crd exists
-{{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
+#if route crd exists and the route is enabled
+{{- if and (.Capabilities.APIVersions.Has "route.openshift.io/v1") .Values.ui.route.enabled }}
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:

--- a/helm/kagent/tests/openshift-route_test.yaml
+++ b/helm/kagent/tests/openshift-route_test.yaml
@@ -1,0 +1,52 @@
+suite: test openshift ui route
+templates:
+  - openshift-route.yaml
+tests:
+  - it: should render the route when the openshift api is present and route is enabled
+    capabilities:
+      apiVersions:
+        - route.openshift.io/v1
+    asserts:
+      - isKind:
+          of: Route
+      - equal:
+          path: apiVersion
+          value: route.openshift.io/v1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-ui
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+      - equal:
+          path: spec.to.kind
+          value: Service
+      - equal:
+          path: spec.to.name
+          value: RELEASE-NAME-ui
+      - equal:
+          path: spec.port.targetPort
+          value: 8080
+      - equal:
+          path: spec.tls.termination
+          value: edge
+      - equal:
+          path: spec.tls.insecureEdgeTerminationPolicy
+          value: Redirect
+      - hasDocuments:
+          count: 1
+
+  - it: should not render the route when ui.route.enabled is false even if the openshift api is present
+    capabilities:
+      apiVersions:
+        - route.openshift.io/v1
+    set:
+      ui.route.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render the route when the openshift api is absent
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -413,6 +413,12 @@ ui:
   #       path: /health
   #       port: http
   #     periodSeconds: 15
+  # -- Gates the OpenShift `Route` for the UI. Additionally conditional on the
+  # `route.openshift.io/v1` API being present, so it is a no-op off-OpenShift.
+  # Set to `false` to front the UI with your own Route/ingress or the bundled
+  # oauth2-proxy instead of the chart's edge-terminated Route.
+  route:
+    enabled: true
 # ==============================================================================
 # LLM PROVIDERS CONFIGURATION
 # ==============================================================================


### PR DESCRIPTION
## Problem

The OpenShift `Route` for the kagent UI (`helm/kagent/templates/openshift-route.yaml`) renders **unconditionally** whenever the `route.openshift.io/v1` API is present — the only guard is the CRD-existence check. There is no value to turn it off.

As raised in #2028, this means that on OpenShift the UI is effectively always exposed via an edge-terminated `Route` straight to `kagent-ui:8080`, with no auth in front. Users who want to front the UI with the bundled `oauth2-proxy` subchart, a custom `Route`, or their own ingress have no supported way to stop the chart from also publishing this unauthenticated `Route`.

## Fix

- Add a `ui.route.enabled` value (default **`true`** to preserve current behavior — existing OpenShift users must not silently lose the Route on upgrade).
- AND it with the existing CRD-presence check, so the Route stays a no-op off-OpenShift and can now be disabled on OpenShift:

  ```gotemplate
  {{- if and (.Capabilities.APIVersions.Has "route.openshift.io/v1") .Values.ui.route.enabled }}
  ```

No other behavior changes.

## Verification (`helm template`)

| Scenario | `kind: Route` rendered |
|---|---|
| `--api-versions route.openshift.io/v1` (default) | ✅ present |
| `--api-versions route.openshift.io/v1 --set ui.route.enabled=false` | ❌ absent |
| no `--api-versions` (CRD guard) | ❌ absent |

Fixes #2028