### PR TITLE
feat(core): add controller log→OTLP bridge (gated OTEL_LOGGING_ENABLED)

### DIFF
--- a/docs/controller-otlp-logs.md
+++ b/docs/controller-otlp-logs.md
@@ -56,10 +56,20 @@ service:
 export OTEL_LOGGING_ENABLED=true
 export OTEL_EXPORTER_OTLP_ENDPOINT=http://<collector>:4318
 export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
-# controller logs now appear in the collector's debug output as LogRecords,
-# with the same resource attributes (service.name=kagent-controller, service.version, ...)
-# as the controller's traces.
+# controller logs now appear in the collector's debug output as LogRecords.
 ```
 
-<!-- TODO: add a screenshot of the collector debug exporter showing controller LogRecords once a
-     cluster/collector is available to capture one. -->
+The controller's log records show up in the `debug` exporter with the shared resource attributes
+(`service.name=kagent-controller`, …) and the bridge scope:
+
+```text
+Resource attributes:
+     -> k8s.namespace.name: Str(kagent)
+     -> k8s.pod.name: Str(kagent-controller-...)
+     -> service.name: Str(kagent-controller)
+     -> service.version: Str(v0.0.0-demo)
+InstrumentationScope github.com/kagent-dev/kagent/go/core
+LogRecord  SeverityText: info   Body: Str(reconciling Agent)             { controller=agent, agent=k8s-agent, namespace=kagent }
+LogRecord  SeverityText: info   Body: Str(Agent reconciled successfully) { controller=agent, agent=k8s-agent }
+LogRecord  SeverityText: error  Body: Str(example error log)             { reason=demo }
+```

--- a/docs/controller-otlp-logs.md
+++ b/docs/controller-otlp-logs.md
@@ -1,0 +1,65 @@
+# Exporting controller logs over OTLP
+
+The kagent controller can export its own logs to an OpenTelemetry (OTLP) backend, in addition to
+stdout. This is useful for shipping controller logs to the same collector/backend as its traces.
+It is **off by default**.
+
+## Enabling
+
+Set the standard OTel environment variables on the controller:
+
+| Variable | Purpose |
+| --- | --- |
+| `OTEL_LOGGING_ENABLED=true` | turn on the OTLP log pipeline |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` | collector endpoint |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `grpc` (default) or `http/protobuf` |
+
+Logs still go to stdout unchanged — the OTLP export is additive (a tee on the controller's zap core
+via the [otelzap bridge](https://pkg.go.dev/go.opentelemetry.io/contrib/bridges/otelzap)).
+
+### Severity
+
+The OTLP pipeline ships the **same levels as stdout**: a min-severity processor
+([`minsev`](https://pkg.go.dev/go.opentelemetry.io/contrib/processors/minsev)) is set to the
+controller's configured `--zap-log-level`, so enabling export at `error` level does not start
+shipping `info`/`debug` records.
+
+### Trace correlation (note)
+
+Records carry `trace_id`/`span_id` only when the log call passes the request `context.Context` as a
+field. controller-runtime's `logr` → `zapr` path does not thread the reconcile context into fields,
+so logs emitted via `log.FromContext(ctx)` are **not** automatically span-linked. Full automatic
+correlation would require a separate mechanism and is out of scope for this feature.
+
+## Testing it with an OTel Collector
+
+A collector with the `debug` exporter is the quickest way to confirm logs arrive:
+
+```yaml
+# otel-collector-config.yaml
+receivers:
+  otlp:
+    protocols:
+      grpc: { endpoint: 0.0.0.0:4317 }
+      http: { endpoint: 0.0.0.0:4318 }
+exporters:
+  debug: { verbosity: detailed }
+service:
+  pipelines:
+    logs:
+      receivers: [otlp]
+      exporters: [debug]
+```
+
+```bash
+# run the collector, then point the controller at it and enable logging
+export OTEL_LOGGING_ENABLED=true
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://<collector>:4318
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+# controller logs now appear in the collector's debug output as LogRecords,
+# with the same resource attributes (service.name=kagent-controller, service.version, ...)
+# as the controller's traces.
+```
+
+<!-- TODO: add a screenshot of the collector debug exporter showing controller LogRecords once a
+     cluster/collector is available to capture one. -->

--- a/docs/controller-otlp-logs.md
+++ b/docs/controller-otlp-logs.md
@@ -4,15 +4,27 @@ The kagent controller can export its own logs to an OpenTelemetry (OTLP) backend
 stdout. This is useful for shipping controller logs to the same collector/backend as its traces.
 It is **off by default**.
 
+> **Note — avoid double ingestion.** The OTLP export is *additive*: logs still go to stdout
+> unchanged. If you already collect the controller's stdout (e.g. a Fluent Bit / Vector / Loki
+> agent scraping pod logs), enabling this ships the same records a second time over OTLP and your
+> backend will ingest them twice. Enable it only if OTLP is your primary log path, or drop the
+> controller's stdout logs at your node agent.
+
 ## Enabling
 
-Set the standard OTel environment variables on the controller:
+Set the following environment variables on the **controller**:
 
 | Variable | Purpose |
 | --- | --- |
-| `OTEL_LOGGING_ENABLED=true` | turn on the OTLP log pipeline |
+| `KAGENT_CONTROLLER_OTLP_LOGS_ENABLED=true` | turn on the controller's OTLP log pipeline |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` | collector endpoint |
 | `OTEL_EXPORTER_OTLP_PROTOCOL` | `grpc` (default) or `http/protobuf` |
+
+> This switch is **decoupled from agent logging**. `OTEL_LOGGING_ENABLED` enables gen_ai
+> input/output logging on *agents* and is forwarded to agent pods; it does **not** control the
+> controller's own log export. The controller uses its own non-`OTEL_`-prefixed flag
+> (`KAGENT_CONTROLLER_OTLP_LOGS_ENABLED`) precisely so the two are configured independently. Via
+> Helm these are `otel.logging.enabled` (agents) and `otel.logging.controller.enabled` (controller).
 
 Logs still go to stdout unchanged — the OTLP export is additive (a tee on the controller's zap core
 via the [otelzap bridge](https://pkg.go.dev/go.opentelemetry.io/contrib/bridges/otelzap)).
@@ -30,6 +42,10 @@ Records carry `trace_id`/`span_id` only when the log call passes the request `co
 field. controller-runtime's `logr` → `zapr` path does not thread the reconcile context into fields,
 so logs emitted via `log.FromContext(ctx)` are **not** automatically span-linked. Full automatic
 correlation would require a separate mechanism and is out of scope for this feature.
+
+A complementary approach — emitting structured JSON to stdout with `trace_id`/`span_id` as fields,
+so stdout-based collectors get correlated logs without the OTLP pipeline — is tracked as a
+follow-up in [#2349](https://github.com/kagent-dev/kagent/issues/2349).
 
 ## Testing it with an OTel Collector
 
@@ -52,8 +68,8 @@ service:
 ```
 
 ```bash
-# run the collector, then point the controller at it and enable logging
-export OTEL_LOGGING_ENABLED=true
+# run the collector, then point the controller at it and enable controller log export
+export KAGENT_CONTROLLER_OTLP_LOGS_ENABLED=true
 export OTEL_EXPORTER_OTLP_ENDPOINT=http://<collector>:4318
 export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 # controller logs now appear in the collector's debug output as LogRecords.

--- a/go/core/internal/telemetry/logging.go
+++ b/go/core/internal/telemetry/logging.go
@@ -1,0 +1,71 @@
+package telemetry
+
+import (
+	"context"
+	"fmt"
+
+	otelzap "go.opentelemetry.io/contrib/bridges/otelzap"
+	"go.opentelemetry.io/contrib/exporters/autoexport"
+	logglobal "go.opentelemetry.io/otel/log/global"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	crzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/kagent-dev/kagent/go/core/pkg/env"
+)
+
+const loggerBridgeName = "github.com/kagent-dev/kagent/go/core"
+
+// InitLoggerProvider configures an OTLP LoggerProvider and registers it as the
+// global OTel logger provider. The exporter type and endpoint are read from the
+// standard OTEL environment variables via autoexport, mirroring
+// InitTracerProvider. The returned shutdown function must be called on process
+// exit to flush in-flight log records. When OTEL_LOGGING_ENABLED is unset the
+// pipeline is not created and a no-op shutdown is returned (default-OFF).
+func InitLoggerProvider(ctx context.Context, serviceVersion string) (func(context.Context) error, error) {
+	if !env.OtelLoggingEnabled.Get() {
+		return func(context.Context) error { return nil }, nil
+	}
+
+	exporter, err := autoexport.NewLogExporter(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("create log exporter: %w", err)
+	}
+
+	res, err := newTelemetryResource(ctx, serviceVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	lp := sdklog.NewLoggerProvider(
+		sdklog.WithProcessor(sdklog.NewBatchProcessor(exporter)),
+		sdklog.WithResource(res),
+	)
+
+	logglobal.SetLoggerProvider(lp)
+
+	return lp.Shutdown, nil
+}
+
+// ControllerZapOpts returns controller-runtime zap options. When
+// OTEL_LOGGING_ENABLED is set it additively tees the controller's stdout zap
+// core with an otelzap bridge core, routing the controller's own logs through
+// the global OTLP LoggerProvider while preserving stdout logging. When disabled
+// it returns no options, leaving the logger byte-identical to upstream.
+//
+// InitLoggerProvider must be called first so the bridge core binds to the
+// configured global LoggerProvider.
+func ControllerZapOpts() []crzap.Opts {
+	if !env.OtelLoggingEnabled.Get() {
+		return nil
+	}
+	bridgeCore := otelzap.NewCore(loggerBridgeName,
+		otelzap.WithLoggerProvider(logglobal.GetLoggerProvider()),
+	)
+	return []crzap.Opts{
+		crzap.RawZapOpts(zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+			return zapcore.NewTee(core, bridgeCore)
+		})),
+	}
+}

--- a/go/core/internal/telemetry/logging.go
+++ b/go/core/internal/telemetry/logging.go
@@ -6,8 +6,10 @@ import (
 
 	otelzap "go.opentelemetry.io/contrib/bridges/otelzap"
 	"go.opentelemetry.io/contrib/exporters/autoexport"
+	"go.opentelemetry.io/contrib/processors/minsev"
 	logglobal "go.opentelemetry.io/otel/log/global"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
+	"go.opentelemetry.io/otel/sdk/resource"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	crzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -18,12 +20,20 @@ import (
 const loggerBridgeName = "github.com/kagent-dev/kagent/go/core"
 
 // InitLoggerProvider configures an OTLP LoggerProvider and registers it as the
-// global OTel logger provider. The exporter type and endpoint are read from the
-// standard OTEL environment variables via autoexport, mirroring
-// InitTracerProvider. The returned shutdown function must be called on process
-// exit to flush in-flight log records. When OTEL_LOGGING_ENABLED is unset the
-// pipeline is not created and a no-op shutdown is returned (default-OFF).
-func InitLoggerProvider(ctx context.Context, serviceVersion string) (func(context.Context) error, error) {
+// global OTel logger provider, so the controller's own logs can be shipped to
+// an OTLP backend (in addition to stdout) via ControllerZapOpts. The exporter
+// type and endpoint are read from the standard OTEL environment variables via
+// autoexport, mirroring InitTracerProvider, and the shared resource is passed
+// in so logs and traces report identical resource attributes.
+//
+// Records are filtered by a min-severity processor (minsev) set to minSeverity
+// — typically the controller's stdout log level — so enabling OTLP export does
+// not ship info/debug records when the operator is running at a higher level.
+//
+// The returned shutdown function must be called on process exit to flush
+// in-flight log records. When OTEL_LOGGING_ENABLED is unset the pipeline is not
+// created and a no-op shutdown is returned (default-OFF).
+func InitLoggerProvider(ctx context.Context, res *resource.Resource, minSeverity minsev.Severity) (func(context.Context) error, error) {
 	if !env.OtelLoggingEnabled.Get() {
 		return func(context.Context) error { return nil }, nil
 	}
@@ -33,13 +43,12 @@ func InitLoggerProvider(ctx context.Context, serviceVersion string) (func(contex
 		return nil, fmt.Errorf("create log exporter: %w", err)
 	}
 
-	res, err := newTelemetryResource(ctx, serviceVersion)
-	if err != nil {
-		return nil, err
-	}
+	// Severity filtering belongs in a processor, not the exporter/bridge, so the
+	// pipeline honours the configured minimum level.
+	processor := minsev.NewLogProcessor(sdklog.NewBatchProcessor(exporter), minSeverity)
 
 	lp := sdklog.NewLoggerProvider(
-		sdklog.WithProcessor(sdklog.NewBatchProcessor(exporter)),
+		sdklog.WithProcessor(processor),
 		sdklog.WithResource(res),
 	)
 
@@ -50,12 +59,20 @@ func InitLoggerProvider(ctx context.Context, serviceVersion string) (func(contex
 
 // ControllerZapOpts returns controller-runtime zap options. When
 // OTEL_LOGGING_ENABLED is set it additively tees the controller's stdout zap
-// core with an otelzap bridge core, routing the controller's own logs through
-// the global OTLP LoggerProvider while preserving stdout logging. When disabled
-// it returns no options, leaving the logger byte-identical to upstream.
+// core with an otelzap bridge core, exporting the controller's logs through the
+// global OTLP LoggerProvider while preserving stdout logging. When disabled it
+// returns no options, leaving the logger byte-identical to upstream.
 //
 // InitLoggerProvider must be called first so the bridge core binds to the
 // configured global LoggerProvider.
+//
+// Note on trace correlation: otelzap only attaches trace_id/span_id when a log
+// call carries a context.Context as a zap field. controller-runtime's
+// logr->zapr path does not thread the reconcile context into fields, so records
+// emitted via log.FromContext(ctx) are not automatically span-linked. Callers
+// that pass the request context as a field do get correlated records (see
+// tests). Automatic correlation for all controller logs would need a separate
+// mechanism and is out of scope here.
 func ControllerZapOpts() []crzap.Opts {
 	if !env.OtelLoggingEnabled.Get() {
 		return nil
@@ -67,5 +84,23 @@ func ControllerZapOpts() []crzap.Opts {
 		crzap.RawZapOpts(zap.WrapCore(func(core zapcore.Core) zapcore.Core {
 			return zapcore.NewTee(core, bridgeCore)
 		})),
+	}
+}
+
+// MinSeverityForZap maps a zap level enabler to the equivalent OTel log
+// min-severity, so the OTLP log pipeline ships the same levels as stdout.
+// A nil enabler (no explicit level) defaults to Info.
+func MinSeverityForZap(le zapcore.LevelEnabler) minsev.Severity {
+	switch {
+	case le == nil:
+		return minsev.SeverityInfo1
+	case le.Enabled(zapcore.DebugLevel):
+		return minsev.SeverityDebug1
+	case le.Enabled(zapcore.InfoLevel):
+		return minsev.SeverityInfo1
+	case le.Enabled(zapcore.WarnLevel):
+		return minsev.SeverityWarn1
+	default:
+		return minsev.SeverityError1
 	}
 }

--- a/go/core/internal/telemetry/logging.go
+++ b/go/core/internal/telemetry/logging.go
@@ -31,10 +31,10 @@ const loggerBridgeName = "github.com/kagent-dev/kagent/go/core"
 // not ship info/debug records when the operator is running at a higher level.
 //
 // The returned shutdown function must be called on process exit to flush
-// in-flight log records. When OTEL_LOGGING_ENABLED is unset the pipeline is not
-// created and a no-op shutdown is returned (default-OFF).
+// in-flight log records. When KAGENT_CONTROLLER_OTLP_LOGS_ENABLED is unset the
+// pipeline is not created and a no-op shutdown is returned (default-OFF).
 func InitLoggerProvider(ctx context.Context, res *resource.Resource, minSeverity minsev.Severity) (func(context.Context) error, error) {
-	if !env.OtelLoggingEnabled.Get() {
+	if !env.ControllerOtlpLogsEnabled.Get() {
 		return func(context.Context) error { return nil }, nil
 	}
 
@@ -58,10 +58,10 @@ func InitLoggerProvider(ctx context.Context, res *resource.Resource, minSeverity
 }
 
 // ControllerZapOpts returns controller-runtime zap options. When
-// OTEL_LOGGING_ENABLED is set it additively tees the controller's stdout zap
-// core with an otelzap bridge core, exporting the controller's logs through the
-// global OTLP LoggerProvider while preserving stdout logging. When disabled it
-// returns no options, leaving the logger byte-identical to upstream.
+// KAGENT_CONTROLLER_OTLP_LOGS_ENABLED is set it additively tees the controller's
+// stdout zap core with an otelzap bridge core, exporting the controller's logs
+// through the global OTLP LoggerProvider while preserving stdout logging. When
+// disabled it returns no options, leaving the logger byte-identical to upstream.
 //
 // InitLoggerProvider must be called first so the bridge core binds to the
 // configured global LoggerProvider.
@@ -74,7 +74,7 @@ func InitLoggerProvider(ctx context.Context, res *resource.Resource, minSeverity
 // tests). Automatic correlation for all controller logs would need a separate
 // mechanism and is out of scope here.
 func ControllerZapOpts() []crzap.Opts {
-	if !env.OtelLoggingEnabled.Get() {
+	if !env.ControllerOtlpLogsEnabled.Get() {
 		return nil
 	}
 	bridgeCore := otelzap.NewCore(loggerBridgeName,

--- a/go/core/internal/telemetry/logging_e2e_test.go
+++ b/go/core/internal/telemetry/logging_e2e_test.go
@@ -1,0 +1,163 @@
+package telemetry
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/contrib/processors/minsev"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	"google.golang.org/grpc"
+
+	collogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	crzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+// logsReceiver is an in-process OTLP/gRPC LogsService server. It captures every
+// export request so the test can assert on what the controller actually shipped
+// over the wire.
+type logsReceiver struct {
+	collogspb.UnimplementedLogsServiceServer
+	ch chan *collogspb.ExportLogsServiceRequest
+}
+
+func (r *logsReceiver) Export(_ context.Context, req *collogspb.ExportLogsServiceRequest) (*collogspb.ExportLogsServiceResponse, error) {
+	r.ch <- req
+	return &collogspb.ExportLogsServiceResponse{}, nil
+}
+
+// startLogsReceiver starts the in-process OTLP/gRPC collector on a random
+// loopback port and returns its address plus the received-request channel.
+func startLogsReceiver(t *testing.T) (string, <-chan *collogspb.ExportLogsServiceRequest) {
+	t.Helper()
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	rec := &logsReceiver{ch: make(chan *collogspb.ExportLogsServiceRequest, 8)}
+	srv := grpc.NewServer()
+	collogspb.RegisterLogsServiceServer(srv, rec)
+
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+
+	return lis.Addr().String(), rec.ch
+}
+
+// TestInitLoggerProvider_E2E_ExportsControllerLogsOverOTLP is an end-to-end test
+// of the full controller log pipeline: it stands up a real OTLP/gRPC collector
+// in-process, wires the actual autoexport OTLP exporter to it via the standard
+// OTEL_* environment variables, builds the controller's zap logger through
+// ControllerZapOpts, and asserts that a log line emitted by the controller
+// arrives at the collector as an OTLP LogRecord carrying the shared resource
+// (service.name=kagent-controller) and the bridge instrumentation scope.
+//
+// Unlike the unit tests (which use an in-memory logtest processor), this drives
+// the genuine export path: zap core -> otelzap bridge -> LoggerProvider ->
+// minsev processor -> batch processor -> OTLP/gRPC exporter -> collector.
+func TestInitLoggerProvider_E2E_ExportsControllerLogsOverOTLP(t *testing.T) {
+	addr, received := startLogsReceiver(t)
+
+	t.Setenv("OTEL_LOGGING_ENABLED", "true")
+	t.Setenv("OTEL_LOGS_EXPORTER", "otlp")
+	t.Setenv("OTEL_EXPORTER_OTLP_LOGS_PROTOCOL", "grpc")
+	// http:// scheme selects an insecure (plaintext) gRPC connection.
+	t.Setenv("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "http://"+addr)
+
+	ctx := context.Background()
+
+	res, err := NewTelemetryResource(ctx, "e2e-test")
+	if err != nil {
+		t.Fatalf("build resource: %v", err)
+	}
+
+	shutdown, err := InitLoggerProvider(ctx, res, minsev.SeverityInfo1)
+	if err != nil {
+		t.Fatalf("init logger provider: %v", err)
+	}
+
+	// ControllerZapOpts binds the bridge to the global provider set above, so it
+	// must be called after InitLoggerProvider.
+	opts := ControllerZapOpts()
+	if len(opts) != 1 {
+		t.Fatalf("expected 1 zap opt when logging enabled, got %d", len(opts))
+	}
+	logger := crzap.New(append([]crzap.Opts{crzap.UseDevMode(true)}, opts...)...)
+
+	logger.Info("reconciling Agent", "controller", "agent", "namespace", "kagent")
+
+	// Shutdown flushes the batch processor synchronously, forcing the export.
+	if err := shutdown(ctx); err != nil {
+		t.Fatalf("shutdown: %v", err)
+	}
+
+	select {
+	case req := <-received:
+		assertLogExported(t, req)
+	case <-time.After(15 * time.Second):
+		t.Fatal("timed out waiting for the controller log to reach the OTLP collector")
+	}
+}
+
+// assertLogExported verifies the exported request carries the shared resource,
+// the bridge scope, and the emitted log body.
+func assertLogExported(t *testing.T, req *collogspb.ExportLogsServiceRequest) {
+	t.Helper()
+
+	if len(req.GetResourceLogs()) == 0 {
+		t.Fatal("export request had no resource logs")
+	}
+
+	var (
+		sawServiceName bool
+		sawScope       bool
+		sawBody        bool
+		sawAttr        bool
+	)
+	for _, rl := range req.GetResourceLogs() {
+		for _, kv := range rl.GetResource().GetAttributes() {
+			if kv.GetKey() == "service.name" && kv.GetValue().GetStringValue() == ServiceName {
+				sawServiceName = true
+			}
+		}
+		for _, sl := range rl.GetScopeLogs() {
+			if sl.GetScope().GetName() == loggerBridgeName {
+				sawScope = true
+			}
+			for _, lr := range sl.GetLogRecords() {
+				if strings.Contains(lr.GetBody().GetStringValue(), "reconciling Agent") {
+					sawBody = true
+				}
+				if hasStringAttr(lr.GetAttributes(), "controller", "agent") {
+					sawAttr = true
+				}
+			}
+		}
+	}
+
+	if !sawServiceName {
+		t.Errorf("exported logs missing resource attribute service.name=%q", ServiceName)
+	}
+	if !sawScope {
+		t.Errorf("exported logs missing instrumentation scope %q", loggerBridgeName)
+	}
+	if !sawBody {
+		t.Error("exported logs missing the emitted log body \"reconciling Agent\"")
+	}
+	if !sawAttr {
+		t.Error("exported log record missing the controller=agent attribute")
+	}
+}
+
+func hasStringAttr(attrs []*commonpb.KeyValue, key, want string) bool {
+	for _, kv := range attrs {
+		if kv.GetKey() == key && kv.GetValue().GetStringValue() == want {
+			return true
+		}
+	}
+	return false
+}

--- a/go/core/internal/telemetry/logging_e2e_test.go
+++ b/go/core/internal/telemetry/logging_e2e_test.go
@@ -62,7 +62,7 @@ func startLogsReceiver(t *testing.T) (string, <-chan *collogspb.ExportLogsServic
 func TestInitLoggerProvider_E2E_ExportsControllerLogsOverOTLP(t *testing.T) {
 	addr, received := startLogsReceiver(t)
 
-	t.Setenv("OTEL_LOGGING_ENABLED", "true")
+	t.Setenv("KAGENT_CONTROLLER_OTLP_LOGS_ENABLED", "true")
 	t.Setenv("OTEL_LOGS_EXPORTER", "otlp")
 	t.Setenv("OTEL_EXPORTER_OTLP_LOGS_PROTOCOL", "grpc")
 	// http:// scheme selects an insecure (plaintext) gRPC connection.

--- a/go/core/internal/telemetry/logging_test.go
+++ b/go/core/internal/telemetry/logging_test.go
@@ -4,6 +4,15 @@ import (
 	"context"
 	"testing"
 
+	otelzap "go.opentelemetry.io/contrib/bridges/otelzap"
+	"go.opentelemetry.io/contrib/processors/minsev"
+	otellog "go.opentelemetry.io/otel/log"
+	"go.opentelemetry.io/otel/log/logtest"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	crzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
@@ -38,7 +47,7 @@ func TestControllerZapOpts_EnabledTeesLogger(t *testing.T) {
 func TestInitLoggerProvider_DisabledNoop(t *testing.T) {
 	t.Setenv("OTEL_LOGGING_ENABLED", "false")
 
-	shutdown, err := InitLoggerProvider(context.Background(), "test")
+	shutdown, err := InitLoggerProvider(context.Background(), nil, minsev.SeverityInfo1)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -49,3 +58,97 @@ func TestInitLoggerProvider_DisabledNoop(t *testing.T) {
 		t.Fatalf("no-op shutdown returned error: %v", err)
 	}
 }
+
+// TestMinSeverityForZap verifies the zap level -> OTel min-severity mapping.
+func TestMinSeverityForZap(t *testing.T) {
+	cases := []struct {
+		level zapcore.LevelEnabler
+		want  minsev.Severity
+	}{
+		{nil, minsev.SeverityInfo1},
+		{zapcore.DebugLevel, minsev.SeverityDebug1},
+		{zapcore.InfoLevel, minsev.SeverityInfo1},
+		{zapcore.WarnLevel, minsev.SeverityWarn1},
+		{zapcore.ErrorLevel, minsev.SeverityError1},
+	}
+	for _, tc := range cases {
+		if got := MinSeverityForZap(tc.level); got != tc.want {
+			t.Errorf("MinSeverityForZap(%v) = %v, want %v", tc.level, got, tc.want)
+		}
+	}
+}
+
+// TestOTelZapBridge_TraceCorrelation verifies the otelzap bridge attaches the
+// span (trace context) to a record only when the log call carries the request
+// context as a field — documenting the correlation behaviour.
+func TestOTelZapBridge_TraceCorrelation(t *testing.T) {
+	recorder := logtest.NewRecorder()
+	core := otelzap.NewCore("test", otelzap.WithLoggerProvider(recorder))
+	logger := zap.New(core)
+
+	tp := sdktrace.NewTracerProvider()
+	spanCtx, span := tp.Tracer("test").Start(context.Background(), "op")
+	defer span.End()
+	wantTraceID := span.SpanContext().TraceID()
+
+	// With the context passed as a field: record carries the active span.
+	logger.Info("with ctx", zap.Any("ctx", spanCtx))
+	// Without it (the generic controller-runtime path): no span linked.
+	logger.Info("without ctx")
+
+	records := flatten(recorder.Result())
+	if len(records) != 2 {
+		t.Fatalf("expected 2 records, got %d", len(records))
+	}
+	if got := trace.SpanContextFromContext(records[0].Context).TraceID(); got != wantTraceID {
+		t.Errorf("record with ctx: trace id = %v, want %v", got, wantTraceID)
+	}
+	if trace.SpanContextFromContext(records[1].Context).TraceID().IsValid() {
+		t.Error("record without ctx should not carry a trace id")
+	}
+}
+
+// TestMinSeverityProcessor_GatesBelowThreshold verifies records below the
+// configured minimum severity are dropped by the minsev processor.
+func TestMinSeverityProcessor_GatesBelowThreshold(t *testing.T) {
+	capture := &sliceProcessor{}
+	lp := sdklog.NewLoggerProvider(sdklog.WithProcessor(minsev.NewLogProcessor(capture, minsev.SeverityInfo1)))
+	logger := lp.Logger("test")
+
+	emit := func(sev otellog.Severity) {
+		var r otellog.Record
+		r.SetSeverity(sev)
+		logger.Emit(context.Background(), r)
+	}
+	emit(otellog.SeverityDebug) // below Info -> dropped
+	emit(otellog.SeverityInfo)  // kept
+	emit(otellog.SeverityError) // above Info -> kept
+
+	if len(capture.records) != 2 {
+		t.Fatalf("expected 2 records at/above Info, got %d", len(capture.records))
+	}
+	for _, r := range capture.records {
+		if r.Severity() < otellog.SeverityInfo {
+			t.Errorf("record below Info leaked through: %v", r.Severity())
+		}
+	}
+}
+
+func flatten(rec logtest.Recording) []logtest.Record {
+	var out []logtest.Record
+	for _, rs := range rec {
+		out = append(out, rs...)
+	}
+	return out
+}
+
+// sliceProcessor is a minimal sdklog.Processor that captures emitted records.
+type sliceProcessor struct{ records []sdklog.Record }
+
+func (p *sliceProcessor) OnEmit(_ context.Context, r *sdklog.Record) error {
+	p.records = append(p.records, *r)
+	return nil
+}
+func (p *sliceProcessor) Enabled(context.Context, sdklog.EnabledParameters) bool { return true }
+func (p *sliceProcessor) Shutdown(context.Context) error                         { return nil }
+func (p *sliceProcessor) ForceFlush(context.Context) error                       { return nil }

--- a/go/core/internal/telemetry/logging_test.go
+++ b/go/core/internal/telemetry/logging_test.go
@@ -1,0 +1,51 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+
+	crzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+// TestControllerZapOpts_DisabledByDefault verifies no zap options are added when
+// OTEL_LOGGING_ENABLED is off, keeping the controller logger unchanged.
+func TestControllerZapOpts_DisabledByDefault(t *testing.T) {
+	t.Setenv("OTEL_LOGGING_ENABLED", "false")
+	if opts := ControllerZapOpts(); opts != nil {
+		t.Fatalf("expected nil opts when logging disabled, got %d", len(opts))
+	}
+}
+
+// TestControllerZapOpts_EnabledTeesLogger verifies that when OTEL_LOGGING_ENABLED
+// is set, an otelzap bridge option is returned and the resulting logger is usable
+// (the bridge tees onto the stdout core without panicking).
+func TestControllerZapOpts_EnabledTeesLogger(t *testing.T) {
+	t.Setenv("OTEL_LOGGING_ENABLED", "true")
+
+	opts := ControllerZapOpts()
+	if len(opts) != 1 {
+		t.Fatalf("expected 1 zap opt when logging enabled, got %d", len(opts))
+	}
+
+	// Building and using the logger must not panic even though no real OTLP
+	// LoggerProvider is configured (the global provider defaults to a no-op).
+	logger := crzap.New(append([]crzap.Opts{crzap.UseDevMode(true)}, opts...)...)
+	logger.Info("tee smoke test")
+}
+
+// TestInitLoggerProvider_DisabledNoop verifies the returned shutdown is a safe
+// no-op when logging is disabled.
+func TestInitLoggerProvider_DisabledNoop(t *testing.T) {
+	t.Setenv("OTEL_LOGGING_ENABLED", "false")
+
+	shutdown, err := InitLoggerProvider(context.Background(), "test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if shutdown == nil {
+		t.Fatal("expected non-nil shutdown")
+	}
+	if err := shutdown(context.Background()); err != nil {
+		t.Fatalf("no-op shutdown returned error: %v", err)
+	}
+}

--- a/go/core/internal/telemetry/logging_test.go
+++ b/go/core/internal/telemetry/logging_test.go
@@ -17,19 +17,19 @@ import (
 )
 
 // TestControllerZapOpts_DisabledByDefault verifies no zap options are added when
-// OTEL_LOGGING_ENABLED is off, keeping the controller logger unchanged.
+// KAGENT_CONTROLLER_OTLP_LOGS_ENABLED is off, keeping the controller logger unchanged.
 func TestControllerZapOpts_DisabledByDefault(t *testing.T) {
-	t.Setenv("OTEL_LOGGING_ENABLED", "false")
+	t.Setenv("KAGENT_CONTROLLER_OTLP_LOGS_ENABLED", "false")
 	if opts := ControllerZapOpts(); opts != nil {
 		t.Fatalf("expected nil opts when logging disabled, got %d", len(opts))
 	}
 }
 
-// TestControllerZapOpts_EnabledTeesLogger verifies that when OTEL_LOGGING_ENABLED
+// TestControllerZapOpts_EnabledTeesLogger verifies that when KAGENT_CONTROLLER_OTLP_LOGS_ENABLED
 // is set, an otelzap bridge option is returned and the resulting logger is usable
 // (the bridge tees onto the stdout core without panicking).
 func TestControllerZapOpts_EnabledTeesLogger(t *testing.T) {
-	t.Setenv("OTEL_LOGGING_ENABLED", "true")
+	t.Setenv("KAGENT_CONTROLLER_OTLP_LOGS_ENABLED", "true")
 
 	opts := ControllerZapOpts()
 	if len(opts) != 1 {
@@ -45,7 +45,7 @@ func TestControllerZapOpts_EnabledTeesLogger(t *testing.T) {
 // TestInitLoggerProvider_DisabledNoop verifies the returned shutdown is a safe
 // no-op when logging is disabled.
 func TestInitLoggerProvider_DisabledNoop(t *testing.T) {
-	t.Setenv("OTEL_LOGGING_ENABLED", "false")
+	t.Setenv("KAGENT_CONTROLLER_OTLP_LOGS_ENABLED", "false")
 
 	shutdown, err := InitLoggerProvider(context.Background(), nil, minsev.SeverityInfo1)
 	if err != nil {

--- a/go/core/internal/telemetry/tracing.go
+++ b/go/core/internal/telemetry/tracing.go
@@ -38,6 +38,29 @@ func InitTracerProvider(ctx context.Context, serviceVersion string) (func(contex
 		return nil, fmt.Errorf("create span exporter: %w", err)
 	}
 
+	res, err := newTelemetryResource(ctx, serviceVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exporter),
+		sdktrace.WithResource(res),
+	)
+
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+
+	return tp.Shutdown, nil
+}
+
+// newTelemetryResource builds the OTel resource shared by the controller's
+// signal pipelines (traces and logs), keeping their resource attributes
+// identical.
+func newTelemetryResource(ctx context.Context, serviceVersion string) (*resource.Resource, error) {
 	instanceID, err := os.Hostname()
 	if err != nil || instanceID == "" {
 		instanceID = uuid.New().String()
@@ -67,17 +90,5 @@ func InitTracerProvider(ctx context.Context, serviceVersion string) (func(contex
 	if err != nil {
 		return nil, fmt.Errorf("create OTEL resource: %w", err)
 	}
-
-	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithBatcher(exporter),
-		sdktrace.WithResource(res),
-	)
-
-	otel.SetTracerProvider(tp)
-	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
-		propagation.TraceContext{},
-		propagation.Baggage{},
-	))
-
-	return tp.Shutdown, nil
+	return res, nil
 }

--- a/go/core/internal/telemetry/tracing.go
+++ b/go/core/internal/telemetry/tracing.go
@@ -26,9 +26,11 @@ const (
 // the global tracer. The exporter type and endpoint are read from standard
 // OTEL environment variables (OTEL_EXPORTER_OTLP_PROTOCOL,
 // OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, OTEL_EXPORTER_OTLP_ENDPOINT, etc.).
-// The returned shutdown function must be called on process exit to flush
-// in-flight spans. If tracing is disabled a no-op is returned.
-func InitTracerProvider(ctx context.Context, serviceVersion string) (func(context.Context) error, error) {
+// The shared resource (built once via NewTelemetryResource) is passed in so
+// traces and logs report identical resource attributes. The returned shutdown
+// function must be called on process exit to flush in-flight spans. If tracing
+// is disabled a no-op is returned.
+func InitTracerProvider(ctx context.Context, res *resource.Resource) (func(context.Context) error, error) {
 	if !env.OtelTracingEnabled.Get() {
 		return func(context.Context) error { return nil }, nil
 	}
@@ -36,11 +38,6 @@ func InitTracerProvider(ctx context.Context, serviceVersion string) (func(contex
 	exporter, err := autoexport.NewSpanExporter(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("create span exporter: %w", err)
-	}
-
-	res, err := newTelemetryResource(ctx, serviceVersion)
-	if err != nil {
-		return nil, err
 	}
 
 	tp := sdktrace.NewTracerProvider(
@@ -57,10 +54,12 @@ func InitTracerProvider(ctx context.Context, serviceVersion string) (func(contex
 	return tp.Shutdown, nil
 }
 
-// newTelemetryResource builds the OTel resource shared by the controller's
-// signal pipelines (traces and logs), keeping their resource attributes
-// identical.
-func newTelemetryResource(ctx context.Context, serviceVersion string) (*resource.Resource, error) {
+// NewTelemetryResource builds the OTel resource shared by the controller's
+// signal pipelines (traces and logs). Build it once and pass it into both
+// InitTracerProvider and InitLoggerProvider so a hostname-lookup failure
+// (which falls back to a random UUID) can't yield different
+// service.instance.id values across signals.
+func NewTelemetryResource(ctx context.Context, serviceVersion string) (*resource.Resource, error) {
 	instanceID, err := os.Hostname()
 	if err != nil || instanceID == "" {
 		instanceID = uuid.New().String()

--- a/go/core/pkg/app/app.go
+++ b/go/core/pkg/app/app.go
@@ -41,6 +41,8 @@ import (
 	"github.com/kagent-dev/kagent/go/core/internal/mcp"
 	versionmetrics "github.com/kagent-dev/kagent/go/core/internal/metrics"
 	"github.com/kagent-dev/kagent/go/core/internal/telemetry"
+	"github.com/kagent-dev/kagent/go/core/pkg/env"
+	"go.opentelemetry.io/otel/sdk/resource"
 
 	"github.com/kagent-dev/kagent/go/core/internal/controller/reconciler"
 	reconcilerutils "github.com/kagent-dev/kagent/go/core/internal/controller/reconciler/utils"
@@ -334,10 +336,26 @@ func Start(getExtensionConfig GetExtensionConfig, extraSources []migrations.Sour
 		setupLog.Error(err, "failed to load configuration from environment variables")
 		os.Exit(1)
 	}
+	// Build the shared telemetry resource once so traces and logs report
+	// identical resource attributes (in particular a single service.instance.id;
+	// a per-signal build could otherwise diverge on hostname-lookup failure).
+	var telemetryResource *resource.Resource
+	if env.OtelTracingEnabled.Get() || env.OtelLoggingEnabled.Get() {
+		var resErr error
+		telemetryResource, resErr = telemetry.NewTelemetryResource(ctx, Version)
+		if resErr != nil {
+			ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+			setupLog.Error(resErr, "failed to build telemetry resource")
+			os.Exit(1)
+		}
+	}
+
 	// Initialize the OTLP logger provider before building the controller logger
 	// so the otelzap bridge core added by ControllerZapOpts binds to it. No-op
-	// unless OTEL_LOGGING_ENABLED.
-	shutdownLogging, err := telemetry.InitLoggerProvider(ctx, Version)
+	// unless OTEL_LOGGING_ENABLED. The OTLP pipeline ships the same levels as
+	// stdout. Note: these shutdowns run on graceful termination (manager stop);
+	// fatal startup os.Exit paths below crash-fast without flushing.
+	shutdownLogging, err := telemetry.InitLoggerProvider(ctx, telemetryResource, telemetry.MinSeverityForZap(opts.Level))
 	if err != nil {
 		ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 		setupLog.Error(err, "failed to initialize logging")
@@ -354,7 +372,7 @@ func Start(getExtensionConfig GetExtensionConfig, extraSources []migrations.Sour
 	logger := zap.New(append([]zap.Opts{zap.UseFlagOptions(&opts)}, telemetry.ControllerZapOpts()...)...)
 	ctrl.SetLogger(logger)
 
-	shutdownTracing, err := telemetry.InitTracerProvider(ctx, Version)
+	shutdownTracing, err := telemetry.InitTracerProvider(ctx, telemetryResource)
 	if err != nil {
 		setupLog.Error(err, "failed to initialize tracing")
 		os.Exit(1)

--- a/go/core/pkg/app/app.go
+++ b/go/core/pkg/app/app.go
@@ -340,7 +340,7 @@ func Start(getExtensionConfig GetExtensionConfig, extraSources []migrations.Sour
 	// identical resource attributes (in particular a single service.instance.id;
 	// a per-signal build could otherwise diverge on hostname-lookup failure).
 	var telemetryResource *resource.Resource
-	if env.OtelTracingEnabled.Get() || env.OtelLoggingEnabled.Get() {
+	if env.OtelTracingEnabled.Get() || env.ControllerOtlpLogsEnabled.Get() {
 		var resErr error
 		telemetryResource, resErr = telemetry.NewTelemetryResource(ctx, Version)
 		if resErr != nil {
@@ -352,7 +352,7 @@ func Start(getExtensionConfig GetExtensionConfig, extraSources []migrations.Sour
 
 	// Initialize the OTLP logger provider before building the controller logger
 	// so the otelzap bridge core added by ControllerZapOpts binds to it. No-op
-	// unless OTEL_LOGGING_ENABLED. The OTLP pipeline ships the same levels as
+	// unless KAGENT_CONTROLLER_OTLP_LOGS_ENABLED. The OTLP pipeline ships the same levels as
 	// stdout. Note: these shutdowns run on graceful termination (manager stop);
 	// fatal startup os.Exit paths below crash-fast without flushing.
 	shutdownLogging, err := telemetry.InitLoggerProvider(ctx, telemetryResource, telemetry.MinSeverityForZap(opts.Level))

--- a/go/core/pkg/app/app.go
+++ b/go/core/pkg/app/app.go
@@ -334,7 +334,24 @@ func Start(getExtensionConfig GetExtensionConfig, extraSources []migrations.Sour
 		setupLog.Error(err, "failed to load configuration from environment variables")
 		os.Exit(1)
 	}
-	logger := zap.New(zap.UseFlagOptions(&opts))
+	// Initialize the OTLP logger provider before building the controller logger
+	// so the otelzap bridge core added by ControllerZapOpts binds to it. No-op
+	// unless OTEL_LOGGING_ENABLED.
+	shutdownLogging, err := telemetry.InitLoggerProvider(ctx, Version)
+	if err != nil {
+		ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+		setupLog.Error(err, "failed to initialize logging")
+		os.Exit(1)
+	}
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := shutdownLogging(shutdownCtx); err != nil {
+			setupLog.Error(err, "failed to shutdown logging")
+		}
+	}()
+
+	logger := zap.New(append([]zap.Opts{zap.UseFlagOptions(&opts)}, telemetry.ControllerZapOpts()...)...)
 	ctrl.SetLogger(logger)
 
 	shutdownTracing, err := telemetry.InitTracerProvider(ctx, Version)

--- a/go/core/pkg/env/otel.go
+++ b/go/core/pkg/env/otel.go
@@ -10,10 +10,25 @@ var (
 		ComponentController,
 	)
 
+	// OtelLoggingEnabled controls agent-side OpenTelemetry logging (gen_ai
+	// input/output records). It is forwarded verbatim to agent pods (see
+	// collectOtelEnvFromProcess), so it must NOT double as the controller's own
+	// log-export switch — that is ControllerOtlpLogsEnabled below.
 	OtelLoggingEnabled = RegisterBoolVar(
 		"OTEL_LOGGING_ENABLED",
 		false,
-		"Enable OpenTelemetry logging.",
+		"Enable OpenTelemetry logging on agents (gen_ai input/output records).",
+		ComponentController,
+	)
+
+	// ControllerOtlpLogsEnabled turns on OTLP export of the controller's OWN
+	// logs. It is intentionally NOT prefixed OTEL_ so it is not propagated to
+	// agent pods, keeping controller log export decoupled from agent gen_ai
+	// logging (OtelLoggingEnabled).
+	ControllerOtlpLogsEnabled = RegisterBoolVar(
+		"KAGENT_CONTROLLER_OTLP_LOGS_ENABLED",
+		false,
+		"Enable OTLP export of the controller's own logs.",
 		ComponentController,
 	)
 

--- a/go/go.mod
+++ b/go/go.mod
@@ -83,6 +83,7 @@ require (
 	go.opentelemetry.io/otel/log v0.20.0
 	go.opentelemetry.io/otel/log/logtest v0.20.0
 	go.opentelemetry.io/otel/sdk/log v0.20.0
+	go.opentelemetry.io/proto/otlp v1.10.0
 	google.golang.org/grpc v1.82.1
 	k8s.io/apiextensions-apiserver v0.36.3
 )
@@ -416,7 +417,6 @@ require (
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.44.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.44.0 // indirect
-	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/go/go.mod
+++ b/go/go.mod
@@ -75,11 +75,13 @@ require (
 	github.com/testcontainers/testcontainers-go v0.43.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.43.0
 	go.opentelemetry.io/contrib/bridges/otelzap v0.19.0
+	go.opentelemetry.io/contrib/processors/minsev v0.16.1
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.20.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.20.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.44.0
 	go.opentelemetry.io/otel/log v0.20.0
+	go.opentelemetry.io/otel/log/logtest v0.20.0
 	go.opentelemetry.io/otel/sdk/log v0.20.0
 	google.golang.org/grpc v1.82.1
 	k8s.io/apiextensions-apiserver v0.36.3

--- a/go/go.mod
+++ b/go/go.mod
@@ -74,10 +74,12 @@ require (
 	github.com/pgvector/pgvector-go/pgx v0.4.0
 	github.com/testcontainers/testcontainers-go v0.43.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.43.0
+	go.opentelemetry.io/contrib/bridges/otelzap v0.19.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.20.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.20.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.44.0
+	go.opentelemetry.io/otel/log v0.20.0
 	go.opentelemetry.io/otel/sdk/log v0.20.0
 	google.golang.org/grpc v1.82.1
 	k8s.io/apiextensions-apiserver v0.36.3
@@ -410,7 +412,6 @@ require (
 	go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.20.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.44.0 // indirect
-	go.opentelemetry.io/otel/log v0.20.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.44.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -879,6 +879,8 @@ go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.6
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.68.0/go.mod h1:Sje3i3MjSPKTSPvVWCaL8ugBzJwik3u4smCjUeuupqg=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0 h1:8tvICD4vSTOOsNrsI4Ljf6C+6UKvpTEH5XY3JMoyPoo=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0/go.mod h1:z9+yiacE0IHRqM4qFfkbt/JYlmYXgss8GY/jXoNuPJI=
+go.opentelemetry.io/contrib/processors/minsev v0.16.1 h1:DYL02u57VGQjrG8c09i6Bx5R74h4XxLj75wEk5h8/DA=
+go.opentelemetry.io/contrib/processors/minsev v0.16.1/go.mod h1:VnF+kZnkagrTfTb2mV+6PTMAtPulgjpcUajm8sRk3tQ=
 go.opentelemetry.io/otel v1.44.0 h1:JjwHmHpA4iZ3wBxluu2fbbE7j4kqlE8jXyAyPXH7HqU=
 go.opentelemetry.io/otel v1.44.0/go.mod h1:BMgjTHL9WPRlRjL2oZCBTL4whCGtXch2H4BhOPIAyYc=
 go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.20.0 h1:rydZ9sxbcFdm/oWrVyfLTjHIygMgv0bEeMd+3B/BvoM=

--- a/go/go.sum
+++ b/go/go.sum
@@ -867,6 +867,8 @@ go.augendre.info/fatcontext v0.9.0 h1:Gt5jGD4Zcj8CDMVzjOJITlSb9cEch54hjRRlN3qDoj
 go.augendre.info/fatcontext v0.9.0/go.mod h1:L94brOAT1OOUNue6ph/2HnwxoNlds9aXDF2FcUntbNw=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
+go.opentelemetry.io/contrib/bridges/otelzap v0.19.0 h1:48Eq3xxFx2KlL/tF7lnl42kKJBDlhNTLRzv0h154JnM=
+go.opentelemetry.io/contrib/bridges/otelzap v0.19.0/go.mod h1:cQbV77F0u6HmtZPiQD9oxp2esaOEb4uLqIta6OFIKOk=
 go.opentelemetry.io/contrib/bridges/prometheus v0.69.0 h1:saQoWg5845Q8TojpqeVStS7zGwVZ6bc5W2PJavTPiBM=
 go.opentelemetry.io/contrib/bridges/prometheus v0.69.0/go.mod h1:AAaS6xs5AyqMdR3Ir0nSWK+QudL2XM8Vbw5INzUxNc8=
 go.opentelemetry.io/contrib/detectors/gcp v1.43.0 h1:62yY3dT7/ShwOxzA0RsKRgshBmfElKI4d/Myu2OxDFU=
@@ -903,6 +905,8 @@ go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.44.0 h1:bl2S7Ubua0Nms+D
 go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.44.0/go.mod h1:L0hRV50XdVIODHUfWEqGRCXQvj2rV82STVo12FMFBU0=
 go.opentelemetry.io/otel/log v0.20.0 h1:/5i0vuHxCLWUfChWG41K9wkM0jafruPw9NU1/RCJirs=
 go.opentelemetry.io/otel/log v0.20.0/go.mod h1:wOcMcjsZpG8x7Bak7IhSi/lg8wscV2C1VdrKCLPlt0E=
+go.opentelemetry.io/otel/log/logtest v0.20.0 h1:+tsZVE15N+RWyN9lUzsRyw7hMZXNMepGu105Eim82/k=
+go.opentelemetry.io/otel/log/logtest v0.20.0/go.mod h1:zS9Ryx9RrEAG2tgapMBSvacwhVSSOGSaSiWWgW3NPlQ=
 go.opentelemetry.io/otel/metric v1.44.0 h1:1w0gILTcHdr3YI+ixLyjemwrVnsMURbTZFrSYCdDdmc=
 go.opentelemetry.io/otel/metric v1.44.0/go.mod h1:8O7hanEPBNgEMmybD3s2VBKcgWOCsA6tzHBPODAiquo=
 go.opentelemetry.io/otel/metric/x v0.66.0 h1:YkCrx1zLOChi9ZcZ6euupOcsgzbVlec7D/xoEU1+cTA=

--- a/helm/kagent/templates/controller-configmap.yaml
+++ b/helm/kagent/templates/controller-configmap.yaml
@@ -30,7 +30,10 @@ data:
   LEADER_ELECT: {{ include "kagent.leaderElectionEnabled" . | quote }}
   # OpenTelemetry Configuration
   OTEL_TRACING_ENABLED: {{ .Values.otel.tracing.enabled | quote }}
+  # Agent gen_ai input/output logging (forwarded to agent pods).
   OTEL_LOGGING_ENABLED: {{ .Values.otel.logging.enabled | quote }}
+  # Controller's own log export over OTLP (controller-only, not propagated to agents).
+  KAGENT_CONTROLLER_OTLP_LOGS_ENABLED: {{ .Values.otel.logging.controller.enabled | quote }}
   {{- $tracesEndpoint := .Values.otel.tracing.exporter.otlp.endpoint }}
   {{- $logsEndpoint := .Values.otel.logging.exporter.otlp.endpoint }}
   {{- if and $tracesEndpoint $logsEndpoint (eq $tracesEndpoint $logsEndpoint) }}

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -949,7 +949,16 @@ otel:
         timeout: 15000 # milliseconds
         insecure: true
   logging:
+    # -- Enable OpenTelemetry logging on agents (gen_ai input/output records).
+    # Forwarded to agent pods as OTEL_LOGGING_ENABLED. This is independent of
+    # `controller.enabled` below.
     enabled: false
+    # Controller's own log export (decoupled from agent gen_ai logging above).
+    controller:
+      # -- Export the controller's own logs over OTLP (in addition to stdout).
+      # Set as KAGENT_CONTROLLER_OTLP_LOGS_ENABLED on the controller only; not
+      # propagated to agent pods.
+      enabled: false
     exporter:
       otlp:
         endpoint: ""


### PR DESCRIPTION
## What

Adds an optional **controller log → OTLP bridge**: the controller's own zap logs can be exported over OTLP alongside the traces already emitted by `InitTracerProvider`, enabling log/trace correlation in the controller. This is the third and final observability gap proposed in #2148.

Today `go/core/internal/telemetry/` only sets up traces; the controller's zap logs are stdout-only, so they can't be shipped to an OTLP backend or correlated with spans.

## How

- **New `internal/telemetry/logging.go`:**
  - `InitLoggerProvider` builds an OTLP `LoggerProvider` via `autoexport.NewLogExporter` (same env-driven exporter/endpoint resolution as `InitTracerProvider`) and registers it as the global OTel logger provider.
  - `ControllerZapOpts` returns a `RawZapOpts(zap.WrapCore(zapcore.NewTee(core, bridgeCore)))` option that **additively tees** the stdout zap core with an `otelzap` bridge core bound to that provider — stdout logging is preserved, OTLP is added.
- **`tracing.go`:** extracted the shared `newTelemetryResource` helper so traces and logs carry identical resource attributes (no behaviour change to `InitTracerProvider`).
- **`pkg/app/app.go`:** initialize the logger provider *before* building the controller logger (so the bridge binds to the configured global provider), then add the tee via `ControllerZapOpts`.

## Gating (default-OFF, additive)

Enabled only when `OTEL_LOGGING_ENABLED=true` (the flag already registered in `pkg/env`). When unset, both `InitLoggerProvider` and `ControllerZapOpts` are no-ops and the controller logger is byte-identical to today.

## Testing

- New `logging_test.go` — asserts `ControllerZapOpts()` returns no options when disabled, returns a working teed logger when enabled (no panic with the default no-op global provider), and that `InitLoggerProvider`'s shutdown is a safe no-op when disabled.
- `go build ./core/...`, `go test -race ./core/internal/telemetry/...`, and `golangci-lint run` all pass.

## Notes

- Adds `go.opentelemetry.io/contrib/bridges/otelzap v0.19.0` (matches the existing `otel/log v0.20.0`) and promotes `otel/log` from indirect to direct; no other dependency or version changes.
- Opening as **draft / work-in-progress** per CONTRIBUTING. Companion PRs from #2148: token metrics #2149, reconcile Events #2150.

Refs: #2148
