### PR TITLE
feat(helm): add controller service annotations

### DIFF
--- a/helm/kagent/templates/controller-service.yaml
+++ b/helm/kagent/templates/controller-service.yaml
@@ -5,6 +5,12 @@ metadata:
   namespace: {{ include "kagent.namespace" . }}
   labels:
     {{- include "kagent.controller.labels" . | nindent 4 }}
+  {{- if .Values.controller.service.annotations }}
+  annotations:
+    {{- with .Values.controller.service.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
 spec:
   type: {{ .Values.controller.service.type }}
   ports:

--- a/helm/kagent/templates/controller-service.yaml
+++ b/helm/kagent/templates/controller-service.yaml
@@ -5,11 +5,9 @@ metadata:
   namespace: {{ include "kagent.namespace" . }}
   labels:
     {{- include "kagent.controller.labels" . | nindent 4 }}
-  {{- if .Values.controller.service.annotations }}
+  {{- with .Values.controller.service.annotations }}
   annotations:
-    {{- with .Values.controller.service.annotations }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.controller.service.type }}

--- a/helm/kagent/tests/controller-service_test.yaml
+++ b/helm/kagent/tests/controller-service_test.yaml
@@ -69,3 +69,17 @@ tests:
       - equal:
           path: metadata.namespace
           value: custom-namespace
+
+  - it: should have correct annotation when set
+    set:
+      controller:
+        service:
+          annotations:
+            PrivateDNSName: kagent
+            service.beta.kubernetes.io/aws-load-balancer-type: nlb-ip
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            PrivateDNSName: kagent
+            service.beta.kubernetes.io/aws-load-balancer-type: nlb-ip

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -229,6 +229,7 @@ controller:
     ports:
       port: 8083
       targetPort: 8083
+    annotations: {}
   # -- Prometheus-style /metrics endpoint for the controller manager.
   # When enabled, provisions a dedicated metrics Service plus the
   # ClusterRoles required for authenticated scrapes. Bind


### PR DESCRIPTION
Adds support for configuring custom annotations on the controller service via `Values.controller.service.annotations`. 

This enables users to pass specific service-level annotations required by integrations like the **AWS Load Balancer Controller** or **ExternalDNS**.