### PR TITLE
Switch default declarative agent runtime to go

### DIFF
--- a/go/api/config/crd/bases/kagent.dev_agents.yaml
+++ b/go/api/config/crd/bases/kagent.dev_agents.yaml
@@ -13111,11 +13111,11 @@ spec:
                         type: array
                     type: object
                   runtime:
-                    default: python
+                    default: go
                     description: |-
                       Runtime specifies which ADK implementation to use for this agent.
-                      - "python": Uses the Python ADK (default, slower startup, full feature set)
-                      - "go": Uses the Go ADK (faster startup, most features supported)
+                      - "go": Uses the Go ADK (default, faster startup, most features supported)
+                      - "python": Uses the Python ADK (slower startup, full feature set)
                       The runtime determines both the container image and readiness probe configuration.
                     enum:
                     - python

--- a/go/api/config/crd/bases/kagent.dev_sandboxagents.yaml
+++ b/go/api/config/crd/bases/kagent.dev_sandboxagents.yaml
@@ -10768,11 +10768,11 @@ spec:
                         type: array
                     type: object
                   runtime:
-                    default: python
+                    default: go
                     description: |-
                       Runtime specifies which ADK implementation to use for this agent.
-                      - "python": Uses the Python ADK (default, slower startup, full feature set)
-                      - "go": Uses the Go ADK (faster startup, most features supported)
+                      - "go": Uses the Go ADK (default, faster startup, most features supported)
+                      - "python": Uses the Python ADK (slower startup, full feature set)
                       The runtime determines both the container image and readiness probe configuration.
                     enum:
                     - python

--- a/go/api/v1alpha2/agent_types.go
+++ b/go/api/v1alpha2/agent_types.go
@@ -269,7 +269,7 @@ func AgentSandboxPlatform(agent AgentObject) SandboxPlatform {
 	return sa.Spec.Platform
 }
 
