### PR TITLE
feat(substrate): bump agent substrate to 0.0.7

### DIFF
--- a/examples/substrate-openclaw/README.md
+++ b/examples/substrate-openclaw/README.md
@@ -17,13 +17,15 @@ atelet:
 Then install the Substrate platform and kagent:
 
 ```bash
-export ATEOM_VERSION=v0.0.7
+export SUBSTRATE_VERSION=0.0.7
 
 helm upgrade --install substrate-crds \
-  oci://ghcr.io/kagent-dev/substrate/helm/substrate-crds
+  oci://ghcr.io/kagent-dev/substrate/helm/substrate-crds \
+  --version "${SUBSTRATE_VERSION}"
 
 helm upgrade --install substrate \
   oci://ghcr.io/kagent-dev/substrate/helm/substrate \
+  --version "${SUBSTRATE_VERSION}" \
   --namespace ate-system \
   --create-namespace -f substrate-values.yaml
 
@@ -32,7 +34,7 @@ make helm-install KAGENT_HELM_EXTRA_ARGS="\
   --set controller.substrate.ateApiEndpoint=dns:///api.ate-system.svc:443 \
   --set controller.substrate.ateApiInsecure=true \
   --set substrateWorkerPool.create=true \
-  --set substrateWorkerPool.ateomImage=ghcr.io/kagent-dev/substrate/ateom-gvisor:${ATEOM_VERSION}"
+  --set substrateWorkerPool.ateomImage=ghcr.io/kagent-dev/substrate/ateom-gvisor:v${SUBSTRATE_VERSION}"
 ```
 
 When `substrateWorkerPool.create=true`, the kagent chart installs a namespace-scoped `WorkerPool` with:
@@ -40,6 +42,8 @@ When `substrateWorkerPool.create=true`, the kagent chart installs a namespace-sc
 - `spec.sandboxClass: gvisor`
 - label `kagent.dev/worker-pool: kagent-default` (matches generated `ActorTemplate` selectors)
 - controller default `workerPool` name set to that pool when `create=true`
+
+**Zero-downtime rollouts:** SandboxAgent config and image rollouts retain the previous `ActorTemplate` until the new golden is Ready (blue-green). Use `substrateWorkerPool.replicas: 2` or higher so a spare worker can build the new golden while the current one keeps serving chat.
 
 ## 2. AgentHarness with Substrate runtime
 

--- a/examples/substrate-openclaw/README.md
+++ b/examples/substrate-openclaw/README.md
@@ -1,13 +1,12 @@
-# kagent agents and agentharness on substrate
+# kagent agents and AgentHarness on Substrate
 
-Follow these instructions to install substrate on a kind cluster. This feature allows you to run AgentHarness (OpenClaw) and declerative Go agents in substrate.
-
+Follow these instructions to install Substrate on a kind cluster. This feature allows you to run AgentHarness (OpenClaw) and declarative Go SandboxAgents on Agent Substrate.
 
 ## 1. Install Substrate on your Kind cluster
 
-This assumes you've configured kind cluster using `make create-kind-cluster`.
+This assumes you've configured a kind cluster using `make create-kind-cluster`.
 
-Create the substrate-values.yaml file:
+Create a `substrate-values.yaml` file:
 
 ```yaml
 atelet:
@@ -15,10 +14,10 @@ atelet:
     - --localhost-registry-replacement=kind-registry:5000
 ```
 
-Then install substrate and kagent:
+Then install the Substrate platform and kagent:
 
 ```bash
-export ATEOM_VERSION=v0.0.6
+export ATEOM_VERSION=v0.0.7
 
 helm upgrade --install substrate-crds \
   oci://ghcr.io/kagent-dev/substrate/helm/substrate-crds
@@ -36,15 +35,19 @@ make helm-install KAGENT_HELM_EXTRA_ARGS="\
   --set substrateWorkerPool.ateomImage=ghcr.io/kagent-dev/substrate/ateom-gvisor:${ATEOM_VERSION}"
 ```
 
-## kagent AgentHarness with substrate runtime
+When `substrateWorkerPool.create=true`, the kagent chart installs a namespace-scoped `WorkerPool` with:
 
-kagent generates a per-harness `ActorTemplate` and uses an existing `WorkerPool`.
+- `spec.sandboxClass: gvisor`
+- label `kagent.dev/worker-pool: kagent-default` (matches generated `ActorTemplate` selectors)
+- controller default `workerPool` name set to that pool when `create=true`
 
-The generated `ActorTemplate` uses `controller.substrate.pauseImage`, `controller.substrate.runscAMD64URL`, `controller.substrate.runscAMD64SHA256`, `controller.substrate.runscARM64URL`, and `controller.substrate.runscARM64SHA256` from the Helm values Override them with `--set` or a values file when you need to pin a different gVisor build.
+## 2. AgentHarness with Substrate runtime
+
+kagent generates a per-harness `ActorTemplate` and schedules actors onto an existing `WorkerPool`.
 
 Create a harness. If `snapshotsConfig` is omitted, kagent defaults it to `gs://ate-snapshots/<namespace>/<agentharnessname>`.
 
