### PR TITLE
fix: intermittent Postgres deadlock for concurrent memory searches

### DIFF
--- a/go/core/internal/database/client_postgres.go
+++ b/go/core/internal/database/client_postgres.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -712,13 +713,14 @@ func (c *postgresClient) SearchAgentMemory(ctx context.Context, agentName, userI
 		}
 	}
 
+	// Access-count bookkeeping is best-effort: a failure must not fail the search.
 	if len(results) > 0 {
 		ids := make([]string, len(results))
 		for i, r := range results {
 			ids[i] = r.ID
 		}
 		if err := c.q.IncrementMemoryAccessCount(ctx, ids); err != nil {
-			return nil, fmt.Errorf("failed to increment access count: %w", err)
+			log.Printf("failed to increment memory access count: %v", err)
 		}
 	}
 

--- a/go/core/internal/database/client_test.go
+++ b/go/core/internal/database/client_test.go
@@ -728,12 +728,13 @@ func TestPruneExpiredMemories(t *testing.T) {
 }
 
 // TestSearchAgentMemoryConcurrentAccessCount verifies concurrent searches over
-// overlapping rows do not deadlock when incrementing access_count, and that
-// search results are always returned even if bookkeeping fails.
+// overlapping rows do not deadlock when incrementing access_count and still
+// return results.
 func TestSearchAgentMemoryConcurrentAccessCount(t *testing.T) {
 	db := setupTestDB(t)
 	client := NewClient(db)
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
 
 	agentName := "concurrent-agent"
 	userID := "concurrent-user"

--- a/go/core/internal/database/client_test.go
+++ b/go/core/internal/database/client_test.go
@@ -726,3 +726,57 @@ func TestPruneExpiredMemories(t *testing.T) {
 	assert.Contains(t, ids, hotMem.ID, "Expired popular memory should have TTL extended and be retained")
 	assert.Contains(t, ids, liveMem.ID, "Non-expired memory should be retained")
 }
+
+// TestSearchAgentMemoryConcurrentAccessCount verifies concurrent searches over
+// overlapping rows do not deadlock when incrementing access_count, and that
+// search results are always returned even if bookkeeping fails.
+func TestSearchAgentMemoryConcurrentAccessCount(t *testing.T) {
+	db := setupTestDB(t)
+	client := NewClient(db)
+	ctx := context.Background()
+
+	agentName := "concurrent-agent"
+	userID := "concurrent-user"
+
+	// Small store so every search hits the same top rows (max overlap).
+	for i := range 5 {
+		err := client.StoreAgentMemory(ctx, &dbpkg.Memory{
+			AgentName: agentName,
+			UserID:    userID,
+			Content:   fmt.Sprintf("shared memory %d", i),
+			Embedding: makeEmbedding(float32(i+1) * 0.15),
+		})
+		require.NoError(t, err)
+	}
+
+	const numGoroutines = 20
+	const searchesPerGoroutine = 10
+
+	var wg sync.WaitGroup
+	errs := make(chan error, numGoroutines*searchesPerGoroutine)
+	wg.Add(numGoroutines)
+
+	for range numGoroutines {
+		go func() {
+			defer wg.Done()
+			for range searchesPerGoroutine {
+				results, err := client.SearchAgentMemory(ctx, agentName, userID, makeEmbedding(0.5), 5)
+				if err != nil {
+					errs <- err
+					return
+				}
+				if len(results) == 0 {
+					errs <- fmt.Errorf("expected search results, got none")
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err, "concurrent memory search must not fail")
+	}
+}

--- a/go/core/internal/database/gen/memory.sql.go
+++ b/go/core/internal/database/gen/memory.sql.go
@@ -58,7 +58,7 @@ WHERE id IN (
 )
 `
 
-// Lock rows in id order so concurrent increments over overlapping sets cannot deadlock.
+// Lock rows in id order to avoid deadlocks between concurrent overlapping increments.
 func (q *Queries) IncrementMemoryAccessCount(ctx context.Context, dollar_1 []string) error {
 	_, err := q.db.Exec(ctx, incrementMemoryAccessCount, dollar_1)
 	return err

--- a/go/core/internal/database/gen/memory.sql.go
+++ b/go/core/internal/database/gen/memory.sql.go
@@ -48,10 +48,17 @@ func (q *Queries) ExtendMemoryTTL(ctx context.Context) error {
 }
 
 const incrementMemoryAccessCount = `-- name: IncrementMemoryAccessCount :exec
-UPDATE memory SET access_count = access_count + 1
-WHERE id = ANY($1::text[])
+UPDATE memory
+SET access_count = access_count + 1
+WHERE id IN (
+    SELECT id FROM memory
+    WHERE id = ANY($1::text[])
+    ORDER BY id
+    FOR UPDATE
+)
 `
 
+// Lock rows in id order so concurrent increments over overlapping sets cannot deadlock.
 func (q *Queries) IncrementMemoryAccessCount(ctx context.Context, dollar_1 []string) error {
 	_, err := q.db.Exec(ctx, incrementMemoryAccessCount, dollar_1)
 	return err

--- a/go/core/internal/database/gen/querier.go
+++ b/go/core/internal/database/gen/querier.go
@@ -25,7 +25,7 @@ type Querier interface {
 	GetTool(ctx context.Context, id string) (Tool, error)
 	GetToolServer(ctx context.Context, name string) (Toolserver, error)
 	HardDeleteCrewAIMemory(ctx context.Context, arg HardDeleteCrewAIMemoryParams) error
-	// Lock rows in id order so concurrent increments over overlapping sets cannot deadlock.
+	// Lock rows in id order to avoid deadlocks between concurrent overlapping increments.
 	IncrementMemoryAccessCount(ctx context.Context, dollar_1 []string) error
 	InsertEvent(ctx context.Context, arg InsertEventParams) error
 	InsertFeedback(ctx context.Context, arg InsertFeedbackParams) error

--- a/go/core/internal/database/gen/querier.go
+++ b/go/core/internal/database/gen/querier.go
@@ -25,6 +25,7 @@ type Querier interface {
 	GetTool(ctx context.Context, id string) (Tool, error)
 	GetToolServer(ctx context.Context, name string) (Toolserver, error)
 	HardDeleteCrewAIMemory(ctx context.Context, arg HardDeleteCrewAIMemoryParams) error
+	// Lock rows in id order so concurrent increments over overlapping sets cannot deadlock.
 	IncrementMemoryAccessCount(ctx context.Context, dollar_1 []string) error
 	InsertEvent(ctx context.Context, arg InsertEventParams) error
 	InsertFeedback(ctx context.Context, arg InsertFeedbackParams) error

--- a/go/core/internal/database/queries/memory.sql
+++ b/go/core/internal/database/queries/memory.sql
@@ -13,7 +13,7 @@ ORDER BY embedding <=> $1 ASC
 LIMIT $4;
 
 -- name: IncrementMemoryAccessCount :exec
--- Lock rows in id order so concurrent increments over overlapping sets cannot deadlock.
+-- Lock rows in id order to avoid deadlocks between concurrent overlapping increments.
 UPDATE memory
 SET access_count = access_count + 1
 WHERE id IN (

--- a/go/core/internal/database/queries/memory.sql
+++ b/go/core/internal/database/queries/memory.sql
@@ -13,8 +13,15 @@ ORDER BY embedding <=> $1 ASC
 LIMIT $4;
 
 -- name: IncrementMemoryAccessCount :exec
-UPDATE memory SET access_count = access_count + 1
-WHERE id = ANY($1::text[]);
+-- Lock rows in id order so concurrent increments over overlapping sets cannot deadlock.
+UPDATE memory
+SET access_count = access_count + 1
+WHERE id IN (
+    SELECT id FROM memory
+    WHERE id = ANY($1::text[])
+    ORDER BY id
+    FOR UPDATE
+);
 
 -- name: ListAgentMemories :many
 SELECT * FROM memory


### PR DESCRIPTION
Close #2135

Fixes intermittent Postgres deadlocks when concurrent memory searches update overlapping rows' `access_count` (e.g. `PrefetchMemoryTool` fanning out per-sentence searches). Row locks are now acquired in id order, and access-count increments are best-effort so a bookkeeping failure no longer fails the search.

The root cause is described in #2135 but in short when two concurrent search requests return results like `["memory_1", "memory_2"]` and `["memory_2", "memory_1"]`, it will result in a deadlock when trying to update the rows.

I've added a concurrency test that reproduced the error without this fix to the query and passed after the fix.