### PR TITLE
feat(sts): send RFC 8707 resource and audience on token exchange

### DIFF
--- a/go/adk/pkg/runner/adapter.go
+++ b/go/adk/pkg/runner/adapter.go
@@ -141,6 +141,24 @@ func buildTokenPropagationPlugin(ctx context.Context, log logr.Logger) (*sts.Tok
 		return nil, fmt.Errorf("failed to initialize STS integration: %w", err)
 	}
 
+	var opts []sts.Option
+	if resource, audience := exchangeTarget(); resource != nil || audience != nil {
+		opts = append(opts, sts.WithExchangeTarget(resource, audience))
+	}
+
 	log.Info("Enabling STS token propagation plugin", "wellKnownURI", stsWellKnownURI)
-	return sts.NewTokenPropagationPlugin(integration, log), nil
+	return sts.NewTokenPropagationPlugin(integration, log, opts...), nil
+}
+
+// exchangeTarget reads the RFC 8707 resource and RFC 8693 audience from the
+// environment. An unset value is returned as nil so it is omitted from the
+// token-exchange request.
+func exchangeTarget() (resource, audience any) {
+	if r := strings.TrimSpace(os.Getenv("KAGENT_TOKEN_RESOURCE")); r != "" {
+		resource = r
+	}
+	if a := strings.TrimSpace(os.Getenv("KAGENT_TOKEN_AUDIENCE")); a != "" {
+		audience = a
+	}
+	return resource, audience
 }

