### PR TITLE
feat(helm): expose OTEL headers, service name, and resource attributes

### DIFF
--- a/helm/kagent/templates/controller-configmap.yaml
+++ b/helm/kagent/templates/controller-configmap.yaml
@@ -27,6 +27,16 @@ data:
   # OpenTelemetry Configuration
   OTEL_TRACING_ENABLED: {{ .Values.otel.tracing.enabled | quote }}
   OTEL_LOGGING_ENABLED: {{ .Values.otel.logging.enabled | quote }}
+  {{- with .Values.otel.serviceName }}
+  OTEL_SERVICE_NAME: {{ . | quote }}
+  {{- end }}
+  {{- if .Values.otel.resourceAttributes }}
+  {{- $pairs := list }}
+  {{- range $k := keys .Values.otel.resourceAttributes | sortAlpha }}
+  {{- $pairs = append $pairs (printf "%s=%s" $k (index $.Values.otel.resourceAttributes $k | toString)) }}
+  {{- end }}
+  OTEL_RESOURCE_ATTRIBUTES: {{ join "," $pairs | quote }}
+  {{- end }}
   {{- $tracesEndpoint := .Values.otel.tracing.exporter.otlp.endpoint }}
   {{- $logsEndpoint := .Values.otel.logging.exporter.otlp.endpoint }}
   {{- if and $tracesEndpoint $logsEndpoint (eq $tracesEndpoint $logsEndpoint) }}
@@ -50,6 +60,20 @@ data:
   OTEL_EXPORTER_OTLP_LOGS_INSECURE: {{ .Values.otel.logging.exporter.otlp.insecure | quote }}
   OTEL_EXPORTER_OTLP_LOGS_TIMEOUT: {{ .Values.otel.logging.exporter.otlp.timeout | quote }}
   {{- end }}
+  {{- end }}
+  {{- if .Values.otel.tracing.exporter.otlp.headers }}
+  {{- $pairs := list }}
+  {{- range $k := keys .Values.otel.tracing.exporter.otlp.headers | sortAlpha }}
+  {{- $pairs = append $pairs (printf "%s=%s" $k (index $.Values.otel.tracing.exporter.otlp.headers $k | toString)) }}
+  {{- end }}
+  OTEL_EXPORTER_OTLP_TRACES_HEADERS: {{ join "," $pairs | quote }}
+  {{- end }}
+  {{- if .Values.otel.logging.exporter.otlp.headers }}
+  {{- $pairs := list }}
+  {{- range $k := keys .Values.otel.logging.exporter.otlp.headers | sortAlpha }}
+  {{- $pairs = append $pairs (printf "%s=%s" $k (index $.Values.otel.logging.exporter.otlp.headers $k | toString)) }}
+  {{- end }}
+  OTEL_EXPORTER_OTLP_LOGS_HEADERS: {{ join "," $pairs | quote }}
   {{- end }}
   {{- if .Values.proxy.url }}
   PROXY_URL: {{ .Values.proxy.url | quote }}

