### PR TITLE
fix(deps): bump google-adk to 1.32.0 for Anthropic thinking blocks

### DIFF
--- a/python/packages/kagent-adk/tests/unittests/models/test_anthropic.py
+++ b/python/packages/kagent-adk/tests/unittests/models/test_anthropic.py
@@ -3,6 +3,8 @@
 from unittest import mock
 
 from anthropic import AsyncAnthropic
+from anthropic.types import ThinkingBlock
+from google.adk.models.anthropic_llm import content_block_to_part
 
 from kagent.adk.models._anthropic import KAgentAnthropicLlm
 
@@ -63,3 +65,23 @@ class TestKAgentAnthropicLlm:
         assert isinstance(result, KAgentAnthropicLlm)
         assert result.model == "claude-3-sonnet-20240229"
         assert result.base_url == "https://api.anthropic.com"
+
+
+class TestAnthropicThinkingBlock:
+    """Regression guard for the google-adk floor that KAgentAnthropicLlm relies on.
+
+    KAgentAnthropicLlm inherits response decoding from google-adk's AnthropicLlm.
+    Models that emit thinking blocks (Claude Sonnet 5 does so by default) return a
+    ThinkingBlock, which google-adk only learned to decode in 1.32.0. On an older
+    pinned version content_block_to_part raises NotImplementedError, so every
+    request against such a model fails. This asserts the resolved dependency can
+    decode a thinking block, catching a silent downgrade below that floor.
+    """
+
+    def test_thinking_block_decodes_to_thought_part(self):
+        block = ThinkingBlock(type="thinking", thinking="working through it", signature="sig")
+
+        part = content_block_to_part(block)
+
+        assert part.thought is True
+        assert part.text == "working through it"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1188,7 +1188,7 @@ wheels = [
 
 [[package]]
 name = "google-adk"
-version = "1.31.1"
+version = "1.32.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiosqlite" },
@@ -1237,9 +1237,9 @@ dependencies = [
     { name = "watchdog" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/f7/e2371e8a871202f47f8911992da7daf8623dd61e714e0af5c6fec019ba67/google_adk-1.31.1.tar.gz", hash = "sha256:e56416264f62e931709da6262bc9fe05140faeb7a889a2fe8f5684617e8a05c3", size = 2408228, upload-time = "2026-04-21T02:06:48.623Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/cb/6c5ad3f7135071ed6465494acb88084b071c750e2215a55c842649f353e4/google_adk-1.32.0.tar.gz", hash = "sha256:539df330a695d8ae5dc1bc3f1155ef03c6c620620cd0b690b8d47865e722e51c", size = 2424585, upload-time = "2026-05-01T00:20:47.888Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/02/6e7b88b122708569004ac024ec7f6773cc9d10ce1b086a4a6668a95ca142/google_adk-1.31.1-py3-none-any.whl", hash = "sha256:8f5d9c67c9a87832c2fe581bd4b1248dddf8964c98351a38e2663f0999bc7209", size = 2850553, upload-time = "2026-04-21T02:06:45.992Z" },
+    { url = "https://files.pythonhosted.org/packages/03/68/c02dee93b09c0af4cc68a6a4fdb330a8e4935ffa9c8ad9640590ca29cca4/google_adk-1.32.0-py3-none-any.whl", hash = "sha256:cee8e8bd1d869f7e01ba3e5aac44b255f70ee3f9bb78cb50b3253ce605703b0d", size = 2869333, upload-time = "2026-05-01T00:20:49.851Z" },
 ]
 
 [[package]]


### PR DESCRIPTION

### What this does

Bumps the resolved `google-adk` version in `python/uv.lock` from `1.31.1` to
`1.32.0`, and adds a regression test guarding the floor.

Fixes #2136.

### Why

The lockfile resolved `google-adk 1.31.1`. In that version,
`content_block_to_part()` only decodes `text` and `tool_use` content blocks and
raises `NotImplementedError("Not supported yet.")` for anything else. Anthropic
models that emit thinking blocks (Claude Sonnet 5 runs adaptive thinking by
default) return a `ThinkingBlock`, so every request routed through the ADK
Anthropic path fails with:

```
NotImplementedError: Not supported yet.
  .../google/adk/models/anthropic_llm.py, in content_block_to_part
```

`kagent`'s `KAgentAnthropicLlm` subclasses google-adk's `AnthropicLlm` and
inherits this response-decoding path, so it is affected as reported.

Support for `ThinkingBlock` and `RedactedThinkingBlock` was added upstream in
`google-adk 1.32.0`. The dependency spec in
`python/packages/kagent-adk/pyproject.toml` is already `google-adk>=1.28.1,<2`,
which permits `1.32.0`; only the lock was behind. This change moves the lock to
the first version that decodes thinking blocks, staying within the existing
`<2` bound, so it is the minimal fix for the reported crash.

### The regression test

`python/packages/kagent-adk/tests/unittests/models/test_anthropic.py` gets a new
`TestAnthropicThinkingBlock.test_thinking_block_decodes_to_thought_part`. It
decodes a `ThinkingBlock` through `content_block_to_part` (the exact path
`KAgentAnthropicLlm` inherits) and asserts the result is a thought `Part`
(`part.thought is True`, `part.text == "working through it"`).

The test fails on `google-adk 1.31.1` with the exact `NotImplementedError` from
the issue and passes on `1.32.0`, so it also guards against a silent downgrade
below the fixed floor.

### Testing

- Full Python suite: `cd python && uv run pytest ./packages/**/tests/` ->
  514 passed, 1 skipped.
- New test: red on `google-adk 1.31.1`, green on `1.32.0`.
- Lint: `uv run ruff check` and `ruff format --diff .` clean on the changed test
  file.

### Scope

The lockfile diff is limited to the `google-adk` version line plus its sdist and
wheel URL/hash/size/upload-time entries; no other package moved.

---

## Suggested labels / metadata

- Type: bug fix (dependency). Small change (<100 LoC) per CONTRIBUTING, so a
  normal (non-draft) PR with the regression test is appropriate.
- No CHANGELOG file convention in this repo; none needed.