--- a/go/adk/pkg/runner/adapter.go
+++ b/go/adk/pkg/runner/adapter.go
@@ -143,8 +143,8 @@ func buildTokenPropagationPlugin(ctx context.Context, log logr.Logger) (*sts.Tok
 
 	// RFC 8707 resource / RFC 8693 audience scope the exchanged token to a
 	// backend. Empty values are omitted from the exchange request.
-	resource := strings.TrimSpace(os.Getenv("KAGENT_TOKEN_RESOURCE"))
-	audience := strings.TrimSpace(os.Getenv("KAGENT_TOKEN_AUDIENCE"))
+	resource := strings.TrimSpace(os.Getenv("KAGENT_STS_RESOURCE"))
+	audience := strings.TrimSpace(os.Getenv("KAGENT_STS_AUDIENCE"))
 
 	log.Info("Enabling STS token propagation plugin", "wellKnownURI", stsWellKnownURI)
 	return sts.NewTokenPropagationPlugin(integration, log, resource, audience), nil

--- a/go/adk/pkg/runner/adapter.go
+++ b/go/adk/pkg/runner/adapter.go
@@ -124,7 +124,7 @@ func buildTokenPropagationPlugin(ctx context.Context, log logr.Logger) (*sts.Tok
 	// Propagate-only mode: keep parity with Python by enabling plugin without STS exchange.
 	if stsWellKnownURI == "" {
 		log.Info("Enabling token propagation plugin without STS exchange")
-		return sts.NewTokenPropagationPlugin(nil, log, "", ""), nil
+		return sts.NewTokenPropagationPlugin(nil, log, nil, nil), nil
 	}
 	defaultSTSConfig := sts.DefaultSTSConfig(stsWellKnownURI)
 
@@ -142,10 +142,22 @@ func buildTokenPropagationPlugin(ctx context.Context, log logr.Logger) (*sts.Tok
 	}
 
 	// RFC 8707 resource / RFC 8693 audience scope the exchanged token to a
-	// backend. Empty values are omitted from the exchange request.
-	resource := strings.TrimSpace(os.Getenv("KAGENT_STS_RESOURCE"))
-	audience := strings.TrimSpace(os.Getenv("KAGENT_STS_AUDIENCE"))
+	// backend. Both are repeatable; empty values are omitted from the request.
+	resource := splitCSV(os.Getenv("KAGENT_STS_RESOURCE"))
+	audience := splitCSV(os.Getenv("KAGENT_STS_AUDIENCE"))
 
 	log.Info("Enabling STS token propagation plugin", "wellKnownURI", stsWellKnownURI)
 	return sts.NewTokenPropagationPlugin(integration, log, resource, audience), nil
+}
+
+// splitCSV parses a comma-separated value into trimmed, non-empty entries,
+// returning nil when none are present so the exchange target stays unset.
+func splitCSV(v string) []string {
+	var out []string
+	for p := range strings.SplitSeq(v, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }

--- a/go/adk/pkg/runner/adapter.go
+++ b/go/adk/pkg/runner/adapter.go
@@ -141,24 +141,11 @@ func buildTokenPropagationPlugin(ctx context.Context, log logr.Logger) (*sts.Tok
 		return nil, fmt.Errorf("failed to initialize STS integration: %w", err)
 	}
 
-	var opts []sts.Option
-	if resource, audience := exchangeTarget(); resource != nil || audience != nil {
-		opts = append(opts, sts.WithExchangeTarget(resource, audience))
-	}
+	// RFC 8707 resource / RFC 8693 audience scope the exchanged token to a
+	// backend. Empty values are omitted by WithExchangeTarget.
+	resource := strings.TrimSpace(os.Getenv("KAGENT_TOKEN_RESOURCE"))
+	audience := strings.TrimSpace(os.Getenv("KAGENT_TOKEN_AUDIENCE"))
 
 	log.Info("Enabling STS token propagation plugin", "wellKnownURI", stsWellKnownURI)
-	return sts.NewTokenPropagationPlugin(integration, log, opts...), nil
-}
-
-// exchangeTarget reads the RFC 8707 resource and RFC 8693 audience from the
-// environment. An unset value is returned as nil so it is omitted from the
-// token-exchange request.
-func exchangeTarget() (resource, audience any) {
-	if r := strings.TrimSpace(os.Getenv("KAGENT_TOKEN_RESOURCE")); r != "" {
-		resource = r
-	}
-	if a := strings.TrimSpace(os.Getenv("KAGENT_TOKEN_AUDIENCE")); a != "" {
-		audience = a
-	}
-	return resource, audience
+	return sts.NewTokenPropagationPlugin(integration, log, sts.WithExchangeTarget(resource, audience)), nil
 }

--- a/go/adk/pkg/runner/adapter.go
+++ b/go/adk/pkg/runner/adapter.go
@@ -124,7 +124,7 @@ func buildTokenPropagationPlugin(ctx context.Context, log logr.Logger) (*sts.Tok
 	// Propagate-only mode: keep parity with Python by enabling plugin without STS exchange.
 	if stsWellKnownURI == "" {
 		log.Info("Enabling token propagation plugin without STS exchange")
-		return sts.NewTokenPropagationPlugin(nil, log), nil
+		return sts.NewTokenPropagationPlugin(nil, log, "", ""), nil
 	}
 	defaultSTSConfig := sts.DefaultSTSConfig(stsWellKnownURI)
 
@@ -142,10 +142,10 @@ func buildTokenPropagationPlugin(ctx context.Context, log logr.Logger) (*sts.Tok
 	}
 
 	// RFC 8707 resource / RFC 8693 audience scope the exchanged token to a
-	// backend. Empty values are omitted by WithExchangeTarget.
+	// backend. Empty values are omitted from the exchange request.
 	resource := strings.TrimSpace(os.Getenv("KAGENT_TOKEN_RESOURCE"))
 	audience := strings.TrimSpace(os.Getenv("KAGENT_TOKEN_AUDIENCE"))
 
 	log.Info("Enabling STS token propagation plugin", "wellKnownURI", stsWellKnownURI)
-	return sts.NewTokenPropagationPlugin(integration, log, sts.WithExchangeTarget(resource, audience)), nil
+	return sts.NewTokenPropagationPlugin(integration, log, resource, audience), nil
 }

--- a/go/adk/pkg/sts/client.go
+++ b/go/adk/pkg/sts/client.go
@@ -82,27 +82,14 @@ func (c *STSClient) buildFormData(req *TokenExchangeRequest) url.Values {
 		}
 	}
 
