### PR TITLE
feat(sts): send RFC 8707 resource and audience on token exchange (Python)

### DIFF
--- a/python/packages/agentsts-adk/src/agentsts/adk/_base.py
+++ b/python/packages/agentsts-adk/src/agentsts/adk/_base.py
@@ -105,14 +105,24 @@ class _TokenCacheEntry:
 class ADKTokenPropagationPlugin(BasePlugin):
     """Plugin for propagating STS tokens to ADK tools."""
 
-    def __init__(self, sts_integration: Optional[STSIntegrationBase] = None):
+    def __init__(
+        self,
+        sts_integration: Optional[STSIntegrationBase] = None,
+        resource: Optional[Union[str, list]] = None,
+        audience: Optional[Union[str, list]] = None,
+    ):
         """Initialize the token propagation plugin.
 
         Args:
             sts_integration: The ADK STS integration instance
+            resource: RFC 8707 resource indicator sent on the token exchange to
+                scope the issued token to a target backend. Omitted when None.
+            audience: RFC 8693 audience sent on the token exchange. Omitted when None.
         """
         super().__init__("ADKTokenPropagationPlugin")
         self.sts_integration = sts_integration
+        self.resource = resource
+        self.audience = audience
         self.token_cache: Dict[str, _TokenCacheEntry] = {}
         self.actor_token_cache: Optional[_TokenCacheEntry] = None
 
@@ -192,6 +202,8 @@ class ADKTokenPropagationPlugin(BasePlugin):
                     subject_token_type=TokenType.JWT,
                     actor_token=actor_token,
                     actor_token_type=TokenType.JWT if actor_token else None,
+                    resource=self.resource,
+                    audience=self.audience,
                 )
             except Exception as e:
                 logger.warning(f"STS token exchange failed: {e}")

--- a/python/packages/agentsts-adk/src/agentsts/adk/_base.py
+++ b/python/packages/agentsts-adk/src/agentsts/adk/_base.py
@@ -3,7 +3,7 @@
 import inspect
 import logging
 import time
-from typing import Awaitable, Callable, Dict, Optional, Union
+from typing import Awaitable, Callable, Dict, List, Optional, Union
 
 import jwt
 from agentsts.core import STSIntegrationBase, TokenType
