### PR TITLE
feat(go-adk): opt-in for forwarded/STS token to override static Authorization

### DIFF
--- a/go/adk/pkg/agent/agent.go
+++ b/go/adk/pkg/agent/agent.go
@@ -51,11 +51,12 @@ func CreateGoogleADKAgentWithSubagentSessionIDs(ctx context.Context, agentConfig
 	}
 
 	propagateToken := strings.ToLower(os.Getenv("KAGENT_PROPAGATE_TOKEN")) == "true"
+	overrideStaticWithForwardedToken := strings.ToLower(os.Getenv("KAGENT_PROPAGATE_TOKEN_OVERRIDES_STATIC")) == "true"
 	var dynamicHeaderProvider mcp.DynamicHeaderProvider
 	if stsPlugin != nil {
 		dynamicHeaderProvider = stsPlugin.HeaderProvider
 	}
-	toolsets := mcp.CreateToolsets(ctx, agentConfig.HttpTools, agentConfig.SseTools, propagateToken, dynamicHeaderProvider)
+	toolsets := mcp.CreateToolsets(ctx, agentConfig.HttpTools, agentConfig.SseTools, propagateToken, overrideStaticWithForwardedToken, dynamicHeaderProvider)
 	subagentSessionIDs := make(map[string]string)
 
 	var remoteAgentTools []tool.Tool

--- a/go/adk/pkg/mcp/registry.go
+++ b/go/adk/pkg/mcp/registry.go
@@ -65,17 +65,18 @@ func allowedRequestHeaders(ctx context.Context, allowed []string) map[string]str
 // mcpServerParams groups connection parameters for an MCP server,
 // reducing parameter sprawl across createTransport / initializeToolSet.
 type mcpServerParams struct {
-	URL                   string
-	Headers               map[string]string
-	AllowedHeaders        []string              // header names to forward from incoming request
-	PropagateToken        bool                  // when true, Authorization is forwarded independently of AllowedHeaders
-	HeaderProvider        DynamicHeaderProvider // optional per-request headers derived from invocation context (e.g., STS exchanged access tokens)
-	ServerType            string                // "http" or "sse"
-	Timeout               *float64
-	SseReadTimeout        *float64
-	TLSInsecureSkipVerify *bool
-	TLSCACertPath         *string
-	TLSDisableSystemCAs   *bool
+	URL                              string
+	Headers                          map[string]string
+	AllowedHeaders                   []string              // header names to forward from incoming request
+	PropagateToken                   bool                  // when true, Authorization is forwarded independently of AllowedHeaders
+	OverrideStaticWithForwardedToken bool                  // when true, a forwarded/STS Authorization takes precedence over a static Authorization
+	HeaderProvider                   DynamicHeaderProvider // optional per-request headers derived from invocation context (e.g., STS exchanged access tokens)
+	ServerType                       string                // "http" or "sse"
+	Timeout                          *float64
+	SseReadTimeout                   *float64
+	TLSInsecureSkipVerify            *bool
+	TLSCACertPath                    *string
+	TLSDisableSystemCAs              *bool
 }
 
 // CreateToolsets creates toolsets from all configured HTTP and SSE MCP servers,