-	// Add optional parameters
-	if req.Resource != nil {
-		switch v := req.Resource.(type) {
-		case string:
-			data.Set("resource", v)
-		case []string:
-			for _, r := range v {
-				data.Add("resource", r)
-			}
-		}
+	// Add optional parameters. resource/audience are RFC 8707/8693 repeatable;
+	// an empty slice sends nothing.
+	for _, r := range req.Resource {
+		data.Add("resource", r)
 	}
 
-	if req.Audience != nil {
-		switch v := req.Audience.(type) {
-		case string:
-			data.Set("audience", v)
-		case []string:
-			for _, a := range v {
-				data.Add("audience", a)
-			}
-		}
+	for _, a := range req.Audience {
+		data.Add("audience", a)
 	}
 
 	if req.Scope != "" {
@@ -135,8 +122,8 @@ func (c *STSClient) ExchangeToken(
 	subjectTokenType TokenType,
 	actorToken string,
 	actorTokenType TokenType,
-	resource any,
-	audience any,
+	resource []string,
+	audience []string,
 	scope string,
 	requestedTokenType TokenType,
 	additionalParameters map[string]any,
@@ -217,8 +204,8 @@ func (c *STSClient) Impersonate(
 	ctx context.Context,
 	subjectToken string,
 	subjectTokenType TokenType,
-	resource any,
-	audience any,
+	resource []string,
+	audience []string,
 	scope string,
 	requestedTokenType TokenType,
 	additionalParameters map[string]any,
@@ -244,8 +231,8 @@ func (c *STSClient) Delegate(
 	subjectTokenType TokenType,
 	actorToken string,
 	actorTokenType TokenType,
-	resource any,
-	audience any,
+	resource []string,
+	audience []string,
 	scope string,
 	requestedTokenType TokenType,
 	additionalParameters map[string]any,

--- a/go/adk/pkg/sts/client_test.go
+++ b/go/adk/pkg/sts/client_test.go
@@ -93,13 +93,64 @@ func TestSTSClientDelegateBuildsRequestData(t *testing.T) {
 		"actor-token",
 		TokenTypeJWT,
 		nil,
-		"https://api.example.com",
+		[]string{"https://api.example.com"},
 		"read write",
 		"",
 		nil,
 	)
 	if err != nil {
 		t.Fatalf("Delegate() error = %v", err)
+	}
+}
+
+func TestBuildFormDataResourceAudience(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		resource []string
+		audience []string
+	}{
+		{name: "single", resource: []string{"https://mcp.example.com"}, audience: []string{"mcp-backend"}},
+		{name: "multiple resources", resource: []string{"https://a.example.com", "https://b.example.com"}},
+		{name: "audience only", audience: []string{"mcp-backend"}},
+		{name: "none omits both keys"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			data := (&STSClient{}).buildFormData(&TokenExchangeRequest{
+				GrantType:        GrantTypeTokenExchange,
+				SubjectToken:     "subject",
+				SubjectTokenType: TokenTypeJWT,
+				Resource:         tt.resource,
+				Audience:         tt.audience,
+			})
+			assertFormMulti(t, data, "resource", tt.resource)
+			assertFormMulti(t, data, "audience", tt.audience)
+		})
+	}
+}
+
+// assertFormMulti checks key carries exactly want in order; an empty want
+// means the key must be absent, never present-but-empty.
+func assertFormMulti(t *testing.T, form url.Values, key string, want []string) {
+	t.Helper()
+	got := form[key]
+	if len(want) == 0 {
+		if form.Has(key) {
+			t.Fatalf("%s = %v, want key absent", key, got)
+		}
+		return
+	}
+	if len(got) != len(want) {
+		t.Fatalf("%s = %v, want %v", key, got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("%s[%d] = %q, want %q", key, i, got[i], want[i])
+		}
 	}
 }
 

--- a/go/adk/pkg/sts/integration.go
+++ b/go/adk/pkg/sts/integration.go
@@ -132,8 +132,8 @@ func (i *STSIntegration) ExchangeToken(
 	ctx context.Context,
 	subjectToken string,
 	subjectTokenType TokenType,
-	resource any,
-	audience any,
+	resource []string,
+	audience []string,
 	scope string,
 	requestedTokenType TokenType,
 ) (*TokenExchangeResponse, error) {
@@ -153,8 +153,8 @@ func (i *STSIntegration) ExchangeTokenWithActorToken(
 	subjectToken string,
 	subjectTokenType TokenType,
 	actorToken string,
-	resource any,
-	audience any,
+	resource []string,
+	audience []string,
 	scope string,
 	requestedTokenType TokenType,
 ) (*TokenExchangeResponse, error) {

--- a/go/adk/pkg/sts/models.go
+++ b/go/adk/pkg/sts/models.go
@@ -40,10 +40,10 @@ type TokenExchangeRequest struct {
 	ActorToken string `json:"actor_token,omitempty"`
 	// ActorTokenType is the type of the actor_token (required if ActorToken is set)
 	ActorTokenType TokenType `json:"actor_token_type,omitempty"`
-	// Resource is the logical name of the target service or resource (optional)
-	Resource any `json:"resource,omitempty"` // Can be string or []string
-	// Audience is the logical name of the target service or resource (optional)
-	Audience any `json:"audience,omitempty"` // Can be string or []string
+	// Resource holds RFC 8707 resource indicators; repeatable (optional)
+	Resource []string `json:"resource,omitempty"`
+	// Audience holds RFC 8693 audiences; repeatable (optional)
+	Audience []string `json:"audience,omitempty"`
 	// Scope is the scope of the requested token (optional)
 	Scope string `json:"scope,omitempty"`
 	// RequestedTokenType is the type of the requested token (optional)

--- a/go/adk/pkg/sts/plugin.go
+++ b/go/adk/pkg/sts/plugin.go
@@ -38,24 +38,15 @@ type TokenPropagationPlugin struct {
 	mu              sync.RWMutex
 	logger          logr.Logger
 	bufferSeconds   int64
-	resource        string // RFC 8707 resource indicator sent on the STS exchange; empty omits it
-	audience        string // RFC 8693 audience sent on the STS exchange; empty omits it
-}
-
-// omitEmpty returns nil for an empty string so the STS client omits the
-// parameter entirely rather than sending it with an empty value.
-func omitEmpty(s string) any {
-	if s == "" {
-		return nil
-	}
-	return s
+	resource        []string // RFC 8707 resource indicators sent on the STS exchange; empty omits them
+	audience        []string // RFC 8693 audiences sent on the STS exchange; empty omits them
 }
 
 // NewTokenPropagationPlugin creates a new token propagation plugin.
 // If integration is nil, the plugin will pass through tokens without exchange.
 // resource and audience scope the exchanged token to a backend; empty values
 // are omitted from the request, leaving the exchange unscoped.
-func NewTokenPropagationPlugin(integration *STSIntegration, logger logr.Logger, resource, audience string) *TokenPropagationPlugin {
+func NewTokenPropagationPlugin(integration *STSIntegration, logger logr.Logger, resource, audience []string) *TokenPropagationPlugin {
 	return &TokenPropagationPlugin{
 		integration:   integration,
 		tokenCache:    make(map[string]*TokenCacheEntry),
@@ -194,8 +185,8 @@ func (p *TokenPropagationPlugin) BeforeRunCallback(ctx agent.InvocationContext) 
 			subjectToken,
 			TokenTypeJWT,
 			actorToken,
-			omitEmpty(p.resource),
-			omitEmpty(p.audience),
+			p.resource,
+			p.audience,
 			"", // scope
 			"", // requestedTokenType
 		)

--- a/go/adk/pkg/sts/plugin.go
+++ b/go/adk/pkg/sts/plugin.go
@@ -38,41 +38,32 @@ type TokenPropagationPlugin struct {
 	mu              sync.RWMutex
 	logger          logr.Logger
 	bufferSeconds   int64
-	resource        any // RFC 8707 resource indicator passed to the STS exchange
-	audience        any // RFC 8693 audience passed to the STS exchange
+	resource        string // RFC 8707 resource indicator sent on the STS exchange; empty omits it
+	audience        string // RFC 8693 audience sent on the STS exchange; empty omits it
 }
 
-// Option configures a TokenPropagationPlugin.
-type Option func(*TokenPropagationPlugin)
-
-// WithExchangeTarget sets the RFC 8707 resource and RFC 8693 audience sent on
-// token-exchange requests. Empty values are omitted from the request, so an
-// unset target leaves the exchange unscoped. Values are single strings, which
-// the STS client always serializes; multi-valued resources are out of scope.
-func WithExchangeTarget(resource, audience string) Option {
-	return func(p *TokenPropagationPlugin) {
-		if resource != "" {
-			p.resource = resource
-		}
-		if audience != "" {
-			p.audience = audience
-		}
+// omitEmpty returns nil for an empty string so the STS client omits the
+// parameter entirely rather than sending it with an empty value.
+func omitEmpty(s string) any {
+	if s == "" {
+		return nil
 	}
+	return s
 }
 
 // NewTokenPropagationPlugin creates a new token propagation plugin.
 // If integration is nil, the plugin will pass through tokens without exchange.
-func NewTokenPropagationPlugin(integration *STSIntegration, logger logr.Logger, opts ...Option) *TokenPropagationPlugin {
-	p := &TokenPropagationPlugin{
+// resource and audience scope the exchanged token to a backend; empty values
+// are omitted from the request, leaving the exchange unscoped.
+func NewTokenPropagationPlugin(integration *STSIntegration, logger logr.Logger, resource, audience string) *TokenPropagationPlugin {
+	return &TokenPropagationPlugin{
 		integration:   integration,
 		tokenCache:    make(map[string]*TokenCacheEntry),
 		logger:        logger.WithName("sts-plugin"),
 		bufferSeconds: 5,
+		resource:      resource,
+		audience:      audience,
 	}
-	for _, opt := range opts {
-		opt(p)
-	}
-	return p
 }
 
 // getCachedToken retrieves a valid cached token for the session.
@@ -203,8 +194,8 @@ func (p *TokenPropagationPlugin) BeforeRunCallback(ctx agent.InvocationContext) 
 			subjectToken,
 			TokenTypeJWT,
 			actorToken,
-			p.resource,
-			p.audience,
+			omitEmpty(p.resource),
+			omitEmpty(p.audience),
 			"", // scope
 			"", // requestedTokenType
 		)

--- a/go/adk/pkg/sts/plugin.go
+++ b/go/adk/pkg/sts/plugin.go
@@ -46,12 +46,17 @@ type TokenPropagationPlugin struct {
 type Option func(*TokenPropagationPlugin)
 
 // WithExchangeTarget sets the RFC 8707 resource and RFC 8693 audience sent on
-// token-exchange requests. A nil value is omitted from the request. Strings or
-// string slices are accepted, matching TokenExchangeRequest.Resource/Audience.
-func WithExchangeTarget(resource, audience any) Option {
+// token-exchange requests. Empty values are omitted from the request, so an
+// unset target leaves the exchange unscoped. Values are single strings, which
+// the STS client always serializes; multi-valued resources are out of scope.
+func WithExchangeTarget(resource, audience string) Option {
 	return func(p *TokenPropagationPlugin) {
-		p.resource = resource
-		p.audience = audience
+		if resource != "" {
+			p.resource = resource
+		}
+		if audience != "" {
+			p.audience = audience
+		}
 	}
 }
 

--- a/go/adk/pkg/sts/plugin.go
+++ b/go/adk/pkg/sts/plugin.go
@@ -38,17 +38,36 @@ type TokenPropagationPlugin struct {
 	mu              sync.RWMutex
 	logger          logr.Logger
 	bufferSeconds   int64
+	resource        any // RFC 8707 resource indicator passed to the STS exchange
+	audience        any // RFC 8693 audience passed to the STS exchange
+}
+
+// Option configures a TokenPropagationPlugin.
+type Option func(*TokenPropagationPlugin)
+
+// WithExchangeTarget sets the RFC 8707 resource and RFC 8693 audience sent on
+// token-exchange requests. A nil value is omitted from the request. Strings or
+// string slices are accepted, matching TokenExchangeRequest.Resource/Audience.
+func WithExchangeTarget(resource, audience any) Option {
+	return func(p *TokenPropagationPlugin) {
+		p.resource = resource
+		p.audience = audience
+	}
 }
 
 // NewTokenPropagationPlugin creates a new token propagation plugin.
 // If integration is nil, the plugin will pass through tokens without exchange.
-func NewTokenPropagationPlugin(integration *STSIntegration, logger logr.Logger) *TokenPropagationPlugin {
-	return &TokenPropagationPlugin{
+func NewTokenPropagationPlugin(integration *STSIntegration, logger logr.Logger, opts ...Option) *TokenPropagationPlugin {
+	p := &TokenPropagationPlugin{
 		integration:   integration,
 		tokenCache:    make(map[string]*TokenCacheEntry),
 		logger:        logger.WithName("sts-plugin"),
 		bufferSeconds: 5,
 	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
 }
 
 // getCachedToken retrieves a valid cached token for the session.
@@ -179,10 +198,10 @@ func (p *TokenPropagationPlugin) BeforeRunCallback(ctx agent.InvocationContext) 
 			subjectToken,
 			TokenTypeJWT,
 			actorToken,
-			nil, // resource
-			nil, // audience
-			"",  // scope
-			"",  // requestedTokenType
+			p.resource,
+			p.audience,
+			"", // scope
+			"", // requestedTokenType
 		)
 		if err != nil {
 			p.logger.Error(err, "STS token exchange failed, tools may not authenticate", "sessionID", sessionID)

--- a/go/adk/pkg/sts/plugin_test.go
+++ b/go/adk/pkg/sts/plugin_test.go
@@ -64,7 +64,7 @@ func (f fakeSession) LastUpdateTime() time.Time { return time.Time{} }
 
 func TestHeaderProvider_UsesSessionIDMethod(t *testing.T) {
 	t.Parallel()
-	plugin := NewTokenPropagationPlugin(nil, logr.Discard())
+	plugin := NewTokenPropagationPlugin(nil, logr.Discard(), "", "")
 	plugin.setCachedToken("sess-123", "token-abc", 0)
 
 	headers := plugin.HeaderProvider(fakeSessionContext{
@@ -125,7 +125,7 @@ func TestBeforeRunCallback_ReusesCachedDynamicActorTokenForExchange(t *testing.T
 		t.Fatalf("NewSTSIntegration() error = %v", err)
 	}
 
-	plugin := NewTokenPropagationPlugin(integration, logr.Discard())
+	plugin := NewTokenPropagationPlugin(integration, logr.Discard(), "", "")
 	for _, sessionID := range []string{"sess-one", "sess-two"} {
 		ctx := context.WithValue(context.Background(), kagentmodels.BearerTokenKey, "subject-token")
 		if _, err := plugin.BeforeRunCallback(&fakeInvocationContext{
@@ -149,19 +149,20 @@ func TestBeforeRunCallback_SendsResourceAndAudience(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		opts         []Option
+		resource     string
+		audience     string
 		wantResource string
 		wantAudience string
 	}{
 		{
 			name:         "configured target is sent",
-			opts:         []Option{WithExchangeTarget("https://mcp.example.com", "mcp-backend")},
+			resource:     "https://mcp.example.com",
+			audience:     "mcp-backend",
 			wantResource: "https://mcp.example.com",
 			wantAudience: "mcp-backend",
 		},
 		{
 			name:         "no target leaves resource and audience unset",
-			opts:         nil,
 			wantResource: "",
 			wantAudience: "",
 		},
@@ -213,7 +214,7 @@ func TestBeforeRunCallback_SendsResourceAndAudience(t *testing.T) {
 				t.Fatalf("NewSTSIntegration() error = %v", err)
 			}
 
-			plugin := NewTokenPropagationPlugin(integration, logr.Discard(), tt.opts...)
+			plugin := NewTokenPropagationPlugin(integration, logr.Discard(), tt.resource, tt.audience)
 			ctx := context.WithValue(context.Background(), kagentmodels.BearerTokenKey, "subject-token")
 			if _, err := plugin.BeforeRunCallback(&fakeInvocationContext{
 				Context:   ctx,

--- a/go/adk/pkg/sts/plugin_test.go
+++ b/go/adk/pkg/sts/plugin_test.go
@@ -171,7 +171,15 @@ func TestBeforeRunCallback_SendsResourceAndAudience(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			var gotResource, gotAudience string
+			type exchangeForm struct {
+				resource string
+				audience string
+				err      error
+			}
+			// Buffered so the handler never blocks on send; the value is read
+			// back on the test goroutine to avoid a data race on the captured form.
+			gotForm := make(chan exchangeForm, 1)
+
 			var srv *httptest.Server
 			srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path == "/.well-known/oauth-authorization-server" {
@@ -186,10 +194,10 @@ func TestBeforeRunCallback_SendsResourceAndAudience(t *testing.T) {
 					return
 				}
 				if err := r.ParseForm(); err != nil {
-					t.Fatalf("ParseForm() error = %v", err)
+					gotForm <- exchangeForm{err: err}
+				} else {
+					gotForm <- exchangeForm{resource: r.FormValue("resource"), audience: r.FormValue("audience")}
 				}
-				gotResource = r.FormValue("resource")
-				gotAudience = r.FormValue("audience")
 				_ = json.NewEncoder(w).Encode(map[string]any{
 					"access_token":      "access-token",
 					"issued_token_type": string(TokenTypeJWT),
@@ -214,11 +222,19 @@ func TestBeforeRunCallback_SendsResourceAndAudience(t *testing.T) {
 				t.Fatalf("BeforeRunCallback() error = %v", err)
 			}
 
-			if gotResource != tt.wantResource {
-				t.Fatalf("resource = %q, want %q", gotResource, tt.wantResource)
-			}
-			if gotAudience != tt.wantAudience {
-				t.Fatalf("audience = %q, want %q", gotAudience, tt.wantAudience)
+			select {
+			case got := <-gotForm:
+				if got.err != nil {
+					t.Fatalf("ParseForm() error = %v", got.err)
+				}
+				if got.resource != tt.wantResource {
+					t.Fatalf("resource = %q, want %q", got.resource, tt.wantResource)
+				}
+				if got.audience != tt.wantAudience {
+					t.Fatalf("audience = %q, want %q", got.audience, tt.wantAudience)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("timed out waiting for token exchange request")
 			}
 		})
 	}

--- a/go/adk/pkg/sts/plugin_test.go
+++ b/go/adk/pkg/sts/plugin_test.go
@@ -64,7 +64,7 @@ func (f fakeSession) LastUpdateTime() time.Time { return time.Time{} }
 
 func TestHeaderProvider_UsesSessionIDMethod(t *testing.T) {
 	t.Parallel()
-	plugin := NewTokenPropagationPlugin(nil, logr.Discard(), "", "")
+	plugin := NewTokenPropagationPlugin(nil, logr.Discard(), nil, nil)
 	plugin.setCachedToken("sess-123", "token-abc", 0)
 
 	headers := plugin.HeaderProvider(fakeSessionContext{
@@ -125,7 +125,7 @@ func TestBeforeRunCallback_ReusesCachedDynamicActorTokenForExchange(t *testing.T
 		t.Fatalf("NewSTSIntegration() error = %v", err)
 	}
 
-	plugin := NewTokenPropagationPlugin(integration, logr.Discard(), "", "")
+	plugin := NewTokenPropagationPlugin(integration, logr.Discard(), nil, nil)
 	for _, sessionID := range []string{"sess-one", "sess-two"} {
 		ctx := context.WithValue(context.Background(), kagentmodels.BearerTokenKey, "subject-token")
 		if _, err := plugin.BeforeRunCallback(&fakeInvocationContext{
@@ -149,15 +149,15 @@ func TestBeforeRunCallback_SendsResourceAndAudience(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		resource     string
-		audience     string
+		resource     []string
+		audience     []string
 		wantResource string
 		wantAudience string
 	}{
 		{
 			name:         "configured target is sent",
-			resource:     "https://mcp.example.com",
-			audience:     "mcp-backend",
+			resource:     []string{"https://mcp.example.com"},
+			audience:     []string{"mcp-backend"},
 			wantResource: "https://mcp.example.com",
 			wantAudience: "mcp-backend",
 		},

--- a/go/adk/pkg/sts/plugin_test.go
+++ b/go/adk/pkg/sts/plugin_test.go
@@ -144,6 +144,86 @@ func TestBeforeRunCallback_ReusesCachedDynamicActorTokenForExchange(t *testing.T
 	}
 }
 
+func TestBeforeRunCallback_SendsResourceAndAudience(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		opts         []Option
+		wantResource string
+		wantAudience string
+	}{
+		{
+			name:         "configured target is sent",
+			opts:         []Option{WithExchangeTarget("https://mcp.example.com", "mcp-backend")},
+			wantResource: "https://mcp.example.com",
+			wantAudience: "mcp-backend",
+		},
+		{
+			name:         "no target leaves resource and audience unset",
+			opts:         nil,
+			wantResource: "",
+			wantAudience: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var gotResource, gotAudience string
+			var srv *httptest.Server
+			srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/.well-known/oauth-authorization-server" {
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						"issuer":         srv.URL,
+						"token_endpoint": srv.URL + "/token",
+					})
+					return
+				}
+				if r.URL.Path != "/token" {
+					http.NotFound(w, r)
+					return
+				}
+				if err := r.ParseForm(); err != nil {
+					t.Fatalf("ParseForm() error = %v", err)
+				}
+				gotResource = r.FormValue("resource")
+				gotAudience = r.FormValue("audience")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"access_token":      "access-token",
+					"issued_token_type": string(TokenTypeJWT),
+				})
+			}))
+			defer srv.Close()
+
+			integration, err := NewSTSIntegration(
+				srv.URL+"/.well-known/oauth-authorization-server",
+				"", nil, nil, 5, true, false,
+			)
+			if err != nil {
+				t.Fatalf("NewSTSIntegration() error = %v", err)
+			}
+
+			plugin := NewTokenPropagationPlugin(integration, logr.Discard(), tt.opts...)
+			ctx := context.WithValue(context.Background(), kagentmodels.BearerTokenKey, "subject-token")
+			if _, err := plugin.BeforeRunCallback(&fakeInvocationContext{
+				Context:   ctx,
+				sessionID: "sess-resource",
+			}); err != nil {
+				t.Fatalf("BeforeRunCallback() error = %v", err)
+			}
+
+			if gotResource != tt.wantResource {
+				t.Fatalf("resource = %q, want %q", gotResource, tt.wantResource)
+			}
+			if gotAudience != tt.wantAudience {
+				t.Fatalf("audience = %q, want %q", gotAudience, tt.wantAudience)
+			}
+		})
+	}
+}
+
 func TestExtractJWTExpiryUsesUnverifiedClaims(t *testing.T) {
 	t.Parallel()
 	want := time.Now().Add(time.Hour).Unix()

--- a/go/core/pkg/env/kagent.go
+++ b/go/core/pkg/env/kagent.go
@@ -94,4 +94,18 @@ var (
 		"Well-known endpoint for the Security Token Service (STS) used for token exchange.",
 		ComponentAgentRuntime,
 	)
+
+	KagentTokenResource = RegisterStringVar(
+		"KAGENT_TOKEN_RESOURCE",
+		"",
+		"RFC 8707 resource indicator sent on STS token-exchange requests to scope the issued token to a target backend.",
+		ComponentAgentRuntime,
+	)
+
+	KagentTokenAudience = RegisterStringVar(
+		"KAGENT_TOKEN_AUDIENCE",
+		"",
+		"RFC 8693 audience sent on STS token-exchange requests. Alternate to KAGENT_TOKEN_RESOURCE for servers that key on audience.",
+		ComponentAgentRuntime,
+	)
 )

--- a/go/core/pkg/env/kagent.go
+++ b/go/core/pkg/env/kagent.go
@@ -95,17 +95,17 @@ var (
 		ComponentAgentRuntime,
 	)
 
-	KagentTokenResource = RegisterStringVar(
-		"KAGENT_TOKEN_RESOURCE",
+	KagentSTSResource = RegisterStringVar(
+		"KAGENT_STS_RESOURCE",
 		"",
 		"RFC 8707 resource indicator sent on STS token-exchange requests to scope the issued token to a target backend.",
 		ComponentAgentRuntime,
 	)
 
-	KagentTokenAudience = RegisterStringVar(
-		"KAGENT_TOKEN_AUDIENCE",
+	KagentSTSAudience = RegisterStringVar(
+		"KAGENT_STS_AUDIENCE",
 		"",
-		"RFC 8693 audience sent on STS token-exchange requests. Alternate to KAGENT_TOKEN_RESOURCE for servers that key on audience.",
+		"RFC 8693 audience sent on STS token-exchange requests. Alternate to KAGENT_STS_RESOURCE for servers that key on audience.",
 		ComponentAgentRuntime,
 	)
 )


### PR DESCRIPTION
## What

The Go ADK token-propagation plugin (`go/adk/pkg/sts`) always passed `nil`
resource and `nil` audience to the STS token exchange, so an issued token
could not be scoped to a specific backend. This wires two optional inputs
through to the exchange:

- `KAGENT_STS_RESOURCE`: RFC 8707 resource indicator (the target backend).
- `KAGENT_STS_AUDIENCE`: RFC 8693 audience, for STS servers that key on it.

Both are read at agent-runtime startup and passed as `resource`/`audience`
parameters to `NewTokenPropagationPlugin`. Empty values are omitted from the
request, so behaviour is unchanged when neither is set.

## Why

Without a resource/audience, the STS returns a token whose audience is not the
MCP backend, so audience-validating backends reject it. RFC 8707 is the
standard way to scope an exchanged token to its intended resource. The STS
client already serialized `resource`/`audience`; only the call site and the
configuration plumbing were missing.

## Notes

- Backwards compatible: no env set means no `resource`/`audience` sent.
- The env vars are registered in `go/core/pkg/env` for discoverability. Moving
  this into the adk config file (with a first-class `Agent` CRD field) is under
  discussion; see the thread below.
