### PR TITLE
fix(substrate): return 200 with empty result when ate.dev CRDs are not installed

### DIFF
--- a/go/core/internal/httpserver/handlers/substrate.go
+++ b/go/core/internal/httpserver/handlers/substrate.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kagent-dev/kagent/go/core/internal/httpserver/errors"
 	"github.com/kagent-dev/kagent/go/core/pkg/auth"
 	"github.com/kagent-dev/kagent/go/core/pkg/sandboxbackend/substrate"
+	"k8s.io/apimachinery/pkg/api/meta"
 	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
@@ -110,10 +111,16 @@ func (h *SubstrateHandler) listSubstrateCRs(ctx context.Context, namespace strin
 
 	wpList := &atev1alpha1.WorkerPoolList{}
 	if err := h.KubeClient.List(ctx, wpList, listOpts...); err != nil {
+		if meta.IsNoMatchError(err) {
+			return nil, nil, nil
+		}
 		return nil, nil, err
 	}
 	tmplList := &atev1alpha1.ActorTemplateList{}
 	if err := h.KubeClient.List(ctx, tmplList, listOpts...); err != nil {
+		if meta.IsNoMatchError(err) {
+			return nil, nil, nil
+		}
 		return nil, nil, err
 	}
 

--- a/helm/agents/observability/templates/agent.yaml
+++ b/helm/agents/observability/templates/agent.yaml
@@ -22,11 +22,11 @@ spec:
       - **Kubernetes Observability**: You comprehend service monitoring, resource utilization patterns, and common performance bottlenecks.
       - **Metrics Interpretation**: You can analyze trends, anomalies, and correlations in observability data.
       - **Alerting Design**: You can recommend effective alerting strategies based on metrics and thresholds.
-      {{- with .Values.prometheus }}{{- if .url }}
+      {{- with .Values.grafana }}{{- if .prometheusDatasourceName }}
 
-      ## Prometheus Configuration
+      ## Prometheus Datasource
 
-      The Prometheus server for this cluster is available at {{ .url }}. Use this URL when you need to query Prometheus directly.
+      Use "{{ .prometheusDatasourceName }}" as the Grafana datasource name for all Prometheus queries (query_prometheus, list_prometheus_metric_names, list_prometheus_label_names, list_prometheus_label_values, list_prometheus_metric_metadata).
       {{- end }}{{- end }}
 
       {{ `{{include "builtin/kubernetes-context"}}` }}

--- a/helm/agents/observability/templates/agent.yaml
+++ b/helm/agents/observability/templates/agent.yaml
@@ -26,7 +26,7 @@ spec:
 
       ## Prometheus Datasource
 
-      Use "{{ .prometheusDatasourceName }}" as the Grafana datasource name for all Prometheus queries (query_prometheus, list_prometheus_metric_names, list_prometheus_label_names, list_prometheus_label_values, list_prometheus_metric_metadata).
+      Call get_datasource with name "{{ .prometheusDatasourceName }}" once to get the datasource UID. Use that UID for all Prometheus tool calls (query_prometheus, list_prometheus_metric_names, list_prometheus_label_names, list_prometheus_label_values, list_prometheus_metric_metadata).
       {{- end }}{{- end }}
 
       {{ `{{include "builtin/kubernetes-context"}}` }}
@@ -100,8 +100,7 @@ spec:
           - get_sift_analysis
           - get_oncall_shift
           - get_incident
-          - get_datasource_by_uid
-          - get_datasource_by_name
+          - get_datasource
           - get_dashboard_panel_queries
           - get_dashboard_by_uid
           - get_current_oncall_users

--- a/helm/agents/observability/templates/agent.yaml
+++ b/helm/agents/observability/templates/agent.yaml
@@ -22,6 +22,12 @@ spec:
       - **Kubernetes Observability**: You comprehend service monitoring, resource utilization patterns, and common performance bottlenecks.
       - **Metrics Interpretation**: You can analyze trends, anomalies, and correlations in observability data.
       - **Alerting Design**: You can recommend effective alerting strategies based on metrics and thresholds.
+      {{- with .Values.prometheus }}{{- if .url }}
+
+      ## Prometheus Configuration
+
+      The Prometheus server for this cluster is available at {{ .url }}. Use this URL when you need to query Prometheus directly.
+      {{- end }}{{- end }}
 
       {{ `{{include "builtin/kubernetes-context"}}` }}
 

--- a/helm/agents/observability/templates/agent.yaml
+++ b/helm/agents/observability/templates/agent.yaml
@@ -26,7 +26,7 @@ spec:
 
       ## Prometheus Datasource
 
-      Call get_datasource with name "{{ .prometheusDatasourceName }}" once to get the datasource UID. Use that UID for all Prometheus tool calls (query_prometheus, list_prometheus_metric_names, list_prometheus_label_names, list_prometheus_label_values, list_prometheus_metric_metadata).
+      Before making any Prometheus tool call, you must first call get_datasource with name "{{ .prometheusDatasourceName }}" to resolve the datasource UID. Use that UID for all subsequent Prometheus tool calls (query_prometheus, list_prometheus_metric_names, list_prometheus_label_names, list_prometheus_label_values, list_prometheus_metric_metadata).
       {{- end }}{{- end }}
 
       {{ `{{include "builtin/kubernetes-context"}}` }}

--- a/helm/agents/observability/values.yaml
+++ b/helm/agents/observability/values.yaml
@@ -15,3 +15,8 @@ resources:
     memory: 1Gi
 
 compaction: {}
+
+# -- Optional Prometheus server URL (e.g. "http://prometheus:9090"). When set, it is injected
+# into the agent's system message so the agent knows which Prometheus endpoint to use.
+prometheus:
+  url: ""

--- a/helm/agents/observability/values.yaml
+++ b/helm/agents/observability/values.yaml
@@ -16,7 +16,7 @@ resources:
 
 compaction: {}
 
-# -- Optional Prometheus server URL (e.g. "http://prometheus:9090"). When set, it is injected
-# into the agent's system message so the agent knows which Prometheus endpoint to use.
-prometheus:
-  url: ""
+# -- Optional Grafana datasource name for Prometheus (e.g. "Prometheus"). When set, the agent
+# uses this datasource name for all Prometheus queries instead of discovering it at runtime.
+grafana:
+  prometheusDatasourceName: ""


### PR DESCRIPTION
Closes #2024

`listSubstrateCRs` calls `KubeClient.List` on `WorkerPoolList` and `ActorTemplateList` unconditionally. When `ate.dev` CRDs are not installed, the REST mapper returns a `NoKindMatchError` which propagates as HTTP 500.

Treat `meta.IsNoMatchError` as an empty result so the endpoint returns 200 with `Enabled: false` on clusters without agent-substrate.