### PR TITLE
fix: set Kind discriminator in ToLegacyTask A2A conversion

### DIFF
--- a/go/core/pkg/a2acompat/trpcv0/convert.go
+++ b/go/core/pkg/a2acompat/trpcv0/convert.go
@@ -60,6 +60,7 @@ func ToLegacyTask(task *a2av1.Task) (*trpc.Task, error) {
 
 	result := &trpc.Task{
 		ID:        string(task.ID),
+		Kind:      trpc.KindTask,
 		ContextID: task.ContextID,
 		Metadata:  task.Metadata,
 		Status: trpc.TaskStatus{

--- a/go/core/pkg/a2acompat/trpcv0/convert_test.go
+++ b/go/core/pkg/a2acompat/trpcv0/convert_test.go
@@ -144,6 +144,9 @@ func assertForwardDataTaskFixture(t *testing.T, task a2av1.Task) {
 
 func assertBackwardTaskFixture(t *testing.T, got *trpc.Task) {
 	t.Helper()
+	if got.Kind != trpc.KindTask {
+		t.Fatalf("task kind = %q, want %q", got.Kind, trpc.KindTask)
+	}
 	if got.ID != "task-v1-rich" {
 		t.Fatalf("task ID = %q", got.ID)
 	}


### PR DESCRIPTION
## Description
Fix Pydantic validation error when resuming tasks after `ask_user` HITL interrupt.

## Problem
When converting A2A v1 tasks back to legacy v0 format in `ToLegacyTask()`, the `Kind` discriminator field was not being set. This caused tasks serialized through the Go controller to be rejected by Python's Pydantic validation with:
```
ValidationError: 1 validation error for KAgentTaskResponse
data.kind
  Input should be 'task' [type=literal_error, input_value='', input_type=str]
```

## Solution
Add `Kind: trpc.KindTask` to the `trpc.Task` struct literal in `ToLegacyTask()`, matching the pattern already used by `toLegacyMessage()`.

## Changes
- **convert.go**: Set `Kind` field in legacy task conversion
- **convert_test.go**: Add regression assertion in `assertBackwardTaskFixture()`

## Testing
- All existing tests pass
- New assertion prevents future regressions

Fixes #2037
