### PR TITLE
Allow configuration of A2A client timeout

### DIFF
--- a/go/core/internal/a2a/a2a_registrar.go
+++ b/go/core/internal/a2a/a2a_registrar.go
@@ -216,7 +216,7 @@ func (a *A2ARegistrar) upsertAgentHandler(ctx context.Context, agent v1alpha2.Ag
 
 	provider := resolveProviderName(ctx, a.cache, agent)
 
-	httpClient := debugHTTPClient()
+	httpClient := a2aHTTPClient()
 	if sa, ok := agent.(*v1alpha2.SandboxAgent); ok &&
 		a.substrateSandboxActorBackend != nil {
 		routerURL := a.ateneRouterURL
@@ -274,8 +274,8 @@ func (a *A2ARegistrar) upsertAgentHandler(ctx context.Context, agent v1alpha2.Ag
 	return nil
 }
 
-// debugHTTPClient returns nil in normal operation, letting the a2aclient SDK apply its
-// default 3-minute request timeout. In debug mode it overrides the dial target so all
+// debugHTTPClient returns nil in normal operation, letting the caller apply its
+// configured timeout. In debug mode it overrides the dial target so all
 // A2A traffic is redirected to a fixed address (e.g. a local proxy).
 func debugHTTPClient() *http.Client {
 	debugAddr := env.KagentA2ADebugAddr.Get()
@@ -290,6 +290,17 @@ func debugHTTPClient() *http.Client {
 			},
 		},
 	}
+}
+
+// a2aHTTPClient returns the HTTP client to use for A2A requests to agent pods.
+// It respects KAGENT_A2A_CLIENT_TIMEOUT (default 0 = no timeout), overriding
+// the a2a-go SDK's built-in 3-minute default which is too short for long-running
+// streaming agents.
+func a2aHTTPClient() *http.Client {
+	if c := debugHTTPClient(); c != nil {
+		return c
+	}
+	return &http.Client{Timeout: env.KagentA2AClientTimeout.Get()}
 }
 
 func (a *A2ARegistrar) a2aRouteURL(agent v1alpha2.AgentObject) string {

--- a/go/core/internal/a2a/a2a_registrar.go
+++ b/go/core/internal/a2a/a2a_registrar.go
@@ -274,33 +274,22 @@ func (a *A2ARegistrar) upsertAgentHandler(ctx context.Context, agent v1alpha2.Ag
 	return nil
 }
 
-// debugHTTPClient returns nil in normal operation, letting the caller apply its
-// configured timeout. In debug mode it overrides the dial target so all
-// A2A traffic is redirected to a fixed address (e.g. a local proxy).
-func debugHTTPClient() *http.Client {
-	debugAddr := env.KagentA2ADebugAddr.Get()
-	if debugAddr == "" {
-		return nil
-	}
-	return &http.Client{
-		Transport: &http.Transport{
+// a2aHTTPClient returns the HTTP client to use for A2A requests to agent pods.
+// It respects KAGENT_A2A_CLIENT_TIMEOUT (default 0 = no timeout), overriding the
+// a2a-go SDK's built-in 3-minute default which is too short for long-running
+// streaming agents. When KAGENT_A2A_DEBUG_ADDR is set, the dial target is
+// redirected to that fixed address (e.g. a local proxy) for debugging.
+func a2aHTTPClient() *http.Client {
+	client := &http.Client{Timeout: env.KagentA2AClientTimeout.Get()}
+	if debugAddr := env.KagentA2ADebugAddr.Get(); debugAddr != "" {
+		client.Transport = &http.Transport{
 			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 				var zeroDialer net.Dialer
 				return zeroDialer.DialContext(ctx, network, debugAddr)
 			},
-		},
+		}
 	}
-}
-
-// a2aHTTPClient returns the HTTP client to use for A2A requests to agent pods.
-// It respects KAGENT_A2A_CLIENT_TIMEOUT (default 0 = no timeout), overriding
-// the a2a-go SDK's built-in 3-minute default which is too short for long-running
-// streaming agents.
-func a2aHTTPClient() *http.Client {
-	if c := debugHTTPClient(); c != nil {
-		return c
-	}
-	return &http.Client{Timeout: env.KagentA2AClientTimeout.Get()}
+	return client
 }
 
 func (a *A2ARegistrar) a2aRouteURL(agent v1alpha2.AgentObject) string {

--- a/go/core/pkg/env/kagent.go
+++ b/go/core/pkg/env/kagent.go
@@ -23,6 +23,16 @@ var (
 		ComponentController,
 	)
 
+	KagentA2AClientTimeout = RegisterDurationVar(
+		"KAGENT_A2A_CLIENT_TIMEOUT",
+		0,
+		"HTTP client timeout for A2A requests from the controller to agent pods. "+
+			"0 (the default) means no timeout, which is recommended for long-running agents "+
+			"that stream responses over SSE. Set a positive duration (e.g. 30m) only if you "+
+			"need a hard upper bound on individual A2A calls.",
+		ComponentController,
+	)
+
 	KagentMCPStateless = RegisterBoolVar(
 		"KAGENT_MCP_STATELESS",
 		false,

--- a/helm/kagent/templates/controller-configmap.yaml
+++ b/helm/kagent/templates/controller-configmap.yaml
@@ -57,6 +57,9 @@ data:
   DATABASE_VECTOR_ENABLED: {{ .Values.database.postgres.vectorEnabled | quote }}
   WATCH_NAMESPACES: {{ include "kagent.watchNamespaces" . | quote }}
   MCP_EGRESS_PLAINTEXT: {{ .Values.controller.mcpEgressPlaintext | default false | quote }}
+  {{- if .Values.controller.a2aClientTimeout }}
+  KAGENT_A2A_CLIENT_TIMEOUT: {{ .Values.controller.a2aClientTimeout | quote }}
+  {{- end }}
   ZAP_LOG_LEVEL: {{ .Values.controller.loglevel | quote }}
   {{- $agentHost := "" }}
   {{- if and .Values.controller.agentDeployment .Values.controller.agentDeployment.host (not (eq .Values.controller.agentDeployment.host "")) }}

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -191,6 +191,16 @@ controller:
   # internally. These values have no effect and will be removed in a future release.
   streaming: null
 
+  # -- HTTP client timeout for A2A requests from the controller to agent pods.
+  # 0 (the default) means no timeout, which is correct for SSE-based streaming agents
+  # that can run for an arbitrarily long time. The previous implicit default was 3m
+  # (inherited from the a2a-go SDK), which caused `context deadline exceeded` errors
+  # for agents that take longer than 3 minutes to complete.
+  # Set a positive Go duration string (e.g. "30m", "1h") only if you need a hard
+  # upper bound on individual A2A calls.
+  # @default -- "" (no timeout)
+  a2aClientTimeout: ""
+
   # -- Namespaces the controller should watch.
   # If empty, the controller will watch ALL available namespaces.
   # @default -- [] (watches all available namespaces)


### PR DESCRIPTION
With this change users can now set `controller.a2aClientTimeout` in their Helm values to override the timeout. Default behavior (empty/0) removes all timeout, preventing the 3-minute SSE cutoff.

Closes #2112

# Problem

The a2a-go SDK applies a hardcoded 3-minute HTTP timeout to all A2A client requests. This causes context deadline exceeded errors when agents take longer than 3 minutes to complete, even during normal SSE streaming operations.

# Proposed Solution

- Add `KAGENT_A2A_CLIENT_TIMEOUT` environment variable (default: 0 = no timeout)
- Create `a2aHTTPClient()` function to build HTTP clients respecting the configured timeout
- Wire the timeout through Helm values (`controller.a2aClientTimeout`) → `ConfigMap` → env var
- Replaces the SDK's 3-minute default with a configurable value suitable for long-running agents

# Changes

- `kagent.go`: Register `KagentA2AClientTimeout` env var
- `a2a_registrar.go`: Implement `a2aHTTPClient()` and use it instead of `debugHTTPClient()`
- `values.yaml`: Add `controller.a2aClientTimeout` Helm value
- `controller-configmap.yaml`: Wire env var to the `ConfigMap`