### PR TITLE
feat(helm): add extraObjects for arbitrary manifests

### DIFF
--- a/helm/kagent/templates/extra-objects.yaml
+++ b/helm/kagent/templates/extra-objects.yaml
@@ -1,0 +1,12 @@
+# Render arbitrary user-supplied manifests so resources such as ExternalSecret,
+# HTTPRoute, or NetworkPolicy can be managed within the same chart lifecycle.
+# Each entry is processed through `tpl`, so values may reference the release
+# context (e.g. {{ include "kagent.fullname" . }} or .Release.Namespace).
+{{- range .Values.extraObjects }}
+---
+{{- if typeIs "string" . }}
+{{ tpl . $ }}
+{{- else }}
+{{ tpl (toYaml .) $ }}
+{{- end }}
+{{- end }}

--- a/helm/kagent/templates/extra-objects.yaml
+++ b/helm/kagent/templates/extra-objects.yaml
@@ -1,7 +1,7 @@
 # Render arbitrary user-supplied manifests so resources such as ExternalSecret,
 # HTTPRoute, or NetworkPolicy can be managed within the same chart lifecycle.
 # Each entry is processed through `tpl`, so values may reference the release
-# context (e.g. {{ include "kagent.fullname" . }} or .Release.Namespace).
+# context (e.g. {{ "{{ include \"kagent.fullname\" . }}" }} or {{ "{{ .Release.Namespace }}" }}).
 {{- range .Values.extraObjects }}
 ---
 {{- if typeIs "string" . }}

--- a/helm/kagent/tests/extra-objects_test.yaml
+++ b/helm/kagent/tests/extra-objects_test.yaml
@@ -1,0 +1,87 @@
+suite: test extra objects
+templates:
+  - extra-objects.yaml
+tests:
+  - it: should not render anything when extraObjects is empty
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a map entry as a manifest
+    set:
+      extraObjects:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: extra-cm
+          data:
+            foo: bar
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: extra-cm
+      - equal:
+          path: data.foo
+          value: bar
+
+  - it: should render multiple entries as separate documents
+    set:
+      extraObjects:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: extra-cm-1
+        - apiVersion: v1
+          kind: Secret
+          metadata:
+            name: extra-secret-1
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: should evaluate tpl expressions against the release context in map entries
+    release:
+      name: my-release
+      namespace: my-namespace
+    set:
+      extraObjects:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: '{{ include "kagent.fullname" . }}-extra'
+            namespace: '{{ .Release.Namespace }}'
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-release-extra
+      - equal:
+          path: metadata.namespace
+          value: my-namespace
+
+  - it: should render and template a multi-line string entry
+    release:
+      name: my-release
+    set:
+      extraObjects:
+        - |
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: {{ include "kagent.fullname" . }}-str
+          data:
+            release: {{ .Release.Name }}
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: my-release-str
+      - equal:
+          path: data.release
+          value: my-release

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -865,21 +865,24 @@ otel:
 # Both map and multi-line string entries are supported. Use this to manage
 # resources such as ExternalSecret, HTTPRoute, or NetworkPolicy within the same
 # chart lifecycle without maintaining a separate chart.
+#
+# To use, replace the empty list below with your manifests, e.g.:
+#   extraObjects:
+#     - apiVersion: external-secrets.io/v1
+#       kind: ExternalSecret
+#       metadata:
+#         name: '{{ include "kagent.fullname" . }}-openai'
+#         namespace: '{{ .Release.Namespace }}'
+#       spec:
+#         secretStoreRef:
+#           name: aws-secretsmanager
+#           kind: ClusterSecretStore
+#         target:
+#           name: kagent-openai
+#         data:
+#           - secretKey: OPENAI_API_KEY
+#             remoteRef:
+#               key: prod/kagent/openai
+#               property: api_key
 # @default -- []
 extraObjects: []
-  # - apiVersion: external-secrets.io/v1
-  #   kind: ExternalSecret
-  #   metadata:
-  #     name: '{{ include "kagent.fullname" . }}-openai'
-  #     namespace: '{{ .Release.Namespace }}'
-  #   spec:
-  #     secretStoreRef:
-  #       name: aws-secretsmanager
-  #       kind: ClusterSecretStore
-  #     target:
-  #       name: kagent-openai
-  #     data:
-  #       - secretKey: OPENAI_API_KEY
-  #         remoteRef:
-  #           key: prod/kagent/openai
-  #           property: api_key

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -854,3 +854,32 @@ otel:
         endpoint: ""
         timeout: 15000 # milliseconds
         insecure: true
+
+# ==============================================================================
+# EXTRA OBJECTS
+# ==============================================================================
+
+# -- Additional arbitrary Kubernetes manifests to deploy alongside the chart.
+# Each list entry is rendered through `tpl`, so values may reference the release
+# context (e.g. `{{ include "kagent.fullname" . }}`, `{{ .Release.Namespace }}`).
+# Both map and multi-line string entries are supported. Use this to manage
+# resources such as ExternalSecret, HTTPRoute, or NetworkPolicy within the same
+# chart lifecycle without maintaining a separate chart.
+# @default -- `[]`
+extraObjects: []
+  # - apiVersion: external-secrets.io/v1
+  #   kind: ExternalSecret
+  #   metadata:
+  #     name: '{{ include "kagent.fullname" . }}-openai'
+  #     namespace: '{{ .Release.Namespace }}'
+  #   spec:
+  #     secretStoreRef:
+  #       name: aws-secretsmanager
+  #       kind: ClusterSecretStore
+  #     target:
+  #       name: kagent-openai
+  #     data:
+  #       - secretKey: OPENAI_API_KEY
+  #         remoteRef:
+  #           key: prod/kagent/openai
+  #           property: api_key

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -865,7 +865,7 @@ otel:
 # Both map and multi-line string entries are supported. Use this to manage
 # resources such as ExternalSecret, HTTPRoute, or NetworkPolicy within the same
 # chart lifecycle without maintaining a separate chart.
-# @default -- `[]`
+# @default -- []
 extraObjects: []
   # - apiVersion: external-secrets.io/v1
   #   kind: ExternalSecret


### PR DESCRIPTION
## Summary

Adds an optional top-level `extraObjects` value that renders arbitrary Kubernetes manifests within the kagent chart. It is empty by default so existing installs stay unaffected. Each entry is rendered through `tpl` so values can reference the release context such as `{{ include "kagent.fullname" . }}` or `{{ .Release.Namespace }}`. Both map and multi-line string entries are supported.

This lets users manage companion resources like `ExternalSecret` or `HTTPRoute` in the same chart lifecycle. It follows a common pattern used by community charts such as:

- grafana
- kube-prometheus-stack
- external-secrets

## Changes

- New template `templates/extra-objects.yaml` ranging over `.Values.extraObjects` (default `[]`).
- Documented `extraObjects` in `values.yaml` with an `ExternalSecret` example.
- Added helm-unittest suite `tests/extra-objects_test.yaml`.

## Testing

`helm unittest helm/kagent` passes. The new suite covers the empty default map entries multiple documents `tpl` evaluation against the release context and multi-line string entries.

## Notes

This change was originally intended for #2165 but was split into its own PR at a maintainer request so each concern can be reviewed on its own.
