### PR TITLE
refactor: update byo sample base images to work with substrate

### DIFF
--- a/python/samples/crewai/poem_flow/Dockerfile
+++ b/python/samples/crewai/poem_flow/Dockerfile
@@ -1,7 +1,9 @@
 ### STAGE 1: base image
 ARG DOCKER_REGISTRY=ghcr.io
 ARG VERSION=latest
-FROM ghcr.io/astral-sh/uv:python3.13-trixie-slim
+# substrate's gVisor (ateom) checkpoint/restore segfaults processes linked against trixie's newer glibc
+# use bookworm to align with the kagent-adk runtime image
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
 
 WORKDIR /app
 
@@ -10,6 +12,14 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
+
+# this mirrors the kagent-adk's uv configuration and is needed to work on substrate
+# as gVisor checkpoint/restore segfaults the base image's system
+# CPython on restore and the standalone build survives. Both this and the bookworm base
+# are needed for BYO to work on substrate as this pins the base image to use a base image with glibc 2.36
+# where as the prvious base image python3.13-trixie-slim used glibc 2.41
+ENV UV_PYTHON_PREFERENCE=only-managed
+ENV UV_PYTHON_INSTALL_DIR=/python
 
 # Copy project files
 COPY samples samples

--- a/python/samples/crewai/research-crew/Dockerfile
+++ b/python/samples/crewai/research-crew/Dockerfile
@@ -1,7 +1,9 @@
 ### STAGE 1: base image
 ARG DOCKER_REGISTRY=ghcr.io
 ARG VERSION=latest
-FROM ghcr.io/astral-sh/uv:python3.13-trixie-slim
+# substrate's gVisor (ateom) checkpoint/restore segfaults processes linked against trixie's newer glibc
+# use bookworm to align with the kagent-adk runtime image
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
 
 WORKDIR /app
 
@@ -10,6 +12,14 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
+
+# this mirrors the kagent-adk's uv configuration and is needed to work on substrate
+# as gVisor checkpoint/restore segfaults the base image's system
+# CPython on restore and the standalone build survives. Both this and the bookworm base
+# are needed for BYO to work on substrate as this pins the base image to use a base image with glibc 2.36
+# where as the prvious base image python3.13-trixie-slim used glibc 2.41
+ENV UV_PYTHON_PREFERENCE=only-managed
+ENV UV_PYTHON_INSTALL_DIR=/python
 
 # Copy project files
 COPY samples samples

--- a/python/samples/langgraph/currency/Dockerfile
+++ b/python/samples/langgraph/currency/Dockerfile
@@ -1,8 +1,8 @@
 ### STAGE 1: base image
 ARG DOCKER_REGISTRY=ghcr.io
 ARG VERSION=latest
-# bookworm (glibc 2.36), NOT trixie (glibc 2.41): substrate's gVisor checkpoint/restore segfaults
-# processes against trixie's newer glibc. Aligns with the kagent-adk runtime image.
+# substrate's gVisor (ateom) checkpoint/restore segfaults processes linked against trixie's newer glibc
+# use bookworm to align with the kagent-adk runtime image
 FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
 
 WORKDIR /app
@@ -13,10 +13,11 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 
-# Use the uv-managed standalone CPython (python-build-standalone), NOT the base image's system
-# Python. REQUIRED for substrate: gVisor checkpoint/restore segfaults the system CPython (a stub
-# that dynamically loads libpython3.13.so) on restore; the standalone build statically embeds
-# libpython and survives. Both this AND the bookworm base above are needed for BYO on substrate.
+# this mirrors the kagent-adk's uv configuration and is needed to work on substrate
+# as gVisor checkpoint/restore segfaults the base image's system
+# CPython on restore and the standalone build survives. Both this and the bookworm base 
+# are needed for BYO to work on substrate as this pins the base image to use a base image with glibc 2.36
+# where as the prvious base image python3.13-trixie-slim used glibc 2.41
 ENV UV_PYTHON_PREFERENCE=only-managed
 ENV UV_PYTHON_INSTALL_DIR=/python
 

--- a/python/samples/langgraph/currency/Dockerfile
+++ b/python/samples/langgraph/currency/Dockerfile
@@ -1,7 +1,9 @@
 ### STAGE 1: base image
 ARG DOCKER_REGISTRY=ghcr.io
 ARG VERSION=latest
-FROM ghcr.io/astral-sh/uv:python3.13-trixie-slim
+# bookworm (glibc 2.36), NOT trixie (glibc 2.41): substrate's gVisor checkpoint/restore segfaults
+# processes against trixie's newer glibc. Aligns with the kagent-adk runtime image.
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
 
 WORKDIR /app
 
@@ -10,6 +12,13 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
+
+# Use the uv-managed standalone CPython (python-build-standalone), NOT the base image's system
+# Python. REQUIRED for substrate: gVisor checkpoint/restore segfaults the system CPython (a stub
+# that dynamically loads libpython3.13.so) on restore; the standalone build statically embeds
+# libpython and survives. Both this AND the bookworm base above are needed for BYO on substrate.
+ENV UV_PYTHON_PREFERENCE=only-managed
+ENV UV_PYTHON_INSTALL_DIR=/python
 
 # Copy project files
 COPY samples samples