@@ -108,8 +108,8 @@ class ADKTokenPropagationPlugin(BasePlugin):
     def __init__(
         self,
         sts_integration: Optional[STSIntegrationBase] = None,
-        resource: Optional[Union[str, list]] = None,
-        audience: Optional[Union[str, list]] = None,
+        resource: Optional[Union[str, List[str]]] = None,
+        audience: Optional[Union[str, List[str]]] = None,
     ):
         """Initialize the token propagation plugin.
 

--- a/python/packages/agentsts-adk/tests/test_adk_integration.py
+++ b/python/packages/agentsts-adk/tests/test_adk_integration.py
@@ -75,9 +75,36 @@ class TestADKTokenPropagationPlugin:
             subject_token_type=TokenType.JWT,
             actor_token="actor-token",
             actor_token_type=TokenType.JWT,
+            resource=None,
+            audience=None,
         )
         assert "sess-key-1" in plugin.token_cache
         assert plugin.token_cache["sess-key-1"].token == "exchanged-token"
+
+    @pytest.mark.asyncio
+    async def test_resource_and_audience_passed_to_exchange(self):
+        """Configured resource/audience are forwarded to the STS exchange (RFC 8707/8693)."""
+        sts = Mock(spec=ADKSTSIntegration)
+        sts.get_subject_token = lambda state: state.get("subject-token")
+        sts.fetch_actor_token = None
+        sts._actor_token = "actor-token"
+        sts.exchange_token = AsyncMock(return_value="exchanged-token")
+        plugin = ADKTokenPropagationPlugin(sts, resource="https://mcp.example.com", audience="mcp-backend")
+        ic = self._make_invocation_context(
+            "sess-resource",
+            headers=None,
+            extra_state={"subject-token": "subject-jwt"},
+        )
+        result = await plugin.before_run_callback(invocation_context=ic)
+        assert result is None
+        sts.exchange_token.assert_called_once_with(
+            subject_token="subject-jwt",
+            subject_token_type=TokenType.JWT,
+            actor_token="actor-token",
+            actor_token_type=TokenType.JWT,
+            resource="https://mcp.example.com",
+            audience="mcp-backend",
+        )
 
     @pytest.mark.asyncio
     async def test_subject_token_callback_returns_none(self):
@@ -124,6 +151,8 @@ class TestADKTokenPropagationPlugin:
             subject_token_type=TokenType.JWT,
             actor_token="actor-token",
             actor_token_type=TokenType.JWT,
+            resource=None,
+            audience=None,
         )
         assert plugin.token_cache["sess-key-4"].token == "exchanged-via-headers"
 
@@ -173,6 +202,8 @@ class TestADKTokenPropagationPlugin:
                 subject_token_type=TokenType.JWT,
                 actor_token="actor-token",
                 actor_token_type=TokenType.JWT,
+                resource=None,
+                audience=None,
             )
             # optional debug log length check
             mock_logger.debug.assert_called()  # at least one debug log
@@ -260,6 +291,8 @@ class TestADKTokenPropagationPlugin:
                 subject_token_type=TokenType.JWT,
                 actor_token="dynamic-actor-token",
                 actor_token_type=TokenType.JWT,
+                resource=None,
+                audience=None,
             )
 
             # Verify debug log for dynamic fetch
@@ -297,6 +330,8 @@ class TestADKTokenPropagationPlugin:
                 subject_token_type=TokenType.JWT,
                 actor_token="dynamic-actor-token-async",
                 actor_token_type=TokenType.JWT,
+                resource=None,
+                audience=None,
             )
 
             # Verify debug log for dynamic fetch

--- a/python/packages/agentsts-adk/tests/test_adk_integration.py
+++ b/python/packages/agentsts-adk/tests/test_adk_integration.py
@@ -107,6 +107,33 @@ class TestADKTokenPropagationPlugin:
         )
 
     @pytest.mark.asyncio
+    async def test_list_resource_and_audience_passed_to_exchange(self):
+        """Repeatable resource/audience lists are forwarded verbatim (RFC 8707/8693)."""
+        sts = Mock(spec=ADKSTSIntegration)
+        sts.get_subject_token = lambda state: state.get("subject-token")
+        sts.fetch_actor_token = None
+        sts._actor_token = "actor-token"
+        sts.exchange_token = AsyncMock(return_value="exchanged-token")
+        resource = ["https://a.example.com", "https://b.example.com"]
+        audience = ["backend-a", "backend-b"]
+        plugin = ADKTokenPropagationPlugin(sts, resource=resource, audience=audience)
+        ic = self._make_invocation_context(
+            "sess-resource-list",
+            headers=None,
+            extra_state={"subject-token": "subject-jwt"},
+        )
+        result = await plugin.before_run_callback(invocation_context=ic)
+        assert result is None
+        sts.exchange_token.assert_called_once_with(
+            subject_token="subject-jwt",
+            subject_token_type=TokenType.JWT,
+            actor_token="actor-token",
+            actor_token_type=TokenType.JWT,
+            resource=resource,
+            audience=audience,
+        )
+
+    @pytest.mark.asyncio
     async def test_subject_token_callback_returns_none(self):
         """Case: get_subject_token callback returns None -> returns None."""
         sts = Mock(spec=ADKSTSIntegration)

--- a/python/packages/kagent-adk/src/kagent/adk/cli.py
+++ b/python/packages/kagent-adk/src/kagent/adk/cli.py
@@ -26,6 +26,8 @@ app = typer.Typer()
 kagent_url_override = os.getenv("KAGENT_URL")
 sts_well_known_uri = os.getenv("STS_WELL_KNOWN_URI")
 propagate_token = os.getenv("KAGENT_PROPAGATE_TOKEN", "").lower() == "true"
+token_resource = os.getenv("KAGENT_TOKEN_RESOURCE") or None
+token_audience = os.getenv("KAGENT_TOKEN_AUDIENCE") or None
 uvicorn_log_level = os.getenv("UVICORN_LOG_LEVEL", os.getenv("LOG_LEVEL", "info")).lower()
 
 
@@ -34,7 +36,7 @@ def create_sts_integration() -> Optional[ADKTokenPropagationPlugin]:
         sts_integration = None
         if sts_well_known_uri:
             sts_integration = ADKSTSIntegration(sts_well_known_uri)
-        return ADKTokenPropagationPlugin(sts_integration)
+        return ADKTokenPropagationPlugin(sts_integration, resource=token_resource, audience=token_audience)
 
 
 def maybe_add_skills(root_agent: BaseAgent):

--- a/python/packages/kagent-adk/src/kagent/adk/cli.py
+++ b/python/packages/kagent-adk/src/kagent/adk/cli.py
@@ -23,11 +23,25 @@ logging.getLogger("google_adk.google.adk.tools.base_authenticated_tool").setLeve
 app = typer.Typer()
 
 
+def _split_csv(value: Optional[str]) -> Optional[list[str]]:
+    """Parse a comma-separated env value into trimmed, non-empty entries.
+
+    Returns None when none are present so the exchange target stays unset.
+    resource/audience are RFC 8707/8693 repeatable, so a list scopes the token
+    to multiple backends.
+    """
+    if not value:
+        return None
+    entries = [p.strip() for p in value.split(",")]
+    entries = [p for p in entries if p]
+    return entries or None
+
+
 kagent_url_override = os.getenv("KAGENT_URL")
 sts_well_known_uri = os.getenv("STS_WELL_KNOWN_URI")
 propagate_token = os.getenv("KAGENT_PROPAGATE_TOKEN", "").lower() == "true"
-token_resource = os.getenv("KAGENT_STS_RESOURCE") or None
-token_audience = os.getenv("KAGENT_STS_AUDIENCE") or None
+token_resource = _split_csv(os.getenv("KAGENT_STS_RESOURCE"))
+token_audience = _split_csv(os.getenv("KAGENT_STS_AUDIENCE"))
 uvicorn_log_level = os.getenv("UVICORN_LOG_LEVEL", os.getenv("LOG_LEVEL", "info")).lower()
 
 

--- a/python/packages/kagent-adk/src/kagent/adk/cli.py
+++ b/python/packages/kagent-adk/src/kagent/adk/cli.py
@@ -26,8 +26,8 @@ app = typer.Typer()
 kagent_url_override = os.getenv("KAGENT_URL")
 sts_well_known_uri = os.getenv("STS_WELL_KNOWN_URI")
 propagate_token = os.getenv("KAGENT_PROPAGATE_TOKEN", "").lower() == "true"
-token_resource = os.getenv("KAGENT_TOKEN_RESOURCE") or None
-token_audience = os.getenv("KAGENT_TOKEN_AUDIENCE") or None
+token_resource = os.getenv("KAGENT_STS_RESOURCE") or None
+token_audience = os.getenv("KAGENT_STS_AUDIENCE") or None
 uvicorn_log_level = os.getenv("UVICORN_LOG_LEVEL", os.getenv("LOG_LEVEL", "info")).lower()
 
 

--- a/python/packages/kagent-adk/tests/unittests/test_cli_sts_env.py
+++ b/python/packages/kagent-adk/tests/unittests/test_cli_sts_env.py
@@ -1,0 +1,22 @@
+"""Tests for STS resource/audience env parsing in the CLI."""
+
+import pytest
+
+from kagent.adk.cli import _split_csv
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (None, None),
+        ("", None),
+        ("   ", None),
+        (",,", None),
+        ("https://mcp.example.com", ["https://mcp.example.com"]),
+        (" https://mcp.example.com ", ["https://mcp.example.com"]),
+        ("https://a.example.com,https://b.example.com", ["https://a.example.com", "https://b.example.com"]),
+        ("a, ,b,", ["a", "b"]),
+    ],
+)
+def test_split_csv(value, expected):
+    assert _split_csv(value) == expected


### PR DESCRIPTION
## What

The Python ADK token-propagation plugin (`agentsts-adk`) called
`exchange_token` without `resource` or `audience`, so an issued token could
not be scoped to a specific backend. This wires two optional inputs through:

- `KAGENT_STS_RESOURCE`: RFC 8707 resource indicator (the target backend).
- `KAGENT_STS_AUDIENCE`: RFC 8693 audience, for STS servers that key on it.

`ADKTokenPropagationPlugin` now accepts `resource`/`audience`; the CLI reads
them from the environment in `create_sts_integration`. Unset values are
omitted from the request, so behaviour is unchanged when neither is set.

## Why

Without a resource/audience, the STS returns a token whose audience is not the
MCP backend, so audience-validating backends reject it. RFC 8707 is the
standard way to scope an exchanged token to its intended resource. The
`exchange_token` API already accepted `resource`/`audience`; only the plugin
call site and the configuration plumbing were missing.

## Notes

- Backwards compatible: no env set means no `resource`/`audience` sent.
- Mirrors the Go ADK change in #2106; same env var names across runtimes.
