### PR TITLE
fix(go-adk): openai embeddings generation

### DIFF
--- a/go/adk/pkg/embedding/embedding.go
+++ b/go/adk/pkg/embedding/embedding.go
@@ -143,7 +143,7 @@ func newAzureOpenAIProvider(cfg *adk.EmbeddingConfig) (*azureOpenAIProvider, err
 		azureEndpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
 	}
 	if azureEndpoint == "" {
-		return nil, fmt.Errorf("azure openAI endpoint must be set via base_url or AZURE_OPENAI_ENDPOINT env var")
+		return nil, fmt.Errorf("Azure OpenAI endpoint must be set via base_url or AZURE_OPENAI_ENDPOINT env var") //nolint:staticcheck // ST1005: keep product name readable
 	}
 
 	apiKey := os.Getenv("AZURE_OPENAI_API_KEY")

--- a/go/adk/pkg/embedding/embedding.go
+++ b/go/adk/pkg/embedding/embedding.go
@@ -8,15 +8,20 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
 	"github.com/go-logr/logr"
 	"github.com/kagent-dev/kagent/go/api/adk"
+	"github.com/ollama/ollama/api"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
 	"google.golang.org/genai"
 )
 
@@ -39,7 +44,6 @@ type Client struct {
 // Config for creating an embedding client.
 type Config struct {
 	EmbeddingConfig *adk.EmbeddingConfig
-	HTTPClient      *http.Client
 }
 
 // New creates a new embedding client.
@@ -50,28 +54,28 @@ func New(cfg Config) (*Client, error) {
 	if cfg.EmbeddingConfig.Model == "" {
 		return nil, fmt.Errorf("embedding model is required")
 	}
-	httpClient := cfg.HTTPClient
-	if httpClient == nil {
-		httpClient = http.DefaultClient
+	p, err := newProvider(cfg.EmbeddingConfig)
+	if err != nil {
+		return nil, err
 	}
 	return &Client{
 		config: cfg.EmbeddingConfig,
-		p:      newProvider(cfg.EmbeddingConfig, httpClient),
+		p:      p,
 	}, nil
 }
 
-func newProvider(cfg *adk.EmbeddingConfig, httpClient *http.Client) provider {
+func newProvider(cfg *adk.EmbeddingConfig) (provider, error) {
 	switch cfg.Provider {
 	case "azure_openai":
-		return &azureOpenAIProvider{config: cfg, httpClient: httpClient}
+		return newAzureOpenAIProvider(cfg)
 	case "ollama":
-		return &ollamaProvider{config: cfg, httpClient: httpClient}
+		return newOllamaProvider(cfg)
 	case "gemini", "vertex_ai":
-		return &geminiProvider{config: cfg}
+		return &geminiProvider{config: cfg}, nil
 	case "bedrock":
-		return &bedrockProvider{config: cfg}
+		return &bedrockProvider{config: cfg}, nil
 	default: // "openai", "", and unknown providers
-		return &openAIProvider{config: cfg, httpClient: httpClient}
+		return newOpenAIProvider(cfg)
 	}
 }
 
@@ -87,177 +91,132 @@ func (c *Client) Generate(ctx context.Context, texts []string) ([][]float32, err
 }
 
 type openAIProvider struct {
-	config     *adk.EmbeddingConfig
-	httpClient *http.Client
+	config *adk.EmbeddingConfig
+	client openai.Client
+}
+
+func newOpenAIProvider(cfg *adk.EmbeddingConfig) (*openAIProvider, error) {
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	opts := []option.RequestOption{
+		option.WithAPIKey(apiKey),
+		option.WithHTTPClient(defaultProviderHTTPClient()),
+	}
+	if cfg.BaseUrl != "" {
+		opts = append(opts, option.WithBaseURL(cfg.BaseUrl))
+	}
+	return &openAIProvider{
+		config: cfg,
+		client: openai.NewClient(opts...),
+	}, nil
 }
 
 func (p *openAIProvider) generate(ctx context.Context, texts []string) ([][]float32, error) {
 	log := logr.FromContextOrDiscard(ctx)
 
-	baseURL := p.config.BaseUrl
-	if baseURL == "" {
-		baseURL = "https://api.openai.com/v1"
-	}
-	url := fmt.Sprintf("%s/embeddings", baseURL)
-
-	reqBody := map[string]any{
-		"input":      texts,
-		"model":      p.config.Model,
-		"dimensions": TargetDimension,
-	}
-	bodyBytes, err := json.Marshal(reqBody)
+	resp, err := p.client.Embeddings.New(ctx, openai.EmbeddingNewParams{
+		Model:      openai.EmbeddingModel(p.config.Model),
+		Input:      openai.EmbeddingNewParamsInputUnion{OfArrayOfStrings: texts},
+		Dimensions: openai.Int(int64(TargetDimension)),
+	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %w", err)
-	}
-	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(bodyBytes))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	if apiKey := os.Getenv("OPENAI_API_KEY"); apiKey != "" {
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", apiKey))
+		return nil, fmt.Errorf("openai embeddings request failed: %w", err)
 	}
 
-	resp, err := p.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to make request: %w", err)
+	raw := make([][]float32, len(resp.Data))
+	for i, item := range resp.Data {
+		raw[i] = float64ToFloat32(item.Embedding)
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
-	}
-
-	var result openAIEmbeddingResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("failed to decode response: %w", err)
-	}
-
-	embeddings := make([][]float32, 0, len(result.Data))
-	for _, item := range result.Data {
-		embedding := item.Embedding
-		if len(embedding) > TargetDimension {
-			log.V(1).Info("Truncating embedding", "from", len(embedding), "to", TargetDimension)
-			embedding = normalizeL2(embedding[:TargetDimension])
-		} else if len(embedding) < TargetDimension {
-			return nil, fmt.Errorf("embedding dimension %d is less than required %d", len(embedding), TargetDimension)
-		}
-		embeddings = append(embeddings, embedding)
-	}
-	log.Info("Successfully generated embeddings", "count", len(embeddings))
-	return embeddings, nil
+	return processEmbeddings(log, raw, "openai")
 }
 
 type azureOpenAIProvider struct {
-	config     *adk.EmbeddingConfig
-	httpClient *http.Client
+	config *adk.EmbeddingConfig
+	client openai.Client
+}
+
+func newAzureOpenAIProvider(cfg *adk.EmbeddingConfig) (*azureOpenAIProvider, error) {
+	apiVersion := os.Getenv("OPENAI_API_VERSION")
+	if apiVersion == "" {
+		apiVersion = "2024-02-15-preview"
+	}
+
+	azureEndpoint := cfg.BaseUrl
+	if azureEndpoint == "" {
+		azureEndpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
+	}
+	if azureEndpoint == "" {
+		return nil, fmt.Errorf("Azure OpenAI endpoint must be set via base_url or AZURE_OPENAI_ENDPOINT env var")
+	}
+
+	apiKey := os.Getenv("AZURE_OPENAI_API_KEY")
+	opts := []option.RequestOption{
+		option.WithBaseURL(strings.TrimSuffix(azureEndpoint, "/") + "/"),
+		option.WithQueryAdd("api-version", apiVersion),
+		option.WithMiddleware(azurePathRewriteMiddleware()),
+		option.WithHeader("Api-Key", apiKey),
+		option.WithHTTPClient(defaultProviderHTTPClient()),
+	}
+	return &azureOpenAIProvider{
+		config: cfg,
+		client: openai.NewClient(opts...),
+	}, nil
 }
 
 func (p *azureOpenAIProvider) generate(ctx context.Context, texts []string) ([][]float32, error) {
-	if p.config.BaseUrl == "" {
-		return nil, fmt.Errorf("base_url is required for Azure OpenAI")
-	}
-	url := fmt.Sprintf("%s/embeddings", p.config.BaseUrl)
+	log := logr.FromContextOrDiscard(ctx)
 
-	reqBody := map[string]any{"input": texts}
-	bodyBytes, err := json.Marshal(reqBody)
+	resp, err := p.client.Embeddings.New(ctx, openai.EmbeddingNewParams{
+		Model:      openai.EmbeddingModel(p.config.Model),
+		Input:      openai.EmbeddingNewParamsInputUnion{OfArrayOfStrings: texts},
+		Dimensions: openai.Int(int64(TargetDimension)),
+	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %w", err)
-	}
-	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(bodyBytes))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	if apiKey := os.Getenv("AZURE_OPENAI_API_KEY"); apiKey != "" {
-		req.Header.Set("api-key", apiKey)
+		return nil, fmt.Errorf("azure openai embeddings request failed: %w", err)
 	}
 
-	resp, err := p.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to make request: %w", err)
+	raw := make([][]float32, len(resp.Data))
+	for i, item := range resp.Data {
+		raw[i] = float64ToFloat32(item.Embedding)
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
-	}
-
-	var result openAIEmbeddingResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("failed to decode response: %w", err)
-	}
-
-	embeddings := make([][]float32, 0, len(result.Data))
-	for _, item := range result.Data {
-		embedding := item.Embedding
-		if len(embedding) > TargetDimension {
-			embedding = normalizeL2(embedding[:TargetDimension])
-		}
-		embeddings = append(embeddings, embedding)
-	}
-	return embeddings, nil
+	return processEmbeddings(log, raw, "azure_openai")
 }
 
 type ollamaProvider struct {
-	config     *adk.EmbeddingConfig
-	httpClient *http.Client
+	config *adk.EmbeddingConfig
+	client *api.Client
+}
+
+func newOllamaProvider(cfg *adk.EmbeddingConfig) (*ollamaProvider, error) {
+	host := cfg.BaseUrl
+	if host == "" {
+		host = os.Getenv("OLLAMA_API_BASE")
+	}
+	if host == "" {
+		host = "http://localhost:11434"
+	}
+
+	baseURL, err := url.Parse(host)
+	if err != nil {
+		return nil, fmt.Errorf("invalid Ollama host URL %q: %w", host, err)
+	}
+	return &ollamaProvider{
+		config: cfg,
+		client: api.NewClient(baseURL, defaultProviderHTTPClient()),
+	}, nil
 }
 
 func (p *ollamaProvider) generate(ctx context.Context, texts []string) ([][]float32, error) {
 	log := logr.FromContextOrDiscard(ctx)
 
-	baseURL := p.config.BaseUrl
-	if baseURL == "" {
-		baseURL = os.Getenv("OLLAMA_API_BASE")
-	}
-	if baseURL == "" {
-		baseURL = "http://localhost:11434"
-	}
-	url := fmt.Sprintf("%s/v1/embeddings", strings.TrimSuffix(baseURL, "/"))
-
-	reqBody := map[string]any{
-		"input": texts,
-		"model": p.config.Model,
-	}
-	bodyBytes, err := json.Marshal(reqBody)
+	resp, err := p.client.Embed(ctx, &api.EmbedRequest{
+		Model:      p.config.Model,
+		Input:      texts,
+		Dimensions: TargetDimension,
+	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %w", err)
+		return nil, fmt.Errorf("ollama embed request failed: %w", err)
 	}
-	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(bodyBytes))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := p.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to make request: %w", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
-	}
-
-	var result openAIEmbeddingResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("failed to decode response: %w", err)
-	}
-
-	embeddings := make([][]float32, 0, len(result.Data))
-	for _, item := range result.Data {
-		embedding := item.Embedding
-		if len(embedding) > TargetDimension {
-			log.V(1).Info("Truncating embedding", "from", len(embedding), "to", TargetDimension)
-			embedding = normalizeL2(embedding[:TargetDimension])
-		} else if len(embedding) < TargetDimension {
-			return nil, fmt.Errorf("embedding dimension %d is less than required %d", len(embedding), TargetDimension)
-		}
-		embeddings = append(embeddings, embedding)
-	}
-	log.Info("Successfully generated embeddings with Ollama", "count", len(embeddings))
-	return embeddings, nil
+	return processEmbeddings(log, resp.Embeddings, "ollama")
 }
 
 type geminiProvider struct {
@@ -285,7 +244,7 @@ func (p *geminiProvider) generate(ctx context.Context, texts []string) ([][]floa
 	}
 
 	targetDim := int32(TargetDimension)
-	embeddings := make([][]float32, len(texts))
+	raw := make([][]float32, len(texts))
 	for i, text := range texts {
 		result, err := p.client.Models.EmbedContent(ctx, p.config.Model, genai.Text(text), &genai.EmbedContentConfig{
 			OutputDimensionality: &targetDim,
@@ -299,11 +258,10 @@ func (p *geminiProvider) generate(ctx context.Context, texts []string) ([][]floa
 			for j, v := range src {
 				emb[j] = float32(v)
 			}
-			embeddings[i] = emb
+			raw[i] = emb
 		}
 	}
-	log.Info("Successfully generated embeddings with Gemini", "count", len(embeddings))
-	return embeddings, nil
+	return processEmbeddings(log, raw, "gemini")
 }
 
 type bedrockProvider struct {
@@ -336,7 +294,7 @@ func (p *bedrockProvider) generate(ctx context.Context, texts []string) ([][]flo
 		return nil, p.initErr
 	}
 
-	embeddings := make([][]float32, 0, len(texts))
+	raw := make([][]float32, 0, len(texts))
 	for i, text := range texts {
 		reqBody, err := json.Marshal(map[string]string{"inputText": text})
 		if err != nil {
@@ -355,37 +313,80 @@ func (p *bedrockProvider) generate(ctx context.Context, texts []string) ([][]flo
 		if err := json.Unmarshal(output.Body, &result); err != nil {
 			return nil, fmt.Errorf("failed to decode Bedrock response for text %d: %w", i, err)
 		}
-		embedding := result.Embedding
-		if len(embedding) > TargetDimension {
-			log.V(1).Info("Truncating embedding", "from", len(embedding), "to", TargetDimension)
-			embedding = normalizeL2(embedding[:TargetDimension])
-		} else if len(embedding) < TargetDimension {
-			return nil, fmt.Errorf("embedding dimension %d is less than required %d", len(embedding), TargetDimension)
-		}
-		embeddings = append(embeddings, embedding)
+		raw = append(raw, result.Embedding)
 	}
-	log.Info("Successfully generated embeddings with Bedrock", "count", len(embeddings))
-	return embeddings, nil
+	return processEmbeddings(log, raw, "bedrock")
 }
 
 type bedrockEmbeddingResponse struct {
 	Embedding []float32 `json:"embedding"`
 }
 
-type openAIEmbeddingResponse struct {
-	Data  []openAIEmbeddingData `json:"data"`
-	Model string                `json:"model"`
-	Usage openAIUsage           `json:"usage"`
+func defaultProviderHTTPClient() *http.Client {
+	return &http.Client{Timeout: 5 * time.Minute}
 }
 
-type openAIEmbeddingData struct {
-	Embedding []float32 `json:"embedding"`
-	Index     int       `json:"index"`
+func processEmbeddings(log logr.Logger, embeddings [][]float32, provider string) ([][]float32, error) {
+	result := make([][]float32, 0, len(embeddings))
+	for _, embedding := range embeddings {
+		if len(embedding) > TargetDimension {
+			log.V(1).Info("Truncating embedding", "from", len(embedding), "to", TargetDimension)
+			embedding = normalizeL2(embedding[:TargetDimension])
+		} else if len(embedding) < TargetDimension {
+			return nil, fmt.Errorf("embedding dimension %d is less than required %d", len(embedding), TargetDimension)
+		}
+		result = append(result, embedding)
+	}
+	log.Info("Successfully generated embeddings", "provider", provider, "count", len(result))
+	return result, nil
 }
 
-type openAIUsage struct {
-	PromptTokens int `json:"prompt_tokens"`
-	TotalTokens  int `json:"total_tokens"`
+func float64ToFloat32(v []float64) []float32 {
+	out := make([]float32, len(v))
+	for i, x := range v {
+		out[i] = float32(x)
+	}
+	return out
+}
+
+// azurePathRewriteMiddleware rewrites .../embeddings to .../openai/deployments/{model}/embeddings.
+// Mirrors models/openai.go so Azure embedding deployments use the same path shape as chat.
+func azurePathRewriteMiddleware() option.Middleware {
+	return func(r *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+		pathSuffix := strings.TrimPrefix(r.URL.Path, "/")
+		var suffix string
+		switch {
+		case strings.HasSuffix(pathSuffix, "chat/completions"):
+			suffix = "chat/completions"
+		case strings.HasSuffix(pathSuffix, "completions"):
+			suffix = "completions"
+		case strings.HasSuffix(pathSuffix, "embeddings"):
+			suffix = "embeddings"
+		default:
+			return next(r)
+		}
+		if r.Body == nil {
+			return next(r)
+		}
+		var buf bytes.Buffer
+		if _, err := buf.ReadFrom(r.Body); err != nil {
+			return nil, err
+		}
+		r.Body = io.NopCloser(&buf)
+		var payload struct {
+			Model string `json:"model"`
+		}
+		if err := json.NewDecoder(bytes.NewReader(buf.Bytes())).Decode(&payload); err != nil || payload.Model == "" {
+			r.Body = io.NopCloser(bytes.NewReader(buf.Bytes()))
+			return next(r)
+		}
+		deployment := url.PathEscape(payload.Model)
+		basePath := strings.TrimSuffix(r.URL.Path, suffix)
+		basePath = strings.TrimRight(basePath, "/")
+		r.URL.Path = basePath + "/openai/deployments/" + deployment + "/" + suffix
+		r.Body = io.NopCloser(bytes.NewReader(buf.Bytes()))
+		return next(r)
+	}
 }
 
 // normalizeL2 normalizes a vector to unit length using L2 norm.

--- a/go/adk/pkg/embedding/embedding.go
+++ b/go/adk/pkg/embedding/embedding.go
@@ -1,11 +1,9 @@
 package embedding
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"math"
 	"net/http"
 	"net/url"
@@ -145,14 +143,19 @@ func newAzureOpenAIProvider(cfg *adk.EmbeddingConfig) (*azureOpenAIProvider, err
 		azureEndpoint = os.Getenv("AZURE_OPENAI_ENDPOINT")
 	}
 	if azureEndpoint == "" {
-		return nil, fmt.Errorf("Azure OpenAI endpoint must be set via base_url or AZURE_OPENAI_ENDPOINT env var")
+		return nil, fmt.Errorf("azure openAI endpoint must be set via base_url or AZURE_OPENAI_ENDPOINT env var")
 	}
 
 	apiKey := os.Getenv("AZURE_OPENAI_API_KEY")
+	baseURL := strings.TrimSuffix(azureEndpoint, "/")
+	if !strings.Contains(baseURL, "/openai/deployments/") {
+		baseURL += "/openai/deployments/" + url.PathEscape(cfg.Model)
+	}
+	baseURL += "/"
+
 	opts := []option.RequestOption{
-		option.WithBaseURL(strings.TrimSuffix(azureEndpoint, "/") + "/"),
+		option.WithBaseURL(baseURL),
 		option.WithQueryAdd("api-version", apiVersion),
-		option.WithMiddleware(azurePathRewriteMiddleware()),
 		option.WithHeader("Api-Key", apiKey),
 		option.WithHTTPClient(defaultProviderHTTPClient()),
 	}
@@ -347,46 +350,6 @@ func float64ToFloat32(v []float64) []float32 {
 		out[i] = float32(x)
 	}
 	return out
-}
-
-// azurePathRewriteMiddleware rewrites .../embeddings to .../openai/deployments/{model}/embeddings.
-// Mirrors models/openai.go so Azure embedding deployments use the same path shape as chat.
-func azurePathRewriteMiddleware() option.Middleware {
-	return func(r *http.Request, next option.MiddlewareNext) (*http.Response, error) {
-		pathSuffix := strings.TrimPrefix(r.URL.Path, "/")
-		var suffix string
-		switch {
-		case strings.HasSuffix(pathSuffix, "chat/completions"):
-			suffix = "chat/completions"
-		case strings.HasSuffix(pathSuffix, "completions"):
-			suffix = "completions"
-		case strings.HasSuffix(pathSuffix, "embeddings"):
-			suffix = "embeddings"
-		default:
-			return next(r)
-		}
-		if r.Body == nil {
-			return next(r)
-		}
-		var buf bytes.Buffer
-		if _, err := buf.ReadFrom(r.Body); err != nil {
-			return nil, err
-		}
-		r.Body = io.NopCloser(&buf)
-		var payload struct {
-			Model string `json:"model"`
-		}
-		if err := json.NewDecoder(bytes.NewReader(buf.Bytes())).Decode(&payload); err != nil || payload.Model == "" {
-			r.Body = io.NopCloser(bytes.NewReader(buf.Bytes()))
-			return next(r)
-		}
-		deployment := url.PathEscape(payload.Model)
-		basePath := strings.TrimSuffix(r.URL.Path, suffix)
-		basePath = strings.TrimRight(basePath, "/")
-		r.URL.Path = basePath + "/openai/deployments/" + deployment + "/" + suffix
-		r.Body = io.NopCloser(bytes.NewReader(buf.Bytes()))
-		return next(r)
-	}
 }
 
 // normalizeL2 normalizes a vector to unit length using L2 norm.

--- a/go/adk/pkg/embedding/embedding_test.go
+++ b/go/adk/pkg/embedding/embedding_test.go
@@ -105,3 +105,221 @@ func TestProcessEmbeddings_RejectsUndersized(t *testing.T) {
 		t.Fatal("expected error for undersized embedding")
 	}
 }
+
+func azureEmbeddingResponse(model string) map[string]any {
+	vec := make([]float64, TargetDimension)
+	vec[0] = 1.0
+	return map[string]any{
+		"object": "list",
+		"data":   []map[string]any{{"object": "embedding", "index": 0, "embedding": vec}},
+		"model":  model,
+		"usage":  map[string]any{"prompt_tokens": 1, "total_tokens": 1},
+	}
+}
+
+func TestAzureOpenAIProvider_RequestShape(t *testing.T) {
+	const (
+		deployment = "text-embedding-3-small"
+		apiVersion = "2024-02-15-preview"
+		apiKey     = "azure-test-key"
+	)
+
+	tests := []struct {
+		name       string
+		setEnv     bool
+		baseURL    string // used when setEnv is false; may contain "%s" for srv.URL
+		wantPath   string
+		wantAPIVer string
+	}{
+		{
+			name:       "root endpoint in base_url",
+			baseURL:    "%s",
+			wantPath:   "/openai/deployments/text-embedding-3-small/embeddings",
+			wantAPIVer: apiVersion,
+		},
+		{
+			name:       "root endpoint trailing slash",
+			baseURL:    "%s/",
+			wantPath:   "/openai/deployments/text-embedding-3-small/embeddings",
+			wantAPIVer: apiVersion,
+		},
+		{
+			name:       "deployment path already in base_url",
+			baseURL:    "%s/openai/deployments/text-embedding-3-small",
+			wantPath:   "/openai/deployments/text-embedding-3-small/embeddings",
+			wantAPIVer: apiVersion,
+		},
+		{
+			name:       "endpoint from AZURE_OPENAI_ENDPOINT env",
+			setEnv:     true,
+			wantPath:   "/openai/deployments/text-embedding-3-small/embeddings",
+			wantAPIVer: apiVersion,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("AZURE_OPENAI_API_KEY", apiKey)
+			t.Setenv("OPENAI_API_VERSION", apiVersion)
+
+			var gotPath, gotAPIKey, gotAPIVersion string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				gotAPIKey = r.Header.Get("Api-Key")
+				gotAPIVersion = r.URL.Query().Get("api-version")
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(azureEmbeddingResponse(deployment))
+			}))
+			defer srv.Close()
+
+			cfg := &adk.EmbeddingConfig{
+				Provider: "azure_openai",
+				Model:    deployment,
+			}
+			if tt.setEnv {
+				t.Setenv("AZURE_OPENAI_ENDPOINT", srv.URL)
+			} else {
+				t.Setenv("AZURE_OPENAI_ENDPOINT", "")
+				cfg.BaseUrl = strings.Replace(tt.baseURL, "%s", srv.URL, 1)
+			}
+
+			client, err := New(Config{EmbeddingConfig: cfg})
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+
+			if _, err := client.Generate(context.Background(), []string{"hello"}); err != nil {
+				t.Fatalf("Generate() error = %v", err)
+			}
+			if gotPath != tt.wantPath {
+				t.Errorf("path = %q, want %q", gotPath, tt.wantPath)
+			}
+			if gotAPIVersion != tt.wantAPIVer {
+				t.Errorf("api-version = %q, want %q", gotAPIVersion, tt.wantAPIVer)
+			}
+			if gotAPIKey != apiKey {
+				t.Errorf("Api-Key = %q, want %q", gotAPIKey, apiKey)
+			}
+		})
+	}
+}
+
+func TestAzureOpenAIProvider_MissingEndpoint(t *testing.T) {
+	t.Setenv("AZURE_OPENAI_ENDPOINT", "")
+	_, err := New(Config{
+		EmbeddingConfig: &adk.EmbeddingConfig{
+			Provider: "azure_openai",
+			Model:    "text-embedding-3-small",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error when Azure OpenAI endpoint is missing")
+	}
+	if !strings.Contains(err.Error(), "Azure OpenAI endpoint") {
+		t.Errorf("error = %q, want mention of Azure OpenAI endpoint", err)
+	}
+}
+
+func TestOllamaProvider_RequestShape(t *testing.T) {
+	const model = "nomic-embed-text"
+
+	tests := []struct {
+		name     string
+		useEnv   bool
+		baseURL  string // may contain "%s" for srv.URL
+		wantPath string
+	}{
+		{
+			name:     "base_url host",
+			baseURL:  "%s",
+			wantPath: "/api/embed",
+		},
+		{
+			name:     "base_url host trailing slash",
+			baseURL:  "%s/",
+			wantPath: "/api/embed",
+		},
+		{
+			name:     "host from OLLAMA_API_BASE env",
+			useEnv:   true,
+			wantPath: "/api/embed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotPath string
+			var gotBody struct {
+				Model      string   `json:"model"`
+				Input      []string `json:"input"`
+				Dimensions int      `json:"dimensions"`
+			}
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Fatalf("read body: %v", err)
+				}
+				if err := json.Unmarshal(body, &gotBody); err != nil {
+					t.Fatalf("unmarshal body: %v", err)
+				}
+				vec := make([]float32, TargetDimension)
+				vec[0] = 1.0
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(map[string]any{
+					"model":      model,
+					"embeddings": [][]float32{vec},
+				})
+			}))
+			defer srv.Close()
+
+			cfg := &adk.EmbeddingConfig{
+				Provider: "ollama",
+				Model:    model,
+			}
+			if tt.useEnv {
+				t.Setenv("OLLAMA_API_BASE", srv.URL)
+			} else {
+				t.Setenv("OLLAMA_API_BASE", "")
+				cfg.BaseUrl = strings.Replace(tt.baseURL, "%s", srv.URL, 1)
+			}
+
+			client, err := New(Config{EmbeddingConfig: cfg})
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+			if _, err := client.Generate(context.Background(), []string{"hello"}); err != nil {
+				t.Fatalf("Generate() error = %v", err)
+			}
+			if gotPath != tt.wantPath {
+				t.Errorf("path = %q, want %q", gotPath, tt.wantPath)
+			}
+			if gotBody.Model != model {
+				t.Errorf("model = %q, want %q", gotBody.Model, model)
+			}
+			if gotBody.Dimensions != TargetDimension {
+				t.Errorf("dimensions = %d, want %d", gotBody.Dimensions, TargetDimension)
+			}
+			if len(gotBody.Input) != 1 || gotBody.Input[0] != "hello" {
+				t.Errorf("input = %v, want [hello]", gotBody.Input)
+			}
+		})
+	}
+}
+
+func TestOllamaProvider_InvalidHost(t *testing.T) {
+	t.Setenv("OLLAMA_API_BASE", "")
+	_, err := New(Config{
+		EmbeddingConfig: &adk.EmbeddingConfig{
+			Provider: "ollama",
+			Model:    "nomic-embed-text",
+			BaseUrl:  "://bad-url",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid Ollama host URL")
+	}
+	if !strings.Contains(err.Error(), "invalid Ollama host URL") {
+		t.Errorf("error = %q, want invalid Ollama host URL", err)
+	}
+}

--- a/go/adk/pkg/embedding/embedding_test.go
+++ b/go/adk/pkg/embedding/embedding_test.go
@@ -1,0 +1,107 @@
+package embedding
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/kagent-dev/kagent/go/adk/pkg/auth"
+	"github.com/kagent-dev/kagent/go/api/adk"
+)
+
+func TestOpenAIProvider_UsesAPIKeyNotKagentToken(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "sk-openai-key")
+
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		if r.URL.Path != "/embeddings" {
+			t.Errorf("path = %q, want /embeddings", r.URL.Path)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		var req struct {
+			Model      string   `json:"model"`
+			Input      []string `json:"input"`
+			Dimensions int      `json:"dimensions"`
+		}
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatalf("unmarshal request: %v", err)
+		}
+		if req.Model != "text-embedding-3-small" {
+			t.Errorf("model = %q, want text-embedding-3-small", req.Model)
+		}
+		if req.Dimensions != TargetDimension {
+			t.Errorf("dimensions = %d, want %d", req.Dimensions, TargetDimension)
+		}
+		if len(req.Input) != 1 || req.Input[0] != "hello" {
+			t.Errorf("input = %v, want [hello]", req.Input)
+		}
+
+		vec := make([]float64, TargetDimension)
+		vec[0] = 1.0
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"object": "list",
+			"data":   []map[string]any{{"object": "embedding", "index": 0, "embedding": vec}},
+			"model":  req.Model,
+			"usage":  map[string]any{"prompt_tokens": 1, "total_tokens": 1},
+		})
+	}))
+	defer srv.Close()
+
+	// kagent auth client exists in-process but must not reach embedding providers.
+	tokenSvc := auth.NewKAgentTokenService("test-app")
+	_ = auth.NewHTTPClientWithToken(tokenSvc)
+
+	client, err := New(Config{
+		EmbeddingConfig: &adk.EmbeddingConfig{
+			Provider: "openai",
+			Model:    "text-embedding-3-small",
+			BaseUrl:  srv.URL,
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	vecs, err := client.Generate(context.Background(), []string{"hello"})
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	if len(vecs) != 1 || len(vecs[0]) != TargetDimension {
+		t.Fatalf("got %d vectors of len %d, want 1 vector of len %d", len(vecs), len(vecs[0]), TargetDimension)
+	}
+	if gotAuth != "Bearer sk-openai-key" {
+		t.Errorf("Authorization = %q, want Bearer sk-openai-key", gotAuth)
+	}
+	if strings.Contains(gotAuth, "kagent") {
+		t.Errorf("Authorization must not contain kagent token, got %q", gotAuth)
+	}
+}
+
+func TestNormalizeL2(t *testing.T) {
+	normed := normalizeL2([]float32{3, 4})
+	var sum float64
+	for _, v := range normed {
+		sum += float64(v) * float64(v)
+	}
+	const eps = 1e-5
+	if diff := 1.0 - sum; diff > eps || diff < -eps {
+		t.Errorf("L2 norm squared = %v, want ~1.0", sum)
+	}
+}
+
+func TestProcessEmbeddings_RejectsUndersized(t *testing.T) {
+	_, err := processEmbeddings(logr.Discard(), [][]float32{{1, 2, 3}}, "test")
+	if err == nil {
+		t.Fatal("expected error for undersized embedding")
+	}
+}

--- a/go/adk/pkg/memory/kagent_service.go
+++ b/go/adk/pkg/memory/kagent_service.go
@@ -64,7 +64,6 @@ func New(cfg Config) (*KagentMemoryService, error) {
 	}
 	embClient, err := embedding.New(embedding.Config{
 		EmbeddingConfig: cfg.EmbeddingConfig,
-		HTTPClient:      client,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create embedding client: %w", err)

--- a/go/adk/pkg/memory/kagent_service_test.go
+++ b/go/adk/pkg/memory/kagent_service_test.go
@@ -36,7 +36,6 @@ func newMockEmbeddingClient(t *testing.T) (*embedding.Client, *httptest.Server) 
 			Model:    "test-model",
 			BaseUrl:  embServer.URL + "/v1",
 		},
-		HTTPClient: embServer.Client(),
 	})
 	if err != nil {
 		t.Fatalf("failed to create mock embedding client: %v", err)


### PR DESCRIPTION
Close #2131 

The main fix is to remove `HTTPClient` passed to embedding client so that it creates its own and attaches auth header properly (one line fix). 

However, since we're here already, I'm also moving OpenAI, Azure, and Ollama providers to use their respective SDK like Bedrock and Gemini instead of doing direct HTTP calls to the endpoints. This ensures better long-term stability and maintainability. Also improves some test coverage + refactoring