### PR TITLE
fix(go-adk): extract system prompt from genai.GenerateContentConfig in Ollama and Bedrock model providers

### DIFF
--- a/go/adk/pkg/models/anthropic_adk.go
+++ b/go/adk/pkg/models/anthropic_adk.go
@@ -103,17 +103,7 @@ func applyAnthropicConfig(params *anthropic.MessageNewParams, cfg *AnthropicConf
 }
 
 func genaiContentsToAnthropicMessages(contents []*genai.Content, config *genai.GenerateContentConfig) ([]anthropic.MessageParam, string) {
-	// Extract system instruction
-	var systemBuilder strings.Builder
-	if config != nil && config.SystemInstruction != nil {
-		for _, p := range config.SystemInstruction.Parts {
-			if p != nil && p.Text != "" {
-				systemBuilder.WriteString(p.Text)
-				systemBuilder.WriteByte('\n')
-			}
-		}
-	}
-	systemPrompt := strings.TrimSpace(systemBuilder.String())
+	systemPrompt := mergeSystemInstructionFromConfig("", config)
 
 	// Collect function responses for matching with function calls
 	functionResponses := make(map[string]*genai.FunctionResponse)

--- a/go/adk/pkg/models/base.go
+++ b/go/adk/pkg/models/base.go
@@ -166,3 +166,23 @@ func lowercaseSchemaTypes(m map[string]any) {
 		}
 	}
 }
+
+// mergeSystemInstructionFromConfig appends Config.SystemInstruction parts to any
+// system text extracted from conversation contents. The Google ADK delivers the
+// agent Instruction via Config.SystemInstruction, not as role-"system" Content.
+func mergeSystemInstructionFromConfig(existing string, config *genai.GenerateContentConfig) string {
+	if config == nil || config.SystemInstruction == nil {
+		return strings.TrimSpace(existing)
+	}
+	var b strings.Builder
+	b.WriteString(existing)
+	for _, p := range config.SystemInstruction.Parts {
+		if p != nil && p.Text != "" {
+			if b.Len() > 0 {
+				b.WriteByte('\n')
+			}
+			b.WriteString(p.Text)
+		}
+	}
+	return strings.TrimSpace(b.String())
+}

