### PR TITLE
feat(helm/kagent): support deployment annotations

### DIFF
--- a/helm/kagent/templates/controller-deployment.yaml
+++ b/helm/kagent/templates/controller-deployment.yaml
@@ -3,6 +3,10 @@ kind: Deployment
 metadata:
   name: {{ include "kagent.fullname" . }}-controller
   namespace: {{ include "kagent.namespace" . }}
+  {{- with .Values.controller.annotations | default .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "kagent.controller.labels" . | nindent 4 }}
 spec:

--- a/helm/kagent/templates/controller-deployment.yaml
+++ b/helm/kagent/templates/controller-deployment.yaml
@@ -3,9 +3,10 @@ kind: Deployment
 metadata:
   name: {{ include "kagent.fullname" . }}-controller
   namespace: {{ include "kagent.namespace" . }}
-  {{- with .Values.controller.annotations | default .Values.annotations }}
+  {{- $annotations := mergeOverwrite (dict) (default dict .Values.annotations) (default dict .Values.controller.annotations) }}
+  {{- if $annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml $annotations | nindent 4 }}
   {{- end }}
   labels:
     {{- include "kagent.controller.labels" . | nindent 4 }}

--- a/helm/kagent/templates/ui-deployment.yaml
+++ b/helm/kagent/templates/ui-deployment.yaml
@@ -3,9 +3,10 @@ kind: Deployment
 metadata:
   name: {{ include "kagent.fullname" . }}-ui
   namespace: {{ include "kagent.namespace" . }}
-  {{- with .Values.ui.annotations | default .Values.annotations }}
+  {{- $annotations := mergeOverwrite (dict) (default dict .Values.annotations) (default dict .Values.ui.annotations) }}
+  {{- if $annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml $annotations | nindent 4 }}
   {{- end }}
   labels:
     {{- include "kagent.labels" . | nindent 4 }}

--- a/helm/kagent/templates/ui-deployment.yaml
+++ b/helm/kagent/templates/ui-deployment.yaml
@@ -3,6 +3,10 @@ kind: Deployment
 metadata:
   name: {{ include "kagent.fullname" . }}-ui
   namespace: {{ include "kagent.namespace" . }}
+  {{- with .Values.ui.annotations | default .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "kagent.labels" . | nindent 4 }}
 spec:

--- a/helm/kagent/tests/controller-deployment_test.yaml
+++ b/helm/kagent/tests/controller-deployment_test.yaml
@@ -77,6 +77,34 @@ tests:
           path: spec.template.spec.containers[0].ports[0].containerPort
           value: 8083
 
+  - it: should set global annotations on deployment
+    template: controller-deployment.yaml
+    set:
+      annotations:
+        app.kubernetes.io/managed-by: "custom"
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            app.kubernetes.io/managed-by: "custom"
+
+  - it: should set controller annotations on deployment and override global ones
+    template: controller-deployment.yaml
+    set:
+      annotations:
+        global-key: "global-value"
+        shared-key: "global-wins"
+      controller:
+        annotations:
+          controller-key: "controller-value"
+          shared-key: "controller-wins"
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            controller-key: "controller-value"
+            shared-key: "controller-wins"
+
   - it: should set substrate ate-api env vars and projected token when substrate is enabled
     template: controller-deployment.yaml
     set:

--- a/helm/kagent/tests/controller-deployment_test.yaml
+++ b/helm/kagent/tests/controller-deployment_test.yaml
@@ -102,6 +102,7 @@ tests:
       - isSubset:
           path: metadata.annotations
           content:
+            global-key: "global-value"
             controller-key: "controller-value"
             shared-key: "controller-wins"
 

--- a/helm/kagent/tests/ui-deployment_test.yaml
+++ b/helm/kagent/tests/ui-deployment_test.yaml
@@ -101,6 +101,7 @@ tests:
       - isSubset:
           path: metadata.annotations
           content:
+            global-key: "global-value"
             ui-key: "ui-value"
             shared-key: "ui-wins"
 

--- a/helm/kagent/tests/ui-deployment_test.yaml
+++ b/helm/kagent/tests/ui-deployment_test.yaml
@@ -76,6 +76,34 @@ tests:
           path: spec.template.spec.containers[0].ports[0].containerPort
           value: 8080
 
+  - it: should set global annotations on deployment
+    template: ui-deployment.yaml
+    set:
+      annotations:
+        app.kubernetes.io/managed-by: "custom"
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            app.kubernetes.io/managed-by: "custom"
+
+  - it: should set ui annotations on deployment and override global ones
+    template: ui-deployment.yaml
+    set:
+      annotations:
+        global-key: "global-value"
+        shared-key: "global-wins"
+      ui:
+        annotations:
+          ui-key: "ui-value"
+          shared-key: "ui-wins"
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            ui-key: "ui-value"
+            shared-key: "ui-wins"
+
   - it: should set podAnnotations
     template: ui-deployment.yaml
     set:

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -27,6 +27,9 @@ fullnameOverride: ""
 # @default -- `.Release.Namespace`
 namespaceOverride: ""
 
+# -- Additional annotations to add to all Kubernetes deployment resources
+annotations: {}
+
 podAnnotations: {}
 
 # -- Additional labels to add to all Kubernetes resources
@@ -214,6 +217,9 @@ controller:
   # off by default.
   mcpEgressPlaintext: false
 
+  # -- Additional annotations to add to the controller Deployment metadata
+  annotations: {}
+
   podAnnotations: {}
 
   # -- Node taints which will be tolerated for `Pod` [scheduling](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).
@@ -337,6 +343,9 @@ substrateWorkerPool:
 # ==============================================================================
 
 ui:
+  # -- Additional annotations to add to the UI Deployment metadata
+  annotations: {}
+
   # -- Public-facing base URL of the UI (e.g. https://kagent.example.com).
   # When set, the controller injects KAGENT_UI_URL into agent pods so that
   # share link tools return full clickable URLs instead of relative paths.


### PR DESCRIPTION
Add support for deployment-level annotations on the controller and UI deployments.

Allows configuring a global annotations map that applies to all deployments, as well as component-specific overrides via `controller.annotations` and `ui.annotations`.