--- a/python/samples/langgraph/hitl-tools/Dockerfile
+++ b/python/samples/langgraph/hitl-tools/Dockerfile
@@ -1,8 +1,8 @@
 ### STAGE 1: base image
 ARG DOCKER_REGISTRY=ghcr.io
 ARG VERSION=latest
-# bookworm (glibc 2.36), NOT trixie (glibc 2.41): substrate's gVisor checkpoint/restore segfaults
-# processes against trixie's newer glibc. Aligns with the kagent-adk runtime image.
+# substrate's gVisor (ateom) checkpoint/restore segfaults processes linked against trixie's newer glibc
+# use bookworm to align with the kagent-adk runtime image
 FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
 
 WORKDIR /app
@@ -13,10 +13,11 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 
-# Use the uv-managed standalone CPython (python-build-standalone), NOT the base image's system
-# Python. REQUIRED for substrate: gVisor checkpoint/restore segfaults the system CPython (a stub
-# that dynamically loads libpython3.13.so) on restore; the standalone build statically embeds
-# libpython and survives. Both this AND the bookworm base above are needed for BYO on substrate.
+# this mirrors the kagent-adk's uv configuration and is needed to work on substrate
+# as gVisor checkpoint/restore segfaults the base image's system
+# CPython on restore and the standalone build survives. Both this and the bookworm base 
+# are needed for BYO to work on substrate as this pins the base image to use a base image with glibc 2.36
+# where as the prvious base image python3.13-trixie-slim used glibc 2.41
 ENV UV_PYTHON_PREFERENCE=only-managed
 ENV UV_PYTHON_INSTALL_DIR=/python
 

--- a/python/samples/langgraph/hitl-tools/Dockerfile
+++ b/python/samples/langgraph/hitl-tools/Dockerfile
@@ -1,7 +1,9 @@
 ### STAGE 1: base image
 ARG DOCKER_REGISTRY=ghcr.io
 ARG VERSION=latest
-FROM ghcr.io/astral-sh/uv:python3.13-trixie-slim
+# bookworm (glibc 2.36), NOT trixie (glibc 2.41): substrate's gVisor checkpoint/restore segfaults
+# processes against trixie's newer glibc. Aligns with the kagent-adk runtime image.
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
 
 WORKDIR /app
 
@@ -10,6 +12,13 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
+
+# Use the uv-managed standalone CPython (python-build-standalone), NOT the base image's system
+# Python. REQUIRED for substrate: gVisor checkpoint/restore segfaults the system CPython (a stub
+# that dynamically loads libpython3.13.so) on restore; the standalone build statically embeds
+# libpython and survives. Both this AND the bookworm base above are needed for BYO on substrate.
+ENV UV_PYTHON_PREFERENCE=only-managed
+ENV UV_PYTHON_INSTALL_DIR=/python
 
 # Copy project files
 COPY samples samples

--- a/python/samples/langgraph/kebab/Dockerfile
+++ b/python/samples/langgraph/kebab/Dockerfile
@@ -1,7 +1,9 @@
 ### STAGE 1: base image
 ARG DOCKER_REGISTRY=ghcr.io
 ARG VERSION=latest
-FROM ghcr.io/astral-sh/uv:python3.13-trixie-slim
+# substrate's gVisor (ateom) checkpoint/restore segfaults processes linked against trixie's newer glibc
+# use bookworm to align with the kagent-adk runtime image
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
 
 WORKDIR /app
 
@@ -11,6 +13,14 @@ RUN apt-get update && apt-get install -y \
     curl \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
+
+# this mirrors the kagent-adk's uv configuration and is needed to work on substrate
+# as gVisor checkpoint/restore segfaults the base image's system
+# CPython on restore and the standalone build survives. Both this and the bookworm base 
+# are needed for BYO to work on substrate as this pins the base image to use a base image with glibc 2.36
+# where as the prvious base image python3.13-trixie-slim used glibc 2.41
+ENV UV_PYTHON_PREFERENCE=only-managed
+ENV UV_PYTHON_INSTALL_DIR=/python
 
 # Same layout as currency: context must be ./python (full uv workspace).
 COPY samples samples


### PR DESCRIPTION
The existing `trixie-slim` image which uses glibc `2.41` runs into a segfault when running on substrate. This is due to gvisor unable to restore a process linked to glibc `2.41` but works against bookworm's glibc `2.36`.  This PR updates the sample crew-ai, and langgraph BYO sample dockerfiles to use a base image confirmed to work with substrate as well as enables the `uv-managed` preference which statically linked libpython which is not corrupted on substrate restore.

**Testing**
- Deployed and tested all variations of the sample BYO agents as `Agent` and `SandboxAgent`.