--- a/go/adk/pkg/models/base_test.go
+++ b/go/adk/pkg/models/base_test.go
@@ -1,0 +1,66 @@
+package models
+
+import (
+	"testing"
+
+	"google.golang.org/genai"
+)
+
+func TestMergeSystemInstructionFromConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing string
+		config   *genai.GenerateContentConfig
+		want     string
+	}{
+		{
+			name: "nil config returns trimmed existing",
+			existing: "  hello  ",
+			want:     "hello",
+		},
+		{
+			name: "config only",
+			config: &genai.GenerateContentConfig{
+				SystemInstruction: &genai.Content{
+					Parts: []*genai.Part{
+						{Text: "You are helpful."},
+						{Text: "Be concise."},
+					},
+				},
+			},
+			want: "You are helpful.\nBe concise.",
+		},
+		{
+			name: "skips empty text parts",
+			config: &genai.GenerateContentConfig{
+				SystemInstruction: &genai.Content{
+					Parts: []*genai.Part{
+						{Text: "  one  "},
+						{Text: ""},
+						{Text: "two"},
+					},
+				},
+			},
+			want: "one  \ntwo",
+		},
+		{
+			name:     "merges existing with config",
+			existing: "From contents",
+			config: &genai.GenerateContentConfig{
+				SystemInstruction: &genai.Content{
+					Parts: []*genai.Part{{Text: "From config"}},
+				},
+			},
+			want: "From contents\nFrom config",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeSystemInstructionFromConfig(tt.existing, tt.config)
+			if got != tt.want {
+				t.Errorf("mergeSystemInstructionFromConfig() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/go/adk/pkg/models/base_test.go
+++ b/go/adk/pkg/models/base_test.go
@@ -14,7 +14,7 @@ func TestMergeSystemInstructionFromConfig(t *testing.T) {
 		want     string
 	}{
 		{
-			name: "nil config returns trimmed existing",
+			name:     "nil config returns trimmed existing",
 			existing: "  hello  ",
 			want:     "hello",
 		},

--- a/go/adk/pkg/models/bedrock.go
+++ b/go/adk/pkg/models/bedrock.go
@@ -196,7 +196,7 @@ func (m *BedrockModel) GenerateContent(ctx context.Context, req *model.LLMReques
 		// Convert content to Bedrock messages.
 		// nameMap is passed so that any tool call recorded in conversation history
 		// is written with the sanitized name Bedrock already knows about.
-		messages, systemInstruction := convertGenaiContentsToBedrockMessages(req.Contents, nameMap)
+		messages, systemInstruction := convertGenaiContentsToBedrockMessages(req.Contents, nameMap, req.Config)
 
 		// temperature/top_p must not be sent when thinking is active. https://docs.aws.amazon.com/bedrock/latest/userguide/claude-messages-extended-thinking.html
 		_, thinkingEnabled := m.Config.AdditionalModelRequestFields["thinking"]
@@ -559,7 +559,7 @@ func truncateToolResult(s string, maxLen int) string {
 // nameMap is the original->sanitized tool name map produced by convertGenaiToolsToBedrock.
 // Any FunctionCall found in the conversation history is written with the sanitized name so
 // that Bedrock can correlate it with the tool spec it already received. A nil nameMap is safe.
-func convertGenaiContentsToBedrockMessages(contents []*genai.Content, nameMap map[string]string) ([]types.Message, string) {
+func convertGenaiContentsToBedrockMessages(contents []*genai.Content, nameMap map[string]string, config *genai.GenerateContentConfig) ([]types.Message, string) {
 	var messages []types.Message
 	var systemInstruction string
 
@@ -684,7 +684,7 @@ func convertGenaiContentsToBedrockMessages(contents []*genai.Content, nameMap ma
 		}
 	}
 
-	return messages, systemInstruction
+	return messages, mergeSystemInstructionFromConfig(systemInstruction, config)
 }
 
 // convertGenaiToolsToBedrock converts genai.Tool to Bedrock Tool format.

--- a/go/adk/pkg/models/bedrock_test.go
+++ b/go/adk/pkg/models/bedrock_test.go
@@ -37,6 +37,7 @@ func TestConvertGenaiContentsToBedrockMessages(t *testing.T) {
 	tests := []struct {
 		name           string
 		contents       []*genai.Content
+		config         *genai.GenerateContentConfig
 		wantMsgCount   int
 		wantSystemText string
 		checkMsg       func(t *testing.T, msgs []types.Message)
@@ -56,6 +57,36 @@ func TestConvertGenaiContentsToBedrockMessages(t *testing.T) {
 			},
 			wantMsgCount:   1,
 			wantSystemText: "You are a helpful assistant",
+		},
+		{
+			name: "system instruction from config",
+			contents: []*genai.Content{
+				{Role: "user", Parts: []*genai.Part{{Text: "Hello"}}},
+			},
+			config: &genai.GenerateContentConfig{
+				SystemInstruction: &genai.Content{
+					Parts: []*genai.Part{
+						{Text: "You are a test agent."},
+						{Text: "Begin EVERY reply with ZEBRA9."},
+					},
+				},
+			},
+			wantMsgCount:   1,
+			wantSystemText: "You are a test agent.\nBegin EVERY reply with ZEBRA9.",
+		},
+		{
+			name: "system instruction from config merges with content role system",
+			contents: []*genai.Content{
+				{Role: "system", Parts: []*genai.Part{{Text: "From contents"}}},
+				{Role: "user", Parts: []*genai.Part{{Text: "Hello"}}},
+			},
+			config: &genai.GenerateContentConfig{
+				SystemInstruction: &genai.Content{
+					Parts: []*genai.Part{{Text: "From config"}},
+				},
+			},
+			wantMsgCount:   1,
+			wantSystemText: "From contents\nFrom config",
 		},
 		{
 			name: "user and model conversation",
@@ -142,7 +173,7 @@ func TestConvertGenaiContentsToBedrockMessages(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			msgs, systemText := convertGenaiContentsToBedrockMessages(tt.contents, nil)
+			msgs, systemText := convertGenaiContentsToBedrockMessages(tt.contents, nil, tt.config)
 			if len(msgs) != tt.wantMsgCount {
 				t.Errorf("expected %d messages, got %d", tt.wantMsgCount, len(msgs))
 			}
@@ -487,7 +518,7 @@ func TestThinkingOnlyInLastAssistantTurn(t *testing.T) {
 		},
 	}
 
-	msgs, _ := convertGenaiContentsToBedrockMessages(contents, nil)
+	msgs, _ := convertGenaiContentsToBedrockMessages(contents, nil, nil)
 	if len(msgs) != 4 {
 		t.Fatalf("want 4 messages, got %d", len(msgs))
 	}
@@ -524,7 +555,7 @@ func TestHistoricalToolResultTruncation(t *testing.T) {
 		},
 	}
 
-	msgs, _ := convertGenaiContentsToBedrockMessages(contents, nil)
+	msgs, _ := convertGenaiContentsToBedrockMessages(contents, nil, nil)
 	if len(msgs) != 2 {
 		t.Fatalf("want 2 messages, got %d", len(msgs))
 	}

--- a/go/adk/pkg/models/ollama_adk.go
+++ b/go/adk/pkg/models/ollama_adk.go
@@ -30,7 +30,7 @@ func (m *OllamaModel) GenerateContent(ctx context.Context, req *model.LLMRequest
 		}
 
 		// Convert content to Ollama messages
-		messages, systemInstruction := convertGenaiContentsToOllamaMessages(req.Contents)
+		messages, systemInstruction := convertGenaiContentsToOllamaMessages(req.Contents, req.Config)
 
 		// Add system instruction as first message if present
 		if systemInstruction != "" {
@@ -233,7 +233,7 @@ func (m *OllamaModel) generateNonStreaming(ctx context.Context, modelName string
 
 // convertGenaiContentsToOllamaMessages converts genai.Content to Ollama message format.
 // Returns messages and system instruction (extracted from system role content).
-func convertGenaiContentsToOllamaMessages(contents []*genai.Content) ([]api.Message, string) {
+func convertGenaiContentsToOllamaMessages(contents []*genai.Content, config *genai.GenerateContentConfig) ([]api.Message, string) {
 	var messages []api.Message
 	var systemInstruction string
 
@@ -328,7 +328,7 @@ func convertGenaiContentsToOllamaMessages(contents []*genai.Content) ([]api.Mess
 		}
 	}
 
-	return messages, systemInstruction
+	return messages, mergeSystemInstructionFromConfig(systemInstruction, config)
 }
 
 // convertGenaiToolsToOllama converts genai.Tool to Ollama tool format.

--- a/go/adk/pkg/models/ollama_test.go
+++ b/go/adk/pkg/models/ollama_test.go
@@ -3,6 +3,8 @@ package models
 import (
 	"reflect"
 	"testing"
+
+	"google.golang.org/genai"
 )
 
 func TestConvertOllamaOptions(t *testing.T) {
@@ -150,5 +152,65 @@ func TestOllamaConfigDefaults(t *testing.T) {
 	converted := convertOllamaOptions(config.Options)
 	if v, ok := converted["temperature"].(float64); !ok || v != 0.8 {
 		t.Errorf("expected temperature 0.8, got %v", converted["temperature"])
+	}
+}
+
+func TestConvertGenaiContentsToOllamaMessages(t *testing.T) {
+	tests := []struct {
+		name           string
+		contents       []*genai.Content
+		config         *genai.GenerateContentConfig
+		wantMsgCount   int
+		wantSystemText string
+	}{
+		{
+			name: "simple user message",
+			contents: []*genai.Content{
+				{Role: "user", Parts: []*genai.Part{{Text: "Hello"}}},
+			},
+			wantMsgCount: 1,
+		},
+		{
+			name: "system instruction from config",
+			contents: []*genai.Content{
+				{Role: "user", Parts: []*genai.Part{{Text: "Hello"}}},
+			},
+			config: &genai.GenerateContentConfig{
+				SystemInstruction: &genai.Content{
+					Parts: []*genai.Part{
+						{Text: "You are a test agent."},
+						{Text: "Begin EVERY reply with ZEBRA9."},
+					},
+				},
+			},
+			wantMsgCount:   1,
+			wantSystemText: "You are a test agent.\nBegin EVERY reply with ZEBRA9.",
+		},
+		{
+			name: "system instruction from config merges with content role system",
+			contents: []*genai.Content{
+				{Role: "system", Parts: []*genai.Part{{Text: "From contents"}}},
+				{Role: "user", Parts: []*genai.Part{{Text: "Hello"}}},
+			},
+			config: &genai.GenerateContentConfig{
+				SystemInstruction: &genai.Content{
+					Parts: []*genai.Part{{Text: "From config"}},
+				},
+			},
+			wantMsgCount:   1,
+			wantSystemText: "From contents\nFrom config",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msgs, systemText := convertGenaiContentsToOllamaMessages(tt.contents, tt.config)
+			if len(msgs) != tt.wantMsgCount {
+				t.Errorf("expected %d messages, got %d", tt.wantMsgCount, len(msgs))
+			}
+			if systemText != tt.wantSystemText {
+				t.Errorf("expected system text %q, got %q", tt.wantSystemText, systemText)
+			}
+		})
 	}
 }

--- a/go/adk/pkg/models/openai_adk.go
+++ b/go/adk/pkg/models/openai_adk.go
@@ -195,16 +195,7 @@ func applyOpenAIConfig(params *openai.ChatCompletionNewParams, cfg *OpenAIConfig
 }
 
 func genaiContentsToOpenAIMessages(contents []*genai.Content, config *genai.GenerateContentConfig) ([]openai.ChatCompletionMessageParamUnion, string) {
-	var systemBuilder strings.Builder
-	if config != nil && config.SystemInstruction != nil {
-		for _, p := range config.SystemInstruction.Parts {
-			if p != nil && p.Text != "" {
-				systemBuilder.WriteString(p.Text)
-				systemBuilder.WriteByte('\n')
-			}
-		}
-	}
-	systemInstruction := strings.TrimSpace(systemBuilder.String())
+	systemInstruction := mergeSystemInstructionFromConfig("", config)
 
 	functionResponses := make(map[string]*genai.FunctionResponse)
 	thoughtSignatures := thoughtSignaturesByToolCallID(contents)

--- a/go/adk/pkg/models/sapaicore_adk.go
+++ b/go/adk/pkg/models/sapaicore_adk.go
@@ -169,16 +169,7 @@ func (m *SAPAICoreModel) buildOrchestrationBody(req *model.LLMRequest, stream bo
 }
 
 func genaiContentsToOrchTemplate(contents []*genai.Content, config *genai.GenerateContentConfig) ([]map[string]any, string) {
-	var systemBuilder strings.Builder
-	if config != nil && config.SystemInstruction != nil {
-		for _, p := range config.SystemInstruction.Parts {
-			if p != nil && p.Text != "" {
-				systemBuilder.WriteString(p.Text)
-				systemBuilder.WriteByte('\n')
-			}
-		}
-	}
-	systemInstruction := strings.TrimSpace(systemBuilder.String())
+	systemInstruction := mergeSystemInstructionFromConfig("", config)
 
 	functionResponses := make(map[string]*genai.FunctionResponse)
 	for _, c := range contents {


### PR DESCRIPTION
Closes #2114 

Updated current unit tests, manually tested with Bedrock and Ollama models.