--- a/helm/kagent/tests/controller-configmap_test.yaml
+++ b/helm/kagent/tests/controller-configmap_test.yaml
@@ -1,0 +1,130 @@
+suite: test controller configmap
+templates:
+  - controller-configmap.yaml
+tests:
+  - it: should render the controller configmap
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-controller
+      - hasDocuments:
+          count: 1
+
+  - it: should not emit OTEL_SERVICE_NAME when otel.serviceName is empty
+    asserts:
+      - notExists:
+          path: data.OTEL_SERVICE_NAME
+
+  - it: should emit OTEL_SERVICE_NAME when otel.serviceName is set
+    set:
+      otel:
+        serviceName: my-kagent
+    asserts:
+      - equal:
+          path: data.OTEL_SERVICE_NAME
+          value: my-kagent
+
+  - it: should not emit OTEL_RESOURCE_ATTRIBUTES when otel.resourceAttributes is empty
+    asserts:
+      - notExists:
+          path: data.OTEL_RESOURCE_ATTRIBUTES
+
+  - it: should emit OTEL_RESOURCE_ATTRIBUTES sorted by key when set
+    set:
+      otel:
+        resourceAttributes:
+          team: platform
+          deployment.environment.name: production
+          langfuse.environment: production
+    asserts:
+      - equal:
+          path: data.OTEL_RESOURCE_ATTRIBUTES
+          value: deployment.environment.name=production,langfuse.environment=production,team=platform
+
+  - it: should not emit OTEL_EXPORTER_OTLP_TRACES_HEADERS when tracing.headers is empty
+    asserts:
+      - notExists:
+          path: data.OTEL_EXPORTER_OTLP_TRACES_HEADERS
+
+  - it: should emit OTEL_EXPORTER_OTLP_TRACES_HEADERS sorted by key when set
+    set:
+      otel:
+        tracing:
+          exporter:
+            otlp:
+              headers:
+                x-tenant-id: platform
+                x-region: us-central1
+    asserts:
+      - equal:
+          path: data.OTEL_EXPORTER_OTLP_TRACES_HEADERS
+          value: x-region=us-central1,x-tenant-id=platform
+
+  - it: should not emit OTEL_EXPORTER_OTLP_LOGS_HEADERS when logging.headers is empty
+    asserts:
+      - notExists:
+          path: data.OTEL_EXPORTER_OTLP_LOGS_HEADERS
+
+  - it: should emit OTEL_EXPORTER_OTLP_LOGS_HEADERS when logging.headers is set
+    set:
+      otel:
+        logging:
+          exporter:
+            otlp:
+              headers:
+                x-log-tenant: platform
+    asserts:
+      - equal:
+          path: data.OTEL_EXPORTER_OTLP_LOGS_HEADERS
+          value: x-log-tenant=platform
+
+  - it: should keep pre-existing OTEL keys unchanged
+    asserts:
+      - equal:
+          path: data.OTEL_TRACING_ENABLED
+          value: "false"
+      - equal:
+          path: data.OTEL_LOGGING_ENABLED
+          value: "false"
+
+  - it: renders the full Langfuse-Cloud style tracing configuration
+    set:
+      otel:
+        serviceName: kagent
+        resourceAttributes:
+          deployment.environment.name: production
+          langfuse.environment: production
+        tracing:
+          enabled: true
+          exporter:
+            otlp:
+              endpoint: https://cloud.langfuse.com/api/public/otel/v1/traces
+              protocol: http/protobuf
+              insecure: false
+              timeout: 15000
+              headers:
+                x-tenant-id: platform
+    asserts:
+      - equal:
+          path: data.OTEL_TRACING_ENABLED
+          value: "true"
+      - equal:
+          path: data.OTEL_SERVICE_NAME
+          value: kagent
+      - equal:
+          path: data.OTEL_RESOURCE_ATTRIBUTES
+          value: deployment.environment.name=production,langfuse.environment=production
+      - equal:
+          path: data.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+          value: https://cloud.langfuse.com/api/public/otel/v1/traces
+      - equal:
+          path: data.OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
+          value: http/protobuf
+      - equal:
+          path: data.OTEL_EXPORTER_OTLP_TRACES_INSECURE
+          value: "false"
+      - equal:
+          path: data.OTEL_EXPORTER_OTLP_TRACES_HEADERS
+          value: x-tenant-id=platform

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -839,6 +839,22 @@ oauth2-proxy:
 # ==============================================================================
 
 otel:
+  # -- Value for the OpenTelemetry `service.name` resource attribute
+  # (OTEL_SERVICE_NAME). When empty the controller falls back to its built-in
+  # default ("kagent-controller"). Takes precedence over `service.name` in
+  # `resourceAttributes` per the OTEL specification.
+  serviceName: ""
+  # -- Extra OpenTelemetry resource attributes (OTEL_RESOURCE_ATTRIBUTES).
+  # Rendered as `key1=value1,key2=value2` and merged with the controller's
+  # built-in resource attributes via `resource.WithFromEnv()`. Useful for
+  # tagging traces/logs with environment, cluster, team, tenant, etc.
+  # @default -- {} (no extra attributes)
+  resourceAttributes: {}
+  # Example:
+  #   resourceAttributes:
+  #     deployment.environment.name: production
+  #     langfuse.environment: production
+  #     team: platform
   tracing:
     enabled: false
     exporter:
@@ -847,6 +863,17 @@ otel:
         protocol: "grpc"
         timeout: 15000 # milliseconds
         insecure: true
+        # -- OTLP exporter headers for traces
+        # (OTEL_EXPORTER_OTLP_TRACES_HEADERS). Rendered as `k1=v1,k2=v2`.
+        # Use for non-secret headers only; for authenticated OTLP backends
+        # (Langfuse Cloud, Honeycomb, Datadog, New Relic, Grafana Cloud, …)
+        # inject the `Authorization` / API-key header from a `Secret` via
+        # `controller.envFrom` — that env var overrides this ConfigMap key.
+        # @default -- {} (no headers)
+        headers: {}
+        # Example (non-secret only):
+        #   headers:
+        #     x-tenant-id: platform
   logging:
     enabled: false
     exporter:
@@ -854,3 +881,9 @@ otel:
         endpoint: ""
         timeout: 15000 # milliseconds
         insecure: true
+        # -- OTLP exporter headers for logs
+        # (OTEL_EXPORTER_OTLP_LOGS_HEADERS). Rendered as `k1=v1,k2=v2`.
+        # See the note under `tracing.exporter.otlp.headers` for how to inject
+        # secret headers via `controller.envFrom`.
+        # @default -- {} (no headers)
+        headers: {}


### PR DESCRIPTION
Fixes #2126.
Design discussion: #2127.

