### PR TITLE
Trigger CI workflows on all release/** branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,11 +2,11 @@ name: CI Build
 
 on:
   push:
-    branches: [main, release/v0.7.x]
+    branches: [main, "release/**"]
     paths-ignore:
       - "**/*.md"
   pull_request:
-    branches: [main, release/v0.7.x]
+    branches: [main, "release/**"]
     paths-ignore:
       - "**/*.md"
   workflow_dispatch:

--- a/.github/workflows/migration-immutability.yaml
+++ b/.github/workflows/migration-immutability.yaml
@@ -2,7 +2,7 @@ name: Migration Immutability
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, "release/**"]
     paths:
       - "go/core/pkg/migrations/**"
 

--- a/.github/workflows/sqlc-generate-check.yaml
+++ b/.github/workflows/sqlc-generate-check.yaml
@@ -2,7 +2,7 @@ name: sqlc Generate Check
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, "release/**"]
     paths:
       - "go/core/internal/database/queries/**"
       - "go/core/internal/database/sqlc.yaml"

--- a/.github/workflows/ui-chromatic.yaml
+++ b/.github/workflows/ui-chromatic.yaml
@@ -5,11 +5,11 @@ name: UI Storybook & Chromatic
 
 on:
   push:
-    branches: [main, release/v0.7.x]
+    branches: [main, "release/**"]
     paths:
       - "ui/**"
   pull_request:
-    branches: [main, release/v0.7.x]
+    branches: [main, "release/**"]
     paths:
       - "ui/**"
   workflow_dispatch:


### PR DESCRIPTION
## Description

Switch the workflow branch filters from hardcoded release branch names to a `release/**` glob, so CI runs on every release branch instead of only the one that happened to be current when the filter was last edited.

## Why

The filters hardcoded `release/v0.7.x` (or were `main`-only). `release/v0.7.x` is long superseded, so PRs targeting current release branches — e.g. `release/v0.9.x` — triggered **no CI** (only branch-agnostic checks like DCO/labelers/snyk ran). A `release/**` glob matches every current and future release branch, so this won't go stale on the next release cut.

## Changes

`branches` filters updated to `[main, "release/**"]`:

- `ci.yaml` — push + pull_request (was `[main, release/v0.7.x]`)
- `ui-chromatic.yaml` — push + pull_request (was `[main, release/v0.7.x]`)
- `migration-immutability.yaml` — pull_request (was `[main]`)
- `sqlc-generate-check.yaml` — pull_request (was `[main]`)

No job logic changed — only the trigger branch filters. The glob still matches `release/v0.7.x`, so nothing that ran before stops running. `migration-immutability` and `sqlc-generate-check` were `main`-only and now also run on release-branch PRs (those checks are relevant to release branches too).

## Notes

- For `pull_request`, GitHub evaluates the trigger from the PR head's workflow file, so this takes effect for PRs cut from `main` once merged, and for future release branches cut from `main`.
- **Existing release branches carry their own stale copies of these filters** and won't inherit this change — it must be backported to each active release branch (e.g. `release/v0.9.x`) for their PRs to get CI.