### PR TITLE
fix(helm): rename $defaultProfider to $defaultProvider

### DIFF
--- a/helm/kagent/templates/modelconfig.yaml
+++ b/helm/kagent/templates/modelconfig.yaml
@@ -1,9 +1,9 @@
 {{- $dot := . }}
 {{- $defaultProvider := .Values.providers.default | default "openAI" }}
-{{- $model := index .Values.providers $defaultProvider }}
-{{- if hasKey .Values.providers  $defaultProvider | not }}
-{{- fail  (printf "Provider key=%s is not found under .Values.providers" $defaultProvider)  }}
+{{- if hasKey .Values.providers $defaultProvider | not }}
+{{- fail (printf "Provider key=%s is not found under .Values.providers" $defaultProvider) }}
 {{- end }}
+{{- $model := index .Values.providers $defaultProvider }}
 ---
 apiVersion: kagent.dev/v1alpha2
 kind: ModelConfig

--- a/helm/kagent/templates/modelconfig.yaml
+++ b/helm/kagent/templates/modelconfig.yaml
@@ -1,8 +1,8 @@
 {{- $dot := . }}
-{{- $defaultProfider := .Values.providers.default | default "openAI" }}
-{{- $model := index .Values.providers $defaultProfider }}
-{{- if hasKey .Values.providers  $defaultProfider | not }}
-{{- fail  (printf "Provider key=%s is not found under .Values.providers" $defaultProfider)  }}
+{{- $defaultProvider := .Values.providers.default | default "openAI" }}
+{{- $model := index .Values.providers $defaultProvider }}
+{{- if hasKey .Values.providers  $defaultProvider | not }}
+{{- fail  (printf "Provider key=%s is not found under .Values.providers" $defaultProvider)  }}
 {{- end }}
 ---
 apiVersion: kagent.dev/v1alpha2


### PR DESCRIPTION
Fixes a typo in `helm/kagent/templates/modelconfig.yaml`. The variable was named `$defaultProfider` instead of `$defaultProvider`.