### PR TITLE
fix(build): pin nodejs to TOOLS_NODE_VERSION in golang-adk-full Dockerfile

### DIFF
--- a/go/Dockerfile.full
+++ b/go/Dockerfile.full
@@ -24,10 +24,14 @@ RUN --mount=type=cache,target=/root/go/pkg/mod,rw \
 
 FROM $BASE_IMAGE_REGISTRY/chainguard/wolfi-base:latest AS srt-builder
 ARG TOOLS_PYTHON_VERSION=3.13
+ARG TOOLS_NODE_VERSION=24
 
+# Pin nodejs to the major version passed via TOOLS_NODE_VERSION. Without the pin, apk
+# silently drifts to whatever Wolfi publishes as `nodejs`, which broke arm64 builds when
+# nodejs-26 shipped instructions QEMU couldn't emulate.
 RUN --mount=type=cache,target=/var/cache/apk,rw \
     apk add --no-cache \
-    bash git ca-certificates nodejs npm node-gyp bubblewrap python-${TOOLS_PYTHON_VERSION} libstdc++
+    bash git ca-certificates "nodejs~${TOOLS_NODE_VERSION}" npm node-gyp bubblewrap python-${TOOLS_PYTHON_VERSION} libstdc++
 
 # Keep the pinned sandbox-runtime revision, but replace its vulnerable locked package versions.
 # Both lodash-es and shell-quote are direct dependencies of sandbox-runtime, so pinning them
@@ -43,10 +47,11 @@ RUN --mount=type=cache,target=/root/.npm \
 
 FROM $BASE_IMAGE_REGISTRY/chainguard/wolfi-base:latest
 ARG TOOLS_PYTHON_VERSION=3.13
+ARG TOOLS_NODE_VERSION=24
 
 RUN --mount=type=cache,target=/var/cache/apk,rw \
     apk add --no-cache \
-    bash ca-certificates curl nodejs bubblewrap socat python-${TOOLS_PYTHON_VERSION} ripgrep libstdc++
+    bash ca-certificates curl "nodejs~${TOOLS_NODE_VERSION}" bubblewrap socat python-${TOOLS_PYTHON_VERSION} ripgrep libstdc++
 
 RUN addgroup -g 1001 goagent && \
     adduser -u 1001 -G goagent -s /bin/bash -D goagent


### PR DESCRIPTION
## Summary

Fixes the `qemu: uncaught target signal 4 (Illegal instruction)` crash that has been breaking every arm64 image build on main since ~14:40 UTC on 2026-07-02.

## Root cause

`go/Dockerfile.full` installs `nodejs` unpinned in two stages:

```dockerfile
# srt-builder (line 30):
apk add --no-cache bash git ca-certificates nodejs npm node-gyp ...

# final runtime (line 49):
apk add --no-cache bash ca-certificates curl nodejs bubblewrap ...
```

`TOOLS_NODE_VERSION=24` is passed as a `--build-arg` from the Makefile but is never actually referenced inside these Dockerfile stages. So when Wolfi published `nodejs-26.4.0-r1`, `apk add nodejs` silently upgraded to a Node 26 binary whose arm64 instructions QEMU 10.2.3 (from `docker/setup-qemu-action@v4`) cannot emulate — every cross-arch build now crashes at `Dockerfile.full:35` during `npm install`.

Evidence this is drift, not something in a recent PR:
- [#2133](https://github.com/kagent-dev/kagent/pull/2133) merged at 14:39 UTC → CI **SUCCESS**
- [#2132](https://github.com/kagent-dev/kagent/actions/runs/28598665763) merged at 14:40 UTC → same QEMU crash, same line
- Every PR pushed since then hits the same failure

## Fix

Match the pattern that `ui/Dockerfile` (lines 13 and 50) already uses: `"nodejs~${TOOLS_NODE_VERSION}"`, and declare `ARG TOOLS_NODE_VERSION=24` in both stages that need it. The `~` operator is Wolfi's fuzzy version match — pins the major line but still allows patch updates within `nodejs-24.x`.

## Changes

| File | Change |
|------|--------|
| `go/Dockerfile.full` | Add `ARG TOOLS_NODE_VERSION=24` to `srt-builder` and final stages; replace `nodejs` with `"nodejs~${TOOLS_NODE_VERSION}"` in both `apk add` commands |

## Test plan

- [ ] `build (golang-adk-full)` passes on arm64
- [ ] All other `build (*)` jobs (which were cascade-cancelling because of the `fail-fast` matrix) pass again
- [ ] Verify installed nodejs is `24.x`, not `26.x`, in the resulting image