### PR TITLE
Trigger CI workflows on all release/** branches (#2117)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,11 +2,11 @@ name: CI Build
 
 on:
   push:
-    branches: [main, release/v0.7.x]
+    branches: [main, "release/**"]
     paths-ignore:
       - "**/*.md"
   pull_request:
-    branches: [main, release/v0.7.x]
+    branches: [main, "release/**"]
     paths-ignore:
       - "**/*.md"
   workflow_dispatch:

--- a/.github/workflows/migration-immutability.yaml
+++ b/.github/workflows/migration-immutability.yaml
@@ -2,7 +2,7 @@ name: Migration Immutability
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, "release/**"]
     paths:
       - "go/core/pkg/migrations/**"
 

--- a/.github/workflows/sqlc-generate-check.yaml
+++ b/.github/workflows/sqlc-generate-check.yaml
@@ -2,7 +2,7 @@ name: sqlc Generate Check
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, "release/**"]
     paths:
       - "go/core/internal/database/queries/**"
       - "go/core/internal/database/sqlc.yaml"

--- a/.github/workflows/ui-chromatic.yaml
+++ b/.github/workflows/ui-chromatic.yaml
@@ -5,11 +5,11 @@ name: UI Storybook & Chromatic
 
 on:
   push:
-    branches: [main, release/v0.7.x]
+    branches: [main, "release/**"]
     paths:
       - "ui/**"
   pull_request:
-    branches: [main, release/v0.7.x]
+    branches: [main, "release/**"]
     paths:
       - "ui/**"
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Backport of #2117 to `release/v0.9.x`: switch the workflow branch filters from hardcoded release names to a `release/**` glob so CI actually runs on PRs targeting this release branch.

Cherry-pick of `83c8ae96` (`-x` provenance recorded).

## Why this is needed on the release branch

Workflow `branches` filters are per-branch. `release/v0.9.x`'s copies still read `[main, release/v0.7.x]` (or `[main]`), so PRs targeting `release/v0.9.x` trigger no CI — only branch-agnostic checks (DCO/labelers/snyk) run. The `main` fix in #2117 does not affect this branch on its own; existing release branches carry their own filters and must have the change backported.

## Changes

`branches` filters updated to `[main, "release/**"]`:

- `ci.yaml` — push + pull_request
- `ui-chromatic.yaml` — push + pull_request
- `migration-immutability.yaml` — pull_request
- `sqlc-generate-check.yaml` — pull_request

Trigger filters only; no job logic changed. The glob still matches `release/v0.7.x`, so nothing that ran before stops.