### PR TITLE
feat(agent): allow declarative agents to call agents in other clusters

### DIFF
--- a/go/api/config/crd/bases/kagent.dev_agents.yaml
+++ b/go/api/config/crd/bases/kagent.dev_agents.yaml
@@ -13169,11 +13169,23 @@ spec:
                           properties:
                             apiGroup:
                               type: string
+                            description:
+                              description: |-
+                                Description is shown for a remote (URL-based) agent tool, since there is no
+                                local Agent CR to read the description from.
+                              type: string
                             kind:
                               type: string
                             name:
                               type: string
                             namespace:
+                              type: string
+                            url:
+                              description: |-
+                                URL, when set on an Agent tool reference, points at a remote A2A endpoint
+                                (e.g. an agent in another cluster reachable over an east-west gateway).
+                                When set, the controller does NOT resolve a local Agent CR — it uses this
+                                URL directly, enabling cross-cluster declarative agent-to-agent tools (#1853).
                               type: string
                           required:
                           - name
@@ -13242,6 +13254,11 @@ spec:
                               type: array
                             apiGroup:
                               type: string
+                            description:
+                              description: |-
+                                Description is shown for a remote (URL-based) agent tool, since there is no
+                                local Agent CR to read the description from.
+                              type: string
                             kind:
                               type: string
                             name:
@@ -13267,6 +13284,13 @@ spec:
                                 type: string
                               maxItems: 50
                               type: array
+                            url:
+                              description: |-
+                                URL, when set on an Agent tool reference, points at a remote A2A endpoint
+                                (e.g. an agent in another cluster reachable over an east-west gateway).
+                                When set, the controller does NOT resolve a local Agent CR — it uses this
+                                URL directly, enabling cross-cluster declarative agent-to-agent tools (#1853).
+                              type: string
                           required:
                           - name
                           type: object

--- a/go/api/config/crd/bases/kagent.dev_sandboxagents.yaml
+++ b/go/api/config/crd/bases/kagent.dev_sandboxagents.yaml
@@ -10826,11 +10826,23 @@ spec:
                           properties:
                             apiGroup:
                               type: string
+                            description:
+                              description: |-
+                                Description is shown for a remote (URL-based) agent tool, since there is no
+                                local Agent CR to read the description from.
+                              type: string
                             kind:
                               type: string
                             name:
                               type: string
                             namespace:
+                              type: string
+                            url:
+                              description: |-
+                                URL, when set on an Agent tool reference, points at a remote A2A endpoint
+                                (e.g. an agent in another cluster reachable over an east-west gateway).
+                                When set, the controller does NOT resolve a local Agent CR — it uses this
+                                URL directly, enabling cross-cluster declarative agent-to-agent tools (#1853).
                               type: string
                           required:
                           - name
@@ -10899,6 +10911,11 @@ spec:
                               type: array
                             apiGroup:
                               type: string
+                            description:
+                              description: |-
+                                Description is shown for a remote (URL-based) agent tool, since there is no
+                                local Agent CR to read the description from.
+                              type: string
                             kind:
                               type: string
                             name:
@@ -10924,6 +10941,13 @@ spec:
                                 type: string
                               maxItems: 50
                               type: array
+                            url:
+                              description: |-
+                                URL, when set on an Agent tool reference, points at a remote A2A endpoint
+                                (e.g. an agent in another cluster reachable over an east-west gateway).
+                                When set, the controller does NOT resolve a local Agent CR — it uses this
+                                URL directly, enabling cross-cluster declarative agent-to-agent tools (#1853).
+                              type: string
                           required:
                           - name
                           type: object

--- a/go/api/v1alpha2/agent_types.go
+++ b/go/api/v1alpha2/agent_types.go
@@ -560,6 +560,16 @@ type TypedReference struct {
 	Name string `json:"name"`
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
+	// URL, when set on an Agent tool reference, points at a remote A2A endpoint
+	// (e.g. an agent in another cluster reachable over an east-west gateway).
+	// When set, the controller does NOT resolve a local Agent CR — it uses this
+	// URL directly, enabling cross-cluster declarative agent-to-agent tools (#1853).
+	// +optional
+	URL string `json:"url,omitempty"`
+	// Description is shown for a remote (URL-based) agent tool, since there is no
+	// local Agent CR to read the description from.
+	// +optional
+	Description string `json:"description,omitempty"`
 }
 
 func (t *TypedReference) GroupKind() schema.GroupKind {

--- a/go/core/internal/controller/translator/agent/compiler.go
+++ b/go/core/internal/controller/translator/agent/compiler.go
@@ -191,6 +191,12 @@ func (a *adkApiTranslator) validateAgent(ctx context.Context, agent v1alpha2.Age
 				return fmt.Errorf("tool must have an agent reference")
 			}
 
+			// Remote (e.g. cross-cluster) agent tool (#1853): there is no local
+			// Agent CR to resolve or recurse into — validation is satisfied.
+			if tool.Agent.URL != "" {
+				continue
+			}
+
 			toolAgent, err := a.getToolAgent(ctx, tool.Agent, agent.GetNamespace())
 			if err != nil {
 				return err
@@ -327,6 +333,30 @@ func (a *adkApiTranslator) translateInlineAgent(ctx context.Context, agent v1alp
 				secretHashBytes = append(secretHashBytes, toolHashBytes...)
 			}
 		case tool.Agent != nil:
+			// Cross-cluster / remote A2A agent tool (#1853): when an explicit URL
+			// is given, use it directly instead of resolving a local Agent CR.
+			// Mirrors the local path's RemoteAgentConfig and honors globalProxyURL.
+			if tool.Agent.URL != "" {
+				targetURL := tool.Agent.URL
+				if a.globalProxyURL != "" {
+					targetURL, headers, err = applyProxyURL(tool.Agent.URL, a.globalProxyURL, headers)
+					if err != nil {
+						return nil, nil, nil, err
+					}
+				}
+				name := tool.Agent.Name
+				if name == "" {
+					name = "remote-agent"
+				}
+				cfg.RemoteAgents = append(cfg.RemoteAgents, adk.RemoteAgentConfig{
+					Name:        utils.ConvertToPythonIdentifier(name),
+					Url:         targetURL,
+					Headers:     headers,
+					Description: tool.Agent.Description,
+				})
+				continue
+			}
+
 			toolAgent, err := a.getToolAgent(ctx, tool.Agent, agent.GetNamespace())
 			if err != nil {
 				return nil, nil, nil, err

--- a/go/core/internal/controller/translator/agent/remote_url_agent_tool_test.go
+++ b/go/core/internal/controller/translator/agent/remote_url_agent_tool_test.go
@@ -1,0 +1,128 @@
+package agent_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	schemev1 "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kagent-dev/kagent/go/api/v1alpha2"
+	agenttranslator "github.com/kagent-dev/kagent/go/core/internal/controller/translator/agent"
+)
+
+// Test_AdkApiTranslator_RemoteURLAgentTool covers cross-cluster declarative A2A
+// (kagent-enterprise#1853). An Agent tool reference that sets an explicit URL must
+// compile into a RemoteAgentConfig pointing at that URL WITHOUT resolving a local
+// Agent CR — the referenced agent lives in another cluster and is not present in
+// this cluster's API server. Without a URL, the same reference fails with
+// "not found", which is the bug this feature fixes.
+func Test_AdkApiTranslator_RemoteURLAgentTool(t *testing.T) {
+	ctx := context.Background()
+	scheme := schemev1.Scheme
+	require.NoError(t, v1alpha2.AddToScheme(scheme))
+
+	modelConfig := &v1alpha2.ModelConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "default-model", Namespace: "test"},
+		Spec: v1alpha2.ModelConfigSpec{
+			Provider: "OpenAI",
+			Model:    "gpt-4o",
+		},
+	}
+	testNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test"}}
+
+	declarativeSpec := func(tools ...*v1alpha2.Tool) v1alpha2.AgentSpec {
+		return v1alpha2.AgentSpec{
+			Type:        v1alpha2.AgentType_Declarative,
+			Description: "test agent",
+			Declarative: &v1alpha2.DeclarativeAgentSpec{
+				SystemMessage: "Test",
+				ModelConfig:   "default-model",
+				Tools:         tools,
+			},
+		}
+	}
+
+	const remoteURL = "http://remote-agent.kagent.svc.cluster.local:8080"
+
+	tests := []struct {
+		name            string
+		tool            *v1alpha2.Tool
+		wantErr         bool
+		errContains     string
+		wantURL         string
+		wantDescription string
+	}{
+		{
+			name: "URL set - resolves to the remote endpoint without a local CR (#1853 fix)",
+			tool: &v1alpha2.Tool{
+				Type: v1alpha2.ToolProviderType_Agent,
+				Agent: &v1alpha2.TypedReference{
+					Name:        "remote-agent",
+					URL:         remoteURL,
+					Description: "Remote netops specialist in the west cluster",
+				},
+			},
+			wantURL:         remoteURL,
+			wantDescription: "Remote netops specialist in the west cluster",
+		},
+		{
+			name: "no URL and no local CR - fails as before (demonstrates the bug)",
+			tool: &v1alpha2.Tool{
+				Type: v1alpha2.ToolProviderType_Agent,
+				Agent: &v1alpha2.TypedReference{
+					Name: "remote-agent",
+				},
+			},
+			wantErr:     true,
+			errContains: "not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Note: only the model config + namespace exist in this cluster. The
+			// referenced "remote-agent" is intentionally NOT created here — it
+			// lives in the peer cluster.
+			kubeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(modelConfig, testNamespace).
+				Build()
+
+			translator := agenttranslator.NewAdkApiTranslator(
+				kubeClient,
+				types.NamespacedName{Name: "default-model", Namespace: "test"},
+				nil,
+				"",
+				nil,
+			)
+
+			sourceAgent := &v1alpha2.Agent{
+				ObjectMeta: metav1.ObjectMeta{Name: "orchestrator", Namespace: "test"},
+				Spec:       declarativeSpec(tt.tool),
+			}
+
+			inputs, err := translator.CompileAgent(ctx, sourceAgent)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, inputs)
+			require.NotNil(t, inputs.Config)
+			require.Len(t, inputs.Config.RemoteAgents, 1)
+			assert.Equal(t, tt.wantURL, inputs.Config.RemoteAgents[0].Url)
+			assert.Equal(t, tt.wantDescription, inputs.Config.RemoteAgents[0].Description)
+		})
+	}
+}

--- a/helm/kagent-crds/templates/kagent.dev_agents.yaml
+++ b/helm/kagent-crds/templates/kagent.dev_agents.yaml
@@ -13169,11 +13169,23 @@ spec:
                           properties:
                             apiGroup:
                               type: string
+                            description:
+                              description: |-
+                                Description is shown for a remote (URL-based) agent tool, since there is no
+                                local Agent CR to read the description from.
+                              type: string
                             kind:
                               type: string
                             name:
                               type: string
                             namespace:
+                              type: string
+                            url:
+                              description: |-
+                                URL, when set on an Agent tool reference, points at a remote A2A endpoint
+                                (e.g. an agent in another cluster reachable over an east-west gateway).
+                                When set, the controller does NOT resolve a local Agent CR — it uses this
+                                URL directly, enabling cross-cluster declarative agent-to-agent tools (#1853).
                               type: string
                           required:
                           - name
@@ -13242,6 +13254,11 @@ spec:
                               type: array
                             apiGroup:
                               type: string
+                            description:
+                              description: |-
+                                Description is shown for a remote (URL-based) agent tool, since there is no
+                                local Agent CR to read the description from.
+                              type: string
                             kind:
                               type: string
                             name:
@@ -13267,6 +13284,13 @@ spec:
                                 type: string
                               maxItems: 50
                               type: array
+                            url:
+                              description: |-
+                                URL, when set on an Agent tool reference, points at a remote A2A endpoint
+                                (e.g. an agent in another cluster reachable over an east-west gateway).
+                                When set, the controller does NOT resolve a local Agent CR — it uses this
+                                URL directly, enabling cross-cluster declarative agent-to-agent tools (#1853).
+                              type: string
                           required:
                           - name
                           type: object

--- a/helm/kagent-crds/templates/kagent.dev_sandboxagents.yaml
+++ b/helm/kagent-crds/templates/kagent.dev_sandboxagents.yaml
@@ -10826,11 +10826,23 @@ spec:
                           properties:
                             apiGroup:
                               type: string
+                            description:
+                              description: |-
+                                Description is shown for a remote (URL-based) agent tool, since there is no
+                                local Agent CR to read the description from.
+                              type: string
                             kind:
                               type: string
                             name:
                               type: string
                             namespace:
+                              type: string
+                            url:
+                              description: |-
+                                URL, when set on an Agent tool reference, points at a remote A2A endpoint
+                                (e.g. an agent in another cluster reachable over an east-west gateway).
+                                When set, the controller does NOT resolve a local Agent CR — it uses this
+                                URL directly, enabling cross-cluster declarative agent-to-agent tools (#1853).
                               type: string
                           required:
                           - name
@@ -10899,6 +10911,11 @@ spec:
                               type: array
                             apiGroup:
                               type: string
+                            description:
+                              description: |-
+                                Description is shown for a remote (URL-based) agent tool, since there is no
+                                local Agent CR to read the description from.
+                              type: string
                             kind:
                               type: string
                             name:
@@ -10924,6 +10941,13 @@ spec:
                                 type: string
                               maxItems: 50
                               type: array
+                            url:
+                              description: |-
+                                URL, when set on an Agent tool reference, points at a remote A2A endpoint
+                                (e.g. an agent in another cluster reachable over an east-west gateway).
+                                When set, the controller does NOT resolve a local Agent CR — it uses this
+                                URL directly, enabling cross-cluster declarative agent-to-agent tools (#1853).
+                              type: string
                           required:
                           - name
                           type: object


### PR DESCRIPTION
## What this fixes

Cross-cluster agent-to-agent (A2A) already works for **BYO** agents — the BYO container makes the A2A call to the remote agent itself, so nothing is resolved. It does **not** work for **declarative** agents.

A declarative agent-as-tool (`tools[].type: Agent`) is resolved by the controller with a lookup in its **own** cluster's API. An agent in another cluster isn't there, so the referencing agent never starts:

```
Agent.kagent.dev "remote-agent" not found
```

Tracking issue: **solo-io/kagent-enterprise#1853** (Telefonica).

## The fix

Let an Agent tool reference carry an optional `url` (and `description`). When a `url` is set, the agent calls that remote A2A endpoint directly — e.g. an agent in another cluster reached over an east-west gateway — instead of resolving a local Agent CR. Declarative agents get the same cross-cluster reach BYO already has. Name-based references are unchanged.

```yaml
tools:
  - type: Agent
    agent:
      name: remote-agent
      url: http://remote-agent.kagent.svc.cluster.local:8080   # remote A2A endpoint
      description: Remote specialist in the peer cluster
```

Under the hood this reuses the exact `RemoteAgentConfig` the local path already builds (`Url = toolAgentURL(agent)`); it just lets you supply the URL instead of deriving it from a local CR.

## Backward compatibility

Purely additive — safe:
- `url`/`description` are **optional**; nothing removed, renamed, or retyped; `name` stays required.
- Applying the new CRD is a schema widening — existing name-based `Agent` objects validate and behave identically. No storage-version change.
- CRD + controller should ship together: old CRD + new controller ⇒ `url` is pruned and the feature no-ops (no break); new CRD + old controller ⇒ `url` stored but ignored. Neither breaks existing agents.

## Files
- `go/api/v1alpha2/agent_types.go` — `url`/`description` on `TypedReference`
- `go/core/internal/controller/translator/agent/compiler.go` — URL fast-path at both resolution sites
- `go/core/internal/controller/translator/agent/remote_url_agent_tool_test.go` — new unit test
- CRDs regenerated with `controller-gen` (`make manifests`) + synced to the Helm chart (`make controller-manifests`)

## Testing Proof
```
$ go test ./core/internal/controller/translator/agent/
ok  github.com/kagent-dev/kagent/go/core/internal/controller/translator/agent  0.237s
```

`gofmt -l` clean · `go vet` clean · deepcopy unchanged. A full end-to-end two-cluster (east↔west over an east-west gateway) live run is being captured and will be added here.

### Live end-to-end proof — cross-cluster declarative A2A (patched OSS kagent v0.9.11)

Two kind clusters, Solo Istio ambient federation + east-west gateway, patched controller on both:
```
east controller image: docker.io/library/kagent-controller:fix1853
west controller image: docker.io/library/kagent-controller:fix1853
```

**Declarative agents Ready on both clusters** (west = remote specialist, east = orchestrator that references it cross-cluster via url):
```
# WEST
NAME           TYPE          RUNTIME   READY   ACCEPTED
remote-agent   Declarative   python    True    True
# EAST
NAME                  TYPE          RUNTIME   READY   ACCEPTED
orchestrator-remote   Declarative   python    True    True
```

**The east orchestrator's cross-cluster tool reference (the new field):**
```yaml
{
    "agent": {
        "description": "Remote specialist in the WEST cluster (cross-cluster A2A)",
        "name": "remote-agent",
        "url": "http://remote-agent.kagent:8080"
    },
    "type": "Agent"
}
```

**Accepted condition (was `ReconcileFailed: Agent.kagent.dev "remote-agent" not found` before the fix):**
```
Accepted=True (Reconciled)
Ready=True (DeploymentReady)
```

**Live A2A call** — invoking the EAST orchestrator; it delegates over A2A to the WEST agent and returns its answer:
```
$ curl -s .../api/a2a/kagent/orchestrator-remote/ -d {message: "who and where are you?"}

**I am the remote-agent in the WEST cluster.**
I'm a remote specialist running in the WEST cluster, ready to assist you with tasks and questions from this location.
```

The reply comes from the **WEST** cluster's agent — proving a declarative EAST agent successfully used a declarative WEST agent over A2A across clusters.

##  What may be a better approach here (maybe another PR in future?)
The ideal long-term UX is the controller auto-deriving the federated URL from a name+cluster reference (so users don't hand-type it), but that needs the controller to know cross-cluster topology. The explicit url is the pragmatic MVP that works with any mesh/gateway today.

## Checklist
- [x] Conventional commit + DCO sign-off
- [x] Unit tests + full translator package green
- [x] `controller-gen` codegen + Helm CRD sync
- [x] Backward compatible (additive optional fields)
- [ ] Docs update on kagent.dev (separate repo)
- [X] End-to-end live proof (in progress)