@@ -86,6 +87,11 @@ type mcpServerParams struct {
 // independently of AllowedHeaders, mirroring the Python ADKTokenPropagationPlugin
 // behaviour triggered by KAGENT_PROPAGATE_TOKEN.
 //
+// When overrideStaticWithForwardedToken is true, a forwarded or STS-exchanged
+// Authorization takes precedence over a static Authorization configured on the
+// server (KAGENT_PROPAGATE_TOKEN_OVERRIDES_STATIC). Default false keeps static
+// headers at the highest precedence.
+//
 // Optional headerProvider can be used to inject per-request headers
 // derived from invocation context (e.g., STS exchanged access tokens).
 func CreateToolsets(
@@ -93,6 +99,7 @@ func CreateToolsets(
 	httpTools []adk.HttpMcpServerConfig,
 	sseTools []adk.SseMcpServerConfig,
 	propagateToken bool,
+	overrideStaticWithForwardedToken bool,
 	headerProvider DynamicHeaderProvider,
 ) []tool.Toolset {
 	log := logr.FromContextOrDiscard(ctx)
@@ -101,17 +108,18 @@ func CreateToolsets(
 	log.Info("Processing HTTP MCP tools", "httpToolsCount", len(httpTools))
 	for i, httpTool := range httpTools {
 		params := mcpServerParams{
-			URL:                   httpTool.Params.Url,
-			Headers:               httpTool.Params.Headers,
-			AllowedHeaders:        httpTool.AllowedHeaders,
-			PropagateToken:        propagateToken,
-			HeaderProvider:        headerProvider,
-			ServerType:            "http",
-			Timeout:               httpTool.Params.Timeout,
-			SseReadTimeout:        httpTool.Params.SseReadTimeout,
-			TLSInsecureSkipVerify: httpTool.Params.TLSInsecureSkipVerify,
-			TLSCACertPath:         httpTool.Params.TLSCACertPath,
-			TLSDisableSystemCAs:   httpTool.Params.TLSDisableSystemCAs,
+			URL:                              httpTool.Params.Url,
+			Headers:                          httpTool.Params.Headers,
+			AllowedHeaders:                   httpTool.AllowedHeaders,
+			PropagateToken:                   propagateToken,
+			OverrideStaticWithForwardedToken: overrideStaticWithForwardedToken,
+			HeaderProvider:                   headerProvider,
+			ServerType:                       "http",
+			Timeout:                          httpTool.Params.Timeout,
+			SseReadTimeout:                   httpTool.Params.SseReadTimeout,
+			TLSInsecureSkipVerify:            httpTool.Params.TLSInsecureSkipVerify,
+			TLSCACertPath:                    httpTool.Params.TLSCACertPath,
+			TLSDisableSystemCAs:              httpTool.Params.TLSDisableSystemCAs,
 		}
 		ts, err := addToolset(ctx, log, params, httpTool.Tools, "HTTP", i+1)
 		if err != nil {
@@ -123,17 +131,18 @@ func CreateToolsets(
 	log.Info("Processing SSE MCP tools", "sseToolsCount", len(sseTools))
 	for i, sseTool := range sseTools {
 		params := mcpServerParams{
-			URL:                   sseTool.Params.Url,
-			Headers:               sseTool.Params.Headers,
-			AllowedHeaders:        sseTool.AllowedHeaders,
-			PropagateToken:        propagateToken,
-			HeaderProvider:        headerProvider,
-			ServerType:            "sse",
-			Timeout:               sseTool.Params.Timeout,
-			SseReadTimeout:        sseTool.Params.SseReadTimeout,
-			TLSInsecureSkipVerify: sseTool.Params.TLSInsecureSkipVerify,
-			TLSCACertPath:         sseTool.Params.TLSCACertPath,
-			TLSDisableSystemCAs:   sseTool.Params.TLSDisableSystemCAs,
+			URL:                              sseTool.Params.Url,
+			Headers:                          sseTool.Params.Headers,
+			AllowedHeaders:                   sseTool.AllowedHeaders,
+			PropagateToken:                   propagateToken,
+			OverrideStaticWithForwardedToken: overrideStaticWithForwardedToken,
+			HeaderProvider:                   headerProvider,
+			ServerType:                       "sse",
+			Timeout:                          sseTool.Params.Timeout,
+			SseReadTimeout:                   sseTool.Params.SseReadTimeout,
+			TLSInsecureSkipVerify:            sseTool.Params.TLSInsecureSkipVerify,
+			TLSCACertPath:                    sseTool.Params.TLSCACertPath,
+			TLSDisableSystemCAs:              sseTool.Params.TLSDisableSystemCAs,
 		}
 		ts, err := addToolset(ctx, log, params, sseTool.Tools, "SSE", i+1)
 		if err != nil {
@@ -227,11 +236,12 @@ func createTransport(ctx context.Context, params mcpServerParams) (mcpsdk.Transp
 	var httpTransport http.RoundTripper = baseTransport
 	if len(params.Headers) > 0 || len(params.AllowedHeaders) > 0 || params.PropagateToken || params.HeaderProvider != nil {
 		httpTransport = &headerRoundTripper{
-			base:           baseTransport,
-			headers:        params.Headers,
-			allowedHeaders: params.AllowedHeaders,
-			propagateToken: params.PropagateToken,
-			headerProvider: params.HeaderProvider,
+			base:                             baseTransport,
+			headers:                          params.Headers,
+			allowedHeaders:                   params.AllowedHeaders,
+			propagateToken:                   params.PropagateToken,
+			overrideStaticWithForwardedToken: params.OverrideStaticWithForwardedToken,
+			headerProvider:                   params.HeaderProvider,
 		}
 	}
 
@@ -257,24 +267,41 @@ func createTransport(ctx context.Context, params mcpServerParams) (mcpsdk.Transp
 }
 
 // headerRoundTripper wraps an http.RoundTripper to add custom headers to all
-// requests. It supports four sources of headers, applied in this order so that
-// higher-priority sources win on collision:
+// requests. By default static headers configured on the MCP server spec have the
+// highest precedence; sources are applied in this order so higher-priority ones
+// win on collision:
 //  1. propagateToken: when true, Authorization is read from the incoming A2A
 //     CallContext and forwarded unconditionally (independent of allowedHeaders).
 //  2. allowedHeaders: explicit per-header forwarding from the A2A CallContext.
 //  3. headerProvider: runtime headers derived from ADK context, such as STS tokens.
 //  4. headers: static key/value pairs configured on the MCP server spec (highest
-//     priority — always wins).
+//     priority — wins by default).
+//
+// When overrideStaticWithForwardedToken is set, static headers are applied first
+// (as defaults) and the forwarded/STS sources are applied last, so a propagated
+// or STS-exchanged Authorization wins over a static one. This supports gateways
+// that require a static M2M token for tool discovery but must receive the
+// end-user token on tool calls.
 type headerRoundTripper struct {
-	base           http.RoundTripper
-	headers        map[string]string
-	allowedHeaders []string // header names (case-insensitive) to forward from A2A context
-	propagateToken bool     // when true, Authorization is forwarded independently
-	headerProvider DynamicHeaderProvider
+	base                             http.RoundTripper
+	headers                          map[string]string
+	allowedHeaders                   []string // header names (case-insensitive) to forward from A2A context
+	propagateToken                   bool     // when true, Authorization is forwarded independently
+	overrideStaticWithForwardedToken bool     // when true, forwarded/STS Authorization wins over static headers
+	headerProvider                   DynamicHeaderProvider
 }
 
 func (rt *headerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	req = req.Clone(req.Context())
+
+	// Static headers configured on the MCP server spec. Applied first (as
+	// defaults) only when forwarded/STS tokens are configured to win; otherwise
+	// they are applied last to retain the default highest-precedence behaviour.
+	if rt.overrideStaticWithForwardedToken {
+		for key, value := range rt.headers {
+			req.Header.Set(key, value)
+		}
+	}
 
 	// When KAGENT_PROPAGATE_TOKEN is set, forward Authorization from the incoming
 	// A2A request independently of allowedHeaders.
@@ -300,9 +327,12 @@ func (rt *headerRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 		}
 	}
 
-	// Apply static headers last — they take precedence over all dynamic sources.
-	for key, value := range rt.headers {
-		req.Header.Set(key, value)
+	// Apply static headers last so they retain the default highest precedence,
+	// unless they were already applied first to let forwarded tokens win.
+	if !rt.overrideStaticWithForwardedToken {
+		for key, value := range rt.headers {
+			req.Header.Set(key, value)
+		}
 	}
 
 	return rt.base.RoundTrip(req)

--- a/go/adk/pkg/mcp/registry_test.go
+++ b/go/adk/pkg/mcp/registry_test.go
@@ -396,3 +396,76 @@ func TestStaticHeaders_OverrideDynamic(t *testing.T) {
 		t.Errorf("Authorization: got %q, want %q", capturedAuth, "Bearer static")
 	}
 }
+
+// TestOverrideStatic_PropagatedTokenWinsOverStatic verifies that with
+// overrideStaticWithForwardedToken set, a token forwarded via propagateToken
+// takes precedence over a static Authorization header, while other static
+// headers still apply.
+func TestOverrideStatic_PropagatedTokenWinsOverStatic(t *testing.T) {
+	t.Parallel()
+	var capturedAuth, capturedStatic string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedAuth = r.Header.Get("Authorization")
+		capturedStatic = r.Header.Get("X-Static")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ctx := a2aCtx(map[string][]string{
+		"Authorization": {"Bearer user-token"},
+	})
+
+	rt := &headerRoundTripper{
+		base:                             http.DefaultTransport,
+		headers:                          map[string]string{"Authorization": "Bearer static-m2m", "X-Static": "keep"},
+		propagateToken:                   true,
+		overrideStaticWithForwardedToken: true,
+	}
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip failed: %v", err)
+	}
+	resp.Body.Close()
+
+	if capturedAuth != "Bearer user-token" {
+		t.Errorf("Authorization: got %q, want %q", capturedAuth, "Bearer user-token")
+	}
+	if capturedStatic != "keep" {
+		t.Errorf("X-Static: got %q, want %q", capturedStatic, "keep")
+	}
+}
+
+// TestOverrideStatic_StaticAppliesWhenNoForwardedToken verifies that with
+// overrideStaticWithForwardedToken set, the static Authorization is still used
+// when no token is forwarded (e.g. an autonomous run with no inbound token).
+func TestOverrideStatic_StaticAppliesWhenNoForwardedToken(t *testing.T) {
+	t.Parallel()
+	var capturedAuth string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	rt := &headerRoundTripper{
+		base:                             http.DefaultTransport,
+		headers:                          map[string]string{"Authorization": "Bearer static-m2m"},
+		propagateToken:                   true,
+		overrideStaticWithForwardedToken: true,
+	}
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip failed: %v", err)
+	}
+	resp.Body.Close()
+
+	if capturedAuth != "Bearer static-m2m" {
+		t.Errorf("Authorization: got %q, want %q", capturedAuth, "Bearer static-m2m")
+	}
+}

--- a/go/core/pkg/env/kagent.go
+++ b/go/core/pkg/env/kagent.go
@@ -70,6 +70,16 @@ var (
 		ComponentAgentRuntime,
 	)
 
+	KagentPropagateTokenOverridesStaticHeaders = RegisterBoolVar(
+		"KAGENT_PROPAGATE_TOKEN_OVERRIDES_STATIC",
+		false,
+		"When true, a forwarded (KAGENT_PROPAGATE_TOKEN) or STS-exchanged Authorization "+
+			"takes precedence over a static Authorization header configured on the MCP server. "+
+			"Use when a gateway requires a static M2M token for tool discovery but must receive "+
+			"the end-user token on tool calls. Default false preserves static-header precedence.",
+		ComponentAgentRuntime,
+	)
+
 	StsWellKnownURI = RegisterStringVar(
 		"STS_WELL_KNOWN_URI",
 		"",


### PR DESCRIPTION
## Problem

Static headers configured on an MCP server (`RemoteMCPServer.headersFrom`) are applied at the **highest precedence** in `headerRoundTripper` — they override an `Authorization` forwarded via `KAGENT_PROPAGATE_TOKEN` or minted by the STS plugin (`go/adk/pkg/mcp/registry.go`).

This is intentional today (guarded by `TestStaticHeaders_OverrideDynamic`), but it breaks a common gateway topology:

- The **controller** discovers a remote MCP server's tools using `RemoteMCPServer.headersFrom` (an M2M / service-account token) — the gateway requires auth to list tools.
- The **agent**, at call time, should forward the **end-user** token so the gateway can impersonate/forward the user identity downstream.

Because the static M2M `Authorization` wins, the agent always sends the M2M token on tool calls and the end-user token never reaches the gateway. Enabling `KAGENT_PROPAGATE_TOKEN` or STS has no effect when the server also carries a static `Authorization`.

## Change

Add `KAGENT_PROPAGATE_TOKEN_OVERRIDES_STATIC` (default `false`). When set, static headers are applied **first as defaults** and the forwarded/STS `Authorization` is applied **last**, so:

- a propagated / STS-exchanged `Authorization` wins over a static one,
- other static headers still apply,
- the static `Authorization` is still used as a fallback when no token is forwarded (e.g. autonomous runs).

Default behaviour is unchanged — existing precedence tests stay green.

## Tests

- `TestOverrideStatic_PropagatedTokenWinsOverStatic`
- `TestOverrideStatic_StaticAppliesWhenNoForwardedToken`
- existing precedence tests unchanged.

## Follow-up

Go runtime only. Python runtime (`agentsts`) parity can follow if this direction is acceptable; a per-server CRD field is a possible future refinement over the env var.