### PR TITLE
fix(ui): chat interface overflows viewport causing input to be hidden below fold

### DIFF
--- a/ui/src/app/agents/[namespace]/[name]/chat/layout.tsx
+++ b/ui/src/app/agents/[namespace]/[name]/chat/layout.tsx
@@ -71,6 +71,7 @@ export default async function ChatLayout({
 
   return (
     <SidebarProvider
+      className="!min-h-0 h-full"
       style={
         {
           "--sidebar-width": "350px",

--- a/ui/src/components/chat/ChatInterface.tsx
+++ b/ui/src/components/chat/ChatInterface.tsx
@@ -919,7 +919,7 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
     );
   }
   return (
-    <div className="flex h-screen w-full min-w-0 flex-col items-center justify-center transition-all duration-300 ease-in-out">
+    <div className="flex h-full w-full min-w-0 flex-col items-center justify-center transition-all duration-300 ease-in-out">
       <div className="flex-1 w-full overflow-hidden relative">
         <ScrollArea ref={containerRef} className="w-full h-full py-12">
           <div className="flex flex-col space-y-5 px-4">

--- a/ui/src/components/chat/ChatLayoutUI.tsx
+++ b/ui/src/components/chat/ChatLayoutUI.tsx
@@ -108,7 +108,7 @@ export default function ChatLayoutUI({
         agentSessions={sessions}
         isLoadingSessions={isLoadingSessions}
       />
-      <main className="flex min-h-svh min-w-0 flex-1 flex-col overflow-x-hidden px-4">
+      <main className="flex min-w-0 flex-1 flex-col overflow-x-hidden px-4">
         <div className="mx-auto flex w-full min-w-0 max-w-6xl flex-1 flex-col">
           <ChatAgentProvider
             agentType={currentAgent.agent.spec.type}


### PR DESCRIPTION
Fixes regression introduced in #2002 that resulted in user's needing to scroll down to see the chat box.

Before fix:
<img width="2952" height="1653" alt="image" src="https://github.com/user-attachments/assets/1718d1e6-8bc8-4abf-b652-978d2b1a30a2" />

After fix:
<img width="2952" height="1653" alt="image" src="https://github.com/user-attachments/assets/442b783d-116b-437a-81b9-7905d4942421" />