> Draft per [`CONTRIBUTING.md > Large changes`](https://github.com/kagent-dev/kagent/blob/main/CONTRIBUTING.md#large-changes-features-refactors) — un-drafting once maintainers weigh in on the API shape in #2127. Slack ping to `#kagent-dev` on CNCF Slack coming from `@nirzeira`.

## Summary

Expose the four standard OpenTelemetry SDK env vars that the controller **already reads** via `autoexport.NewSpanExporter` and `resource.WithFromEnv` in `go/core/internal/telemetry/tracing.go`, but that `helm/kagent/values.yaml` did not surface:

| Chart key (new) | Rendered env var |
| --- | --- |
| `otel.serviceName` | `OTEL_SERVICE_NAME` |
| `otel.resourceAttributes` (map) | `OTEL_RESOURCE_ATTRIBUTES` |
| `otel.tracing.exporter.otlp.headers` (map) | `OTEL_EXPORTER_OTLP_TRACES_HEADERS` |
| `otel.logging.exporter.otlp.headers` (map) | `OTEL_EXPORTER_OTLP_LOGS_HEADERS` |

Maps serialize to `key1=value1,key2=value2` with **sorted keys** (same pattern already used for `DEFAULT_AGENT_POD_LABELS`). Everything renders **only when non-empty** → `helm template` output is byte-identical for existing installs. No controller code change is required.

Unblocks self-service tracing to any authenticated OTLP backend (**Langfuse Cloud**, Honeycomb, Datadog, Grafana Cloud, New Relic, …) without the current workaround of maintaining out-of-band `ConfigMap` + `Secret` and wiring them via `controller.envFrom`.

## What changed

- `helm/kagent/values.yaml` — new keys with inline docs pointing users to `controller.envFrom` for secret headers.
- `helm/kagent/templates/controller-configmap.yaml` — conditional rendering of the four env vars.
- `helm/kagent/tests/controller-configmap_test.yaml` — new suite (11 tests) covering:
  - backward compat: none of the new keys render with default values
  - each new field renders independently when set
  - map fields serialize with sorted keys
  - full Langfuse-Cloud style end-to-end render

## Non-changes

- **No Go / Python controller change.** The controller already understands these env vars via the standard OTEL SDK. This is a chart-surface fix only.
- **No new secret-injection schema.** Secret OTLP headers (Basic auth for Langfuse, API keys for Honeycomb / Datadog / …) stay on the existing `controller.envFrom` extension point — the ConfigMap `OTEL_EXPORTER_OTLP_TRACES_HEADERS` is transparently overridden by the Pod-level env var. `values.yaml` comments document this. Happy to add `headersSecretRef` in a follow-up if maintainers prefer.
- **`helm/tools/querydoc/templates/configmap.yaml`** has the same gap but is intentionally left for a separate PR to keep this reviewable.

## Verification

```
$ helm lint helm/kagent/
==> Linting helm/kagent/
[INFO] Chart.yaml: icon is recommended
1 chart(s) linted, 0 chart(s) failed

$ helm unittest helm/kagent
Charts:      1 passed, 1 total
Test Suites: 16 passed, 16 total
Tests:       225 passed, 225 total
```

Rendered output with defaults (unchanged from `main`):

```yaml
# OpenTelemetry Configuration
OTEL_TRACING_ENABLED: "false"
OTEL_LOGGING_ENABLED: "false"
# Using separate endpoints for traces and logs
```

Rendered output with a Langfuse-Cloud style overlay:

```yaml
OTEL_TRACING_ENABLED: "true"
OTEL_SERVICE_NAME: "kagent"
OTEL_RESOURCE_ATTRIBUTES: "deployment.environment.name=production,langfuse.environment=production"
OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "https://cloud.langfuse.com/api/public/otel/v1/traces"
OTEL_EXPORTER_OTLP_TRACES_PROTOCOL: "http/protobuf"
OTEL_EXPORTER_OTLP_TRACES_INSECURE: "false"
OTEL_EXPORTER_OTLP_TRACES_HEADERS: "x-tenant-id=platform"
```

## Downstream context

The workaround this PR obsoletes is currently deployed in [`elementor/elementor-cloud-external-charts@1e8b9436`](https://github.com/elementor/elementor-cloud-external-charts/commit/1e8b9436625c1d0cc3753a114092e7ae04f7d4e2) + [`elementor/elementor-agents@13545eb`](https://github.com/elementor/elementor-agents/commit/13545eb962930d03c5af192cbf691282e855cdfc). Both will be simplified to native `otel.*` values once this lands.

## Checklist

- [x] DCO signoff on commit
- [x] Backward compatible (`helm template` output byte-identical with default values)
- [x] `helm lint` clean
- [x] `helm unittest helm/kagent` — 225/225 passing (11 new tests)
- [x] Issue opened first (#2126) per `CONTRIBUTING.md`
- [x] Design discussion opened (#2127)
- [ ] Slack ping to `#kagent-dev` on CNCF Slack (owner: `@nirzeira`)
- [ ] Maintainer sign-off on API shape (#2127)
