### PR TITLE
fix(helm): omit empty repository segment in bundled image path

### DIFF
--- a/helm/kagent/templates/_helpers.tpl
+++ b/helm/kagent/templates/_helpers.tpl
@@ -182,7 +182,8 @@ Bundled PostgreSQL image - constructs the full image reference from registry/rep
 */}}
 {{- define "kagent.postgresql.image" -}}
 {{- $pg := .Values.database.postgres.bundled -}}
-{{- printf "%s/%s/%s:%s" $pg.image.registry $pg.image.repository $pg.image.name $pg.image.tag -}}
+{{- $parts := compact (list $pg.image.registry $pg.image.repository $pg.image.name) -}}
+{{- printf "%s:%s" (join "/" $parts) $pg.image.tag -}}
 {{- end -}}
 
 {{/*

--- a/helm/kagent/tests/postgresql_test.yaml
+++ b/helm/kagent/tests/postgresql_test.yaml
@@ -119,6 +119,26 @@ tests:
           path: spec.template.spec.containers[0].image
           value: my-registry.example.com/myorg/postgres:15
 
+  - it: should omit empty repository segment in image
+    template: postgresql.yaml
+    documentIndex: 2
+    set:
+      database:
+        postgres:
+          bundled:
+            image:
+              registry: docker.io
+              repository: ""
+              name: postgres
+              tag: "18.3-alpine"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/postgres:18.3-alpine
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "//"
+
   - it: should read POSTGRES_PASSWORD from chart-managed secret
     template: postgresql.yaml
     documentIndex: 2


### PR DESCRIPTION
## What

Fix the bundled-PostgreSQL image helper so an empty `image.repository` renders a valid reference (`registry/name:tag`) instead of `registry//name:tag`, which is an invalid image reference and sends the pod into `ImagePullBackOff`.  I observed this on AKS with Helm Chart 0.9.9.

## Why

`templates/_helpers.tpl` builds the image with a `printf` that always emits the same `registry/repository/name:tag` shape — it writes a `/` between every segment whether or not that segment is empty:

```gotemplate
{{- define "kagent.postgresql.image" -}}
{{- $pg := .Values.database.postgres.bundled -}}
{{- printf "%s/%s/%s:%s" $pg.image.registry $pg.image.repository $pg.image.name $pg.image.tag -}}
{{- end -}}
```

`printf "%s/%s/%s:%s"` always inserts a `/` between segments, so an empty `repository` (a valid configuration for images that live at the root of a registry) leaves an empty path segment and renders a double slash:

```
docker.io//postgres:18.3-alpine   # invalid reference -> ImagePullBackOff
```

The `kagent.postgresql.image` helper is unchanged across `v0.9.9`, `v0.9.10`, `v0.10.0-beta1`, and `main` (the `printf` line is identical at each), so the issue affects the current stable line and the next (`v0.10.x`) release line.

## Fix

Build the path as a list, drop empty segments with `compact`, then `join` with `/`.  This needs no `if`/`else`: an empty `registry` and/or `repository` is simply left out, so leaving `repository` blank produces a valid reference (the supported way to pull an image from the root of a registry) instead of a broken one:

```gotemplate
{{- define "kagent.postgresql.image" -}}
{{- $pg := .Values.database.postgres.bundled -}}
{{- $parts := compact (list $pg.image.registry $pg.image.repository $pg.image.name) -}}
{{- printf "%s:%s" (join "/" $parts) $pg.image.tag -}}
{{- end -}}
```

Rendered results:

| registry | repository | name | result |
|---|---|---|---|
| `docker.io` | `library` | `postgres` | `docker.io/library/postgres:tag` (unchanged) |
| `docker.io` | `""` | `postgres` | `docker.io/postgres:tag` (fixed) |
| `""` | `""` | `postgres` | `postgres:tag` |

## Tests

Added one case to `helm/kagent/tests/postgresql_test.yaml` covering the empty-repository path (developed test-first). The existing `default pgvector image` and `custom image` tests already guard the non-empty path, so no regression test was
duplicated.

```yaml
  - it: should omit empty repository segment in image
    template: postgresql.yaml
    documentIndex: 2
    set:
      database:
        postgres:
          bundled:
            image:
              registry: docker.io
              repository: ""
              name: postgres
              tag: "18.3-alpine"
    asserts:
      - equal:
          path: spec.template.spec.containers[0].image
          value: docker.io/postgres:18.3-alpine
      - notMatchRegex:
          path: spec.template.spec.containers[0].image
          pattern: "//"
```

The test fails without this change (`docker.io//postgres:18.3-alpine`) and passes with it — revert the `_helpers.tpl` hunk to reproduce.

## How to verify

```bash
make helm-version                                   # generate Chart.yaml from template
helm unittest helm/kagent                           # full suite green (incl. new case)
helm lint helm/kagent

# test-independent reproduction:
helm template t helm/kagent \
  --set database.postgres.bundled.image.repository="" | grep image:
# before: docker.io//postgres:18.3-alpine
# after:  docker.io/postgres:18.3-alpine
```

## Scope

Limited to the bundled-PostgreSQL helper (`kagent.postgresql.image`), where the `//` template bug is confirmed. The doc2vec/QueryDoc MCP image lives in a separate chart (`helm/tools/querydoc`) and is assembled controller-side from `IMAGE_REGISTRY` / `IMAGE_REPOSITORY` / `IMAGE_TAG` env vars, so it is intentionally **not** changed here. If it exhibits the same `//` symptom at deploy time, it should be addressed separately (likely in the controller join logic), not in this chart.

A backport to the `v0.9.x` stable line may be worthwhile since the bug is present there — maintainers' call.

## Checklist

- [x] Commit is DCO signed-off (`git commit -s`).
- [x] `helm unittest helm/kagent` green; `helm lint helm/kagent` clean.
- [x] Diff limited to `templates/_helpers.tpl` and `tests/postgresql_test.yaml`
      (generated `Chart.yaml`/`Chart.lock`/`charts/*.tgz`/`dist/` excluded).
- [x] Test fails without the fix, passes with it.