-- **Worker pool** — reference an existing pool (`workerPoolRef`) or configure a controller default WorkerPool
+- **Worker pool** — reference an existing pool (`workerPoolRef`) or configure a controller default WorkerPool. The target pool must carry label `kagent.dev/worker-pool: <pool-name>`. The kagent Helm-managed pool gets this label automatically; externally owned pools must add it manually.
 
 ```yaml
 apiVersion: kagent.dev/v1alpha2
@@ -83,23 +86,15 @@ metadata:
     kagent.dev/agent-harness: peterj-claw
 spec:
   pauseImage: gcr.io/gke-release/pause@sha256:bcbd57ba5653580ec647b16d8163cdd1112df3609129b01f912a8032e48265da
-  runsc:
-    amd64:
-      url: gs://gvisor/releases/nightly/2026-06-02/x86_64/runsc
-      sha256Hash: efd12935f6654c91a1389710eb8dfa4d12b6b9be00db87526dc2eb584ad00119
-    arm64:
-      url: gs://gvisor/releases/nightly/2026-05-19/aarch64/runsc
-      sha256Hash: 1ba2366ae2efceba166046f51a4104f9261c9cb72c6db8f5b3fe2dc57dea86b9
-  workerPoolRef:
-    name: peterj-claw-wp
-    namespace: kagent
+  sandboxClass: gvisor
+  workerSelector:
+    matchLabels:
+      kagent.dev/worker-pool: kagent-default
   snapshotsConfig:
     location: gs://ate-snapshots/kagent/peterj-claw
   containers:
   - name: openclaw
     image: ghcr.io/kagent-dev/nemoclaw/sandbox-base@sha256:d52bee415dc4c0dba7164f9eabe727574c056d4f211781f20af249707883a3b4
-    ports:
-    - containerPort: 80
     command:
     - /bin/sh
     - -c

--- a/go/api/httpapi/substrate.go
+++ b/go/api/httpapi/substrate.go
@@ -28,7 +28,8 @@ type SubstrateActorTemplateEntry struct {
 	Phase           string `json:"phase,omitempty"`
 	GoldenActorID   string `json:"goldenActorId,omitempty"`
 	GoldenSnapshot  string `json:"goldenSnapshot,omitempty"`
-	WorkerPoolRef   string `json:"workerPoolRef,omitempty"`
+	SandboxClass    string `json:"sandboxClass,omitempty"`
+	WorkerSelector  string `json:"workerSelector,omitempty"`
 	HarnessName     string `json:"harnessName,omitempty"`
 	ManagedByKagent bool   `json:"managedByKagent"`
 }
@@ -42,7 +43,8 @@ type SubstrateActorEntry struct {
 	AteomPodNamespace      string `json:"ateomPodNamespace,omitempty"`
 	AteomPodName           string `json:"ateomPodName,omitempty"`
 	AteomPodIP             string `json:"ateomPodIp,omitempty"`
-	LastSnapshot           string `json:"lastSnapshot,omitempty"`
+	LatestSnapshot         string `json:"latestSnapshot,omitempty"`
+	WorkerPoolName         string `json:"workerPoolName,omitempty"`
 	InProgressSnapshot     string `json:"inProgressSnapshot,omitempty"`
 	Version                int64  `json:"version,omitempty"`
 }

--- a/go/core/internal/controller/reconciler/reconciler.go
+++ b/go/core/internal/controller/reconciler/reconciler.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kagent-dev/kagent/go/core/internal/controller/translator"
 	"github.com/kagent-dev/kagent/go/core/pkg/egress"
 	"github.com/kagent-dev/kagent/go/core/pkg/sandboxbackend"
+	"github.com/kagent-dev/kagent/go/core/pkg/sandboxbackend/substrate"
 	"github.com/kagent-dev/kmcp/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -151,11 +152,19 @@ func (a *kagentReconciler) ReconcileKagentSandboxAgent(ctx context.Context, req 
 	}
 
 	err := a.reconcileSandboxAgent(ctx, sandboxAgent)
+	if errors.Is(err, substrate.ErrActorTemplateReconcilePending) {
+		// A spec-drift recreate is mid-flight; report not-ready without failing
+		// the resource and return the sentinel so the controller requeues.
+		if statusErr := a.reconcileSandboxAgentStatus(ctx, sandboxAgent, nil, true); statusErr != nil {
+			return statusErr
+		}
+		return err
+	}
 	if err != nil {
 		reconcileLog.Error(err, "failed to reconcile sandboxagent", "sandboxagent", req.NamespacedName)
 	}
 
-	return a.reconcileSandboxAgentStatus(ctx, sandboxAgent, err)
+	return a.reconcileSandboxAgentStatus(ctx, sandboxAgent, err, false)
 }
 
 func (a *kagentReconciler) handleDeletedAgentResource(ctx context.Context, req ctrl.Request, resourceName string) error {
@@ -240,14 +249,18 @@ func (a *kagentReconciler) reconcileSandboxAgent(ctx context.Context, sa *v1alph
 	})
 }
 
-func (a *kagentReconciler) reconcileSandboxAgentStatus(ctx context.Context, sa *v1alpha2.SandboxAgent, reconcileErr error) error {
+func (a *kagentReconciler) reconcileSandboxAgentStatus(ctx context.Context, sa *v1alpha2.SandboxAgent, reconcileErr error, actorTemplatePending bool) error {
 	deployedCondition := metav1.Condition{
 		Type:               v1alpha2.AgentConditionTypeReady,
 		Status:             metav1.ConditionUnknown,
 		ObservedGeneration: sa.Generation,
 	}
 
-	if a.sandboxBackend == nil {
+	if actorTemplatePending {
+		deployedCondition.Status = metav1.ConditionFalse
+		deployedCondition.Reason = "ActorTemplateRecreating"
+		deployedCondition.Message = "waiting for ActorTemplate golden actor deletion and recreate"
+	} else if a.sandboxBackend == nil {
 		deployedCondition.Status = metav1.ConditionUnknown
 		deployedCondition.Reason = "SandboxBackendNotConfigured"
 		deployedCondition.Message = "Sandbox backend is not configured"
@@ -925,6 +938,7 @@ func (r *kagentReconciler) GetOwnedResourceTypes() []client.Object {
 // Function initially copied from https://github.com/open-telemetry/opentelemetry-operator/blob/e6d96f006f05cff0bc3808da1af69b6b636fbe88/internal/controllers/common.go#L141-L192
 func (a *kagentReconciler) reconcileDesiredObjects(ctx context.Context, owner metav1.Object, desiredObjects []client.Object, ownedObjects map[types.UID]client.Object) error {
 	var errs []error
+	actorTemplatePending := false
 	for _, desired := range desiredObjects {
 		l := reconcileLog.WithValues(
 			"object_name", desired.GetName(),
@@ -935,6 +949,11 @@ func (a *kagentReconciler) reconcileDesiredObjects(ctx context.Context, owner me
 		if _, ok := desired.(*atev1alpha1.ActorTemplate); ok {
 			if r, ok := a.sandboxBackend.(actorTemplateReconciler); ok {
 				if err := r.ReconcileActorTemplate(ctx, desired); err != nil {
+					if errors.Is(err, substrate.ErrActorTemplateReconcilePending) {
+						actorTemplatePending = true
+						pruneOwnedActorTemplate(ownedObjects, desired)
+						continue
+					}
 					l.Error(err, "failed to reconcile ActorTemplate")
 					errs = append(errs, err)
 					continue
@@ -964,6 +983,9 @@ func (a *kagentReconciler) reconcileDesiredObjects(ctx context.Context, owner me
 
 	if len(errs) > 0 {
 		return fmt.Errorf("failed to create objects for %s: %w", owner.GetName(), errors.Join(errs...))
+	}
+	if actorTemplatePending {
+		return substrate.ErrActorTemplateReconcilePending
 	}
 
 	// Pruning owned objects in the cluster which are not should not be present after the reconciliation.

--- a/go/core/internal/controller/reconciler/reconciler.go
+++ b/go/core/internal/controller/reconciler/reconciler.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 	"github.com/hashicorp/go-multierror"
 	reconcilerutils "github.com/kagent-dev/kagent/go/core/internal/controller/reconciler/utils"
 	"github.com/kagent-dev/kagent/go/core/internal/controller/translator"
@@ -930,6 +931,19 @@ func (a *kagentReconciler) reconcileDesiredObjects(ctx context.Context, owner me
 			"object_kind", desired.GetObjectKind(),
 		)
 
+		// Substrate ActorTemplate.spec is immutable, delegate to the sandbox backend to handle spec drift.
+		if _, ok := desired.(*atev1alpha1.ActorTemplate); ok {
+			if r, ok := a.sandboxBackend.(actorTemplateReconciler); ok {
+				if err := r.ReconcileActorTemplate(ctx, desired); err != nil {
+					l.Error(err, "failed to reconcile ActorTemplate")
+					errs = append(errs, err)
+					continue
+				}
+				pruneOwnedActorTemplate(ownedObjects, desired)
+				continue
+			}
+		}
+
 		// existing is an object the controller runtime will hydrate for us
 		// we obtain the existing object by deep copying the desired object because it's the most convenient way
 		existing := desired.DeepCopyObject().(client.Object)
@@ -959,6 +973,25 @@ func (a *kagentReconciler) reconcileDesiredObjects(ctx context.Context, owner me
 	}
 
 	return nil
+}
+
+// actorTemplateReconciler is implemented by sandbox backends that own substrate
+// ActorTemplate objects and need immutable-spec aware create/recreate semantics.
+type actorTemplateReconciler interface {
+	ReconcileActorTemplate(ctx context.Context, desired client.Object) error
+}
+
+// pruneOwnedActorTemplate removes the live ActorTemplate matching desired from the
+// prune set so it is not garbage collected.
+func pruneOwnedActorTemplate(owned map[types.UID]client.Object, desired client.Object) {
+	for uid, obj := range owned {
+		if _, ok := obj.(*atev1alpha1.ActorTemplate); !ok {
+			continue
+		}
+		if obj.GetName() == desired.GetName() && obj.GetNamespace() == desired.GetNamespace() {
+			delete(owned, uid)
+		}
+	}
 }
 
 // modified version of controllerutil.CreateOrUpdate to support proto based objects like istio

--- a/go/core/internal/controller/sandboxagent_controller.go
+++ b/go/core/internal/controller/sandboxagent_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -86,6 +87,9 @@ func (r *SandboxAgentController) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	if err := r.Reconciler.ReconcileKagentSandboxAgent(ctx, req); err != nil {
+		if errors.Is(err, substrate.ErrActorTemplateReconcilePending) {
+			return ctrl.Result{RequeueAfter: agentHarnessNotReadyRequeue}, nil
+		}
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{}, nil

--- a/go/core/internal/httpserver/handlers/substrate.go
+++ b/go/core/internal/httpserver/handlers/substrate.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kagent-dev/kagent/go/core/internal/httpserver/errors"
 	"github.com/kagent-dev/kagent/go/core/pkg/auth"
 	"github.com/kagent-dev/kagent/go/core/pkg/sandboxbackend/substrate"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
@@ -137,19 +138,14 @@ func (h *SubstrateHandler) listSubstrateCRs(ctx context.Context, namespace strin
 			Phase:           string(tmpl.Status.Phase),
 			GoldenActorID:   tmpl.Status.GoldenActorID,
 			GoldenSnapshot:  tmpl.Status.GoldenSnapshot,
+			SandboxClass:    string(tmpl.Spec.SandboxClass),
+			WorkerSelector:  labelSelectorString(tmpl.Spec.WorkerSelector),
 			ManagedByKagent: tmpl.Labels["app.kubernetes.io/managed-by"] == "kagent",
 		}
 		if harness := strings.TrimSpace(tmpl.Labels[substrate.HarnessLabelKey]); harness != "" {
 			entry.HarnessName = harness
 		} else if agentName := substrate.SandboxAgentNameFromLabels(tmpl.Labels); agentName != "" {
 			entry.HarnessName = agentName
-		}
-		if ref := tmpl.Spec.WorkerPoolRef; ref.Name != "" {
-			wpNS := ref.Namespace
-			if wpNS == "" {
-				wpNS = tmpl.Namespace
-			}
-			entry.WorkerPoolRef = wpNS + "/" + ref.Name
 		}
 		templates = append(templates, entry)
 	}
@@ -215,10 +211,38 @@ func actorEntryFromPB(a *ateapipb.Actor) api.SubstrateActorEntry {
 		AteomPodNamespace:      a.GetAteomPodNamespace(),
 		AteomPodName:           a.GetAteomPodName(),
 		AteomPodIP:             a.GetAteomPodIp(),
-		LastSnapshot:           a.GetLastSnapshot(),
+		LatestSnapshot:         snapshotInfoString(a.GetLatestSnapshotInfo()),
+		WorkerPoolName:         a.GetWorkerPoolName(),
 		InProgressSnapshot:     a.GetInProgressSnapshot(),
 		Version:                a.GetVersion(),
 	}
+}
+
+// snapshotInfoString renders a SnapshotInfo as a single location string.
+func snapshotInfoString(s *ateapipb.SnapshotInfo) string {
+	if s == nil {
+		return ""
+	}
+	if ext := s.GetExternal(); ext != nil {
+		return ext.GetSnapshotUriPrefix()
+	}
+	if loc := s.GetLocal(); loc != nil {
+		return loc.GetSnapshotPrefix()
+	}
+	return ""
+}
+
+// labelSelectorString renders a metav1.LabelSelector as a compact human-readable
+// string (e.g. "kagent.dev/worker-pool=kagent-default") for UI display.
+func labelSelectorString(sel *metav1.LabelSelector) string {
+	if sel == nil {
+		return ""
+	}
+	s, err := metav1.LabelSelectorAsSelector(sel)
+	if err != nil {
+		return ""
+	}
+	return s.String()
 }
 
 func workerEntryFromPB(w *ateapipb.Worker) api.SubstrateWorkerEntry {

--- a/go/core/internal/httpserver/handlers/substrate.go
+++ b/go/core/internal/httpserver/handlers/substrate.go
@@ -139,7 +139,7 @@ func (h *SubstrateHandler) listSubstrateCRs(ctx context.Context, namespace strin
 			GoldenActorID:   tmpl.Status.GoldenActorID,
 			GoldenSnapshot:  tmpl.Status.GoldenSnapshot,
 			SandboxClass:    string(tmpl.Spec.SandboxClass),
-			WorkerSelector:  labelSelectorString(tmpl.Spec.WorkerSelector),
+			WorkerSelector:  labelSelectorString(ctx, tmpl.Spec.WorkerSelector),
 			ManagedByKagent: tmpl.Labels["app.kubernetes.io/managed-by"] == "kagent",
 		}
 		if harness := strings.TrimSpace(tmpl.Labels[substrate.HarnessLabelKey]); harness != "" {
@@ -234,13 +234,14 @@ func snapshotInfoString(s *ateapipb.SnapshotInfo) string {
 
 // labelSelectorString renders a metav1.LabelSelector as a compact human-readable
 // string (e.g. "kagent.dev/worker-pool=kagent-default") for UI display.
-func labelSelectorString(sel *metav1.LabelSelector) string {
+func labelSelectorString(ctx context.Context, sel *metav1.LabelSelector) string {
 	if sel == nil {
 		return ""
 	}
 	s, err := metav1.LabelSelectorAsSelector(sel)
 	if err != nil {
-		return ""
+		ctrllog.FromContext(ctx).Info("invalid ActorTemplate workerSelector", "error", err)
+		return "<invalid selector>"
 	}
 	return s.String()
 }

--- a/go/core/internal/httpserver/handlers/substrate_test.go
+++ b/go/core/internal/httpserver/handlers/substrate_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/kagent-dev/kagent/go/core/pkg/sandboxbackend/substrate"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
-	corev1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -96,7 +95,10 @@ func TestHandleGetSubstrateStatus(t *testing.T) {
 				},
 			},
 			Spec: atev1alpha1.ActorTemplateSpec{
-				WorkerPoolRef: corev1.ObjectReference{Name: "default-wp", Namespace: "kagent"},
+				SandboxClass: atev1alpha1.SandboxClassGvisor,
+				WorkerSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{substrate.WorkerPoolLabelKey: "default-wp"},
+				},
 			},
 			Status: atev1alpha1.ActorTemplateStatus{Phase: atev1alpha1.PhaseReady, GoldenActorID: "golden-1"},
 		},
@@ -135,6 +137,8 @@ func TestHandleGetSubstrateStatus(t *testing.T) {
 	require.Equal(t, "Ready", wrapped.Data.ActorTemplates[0].Phase)
 	require.True(t, wrapped.Data.ActorTemplates[0].ManagedByKagent)
 	require.Equal(t, "my-claw", wrapped.Data.ActorTemplates[0].HarnessName)
+	require.Equal(t, "gvisor", wrapped.Data.ActorTemplates[0].SandboxClass)
+	require.Equal(t, substrate.WorkerPoolLabelKey+"=default-wp", wrapped.Data.ActorTemplates[0].WorkerSelector)
 	require.Len(t, wrapped.Data.Actors, 1)
 	require.Equal(t, "Running", wrapped.Data.Actors[0].Status)
 	require.Len(t, wrapped.Data.Workers, 1)

--- a/go/core/pkg/app/app.go
+++ b/go/core/pkg/app/app.go
@@ -151,10 +151,6 @@ type Config struct {
 		DefaultWorkerPoolNamespace string
 		DefaultWorkerPoolName      string
 		PauseImage                 string
-		RunscAMD64URL              string
-		RunscAMD64SHA256           string
-		RunscARM64URL              string
-		RunscARM64SHA256           string
 	}
 }
 
@@ -215,11 +211,6 @@ func (cfg *Config) SetFlags(commandLine *flag.FlagSet) {
 	commandLine.StringVar(&cfg.Substrate.DefaultWorkerPoolNamespace, "substrate-default-workerpool-namespace", kagentNamespace, "Default Agent Substrate WorkerPool namespace when spec.substrate.workerPoolRef is unset.")
 	commandLine.StringVar(&cfg.Substrate.DefaultWorkerPoolName, "substrate-default-workerpool-name", "", "Default Agent Substrate WorkerPool name when spec.substrate.workerPoolRef is unset.")
 	commandLine.StringVar(&cfg.Substrate.PauseImage, "substrate-pause-image", "gcr.io/gke-release/pause@sha256:bcbd57ba5653580ec647b16d8163cdd1112df3609129b01f912a8032e48265da", "Pause image for generated ActorTemplates.")
-	// Please note: the 2026-06-13 nightly breaks checkpoint, so don't jump straight to the latest. See https://github.com/kagent-dev/kagent/pull/2035.
-	commandLine.StringVar(&cfg.Substrate.RunscAMD64URL, "substrate-runsc-amd64-url", "gs://gvisor/releases/nightly/2026-06-02/x86_64/runsc", "gVisor runsc URL for amd64.")
-	commandLine.StringVar(&cfg.Substrate.RunscAMD64SHA256, "substrate-runsc-amd64-sha256", "efd12935f6654c91a1389710eb8dfa4d12b6b9be00db87526dc2eb584ad00119", "gVisor runsc sha256 for amd64.")
-	commandLine.StringVar(&cfg.Substrate.RunscARM64URL, "substrate-runsc-arm64-url", "gs://gvisor/releases/nightly/2026-05-19/aarch64/runsc", "gVisor runsc URL for arm64.")
-	commandLine.StringVar(&cfg.Substrate.RunscARM64SHA256, "substrate-runsc-arm64-sha256", "1ba2366ae2efceba166046f51a4104f9261c9cb72c6db8f5b3fe2dc57dea86b9", "gVisor runsc sha256 for arm64.")
 	commandLine.StringVar(&agent_translator.DefaultServiceAccountName, "default-service-account-name", "", "Global default ServiceAccount name for agent pods. When set, agents without an explicit serviceAccountName will use this instead of creating a per-agent ServiceAccount.")
 
 	commandLine.Var(&MapValue{Target: &agent_translator.DefaultAgentPodLabels}, "default-agent-pod-labels", "Comma-separated key=value pairs of labels to apply to all agent pod templates (e.g. 'team=platform,env=prod'). Per-agent labels take precedence.")
@@ -805,11 +796,7 @@ func substrateAppConfig(cfg *Config) substrate.Config {
 
 func substrateLifecycleFromConfig(kubeClient client.Client, cfg *Config, ate *substrate.Client) *substrate.Lifecycle {
 	return substrate.NewLifecycle(kubeClient, substrate.LifecycleDefaults{
-		PauseImage:       cfg.Substrate.PauseImage,
-		RunscAMD64URL:    cfg.Substrate.RunscAMD64URL,
-		RunscAMD64SHA256: cfg.Substrate.RunscAMD64SHA256,
-		RunscARM64URL:    cfg.Substrate.RunscARM64URL,
-		RunscARM64SHA256: cfg.Substrate.RunscARM64SHA256,
+		PauseImage: cfg.Substrate.PauseImage,
 		// ImageRegistry/ImageRepository mirror the declarative-agent image config
 		// (--image-registry/--image-repository) so digest-pinned acp-sandbox
 		// workload images resolve against the same (possibly private/mirrored)

--- a/go/core/pkg/sandboxbackend/substrate/agent_actor.go
+++ b/go/core/pkg/sandboxbackend/substrate/agent_actor.go
@@ -81,7 +81,10 @@ func (b *SandboxAgentActorBackend) EnsureSessionActor(ctx context.Context, sa *v
 
 	switch actor.GetStatus() {
 	case ateapipb.Actor_STATUS_RUNNING, ateapipb.Actor_STATUS_RESUMING:
-	case ateapipb.Actor_STATUS_SUSPENDED, ateapipb.Actor_STATUS_UNSPECIFIED:
+	case ateapipb.Actor_STATUS_SUSPENDED, ateapipb.Actor_STATUS_UNSPECIFIED,
+		ateapipb.Actor_STATUS_PAUSED, ateapipb.Actor_STATUS_PAUSING:
+		// PAUSED/PAUSING keep a node-local snapshot; ResumeActor brings them back
+		// the same as a suspended actor.
 		_, err = b.client.ResumeActor(ctx, actorID)
 		if err != nil {
 			return sandboxbackend.EnsureResult{}, wrapResumeActorError(actorID, err)

--- a/go/core/pkg/sandboxbackend/substrate/agent_lifecycle.go
+++ b/go/core/pkg/sandboxbackend/substrate/agent_lifecycle.go
@@ -102,15 +102,15 @@ func (p *Lifecycle) buildSandboxAgentActorTemplate(
 			Annotations: annotations,
 		},
 		Spec: atev1alpha1.ActorTemplateSpec{
-			PauseImage: p.Defaults.PauseImage,
-			Runsc:      defaultRunscConfig(p.Defaults),
+			PauseImage:   p.Defaults.PauseImage,
+			SandboxClass: atev1alpha1.SandboxClassGvisor,
 			Containers: []atev1alpha1.Container{{
 				Name:    defaultKagentContainer,
 				Image:   image,
 				Command: command,
 				Env:     actorTemplateEnvFromPodEnv(append(containerEnv, kagentContainer.Env...)),
 			}},
-			WorkerPoolRef: corev1.ObjectReference{Name: wpKey.Name, Namespace: wpKey.Namespace},
+			WorkerSelector: workerSelectorForPool(wpKey),
 			SnapshotsConfig: atev1alpha1.SnapshotsConfig{
 				Location: sandboxAgentSnapshotsLocation(sa),
 			},

--- a/go/core/pkg/sandboxbackend/substrate/agent_lifecycle_test.go
+++ b/go/core/pkg/sandboxbackend/substrate/agent_lifecycle_test.go
@@ -255,7 +255,7 @@ func TestBuildSandboxAgentActorTemplate(t *testing.T) {
 			c := tmpl.Spec.Containers[0]
 			require.Equal(t, pinnedImage, c.Image, "ActorTemplate must use the digest-pinned image")
 			require.Equal(t, tc.wantCommand, c.Command)
-			require.Equal(t, wpKey.Name, tmpl.Spec.WorkerPoolRef.Name)
+			require.Equal(t, wpKey.Name, tmpl.Spec.WorkerSelector.MatchLabels["kagent.dev/worker-pool"])
 
 			names := actorEnvNames(c.Env)
 			require.True(t, names["KAGENT_NAME"], "KAGENT_NAME must be a literal env var")

--- a/go/core/pkg/sandboxbackend/substrate/agentharness_actor.go
+++ b/go/core/pkg/sandboxbackend/substrate/agentharness_actor.go
@@ -69,7 +69,10 @@ func (b *AgentHarnessSessionActorBackend) EnsureSessionActor(ctx context.Context
 	switch actor.GetStatus() {
 	case ateapipb.Actor_STATUS_RUNNING, ateapipb.Actor_STATUS_RESUMING:
 		// already active or waking
-	case ateapipb.Actor_STATUS_SUSPENDED, ateapipb.Actor_STATUS_UNSPECIFIED:
+	case ateapipb.Actor_STATUS_SUSPENDED, ateapipb.Actor_STATUS_UNSPECIFIED,
+		ateapipb.Actor_STATUS_PAUSED, ateapipb.Actor_STATUS_PAUSING:
+		// PAUSED/PAUSING keep a node-local snapshot; ResumeActor brings them back
+		// the same as a suspended actor.
 		if _, err = b.client.ResumeActor(ctx, actorID); err != nil {
 			return sandboxbackend.EnsureResult{}, wrapResumeActorError(actorID, err)
 		}

--- a/go/core/pkg/sandboxbackend/substrate/agents_backend.go
+++ b/go/core/pkg/sandboxbackend/substrate/agents_backend.go
@@ -101,6 +101,17 @@ func buildSandboxAgentConfigSecret(sa *v1alpha2.SandboxAgent, in sandboxbackend.
 	}
 }
 
+func (b *AgentsBackend) ReconcileActorTemplate(ctx context.Context, desired client.Object) error {
+	tmpl, ok := desired.(*atev1alpha1.ActorTemplate)
+	if !ok {
+		return fmt.Errorf("substrate sandbox backend cannot reconcile %T as an ActorTemplate", desired)
+	}
+	if b.Lifecycle == nil || b.Lifecycle.Client == nil {
+		return fmt.Errorf("substrate lifecycle is not configured")
+	}
+	return reconcileActorTemplate(ctx, b.Lifecycle.Client, b.AteClient, tmpl)
+}
+
 func (b *AgentsBackend) ComputeReady(ctx context.Context, cl client.Client, nn types.NamespacedName) (metav1.ConditionStatus, string, string) {
 	sa := &v1alpha2.SandboxAgent{}
 	if err := cl.Get(ctx, nn, sa); err != nil {

--- a/go/core/pkg/sandboxbackend/substrate/delete_actor.go
+++ b/go/core/pkg/sandboxbackend/substrate/delete_actor.go
@@ -47,6 +47,13 @@ func deleteActor(ctx context.Context, c *Client, actorID string) (bool, error) {
 			return false, fmt.Errorf("suspend actor %q: %w", actorID, err)
 		}
 		return false, nil
+	case ateapipb.Actor_STATUS_PAUSED:
+		if _, err := c.ResumeActor(ctx, actorID); err != nil && status.Code(err) != codes.NotFound {
+			return false, fmt.Errorf("resume paused actor %q before delete: %w", actorID, err)
+		}
+		return false, nil
+	case ateapipb.Actor_STATUS_PAUSING:
+		return false, nil
 	default:
 		_ = c.SuspendActor(ctx, actorID)
 		return false, nil

--- a/go/core/pkg/sandboxbackend/substrate/lifecycle.go
+++ b/go/core/pkg/sandboxbackend/substrate/lifecycle.go
@@ -2,6 +2,7 @@ package substrate
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/kagent-dev/kagent/go/api/v1alpha2"
@@ -21,6 +22,11 @@ func (p *Lifecycle) EnsureGeneratedTemplate(ctx context.Context, ah *v1alpha2.Ag
 
 	tmplKey, err := p.ensureActorTemplate(ctx, ah, wpKey)
 	if err != nil {
+		// A spec-drift recreate is mid-flight (golden actor still deleting);
+		// report not-ready without failing so the controller requeues.
+		if errors.Is(err, ErrActorTemplateReconcilePending) {
+			return LifecycleState{ActorTemplateReady: false}, nil
+		}
 		return LifecycleState{}, err
 	}
 

--- a/go/core/pkg/sandboxbackend/substrate/lifecycle_actortemplate.go
+++ b/go/core/pkg/sandboxbackend/substrate/lifecycle_actortemplate.go
@@ -41,7 +41,7 @@ func actorTemplateSpecEqual(a, b atev1alpha1.ActorTemplateSpec) bool {
 // reconcileActorTemplate applies the desired ActorTemplate with immutable-spec semantics:
 //
 //   - not found        -> create
-//   - spec matches     -> patch labels/owner refs only (never the spec)
+//   - spec matches     -> patch labels/annotations/owner refs only (never the spec)
 //   - spec drifts      -> delete the golden actor, delete the CR, recreate
 //
 // On spec drift it performs at most one mutating step per call. When more work
@@ -61,15 +61,18 @@ func reconcileActorTemplate(ctx context.Context, c client.Client, ate *Client, d
 		return fmt.Errorf("get ActorTemplate %s: %w", key, err)
 	}
 
-	// If the spec is semantically equal, update the labels and owner references only.
+	// If the spec is semantically equal, update the labels and annotations and owner references only.
 	if actorTemplateSpecEqual(existing.Spec, desired.Spec) {
-		merged := mergeLabels(existing.Labels, desired.Labels)
-		if maps.Equal(existing.Labels, merged) &&
+		mergedLabels := mergeLabels(existing.Labels, desired.Labels)
+		mergedAnnotations := mergeLabels(existing.Annotations, desired.Annotations)
+		if maps.Equal(existing.Labels, mergedLabels) &&
+			maps.Equal(existing.Annotations, mergedAnnotations) &&
 			apiequality.Semantic.DeepEqual(existing.OwnerReferences, desired.OwnerReferences) {
 			return nil
 		}
 		patch := client.MergeFrom(existing.DeepCopy())
-		existing.Labels = merged
+		existing.Labels = mergedLabels
+		existing.Annotations = mergedAnnotations
 		existing.OwnerReferences = desired.OwnerReferences
 		if err := c.Patch(ctx, existing, patch); err != nil {
 			return fmt.Errorf("patch ActorTemplate %s metadata: %w", key, err)

--- a/go/core/pkg/sandboxbackend/substrate/lifecycle_actortemplate.go
+++ b/go/core/pkg/sandboxbackend/substrate/lifecycle_actortemplate.go
@@ -8,10 +8,11 @@ import (
 
 	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 	"github.com/kagent-dev/kagent/go/api/v1alpha2"
-	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -21,22 +22,76 @@ func (p *Lifecycle) ensureActorTemplate(ctx context.Context, ah *v1alpha2.AgentH
 	if err != nil {
 		return types.NamespacedName{}, err
 	}
-
-	existing := &atev1alpha1.ActorTemplate{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      key.Name,
-			Namespace: key.Namespace,
-		},
-	}
-	if _, err := controllerutil.CreateOrUpdate(ctx, p.Client, existing, func() error {
-		existing.Labels = mergeLabels(existing.Labels, desired.Labels)
-		existing.OwnerReferences = desired.OwnerReferences
-		existing.Spec = desired.Spec
-		return nil
-	}); err != nil {
+	if err := reconcileActorTemplate(ctx, p.Client, p.AteClient, desired); err != nil {
 		return types.NamespacedName{}, fmt.Errorf("reconcile ActorTemplate %s: %w", key, err)
 	}
 	return key, nil
+}
+
+// actorTemplateSpecEqual reports whether two ActorTemplate specs are semantically equal.
+func actorTemplateSpecEqual(a, b atev1alpha1.ActorTemplateSpec) bool {
+	return apiequality.Semantic.DeepEqual(a, b)
+}
+
+// reconcileActorTemplate applies the desired ActorTemplate with immutable-spec semantics:
+//
+//   - not found        -> create
+//   - spec matches     -> patch labels/owner refs only (never the spec)
+//   - spec drifts      -> delete the golden actor, delete the CR, recreate
+//
+// On spec drift it performs at most one mutating step per call and returns nil so the caller requeues.
+func reconcileActorTemplate(ctx context.Context, c client.Client, ate *Client, desired *atev1alpha1.ActorTemplate) error {
+	key := client.ObjectKeyFromObject(desired)
+
+	existing := &atev1alpha1.ActorTemplate{}
+	err := c.Get(ctx, key, existing)
+	if apierrors.IsNotFound(err) {
+		if err := c.Create(ctx, desired); err != nil {
+			return fmt.Errorf("create ActorTemplate %s: %w", key, err)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get ActorTemplate %s: %w", key, err)
+	}
+
+	// If the spec is semantically equal, update the labels and owner references only.
+	if actorTemplateSpecEqual(existing.Spec, desired.Spec) {
+		merged := mergeLabels(existing.Labels, desired.Labels)
+		if maps.Equal(existing.Labels, merged) &&
+			apiequality.Semantic.DeepEqual(existing.OwnerReferences, desired.OwnerReferences) {
+			return nil
+		}
+		patch := client.MergeFrom(existing.DeepCopy())
+		existing.Labels = merged
+		existing.OwnerReferences = desired.OwnerReferences
+		if err := c.Patch(ctx, existing, patch); err != nil {
+			return fmt.Errorf("patch ActorTemplate %s metadata: %w", key, err)
+		}
+		return nil
+	}
+
+	// Delete the golden actor since it is an external ate-api resource
+	if goldenID := strings.TrimSpace(existing.Status.GoldenActorID); goldenID != "" {
+		done, derr := deleteGoldenActor(ctx, ate, goldenID)
+		if derr != nil {
+			return fmt.Errorf("delete golden actor %q before recreating ActorTemplate %s: %w", goldenID, key, derr)
+		}
+		if !done {
+			return nil
+		}
+	}
+	if err := c.Delete(ctx, existing); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete ActorTemplate %s for recreate: %w", key, err)
+	}
+	if err := c.Create(ctx, desired); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			// The previous CR is still terminating; recreate on the next pass.
+			return nil
+		}
+		return fmt.Errorf("recreate ActorTemplate %s: %w", key, err)
+	}
+	return nil
 }
 
 func (p *Lifecycle) buildActorTemplate(ctx context.Context, ah *v1alpha2.AgentHarness, wpKey types.NamespacedName) (*atev1alpha1.ActorTemplate, error) {
@@ -100,8 +155,8 @@ func (p *Lifecycle) buildActorTemplate(ctx context.Context, ah *v1alpha2.AgentHa
 			Labels:    lifecycleLabels(ah),
 		},
 		Spec: atev1alpha1.ActorTemplateSpec{
-			PauseImage: p.Defaults.PauseImage,
-			Runsc:      defaultRunscConfig(p.Defaults),
+			PauseImage:   p.Defaults.PauseImage,
+			SandboxClass: atev1alpha1.SandboxClassGvisor,
 			Containers: []atev1alpha1.Container{
 				{
 					Name:  containerName,
@@ -114,10 +169,7 @@ func (p *Lifecycle) buildActorTemplate(ctx context.Context, ah *v1alpha2.AgentHa
 					Env: containerEnv,
 				},
 			},
-			WorkerPoolRef: corev1.ObjectReference{
-				Name:      wpKey.Name,
-				Namespace: wpKey.Namespace,
-			},
+			WorkerSelector: workerSelectorForPool(wpKey),
 			SnapshotsConfig: atev1alpha1.SnapshotsConfig{
 				Location: substrateSnapshotsLocation(ah),
 			},

--- a/go/core/pkg/sandboxbackend/substrate/lifecycle_actortemplate.go
+++ b/go/core/pkg/sandboxbackend/substrate/lifecycle_actortemplate.go
@@ -2,6 +2,7 @@ package substrate
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"strings"
@@ -15,6 +16,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
+
+// ErrActorTemplateReconcilePending indicates ActorTemplate reconciliation started
+// a multi-step recreate (e.g. golden-actor deletion) and callers should requeue.
+var ErrActorTemplateReconcilePending = errors.New("actor template reconciliation pending")
 
 func (p *Lifecycle) ensureActorTemplate(ctx context.Context, ah *v1alpha2.AgentHarness, wpKey types.NamespacedName) (types.NamespacedName, error) {
 	key := types.NamespacedName{Namespace: ah.Namespace, Name: actorTemplateName(ah)}
@@ -39,7 +44,8 @@ func actorTemplateSpecEqual(a, b atev1alpha1.ActorTemplateSpec) bool {
 //   - spec matches     -> patch labels/owner refs only (never the spec)
 //   - spec drifts      -> delete the golden actor, delete the CR, recreate
 //
-// On spec drift it performs at most one mutating step per call and returns nil so the caller requeues.
+// On spec drift it performs at most one mutating step per call. When more work
+// remains it returns ErrActorTemplateReconcilePending so callers requeue.
 func reconcileActorTemplate(ctx context.Context, c client.Client, ate *Client, desired *atev1alpha1.ActorTemplate) error {
 	key := client.ObjectKeyFromObject(desired)
 
@@ -78,7 +84,7 @@ func reconcileActorTemplate(ctx context.Context, c client.Client, ate *Client, d
 			return fmt.Errorf("delete golden actor %q before recreating ActorTemplate %s: %w", goldenID, key, derr)
 		}
 		if !done {
-			return nil
+			return ErrActorTemplateReconcilePending
 		}
 	}
 	if err := c.Delete(ctx, existing); err != nil && !apierrors.IsNotFound(err) {
@@ -87,7 +93,7 @@ func reconcileActorTemplate(ctx context.Context, c client.Client, ate *Client, d
 	if err := c.Create(ctx, desired); err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			// The previous CR is still terminating; recreate on the next pass.
-			return nil
+			return ErrActorTemplateReconcilePending
 		}
 		return fmt.Errorf("recreate ActorTemplate %s: %w", key, err)
 	}

--- a/go/core/pkg/sandboxbackend/substrate/lifecycle_delete_test.go
+++ b/go/core/pkg/sandboxbackend/substrate/lifecycle_delete_test.go
@@ -53,6 +53,14 @@ func (r *recordingActorClient) ResumeActor(context.Context, *ateapipb.ResumeActo
 	panic("not used")
 }
 
+func (r *recordingActorClient) PauseActor(context.Context, *ateapipb.PauseActorRequest, ...grpc.CallOption) (*ateapipb.PauseActorResponse, error) {
+	panic("not used")
+}
+
+func (r *recordingActorClient) UpdateActor(context.Context, *ateapipb.UpdateActorRequest, ...grpc.CallOption) (*ateapipb.UpdateActorResponse, error) {
+	panic("not used")
+}
+
 func (r *recordingActorClient) ListWorkers(context.Context, *ateapipb.ListWorkersRequest, ...grpc.CallOption) (*ateapipb.ListWorkersResponse, error) {
 	panic("not used")
 }

--- a/go/core/pkg/sandboxbackend/substrate/lifecycle_shared.go
+++ b/go/core/pkg/sandboxbackend/substrate/lifecycle_shared.go
@@ -9,6 +9,7 @@ import (
 	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 	"github.com/kagent-dev/kagent/go/api/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -16,15 +17,16 @@ import (
 const (
 	defaultSnapshotsBucket   = "ate-snapshots"
 	defaultOpenClawContainer = "openclaw"
+
+	// Referenced by generated ActorTemplates to gate scheduling onto a WorkerPool.
+	// The kagent Helm chart stamps it on the WorkerPool it manages;
+	// externally-owned pools must carry it to remain eligible.
+	WorkerPoolLabelKey = "kagent.dev/worker-pool"
 )
 
 // LifecycleDefaults are cluster-wide defaults for generated ActorTemplate lifecycle.
 type LifecycleDefaults struct {
 	PauseImage           string
-	RunscAMD64URL        string
-	RunscAMD64SHA256     string
-	RunscARM64URL        string
-	RunscARM64SHA256     string
 	DefaultWorkloadImage string
 	DefaultWorkerPool    types.NamespacedName
 	// ImageRegistry and ImageRepository are the runtime registry/repository used
@@ -74,16 +76,12 @@ type LifecycleState struct {
 	ActorTemplateReady bool
 }
 
-func defaultRunscConfig(d LifecycleDefaults) atev1alpha1.RunscConfig {
-	return atev1alpha1.RunscConfig{
-		AMD64: &atev1alpha1.RunscPlatformConfig{
-			URL:        d.RunscAMD64URL,
-			SHA256Hash: d.RunscAMD64SHA256,
-		},
-		ARM64: &atev1alpha1.RunscPlatformConfig{
-			URL:        d.RunscARM64URL,
-			SHA256Hash: d.RunscARM64SHA256,
-		},
+func workerSelectorForPool(wpKey types.NamespacedName) *metav1.LabelSelector {
+	if wpKey.Name == "" {
+		return nil
+	}
+	return &metav1.LabelSelector{
+		MatchLabels: map[string]string{WorkerPoolLabelKey: wpKey.Name},
 	}
 }
 

--- a/go/core/pkg/sandboxbackend/substrate/lifecycle_test.go
+++ b/go/core/pkg/sandboxbackend/substrate/lifecycle_test.go
@@ -204,6 +204,68 @@ func TestReconcileActorTemplateRecreatesOnSpecDrift(t *testing.T) {
 	require.Empty(t, got.Status.GoldenActorID, "recreated template starts without a golden actor")
 }
 
+func TestReconcileActorTemplatePatchesAnnotationsWhenSpecMatches(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(atev1alpha1.AddToScheme(scheme))
+
+	key := types.NamespacedName{Namespace: "kagent", Name: "agent-openai"}
+	spec := atev1alpha1.ActorTemplateSpec{
+		PauseImage:   "registry.example/pause@sha256:a0",
+		SandboxClass: atev1alpha1.SandboxClassGvisor,
+		Containers: []atev1alpha1.Container{{
+			Name:  "kagent",
+			Image: "registry.example/app@sha256:1111111111111111111111111111111111111111111111111111111111111111",
+		}},
+	}
+
+	existing := &atev1alpha1.ActorTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        key.Name,
+			Namespace:   key.Namespace,
+			Labels:      map[string]string{SandboxAgentLabelKey: "agent"},
+			Annotations: map[string]string{desiredGenerationAnnotation: "4"},
+		},
+		Spec:   spec,
+		Status: atev1alpha1.ActorTemplateStatus{Phase: atev1alpha1.PhaseReady},
+	}
+	kube := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+
+	desired := &atev1alpha1.ActorTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        key.Name,
+			Namespace:   key.Namespace,
+			Labels:      map[string]string{SandboxAgentLabelKey: "agent"},
+			Annotations: map[string]string{desiredGenerationAnnotation: "6"},
+		},
+		Spec: spec,
+	}
+
+	require.NoError(t, reconcileActorTemplate(context.Background(), kube, nil, desired))
+
+	var got atev1alpha1.ActorTemplate
+	require.NoError(t, kube.Get(context.Background(), key, &got))
+	require.Equal(t, "6", got.Annotations[desiredGenerationAnnotation], "flip-back must bump desired-generation without recreating the template")
+
+	// After the annotation is current, routing must prefer this template over a stale Ready sibling.
+	stale := &atev1alpha1.ActorTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "agent-gemini",
+			Namespace:   key.Namespace,
+			Labels:      map[string]string{SandboxAgentLabelKey: "agent"},
+			Annotations: map[string]string{desiredGenerationAnnotation: "5"},
+		},
+		Status: atev1alpha1.ActorTemplateStatus{Phase: atev1alpha1.PhaseReady},
+	}
+	require.NoError(t, kube.Create(context.Background(), stale))
+
+	current, err := ResolveCurrentActorTemplate(context.Background(), kube, key.Namespace, "agent")
+	require.NoError(t, err)
+	require.NotNil(t, current)
+	require.Equal(t, "agent-openai", current.Name)
+}
+
 func TestReconcileActorTemplatePendingDuringGoldenActorDelete(t *testing.T) {
 	t.Parallel()
 

--- a/go/core/pkg/sandboxbackend/substrate/lifecycle_test.go
+++ b/go/core/pkg/sandboxbackend/substrate/lifecycle_test.go
@@ -2,6 +2,7 @@ package substrate
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
@@ -187,7 +188,11 @@ func TestReconcileActorTemplateRecreatesOnSpecDrift(t *testing.T) {
 	var got atev1alpha1.ActorTemplate
 	var recreated bool
 	for range 5 {
-		require.NoError(t, reconcileActorTemplate(context.Background(), kube, ate, desired.DeepCopy()))
+		err := reconcileActorTemplate(context.Background(), kube, ate, desired.DeepCopy())
+		if errors.Is(err, ErrActorTemplateReconcilePending) {
+			continue
+		}
+		require.NoError(t, err)
 		if err := kube.Get(context.Background(), key, &got); err == nil && got.Spec.Containers[0].Image == newImage {
 			recreated = true
 			break
@@ -197,4 +202,52 @@ func TestReconcileActorTemplateRecreatesOnSpecDrift(t *testing.T) {
 	require.True(t, recreated, "ActorTemplate should be recreated with the new image")
 	require.Equal(t, []string{"golden-1"}, rec.deleted, "golden actor must be deleted before recreate")
 	require.Empty(t, got.Status.GoldenActorID, "recreated template starts without a golden actor")
+}
+
+func TestReconcileActorTemplatePendingDuringGoldenActorDelete(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(v1alpha2.AddToScheme(scheme))
+	utilruntime.Must(atev1alpha1.AddToScheme(scheme))
+
+	key := types.NamespacedName{Namespace: "kagent", Name: "claw"}
+	oldImage := "registry.example/acp@sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	newImage := "registry.example/acp@sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	spec := func(image string) atev1alpha1.ActorTemplateSpec {
+		return atev1alpha1.ActorTemplateSpec{
+			PauseImage:   "registry.example/pause@sha256:" + "a0",
+			SandboxClass: atev1alpha1.SandboxClassGvisor,
+			Containers: []atev1alpha1.Container{{
+				Name:  "openclaw",
+				Image: image,
+			}},
+			SnapshotsConfig: atev1alpha1.SnapshotsConfig{Location: "gs://ate-snapshots/kagent/claw"},
+		}
+	}
+
+	existing := &atev1alpha1.ActorTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace},
+		Spec:       spec(oldImage),
+		Status:     atev1alpha1.ActorTemplateStatus{GoldenActorID: "golden-1", Phase: atev1alpha1.PhaseReady},
+	}
+	kube := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&atev1alpha1.ActorTemplate{}).
+		WithObjects(existing).
+		Build()
+	rec := &recordingActorClient{}
+	ate := &Client{ControlClient: rec}
+	desired := &atev1alpha1.ActorTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace},
+		Spec:       spec(newImage),
+	}
+
+	err := reconcileActorTemplate(context.Background(), kube, ate, desired)
+	require.ErrorIs(t, err, ErrActorTemplateReconcilePending)
+
+	var got atev1alpha1.ActorTemplate
+	require.NoError(t, kube.Get(context.Background(), key, &got))
+	require.Equal(t, oldImage, got.Spec.Containers[0].Image)
+	require.Equal(t, []string{"golden-1"}, rec.deleted)
 }

--- a/go/core/pkg/sandboxbackend/substrate/lifecycle_test.go
+++ b/go/core/pkg/sandboxbackend/substrate/lifecycle_test.go
@@ -141,3 +141,60 @@ func TestEnsureActorTemplateDoesNotUpdateWhenDesiredStateMatches(t *testing.T) {
 	require.NoError(t, err)
 	require.Zero(t, updateCalls, "matching desired ActorTemplate should not be updated")
 }
+
+func TestReconcileActorTemplateRecreatesOnSpecDrift(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(v1alpha2.AddToScheme(scheme))
+	utilruntime.Must(atev1alpha1.AddToScheme(scheme))
+
+	key := types.NamespacedName{Namespace: "kagent", Name: "claw"}
+	baseSpec := func(image string) atev1alpha1.ActorTemplateSpec {
+		return atev1alpha1.ActorTemplateSpec{
+			PauseImage:   "registry.example/pause@sha256:" + "a0",
+			SandboxClass: atev1alpha1.SandboxClassGvisor,
+			Containers: []atev1alpha1.Container{{
+				Name:  "openclaw",
+				Image: image,
+			}},
+			SnapshotsConfig: atev1alpha1.SnapshotsConfig{Location: "gs://ate-snapshots/kagent/claw"},
+		}
+	}
+
+	oldImage := "registry.example/acp@sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	newImage := "registry.example/acp@sha256:2222222222222222222222222222222222222222222222222222222222222222"
+
+	existing := &atev1alpha1.ActorTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace},
+		Spec:       baseSpec(oldImage),
+		Status:     atev1alpha1.ActorTemplateStatus{GoldenActorID: "golden-1", Phase: atev1alpha1.PhaseReady},
+	}
+
+	kube := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&atev1alpha1.ActorTemplate{}).
+		WithObjects(existing).
+		Build()
+	rec := &recordingActorClient{}
+	ate := &Client{ControlClient: rec}
+
+	desired := &atev1alpha1.ActorTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace},
+		Spec:       baseSpec(newImage),
+	}
+
+	var got atev1alpha1.ActorTemplate
+	var recreated bool
+	for range 5 {
+		require.NoError(t, reconcileActorTemplate(context.Background(), kube, ate, desired.DeepCopy()))
+		if err := kube.Get(context.Background(), key, &got); err == nil && got.Spec.Containers[0].Image == newImage {
+			recreated = true
+			break
+		}
+	}
+
+	require.True(t, recreated, "ActorTemplate should be recreated with the new image")
+	require.Equal(t, []string{"golden-1"}, rec.deleted, "golden actor must be deleted before recreate")
+	require.Empty(t, got.Status.GoldenActorID, "recreated template starts without a golden actor")
+}

--- a/go/core/pkg/sandboxbackend/substrate/list.go
+++ b/go/core/pkg/sandboxbackend/substrate/list.go
@@ -45,6 +45,10 @@ func ActorStatusLabel(status ateapipb.Actor_Status) string {
 		return "Suspending"
 	case ateapipb.Actor_STATUS_SUSPENDED:
 		return "Suspended"
+	case ateapipb.Actor_STATUS_PAUSING:
+		return "Pausing"
+	case ateapipb.Actor_STATUS_PAUSED:
+		return "Paused"
 	case ateapipb.Actor_STATUS_UNSPECIFIED:
 		return "Unknown"
 	default:

--- a/go/go.mod
+++ b/go/go.mod
@@ -325,7 +325,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
-	github.com/pelletier/go-toml/v2 v2.3.1 // indirect
+	github.com/pelletier/go-toml/v2 v2.4.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
@@ -450,4 +450,4 @@ require (
 
 tool sigs.k8s.io/kube-api-linter/cmd/golangci-lint-kube-api-linter
 
-replace github.com/agent-substrate/substrate => github.com/kagent-dev/substrate v0.0.6
+replace github.com/agent-substrate/substrate => github.com/kagent-dev/substrate v0.0.7

--- a/go/go.sum
+++ b/go/go.sum
@@ -500,8 +500,8 @@ github.com/kagent-dev/mockllm v0.0.5 h1:mm9Ml3NH6/E/YKVMgMwWYMNsNGkDze6I6TC0ppHZ
 github.com/kagent-dev/mockllm v0.0.5/go.mod h1:tDLemRsTZa1NdHaDbg3sgFk9cT1QWvMPlBtLVD6I2mA=
 github.com/kagent-dev/mockmcp v0.0.0-20260520211643-dcd475b74085 h1:5bYxRc6K6+JiFMYGSJpQ7y18PzTGXUmUtVXY7Fqh0Ew=
 github.com/kagent-dev/mockmcp v0.0.0-20260520211643-dcd475b74085/go.mod h1:vTMste7c+XiDOQyhe6iGPKLbMy3chY/h2fL3Dox5fAE=
-github.com/kagent-dev/substrate v0.0.6 h1:WR3mTKAYW4jMz3ojhM87jLjDYgy2ZYgU1TvzheHI8OI=
-github.com/kagent-dev/substrate v0.0.6/go.mod h1:TgdtEUV6iaflJTwmS8ONiGsyyJD+5okPZj2H6mM8WlA=
+github.com/kagent-dev/substrate v0.0.7 h1:zf4NryZxpVy/tLhlWQSPgINkoPAse00e38+EH2UQ/oE=
+github.com/kagent-dev/substrate v0.0.7/go.mod h1:2ri5mTz714LWinayPQG1d4G/kMuzbqvRXlrUrpc7N9Y=
 github.com/karamaru-alpha/copyloopvar v1.2.2 h1:yfNQvP9YaGQR7VaWLYcfZUlRP2eo2vhExWKxD/fP6q0=
 github.com/karamaru-alpha/copyloopvar v1.2.2/go.mod h1:oY4rGZqZ879JkJMtX3RRkcXRkmUvH0x35ykgaKgsgJY=
 github.com/kisielk/errcheck v1.10.0 h1:Lvs/YAHP24YKg08LA8oDw2z9fJVme090RAXd90S+rrw=
@@ -659,8 +659,8 @@ github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT9
 github.com/otiai10/mint v1.3.1/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
 github.com/pb33f/ordered-map/v2 v2.3.1 h1:5319HDO0aw4DA4gzi+zv4FXU9UlSs3xGZ40wcP1nBjY=
 github.com/pb33f/ordered-map/v2 v2.3.1/go.mod h1:qxFQgd0PkVUtOMCkTapqotNgzRhMPL7VvaHKbd1HnmQ=
-github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=
-github.com/pelletier/go-toml/v2 v2.3.1/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
+github.com/pelletier/go-toml/v2 v2.4.0 h1:Mwu0mAkUKbittDs3/ADDWXqMmq3EOK2VHiuCkV00Row=
+github.com/pelletier/go-toml/v2 v2.4.0/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pgvector/pgvector-go v0.4.0 h1:879hQCnuix1bkfa5TQISnnK9ik4Fo+cHj2vuZSgW5v4=
 github.com/pgvector/pgvector-go v0.4.0/go.mod h1:4fSXyjl1TYAIdByAql6JazKWRr2s7J0g4hcRY5cBFCk=
 github.com/pgvector/pgvector-go/pgx v0.4.0 h1:wHFoQRtCksVfmrBaHoxeT8IkonmnxlvnLzz3T4EW9Y0=

--- a/helm/kagent/templates/controller-deployment.yaml
+++ b/helm/kagent/templates/controller-deployment.yaml
@@ -125,22 +125,6 @@ spec:
             - name: SUBSTRATE_PAUSE_IMAGE
               value: {{ . | quote }}
             {{- end }}
-            {{- with .Values.controller.substrate.runscAMD64URL }}
-            - name: SUBSTRATE_RUNSC_AMD64_URL
-              value: {{ . | quote }}
-            {{- end }}
-            {{- with .Values.controller.substrate.runscAMD64SHA256 }}
-            - name: SUBSTRATE_RUNSC_AMD64_SHA256
-              value: {{ . | quote }}
-            {{- end }}
-            {{- with .Values.controller.substrate.runscARM64URL }}
-            - name: SUBSTRATE_RUNSC_ARM64_URL
-              value: {{ . | quote }}
-            {{- end }}
-            {{- with .Values.controller.substrate.runscARM64SHA256 }}
-            - name: SUBSTRATE_RUNSC_ARM64_SHA256
-              value: {{ . | quote }}
-            {{- end }}
             {{- end }}
           envFrom:
             - configMapRef:

--- a/helm/kagent/templates/substrate-workerpool.yaml
+++ b/helm/kagent/templates/substrate-workerpool.yaml
@@ -9,7 +9,16 @@ metadata:
   namespace: {{ include "kagent.namespace" . }}
   labels:
     {{- include "kagent.labels" . | nindent 4 }}
+    kagent.dev/worker-pool: {{ .Values.substrateWorkerPool.name | quote }}
+    {{- with .Values.substrateWorkerPool.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.substrateWorkerPool.replicas }}
   ateomImage: {{ .Values.substrateWorkerPool.ateomImage | quote }}
+  sandboxClass: {{ .Values.substrateWorkerPool.sandboxClass | default "gvisor" | quote }}
+  {{- with .Values.substrateWorkerPool.template }}
+  template:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -322,10 +322,11 @@ substrateWorkerPool:
   name: kagent-default
   replicas: 1
   ateomImage: ""
-  # sandboxClass selects the sandbox runtime family (gvisor|microvm).
+  # sandboxClass selects the sandbox runtime family (gvisor|microvm). kagent-generated
+  # ActorTemplates currently hardcode gvisor; set this to gvisor until microvm is supported.
   sandboxClass: gvisor
   # Extra labels merged onto the WorkerPool metadata (in addition to the
-  # kagent.dev/worker-pool selector label that generated ActorTemplates match).
+  # kagent.dev/worker-pool label used by generated ActorTemplates to select this pool).
   labels: {}
   # Optional pod scheduling/resources for worker pods (WorkerPool.spec.template).
   # nodeSelector / tolerations / priorityClassName / nodeAffinity / resources.

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -282,10 +282,6 @@ controller:
       namespace: ""
       name: ""
     # pauseImage: "gcr.io/gke-release/pause@sha256:bcbd57ba5653580ec647b16d8163cdd1112df3609129b01f912a8032e48265da"
-    # runscAMD64URL: "gs://gvisor/releases/nightly/2026-06-02/x86_64/runsc"
-    # runscAMD64SHA256: "efd12935f6654c91a1389710eb8dfa4d12b6b9be00db87526dc2eb584ad00119"
-    # runscARM64URL: "gs://gvisor/releases/nightly/2026-05-19/aarch64/runsc"
-    # runscARM64SHA256: "1ba2366ae2efceba166046f51a4104f9261c9cb72c6db8f5b3fe2dc57dea86b9"
     # Example when enabled:
     #   enabled: true
     #   ateApiEndpoint: "dns:///api.ate-system.svc:443"
@@ -326,6 +322,14 @@ substrateWorkerPool:
   name: kagent-default
   replicas: 1
   ateomImage: ""
+  # sandboxClass selects the sandbox runtime family (gvisor|microvm).
+  sandboxClass: gvisor
+  # Extra labels merged onto the WorkerPool metadata (in addition to the
+  # kagent.dev/worker-pool selector label that generated ActorTemplates match).
+  labels: {}
+  # Optional pod scheduling/resources for worker pods (WorkerPool.spec.template).
+  # nodeSelector / tolerations / priorityClassName / nodeAffinity / resources.
+  template: {}
 
 # ==============================================================================
 # UI CONFIGURATION

--- a/ui/src/components/substrate/SubstrateStatusView.tsx
+++ b/ui/src/components/substrate/SubstrateStatusView.tsx
@@ -135,7 +135,8 @@ function ActorTemplatesTable({ rows }: { rows: SubstrateActorTemplateEntry[] }) 
           <tr className="text-left text-xs uppercase tracking-wider text-muted-foreground">
             <th className="py-2 pr-4 font-medium">Template</th>
             <th className="py-2 pr-4 font-medium">Phase</th>
-            <th className="py-2 pr-4 font-medium">Worker pool</th>
+            <th className="py-2 pr-4 font-medium">Sandbox class</th>
+            <th className="py-2 pr-4 font-medium">Worker selector</th>
             <th className="py-2 font-medium">Harness</th>
           </tr>
         </thead>
@@ -154,7 +155,8 @@ function ActorTemplatesTable({ rows }: { rows: SubstrateActorTemplateEntry[] }) 
               <td className="py-3 pr-4">
                 <StatusChip label={t.phase ?? ""} />
               </td>
-              <td className="py-3 pr-4 text-muted-foreground">{t.workerPoolRef ?? "—"}</td>
+              <td className="py-3 pr-4 text-muted-foreground">{t.sandboxClass ?? "—"}</td>
+              <td className="py-3 pr-4 font-mono text-[11px] text-muted-foreground">{t.workerSelector ?? "—"}</td>
               <td className="py-3">
                 {t.harnessName ? (
                   <Link

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -491,7 +491,8 @@ export interface SubstrateActorTemplateEntry {
   phase?: string;
   goldenActorId?: string;
   goldenSnapshot?: string;
-  workerPoolRef?: string;
+  sandboxClass?: string;
+  workerSelector?: string;
   harnessName?: string;
   managedByKagent: boolean;
 }
@@ -504,7 +505,8 @@ export interface SubstrateActorEntry {
   ateomPodNamespace?: string;
   ateomPodName?: string;
   ateomPodIp?: string;
-  lastSnapshot?: string;
+  latestSnapshot?: string;
+  workerPoolName?: string;
   inProgressSnapshot?: string;
   version?: number;
 }


### PR DESCRIPTION
**Changes in this version (that affects Kagent):**

- `ActorTemplate` spec became immutable -> delete golden actor and delete / recreate template on spec drift for sandbox agents and agent harness reconciler
- `workerPoolRef` removed from actor template -> kagent uses worker selector and `SandboxClass` instead; helm `WorkerPool` gets the `kagent.dev/worker-pool: <name>` label automatically
- `runsc` config decoupled from actor template -> removed relevant flags, they're owned by `SandboxConfig` now
- New `PAUSED` state and `PauseActor` RPC
- `last_snapshot` proto field replaced by `lastest_snapshot_info`

**Installation note:**

You will likely need to wipe stale actor states in Valkey due to the last change above (see below). If you still run into issues with agents not getting ready, delete and reapply them. Existing session data are persisted in Kagent DB, so it will not be lost.

```bash
# When getting actors, you will likely run into this error
kubectl ate get actors
# Error: failed to list actors: rpc error: code = Internal desc = internal server error

# Flush all Valkey primaries
kubectl exec -n ate-system valkey-cluster-0 -- valkey-cli FLUSHALL
```