-// EffectiveDeclarativeRuntime returns the ADK runtime from spec fields (defaults to Python).
+// EffectiveDeclarativeRuntime returns the ADK runtime from spec fields (defaults to Python when not set).
 func EffectiveDeclarativeRuntime(spec *AgentSpec) DeclarativeRuntime {
 	if spec == nil {
 		return DeclarativeRuntime_Python

--- a/go/api/v1alpha2/agent_types.go
+++ b/go/api/v1alpha2/agent_types.go
@@ -168,11 +168,11 @@ type GitRepo struct {
 // +kubebuilder:validation:XValidation:rule="!has(self.systemMessage) || !has(self.systemMessageFrom)",message="systemMessage and systemMessageFrom are mutually exclusive"
 type DeclarativeAgentSpec struct {
 	// Runtime specifies which ADK implementation to use for this agent.
-	// - "python": Uses the Python ADK (default, slower startup, full feature set)
-	// - "go": Uses the Go ADK (faster startup, most features supported)
+	// - "go": Uses the Go ADK (default, faster startup, most features supported)
+	// - "python": Uses the Python ADK (slower startup, full feature set)
 	// The runtime determines both the container image and readiness probe configuration.
 	// +optional
-	// +kubebuilder:default=python
+	// +kubebuilder:default=go
 	Runtime DeclarativeRuntime `json:"runtime,omitempty"`
 	// SystemMessage is a string specifying the system message for the agent.
 	// When PromptTemplate is set, this field is treated as a Go text/template

--- a/go/core/test/e2e/invoke_api_test.go
+++ b/go/core/test/e2e/invoke_api_test.go
@@ -170,6 +170,18 @@ type AgentOptions struct {
 	PromptTemplate *v1alpha2.PromptTemplateSpec
 }
 
+func pythonRuntime() *v1alpha2.DeclarativeRuntime {
+	r := v1alpha2.DeclarativeRuntime_Python
+	return &r
+}
+
+func requireAgentRuntime(t *testing.T, cli client.Client, agent *v1alpha2.Agent, want v1alpha2.DeclarativeRuntime) {
+	t.Helper()
+	got := &v1alpha2.Agent{}
+	require.NoError(t, cli.Get(t.Context(), client.ObjectKeyFromObject(agent), got))
+	require.Equal(t, want, got.Spec.Declarative.Runtime)
+}
+
 // setupAgentWithOptions creates and returns an agent resource with custom options
 func setupAgentWithOptions(t *testing.T, cli client.Client, modelConfigName string, tools []*v1alpha2.Tool, opts AgentOptions) *v1alpha2.Agent {
 	agent := generateAgent(modelConfigName, tools, opts)
@@ -1079,12 +1091,11 @@ func TestE2EInvokeCrewAIAgent(t *testing.T) {
 }
 
 func TestE2EInvokeSTSIntegration(t *testing.T) {
-	runE2EInvokeSTSIntegration(t, "python", nil)
+	runE2EInvokeSTSIntegration(t, "go", nil)
 }
 
-func TestE2EGoInvokeSTSIntegration(t *testing.T) {
-	goRuntime := v1alpha2.DeclarativeRuntime_Go
-	runE2EInvokeSTSIntegration(t, "go", &goRuntime)
+func TestE2EPythonInvokeSTSIntegration(t *testing.T) {
+	runE2EInvokeSTSIntegration(t, "python", pythonRuntime())
 }
 
 func runE2EInvokeSTSIntegration(t *testing.T, runtimeName string, runtimeOverride *v1alpha2.DeclarativeRuntime) {
@@ -1133,6 +1144,9 @@ func runE2EInvokeSTSIntegration(t *testing.T, runtimeName string, runtimeOverrid
 			},
 		},
 	})
+	if runtimeOverride == nil {
+		requireAgentRuntime(t, cli, agent, v1alpha2.DeclarativeRuntime_Go)
+	}
 
 	// access token for test user with the may act claim allowing system:serviceaccount:kagent:test-sts to
 	// perform operations on behalf of the test user
@@ -1273,12 +1287,11 @@ func TestE2ESkillImagePullSecrets(t *testing.T) {
 }
 
 func TestE2EDeclarativeAgentNetworkAllowlistWithSkills(t *testing.T) {
-	runDeclarativeAgentNetworkAllowlistWithSkills(t, "python", nil)
+	runDeclarativeAgentNetworkAllowlistWithSkills(t, "default", nil)
 }
 
-func TestE2EGoDeclarativeAgentNetworkAllowlistWithSkills(t *testing.T) {
-	goRuntime := v1alpha2.DeclarativeRuntime_Go
-	runDeclarativeAgentNetworkAllowlistWithSkills(t, "go", &goRuntime)
+func TestE2EPythonDeclarativeAgentNetworkAllowlistWithSkills(t *testing.T) {
+	runDeclarativeAgentNetworkAllowlistWithSkills(t, "python", pythonRuntime())
 }
 
 func runDeclarativeAgentNetworkAllowlistWithSkills(t *testing.T, runtimeName string, runtimeOverride *v1alpha2.DeclarativeRuntime) {
@@ -1377,29 +1390,21 @@ func TestE2EInvokePassthroughAgent(t *testing.T) {
 	})
 }
 
-func TestE2EInvokeGolangADKAgent(t *testing.T) {
-	// Setup mock server
+func TestE2EAgentDefaultRuntimeIsGo(t *testing.T) {
 	baseURL, stopServer := setupMockServer(t, "mocks/invoke_golang_adk_agent.json")
 	defer stopServer()
 
-	// Setup Kubernetes client
 	cli := setupK8sClient(t, false)
-
-	// Setup model config pointing at mock server
 	modelCfg := setupModelConfig(t, cli, baseURL)
 
-	// Create a declarative agent that uses the Go ADK runtime
-	goRuntime := v1alpha2.DeclarativeRuntime_Go
 	agent := setupAgentWithOptions(t, cli, modelCfg.Name, nil, AgentOptions{
-		Name:          "golang-adk-test",
+		Name:          "default-runtime-test",
 		SystemMessage: "You are a helpful test agent. Answer concisely.",
-		Runtime:       &goRuntime,
 	})
+	requireAgentRuntime(t, cli, agent, v1alpha2.DeclarativeRuntime_Go)
 
-	// Setup A2A client
 	a2aClient := setupA2AClient(t, agent)
 
-	// Run tests
 	t.Run("sync_invocation", func(t *testing.T) {
 		runSyncTest(t, a2aClient, "What is 2+2?", "4", nil)
 	})
@@ -1450,19 +1455,16 @@ func runMemoryAgentTest(t *testing.T, extraOpts AgentOptions) {
 }
 
 // TestE2EMemoryWithAgent runs the agent with memory enabled against the mock
-// (invoke_memory_agent.json). Two ModelConfigs are used: one for chat (gpt-4.1-mini)
-// and one for embeddings (text-embedding-3-small) so LiteLLM calls the correct APIs.
+// (invoke_memory_agent.json) using the default (Go) ADK runtime.
 func TestE2EMemoryWithAgent(t *testing.T) {
 	runMemoryAgentTest(t, AgentOptions{Name: "memory-test-agent"})
 }
 
-// TestE2EMemoryWithGoADKAgent is the same as TestE2EMemoryWithAgent but uses
-// the Go ADK runtime to verify memory works end-to-end with the Go runtime.
-func TestE2EMemoryWithGoADKAgent(t *testing.T) {
-	goRuntime := v1alpha2.DeclarativeRuntime_Go
+// TestE2EMemoryWithPythonAgent verifies memory with the Python ADK runtime.
+func TestE2EMemoryWithPythonAgent(t *testing.T) {
 	runMemoryAgentTest(t, AgentOptions{
-		Name:    "memory-go-adk-test",
-		Runtime: &goRuntime,
+		Name:    "memory-python-test",
+		Runtime: pythonRuntime(),
 	})
 }
 
@@ -1583,6 +1585,7 @@ func TestE2EIAgentRunsCode(t *testing.T) {
 	modelCfg := setupModelConfig(t, cli, baseURL)
 	agent := setupAgentWithOptions(t, cli, modelCfg.Name, nil, AgentOptions{
 		ExecuteCode: new(true),
+		Runtime:     pythonRuntime(),
 	})
 
 	// Setup A2A client
@@ -1603,6 +1606,7 @@ func TestE2ESandboxAgentNetworkAllowlistWithExecuteCode(t *testing.T) {
 	t.Run("deny_by_default", func(t *testing.T) {
 		agent := setupSandboxAgentWithOptions(t, cli, modelCfg.Name, nil, AgentOptions{
 			ExecuteCode: new(true),
+			Runtime:     pythonRuntime(),
 		})
 
 		a2aClient := setupSandboxA2AClient(t, agent)
@@ -1612,6 +1616,7 @@ func TestE2ESandboxAgentNetworkAllowlistWithExecuteCode(t *testing.T) {
 	t.Run("allowlist_enables_access", func(t *testing.T) {
 		agent := setupSandboxAgentWithOptions(t, cli, modelCfg.Name, nil, AgentOptions{
 			ExecuteCode: new(true),
+			Runtime:     pythonRuntime(),
 			Sandbox: &v1alpha2.SandboxConfig{
 				Network: &v1alpha2.NetworkConfig{
 					AllowedDomains: []string{controllerHost},

--- a/helm/agents/argo-rollouts/templates/agent.yaml
+++ b/helm/agents/argo-rollouts/templates/agent.yaml
@@ -9,7 +9,7 @@ spec:
   description: The Argo Rollouts Converter AI Agent specializes in converting Kubernetes Deployments to Argo Rollouts.
   type: Declarative
   declarative:
-    runtime: {{ .Values.runtime | default "python" }}
+    runtime: {{ .Values.runtime | default "go" }}
     systemMessage: |
       You are an Argo Rollouts specialist focused on progressive delivery and deployment automation. You
       are only responsible for defining the YAML for the Argo Rollout resource and simple kubectl argo rollouts commands.

--- a/helm/agents/argo-rollouts/values.yaml
+++ b/helm/agents/argo-rollouts/values.yaml
@@ -7,7 +7,7 @@ memory:
   # Optional reference to a ModelConfig resource for the agent's memory.
   modelConfigRef: ""
 
-# -- Optional runtime specification for the agent. If not specified, it will default to "python". Supported runtimes include "python" and "go".
+# -- Optional runtime specification for the agent. If not specified, it will default to "go". Supported runtimes include "python" and "go".
 runtime: ""
 
 imagePullSecrets: []

--- a/helm/agents/cilium-debug/templates/agent.yaml
+++ b/helm/agents/cilium-debug/templates/agent.yaml
@@ -9,7 +9,7 @@ spec:
   description: Cilium debug agent can help with debugging, troubleshooting, and advanced diagnostics of Cilium installations in Kubernetes clusters.
   type: Declarative
   declarative:
-    runtime: {{ .Values.runtime | default "python" }}
+    runtime: {{ .Values.runtime | default "go" }}
     modelConfig: {{ .Values.modelConfigRef | default (printf "%s" (include "kagent.defaultModelConfigName" .)) }}
     {{- with .Values.memory }}
     {{- if .enabled }}

--- a/helm/agents/cilium-debug/values.yaml
+++ b/helm/agents/cilium-debug/values.yaml
@@ -7,7 +7,7 @@ memory:
   # Optional reference to a ModelConfig resource for the agent's memory.
   modelConfigRef: ""
 
-# -- Optional runtime specification for the agent. If not specified, it will default to "python". Supported runtimes include "python" and "go".
+# -- Optional runtime specification for the agent. If not specified, it will default to "go". Supported runtimes include "python" and "go".
 runtime: ""
 
 imagePullSecrets: []

--- a/helm/agents/cilium-manager/templates/agent.yaml
+++ b/helm/agents/cilium-manager/templates/agent.yaml
@@ -9,7 +9,7 @@ spec:
   description: Cilium manager agent knows how to install, configure, monitor, and troubleshoot Cilium in Kubernetes environments
   type: Declarative
   declarative:
-    runtime: {{ .Values.runtime | default "python" }}
+    runtime: {{ .Values.runtime | default "go" }}
     modelConfig: {{ .Values.modelConfigRef | default (printf "%s" (include "kagent.defaultModelConfigName" .)) }}
     {{- with .Values.memory }}
     {{- if .enabled }}

--- a/helm/agents/cilium-manager/values.yaml
+++ b/helm/agents/cilium-manager/values.yaml
@@ -7,7 +7,7 @@ memory:
   # Optional reference to a ModelConfig resource for the agent's memory.
   modelConfigRef: ""
 
-# -- Optional runtime specification for the agent. If not specified, it will default to "python". Supported runtimes include "python" and "go".
+# -- Optional runtime specification for the agent. If not specified, it will default to "go". Supported runtimes include "python" and "go".
 runtime: ""
 
 imagePullSecrets: []

--- a/helm/agents/cilium-policy/templates/agent.yaml
+++ b/helm/agents/cilium-policy/templates/agent.yaml
@@ -9,7 +9,7 @@ spec:
   description: Cilium policy agent knows how to create CiliumNetworkPolicy and CiliumClusterwideNetworkPolicy resources from natural language
   type: Declarative
   declarative:
-    runtime: {{ .Values.runtime | default "python" }}
+    runtime: {{ .Values.runtime | default "go" }}
     modelConfig: {{ .Values.modelConfigRef | default (printf "%s" (include "kagent.defaultModelConfigName" .)) }}
     {{- with .Values.memory }}
     {{- if .enabled }}

--- a/helm/agents/cilium-policy/values.yaml
+++ b/helm/agents/cilium-policy/values.yaml
@@ -7,7 +7,7 @@ memory:
   # Optional reference to a ModelConfig resource for the agent's memory.
   modelConfigRef: ""
 
-# -- Optional runtime specification for the agent. If not specified, it will default to "python". Supported runtimes include "python" and "go".
+# -- Optional runtime specification for the agent. If not specified, it will default to "go". Supported runtimes include "python" and "go".
 runtime: ""
 
 imagePullSecrets: []

--- a/helm/agents/helm/templates/agent.yaml
+++ b/helm/agents/helm/templates/agent.yaml
@@ -9,7 +9,7 @@ spec:
   description: The Helm Expert AI Agent specializing in using Helm for Kubernetes cluster management and operations. This agent is equipped with a range of tools to manage Helm releases and troubleshoot Helm-related issues.
   type: Declarative
   declarative:
-    runtime: {{ .Values.runtime | default "python" }}
+    runtime: {{ .Values.runtime | default "go" }}
     systemMessage: |-
       # Helm AI Agent System Prompt
 

--- a/helm/agents/helm/values.yaml
+++ b/helm/agents/helm/values.yaml
@@ -7,7 +7,7 @@ memory:
   # Optional reference to a ModelConfig resource for the agent's memory.
   modelConfigRef: ""
 
-# -- Optional runtime specification for the agent. If not specified, it will default to "python". Supported runtimes include "python" and "go".
+# -- Optional runtime specification for the agent. If not specified, it will default to "go". Supported runtimes include "python" and "go".
 runtime: ""
 
 imagePullSecrets: []

--- a/helm/agents/istio/templates/agent.yaml
+++ b/helm/agents/istio/templates/agent.yaml
@@ -9,7 +9,7 @@ spec:
   description: An Istio Expert AI Agent specializing in Istio operations, troubleshooting, and maintenance.
   type: Declarative
   declarative:
-    runtime: {{ .Values.runtime | default "python" }}
+    runtime: {{ .Values.runtime | default "go" }}
     systemMessage: |
       You are a Kubernetes and Istio Expert AI Agent with comprehensive knowledge of container orchestration, service mesh architecture, and cloud-native systems. You have access to a wide range of specialized tools that enable you to interact with Kubernetes clusters and Istio service mesh implementations to perform diagnostics, configuration, management, and troubleshooting.
 

--- a/helm/agents/istio/values.yaml
+++ b/helm/agents/istio/values.yaml
@@ -7,7 +7,7 @@ memory:
   # Optional reference to a ModelConfig resource for the agent's memory.
   modelConfigRef: ""
 
-# -- Optional runtime specification for the agent. If not specified, it will default to "python". Supported runtimes include "python" and "go".
+# -- Optional runtime specification for the agent. If not specified, it will default to "go". Supported runtimes include "python" and "go".
 runtime: ""
 
 imagePullSecrets: []

--- a/helm/agents/k8s/templates/agent.yaml
+++ b/helm/agents/k8s/templates/agent.yaml
@@ -9,7 +9,7 @@ spec:
   description: An Kubernetes Expert AI Agent specializing in cluster operations, troubleshooting, and maintenance.
   type: Declarative
   declarative:
-    runtime: {{ .Values.runtime | default "python" }}
+    runtime: {{ .Values.runtime | default "go" }}
     systemMessage: |
       # Kubernetes AI Agent System Prompt
 

--- a/helm/agents/k8s/values.yaml
+++ b/helm/agents/k8s/values.yaml
@@ -7,7 +7,7 @@ memory:
   # Optional reference to a ModelConfig resource for the agent's memory.
   modelConfigRef: ""
 
-# -- Optional runtime specification for the agent. If not specified, it will default to "python". Supported runtimes include "python" and "go".
+# -- Optional runtime specification for the agent. If not specified, it will default to "go". Supported runtimes include "python" and "go".
 runtime: ""
 
 imagePullSecrets: []

--- a/helm/agents/kgateway/templates/agent.yaml
+++ b/helm/agents/kgateway/templates/agent.yaml
@@ -9,7 +9,7 @@ spec:
   description: A kgateway Expert, a specialized AI assistant with deep knowledge of kgateway, the cloud-native API gateway built on top of Envoy proxy and the Kubernetes Gateway API.
   type: Declarative
   declarative:
-    runtime: {{ .Values.runtime | default "python" }}
+    runtime: {{ .Values.runtime | default "go" }}
     systemMessage: |
       You are kgateway Expert, a specialized AI assistant with deep knowledge of kgateway, the cloud-native API gateway built on top of Envoy proxy and the Kubernetes Gateway API. Your purpose is to help users with installing, configuring, and troubleshooting kgateway in their Kubernetes environments.
 

--- a/helm/agents/kgateway/values.yaml
+++ b/helm/agents/kgateway/values.yaml
@@ -7,7 +7,7 @@ memory:
   # Optional reference to a ModelConfig resource for the agent's memory.
   modelConfigRef: ""
 
-# -- Optional runtime specification for the agent. If not specified, it will default to "python". Supported runtimes include "python" and "go".
+# -- Optional runtime specification for the agent. If not specified, it will default to "go". Supported runtimes include "python" and "go".
 runtime: ""
 
 imagePullSecrets: []

--- a/helm/agents/observability/templates/agent.yaml
+++ b/helm/agents/observability/templates/agent.yaml
@@ -9,7 +9,7 @@ spec:
   description: An Observability-oriented Agent specialized in using Prometheus, Grafana, and Kubernetes for monitoring and observability. This agent is equipped with a range of tools to query Prometheus for metrics, create Grafana dashboards, and verify Kubernetes resources.
   type: Declarative
   declarative:
-    runtime: {{ .Values.runtime | default "python" }}
+    runtime: {{ .Values.runtime | default "go" }}
     systemMessage: |
       # Observability AI Agent System Prompt
 

--- a/helm/agents/observability/values.yaml
+++ b/helm/agents/observability/values.yaml
@@ -7,7 +7,7 @@ memory:
   # Optional reference to a ModelConfig resource for the agent's memory.
   modelConfigRef: ""
 
-# -- Optional runtime specification for the agent. If not specified, it will default to "python". Supported runtimes include "python" and "go".
+# -- Optional runtime specification for the agent. If not specified, it will default to "go". Supported runtimes include "python" and "go".
 runtime: ""
 
 imagePullSecrets: []

--- a/helm/agents/promql/templates/agent.yaml
+++ b/helm/agents/promql/templates/agent.yaml
@@ -9,7 +9,7 @@ spec:
   description: GeneratePromQLTool generates PromQL queries from natural language descriptions.
   type: Declarative
   declarative:
-    runtime: {{ .Values.runtime | default "python" }}
+    runtime: {{ .Values.runtime | default "go" }}
     modelConfig: {{ .Values.modelConfigRef | default (printf "%s" (include "kagent.defaultModelConfigName" .)) }}
     {{- with .Values.memory }}
     {{- if .enabled }}

--- a/helm/agents/promql/values.yaml
+++ b/helm/agents/promql/values.yaml
@@ -7,7 +7,7 @@ memory:
   # Optional reference to a ModelConfig resource for the agent's memory.
   modelConfigRef: ""
 
-# -- Optional runtime specification for the agent. If not specified, it will default to "python". Supported runtimes include "python" and "go".
+# -- Optional runtime specification for the agent. If not specified, it will default to "go". Supported runtimes include "python" and "go".
 runtime: ""
 
 imagePullSecrets: []

--- a/helm/kagent-crds/templates/kagent.dev_agents.yaml
+++ b/helm/kagent-crds/templates/kagent.dev_agents.yaml
@@ -13111,11 +13111,11 @@ spec:
                         type: array
                     type: object
                   runtime:
-                    default: python
+                    default: go
                     description: |-
                       Runtime specifies which ADK implementation to use for this agent.
-                      - "python": Uses the Python ADK (default, slower startup, full feature set)
-                      - "go": Uses the Go ADK (faster startup, most features supported)
+                      - "go": Uses the Go ADK (default, faster startup, most features supported)
+                      - "python": Uses the Python ADK (slower startup, full feature set)
                       The runtime determines both the container image and readiness probe configuration.
                     enum:
                     - python

--- a/helm/kagent-crds/templates/kagent.dev_sandboxagents.yaml
+++ b/helm/kagent-crds/templates/kagent.dev_sandboxagents.yaml
@@ -10768,11 +10768,11 @@ spec:
                         type: array
                     type: object
                   runtime:
-                    default: python
+                    default: go
                     description: |-
                       Runtime specifies which ADK implementation to use for this agent.
-                      - "python": Uses the Python ADK (default, slower startup, full feature set)
-                      - "go": Uses the Go ADK (faster startup, most features supported)
+                      - "go": Uses the Go ADK (default, faster startup, most features supported)
+                      - "python": Uses the Python ADK (slower startup, full feature set)
                       The runtime determines both the container image and readiness probe configuration.
                     enum:
                     - python

--- a/ui/src/app/actions/agents.ts
+++ b/ui/src/app/actions/agents.ts
@@ -25,7 +25,7 @@ function declarativeRuntimeFromForm(agentFormData: AgentFormData): DeclarativeRu
   if (agentFormData.sandboxPlatform === "substrate") {
     return "go";
   }
-  return agentFormData.declarativeRuntime === "go" ? "go" : "python";
+  return agentFormData.declarativeRuntime === "python" ? "python" : "go";
 }
 
 function attachPromptTemplateToDeclarative(decl: DeclarativeAgentSpec, agentFormData: AgentFormData) {

--- a/ui/src/app/agents/new/page.tsx
+++ b/ui/src/app/agents/new/page.tsx
@@ -139,7 +139,7 @@ function AgentPageContent({ isEditMode, agentName, agentNamespace }: AgentPageCo
     imagePullSecrets: [""],
     envPairs: [{ name: "", value: "", isSecret: false }],
     stream: false,
-    declarativeRuntime: "python",
+    declarativeRuntime: "go",
     contextConfig: undefined,
     serviceAccountName: "",
     promptSourceRows: [newPromptSourceRow()],

--- a/ui/src/components/agent-form/DeclarativeRuntimeField.tsx
+++ b/ui/src/components/agent-form/DeclarativeRuntimeField.tsx
@@ -22,8 +22,8 @@ export function DeclarativeRuntimeField({ value, onChange, disabled }: Declarati
           <SelectValue placeholder="Select runtime…" />
         </SelectTrigger>
         <SelectContent>
-          <SelectItem value="python">Python</SelectItem>
           <SelectItem value="go">Go</SelectItem>
+          <SelectItem value="python">Python</SelectItem>
         </SelectContent>
       </Select>
     </FieldRoot>


### PR DESCRIPTION
- This only applies to **new** agents created after this change via CRD or UI/API
- Existing user-created agents will not be affected, if your agents are currently in python, they will not be affected unless you manually switch it to `runtime: go`
- Agents managed by helm (e.g. k8s-agent) will be upgraded to go runtime after this change
- Most e2e tests will be run on go agents as a result, certain test cases have been modified to run only for python