### PR TITLE
feat(helm/kagent): allow disabling default modelconfig

### DIFF
--- a/helm/kagent/templates/modelconfig-secret.yaml
+++ b/helm/kagent/templates/modelconfig-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.providers }}
 {{- $dot := . }}
 {{- $model := index $dot.Values.providers $dot.Values.providers.default  }}
 {{- if and $model.apiKeySecretRef $model.apiKey }}
@@ -12,4 +13,5 @@ metadata:
 type: Opaque
 data:
   {{ $model.apiKeySecretKey | default (printf "%s_API_KEY" $model.provider | upper) }}: {{ $model.apiKey | b64enc }}
+{{- end }}
 {{- end }}

--- a/helm/kagent/templates/modelconfig-secret.yaml
+++ b/helm/kagent/templates/modelconfig-secret.yaml
@@ -1,6 +1,8 @@
 {{- if .Values.providers }}
 {{- $dot := . }}
-{{- $model := index $dot.Values.providers $dot.Values.providers.default  }}
+{{- $defaultProvider := .Values.providers.default | default "openAI" }}
+{{- if hasKey .Values.providers $defaultProvider }}
+{{- $model := index .Values.providers $defaultProvider }}
 {{- if and $model.apiKeySecretRef $model.apiKey }}
 ---
 apiVersion: v1
@@ -13,5 +15,6 @@ metadata:
 type: Opaque
 data:
   {{ $model.apiKeySecretKey | default (printf "%s_API_KEY" $model.provider | upper) }}: {{ $model.apiKey | b64enc }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm/kagent/templates/modelconfig.yaml
+++ b/helm/kagent/templates/modelconfig.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.providers }}
 {{- $dot := . }}
 {{- $defaultProvider := .Values.providers.default | default "openAI" }}
 {{- if hasKey .Values.providers $defaultProvider | not }}
@@ -39,3 +40,4 @@ spec:
   {{- toYaml $model.config | nindent 4 }}
   {{- end }}
   {{- end }}
+{{- end }}

--- a/helm/kagent/templates/modelconfig.yaml
+++ b/helm/kagent/templates/modelconfig.yaml
@@ -36,7 +36,7 @@ spec:
     {{- toYaml $model.tls | nindent 4 }}
   {{- end }}
   {{- if $model.config }}
-  {{ $dot.Values.providers.default }}:
+  {{ $defaultProvider }}:
   {{- toYaml $model.config | nindent 4 }}
   {{- end }}
   {{- end }}

--- a/helm/kagent/tests/modelconfig-secret_test.yaml
+++ b/helm/kagent/tests/modelconfig-secret_test.yaml
@@ -99,4 +99,10 @@ tests:
     asserts:
       - equal:
           path: metadata.namespace
-          value: custom-namespace 
+          value: custom-namespace
+  - it: should not render secret when providers is set to null
+    set:
+      providers: null
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/helm/kagent/tests/modelconfig_test.yaml
+++ b/helm/kagent/tests/modelconfig_test.yaml
@@ -170,3 +170,10 @@ tests:
       - equal:
           path: metadata.namespace
           value: custom-namespace
+
+  - it: should not render modelconfig when providers is set to null
+    set:
+      providers: null
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
Wrap `modelconfig` and `modelconfig-secret` templates in a conditional check for `.Values.providers`.
This allows users to completely disable the default modelconfig generation by setting providers to null.

Add tests to verify that no documents are rendered when providers is null.