### PR TITLE
Remove cr.kagent.dev alias usage

### DIFF
--- a/contrib/cncf/technical-review.md
+++ b/contrib/cncf/technical-review.md
@@ -379,7 +379,7 @@ Kagent follows semantic versioning ([https://semver.org/](https://semver.org/)):
 
 Release artifacts:
 
-- Container images: `cr.kagent.dev/kagent-dev/kagent/*`
+- Container images: `ghcr.io/kagent-dev/kagent/*`
 - Helm charts: `oci://ghcr.io/kagent-dev/kagent/helm/*`
 - CLI binaries: GitHub releases
 - Release notes: GitHub releases with changelog

--- a/go/core/internal/controller/translator/agent/adk_api_translator.go
+++ b/go/core/internal/controller/translator/agent/adk_api_translator.go
@@ -109,7 +109,7 @@ func normalizeImageDigest(digest string) string {
 }
 
 var DefaultImageConfig = ImageConfig{
-	Registry:   "cr.kagent.dev",
+	Registry:   "ghcr.io",
 	Tag:        version.Get().Version,
 	PullPolicy: string(corev1.PullIfNotPresent),
 	PullSecret: "",
@@ -127,7 +127,7 @@ var GoADKFullImageDigest string
 // DefaultSkillsInitImageConfig is the image config for the skills-init container
 // that clones skill repositories from Git and pulls OCI skill images.
 var DefaultSkillsInitImageConfig = ImageConfig{
-	Registry:   "cr.kagent.dev",
+	Registry:   "ghcr.io",
 	Tag:        version.Get().Version,
 	PullPolicy: string(corev1.PullIfNotPresent),
 	Repository: "kagent-dev/kagent/skills-init",

--- a/go/core/internal/controller/translator/agent/imageconfig_test.go
+++ b/go/core/internal/controller/translator/agent/imageconfig_test.go
@@ -8,11 +8,11 @@ import (
 
 func TestImageConfigImage(t *testing.T) {
 	cfg := ImageConfig{
-		Registry:   "cr.kagent.dev",
+		Registry:   "ghcr.io",
 		Repository: "kagent-dev/kagent/app",
 		Tag:        "v1.0.0",
 	}
-	require.Equal(t, "cr.kagent.dev/kagent-dev/kagent/app:v1.0.0", cfg.Image())
+	require.Equal(t, "ghcr.io/kagent-dev/kagent/app:v1.0.0", cfg.Image())
 }
 
 func TestImageConfigPinnedImage(t *testing.T) {
@@ -28,7 +28,7 @@ func TestImageConfigPinnedImage(t *testing.T) {
 
 func TestImageConfigPinnedImageWithoutDigest(t *testing.T) {
 	cfg := ImageConfig{
-		Registry:   "cr.kagent.dev",
+		Registry:   "ghcr.io",
 		Repository: "kagent-dev/kagent/app",
 		Tag:        "v1.0.0",
 	}
@@ -83,13 +83,13 @@ func TestResolvePythonRuntimeImageWithDigest(t *testing.T) {
 	PythonADKImageDigest = "sha256:app-digest"
 	PythonADKFullImageDigest = "sha256:app-full-digest"
 
-	got, err := resolvePythonRuntimeImage("cr.kagent.dev", false)
+	got, err := resolvePythonRuntimeImage("ghcr.io", false)
 	require.NoError(t, err)
-	require.Equal(t, "cr.kagent.dev/kagent-dev/kagent/app@sha256:app-digest", got)
+	require.Equal(t, "ghcr.io/kagent-dev/kagent/app@sha256:app-digest", got)
 
-	gotFull, err := resolvePythonRuntimeImage("cr.kagent.dev", true)
+	gotFull, err := resolvePythonRuntimeImage("ghcr.io", true)
 	require.NoError(t, err)
-	require.Equal(t, "cr.kagent.dev/kagent-dev/kagent/app@sha256:app-full-digest", gotFull)
+	require.Equal(t, "ghcr.io/kagent-dev/kagent/app@sha256:app-full-digest", gotFull)
 }
 
 func TestResolvePythonFullRuntimeImageWithoutDigest(t *testing.T) {
@@ -99,7 +99,7 @@ func TestResolvePythonFullRuntimeImageWithoutDigest(t *testing.T) {
 	})
 	PythonADKFullImageDigest = ""
 
-	_, err := resolvePythonRuntimeImage("cr.kagent.dev", true)
+	_, err := resolvePythonRuntimeImage("ghcr.io", true)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "app-full")
 }
@@ -122,7 +122,7 @@ func TestResolvePythonRuntimeImageWithoutDigest(t *testing.T) {
 	})
 	PythonADKImageDigest = ""
 
-	_, err := resolvePythonRuntimeImage("cr.kagent.dev", false)
+	_, err := resolvePythonRuntimeImage("ghcr.io", false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "app")
 }

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_a2a_config.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_a2a_config.json
@@ -186,7 +186,7 @@
                     "value": "http://kagent-controller.kagent:8083"
                   }
                 ],
-                "image": "cr.kagent.dev/kagent-dev/kagent/app@sha256:test-app",
+                "image": "ghcr.io/kagent-dev/kagent/app@sha256:test-app",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "kagent",
                 "ports": [

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_allowed_headers.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_allowed_headers.json
@@ -196,7 +196,7 @@
                     "value": "http://kagent-controller.kagent:8083"
                   }
                 ],
-                "image": "cr.kagent.dev/kagent-dev/kagent/app@sha256:test-app",
+                "image": "ghcr.io/kagent-dev/kagent/app@sha256:test-app",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "kagent",
                 "ports": [

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_code.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_code.json
@@ -193,7 +193,7 @@
                     "value": "/config/srt-settings.json"
                   }
                 ],
-                "image": "cr.kagent.dev/kagent-dev/kagent/app@sha256:test-app-full",
+                "image": "ghcr.io/kagent-dev/kagent/app@sha256:test-app-full",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "kagent",
                 "ports": [

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_context_config.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_context_config.json
@@ -207,7 +207,7 @@
                     "value": "http://kagent-controller.kagent:8083"
                   }
                 ],
-                "image": "cr.kagent.dev/kagent-dev/kagent/app@sha256:test-app",
+                "image": "ghcr.io/kagent-dev/kagent/app@sha256:test-app",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "kagent",
                 "ports": [

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_cross_namespace_tools.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_cross_namespace_tools.json
@@ -202,7 +202,7 @@
                     "value": "http://kagent-controller.kagent:8083"
                   }
                 ],
-                "image": "cr.kagent.dev/kagent-dev/kagent/app@sha256:test-app",
+                "image": "ghcr.io/kagent-dev/kagent/app@sha256:test-app",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "kagent",
                 "ports": [

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_custom_sa.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_custom_sa.json
@@ -155,7 +155,7 @@
                     "value": "http://kagent-controller.kagent:8083"
                   }
                 ],
-                "image": "cr.kagent.dev/kagent-dev/kagent/app@sha256:test-app",
+                "image": "ghcr.io/kagent-dev/kagent/app@sha256:test-app",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "kagent",
                 "ports": [

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_default_sa.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_default_sa.json
@@ -155,7 +155,7 @@
                     "value": "http://kagent-controller.kagent:8083"
                   }
                 ],
-                "image": "cr.kagent.dev/kagent-dev/kagent/app@sha256:test-app",
+                "image": "ghcr.io/kagent-dev/kagent/app@sha256:test-app",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "kagent",
                 "ports": [

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_embedding_provider.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_embedding_provider.json
@@ -202,7 +202,7 @@
                     "value": "http://kagent-controller.kagent:8083"
                   }
                 ],
-                "image": "cr.kagent.dev/kagent-dev/kagent/app@sha256:test-app",
+                "image": "ghcr.io/kagent-dev/kagent/app@sha256:test-app",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "kagent",
                 "ports": [

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_extra_containers.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_extra_containers.json
@@ -180,7 +180,7 @@
                     "value": "http://kagent-controller.kagent:8083"
                   }
                 ],
-                "image": "cr.kagent.dev/kagent-dev/kagent/app@sha256:test-app",
+                "image": "ghcr.io/kagent-dev/kagent/app@sha256:test-app",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "kagent",
                 "ports": [

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_git_skills.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_git_skills.json
@@ -215,7 +215,7 @@
                     "value": "/config/srt-settings.json"
                   }
                 ],
-                "image": "cr.kagent.dev/kagent-dev/kagent/app@sha256:test-app-full",
+                "image": "ghcr.io/kagent-dev/kagent/app@sha256:test-app-full",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "kagent",
                 "ports": [
@@ -265,7 +265,7 @@
             ],
             "initContainers": [
               {
-                "image": "cr.kagent.dev/kagent-dev/kagent/skills-init:dev",
+                "image": "ghcr.io/kagent-dev/kagent/skills-init:dev",
                 "name": "skills-init",
                 "resources": {
                   "limits": {

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_http_toolserver.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_http_toolserver.json
@@ -195,7 +195,7 @@
                     "value": "http://kagent-controller.kagent:8083"
                   }
                 ],
-                "image": "cr.kagent.dev/kagent-dev/kagent/app@sha256:test-app",
+                "image": "ghcr.io/kagent-dev/kagent/app@sha256:test-app",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "kagent",
                 "ports": [

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_mcp_service.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_mcp_service.json
@@ -191,7 +191,7 @@
                     "value": "http://kagent-controller.kagent:8083"
                   }
                 ],
-                "image": "cr.kagent.dev/kagent-dev/kagent/app@sha256:test-app",
+                "image": "ghcr.io/kagent-dev/kagent/app@sha256:test-app",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "kagent",
                 "ports": [

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_memory.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_memory.json
@@ -191,7 +191,7 @@
                     "value": "http://kagent-controller.kagent:8083"
                   }
                 ],
-                "image": "cr.kagent.dev/kagent-dev/kagent/app@sha256:test-app",
+                "image": "ghcr.io/kagent-dev/kagent/app@sha256:test-app",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "kagent",
                 "ports": [

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_nested_agent.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_nested_agent.json
@@ -189,7 +189,7 @@
                     "value": "http://kagent-controller.kagent:8083"
                   }
                 ],
-                "image": "cr.kagent.dev/kagent-dev/kagent/app@sha256:test-app",
+                "image": "ghcr.io/kagent-dev/kagent/app@sha256:test-app",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "kagent",
                 "ports": [

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_passthrough.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_passthrough.json
@@ -173,7 +173,7 @@
                     "value": "http://kagent-controller.kagent:8083"
                   }
                 ],
-                "image": "cr.kagent.dev/kagent-dev/kagent/app@sha256:test-app",
+                "image": "ghcr.io/kagent-dev/kagent/app@sha256:test-app",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "kagent",
                 "ports": [

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_prompt_template.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_prompt_template.json
@@ -193,7 +193,7 @@
                     "value": "http://kagent-controller.kagent:8083"
                   }
                 ],
-                "image": "cr.kagent.dev/kagent-dev/kagent/app@sha256:test-app",
+                "image": "ghcr.io/kagent-dev/kagent/app@sha256:test-app",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "kagent",
                 "ports": [

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_proxy.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_proxy.json
@@ -202,7 +202,7 @@
                     "value": "http://kagent-controller.kagent:8083"
                   }
                 ],
-                "image": "cr.kagent.dev/kagent-dev/kagent/app@sha256:test-app",
+                "image": "ghcr.io/kagent-dev/kagent/app@sha256:test-app",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "kagent",
                 "ports": [

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_proxy_external_remotemcp.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_proxy_external_remotemcp.json
@@ -191,7 +191,7 @@
                     "value": "http://kagent-controller.kagent:8083"
                   }
                 ],
-                "image": "cr.kagent.dev/kagent-dev/kagent/app@sha256:test-app",
+                "image": "ghcr.io/kagent-dev/kagent/app@sha256:test-app",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "kagent",
                 "ports": [

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_proxy_mcpserver.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_proxy_mcpserver.json
@@ -194,7 +194,7 @@
                     "value": "http://kagent-controller.kagent:8083"
                   }
                 ],
-                "image": "cr.kagent.dev/kagent-dev/kagent/app@sha256:test-app",
+                "image": "ghcr.io/kagent-dev/kagent/app@sha256:test-app",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "kagent",
                 "ports": [

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_proxy_mcpserver_custom_timeout.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_proxy_mcpserver_custom_timeout.json
@@ -194,7 +194,7 @@
                     "value": "http://kagent-controller.kagent:8083"
                   }
                 ],
-                "image": "cr.kagent.dev/kagent-dev/kagent/app@sha256:test-app",
+                "image": "ghcr.io/kagent-dev/kagent/app@sha256:test-app",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "kagent",
                 "ports": [

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_proxy_service.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_proxy_service.json
@@ -193,7 +193,7 @@
                     "value": "http://kagent-controller.kagent:8083"
                   }
                 ],
-                "image": "cr.kagent.dev/kagent-dev/kagent/app@sha256:test-app",
+                "image": "ghcr.io/kagent-dev/kagent/app@sha256:test-app",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "kagent",
                 "ports": [

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_require_approval.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_require_approval.json
@@ -197,7 +197,7 @@
                     "value": "http://kagent-controller.kagent:8083"
                   }
                 ],
-                "image": "cr.kagent.dev/kagent-dev/kagent/app@sha256:test-app",
+                "image": "ghcr.io/kagent-dev/kagent/app@sha256:test-app",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "kagent",
                 "ports": [

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_scheduling_attributes.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_scheduling_attributes.json
@@ -206,7 +206,7 @@
                     "value": "http://kagent-controller.kagent:8083"
                   }
                 ],
-                "image": "cr.kagent.dev/kagent-dev/kagent/app@sha256:test-app",
+                "image": "ghcr.io/kagent-dev/kagent/app@sha256:test-app",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "kagent",
                 "ports": [

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_security_context.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_security_context.json
@@ -187,7 +187,7 @@
                     "value": "http://kagent-controller.kagent:8083"
                   }
                 ],
-                "image": "cr.kagent.dev/kagent-dev/kagent/app@sha256:test-app",
+                "image": "ghcr.io/kagent-dev/kagent/app@sha256:test-app",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "kagent",
                 "ports": [

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_skills.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_skills.json
@@ -215,7 +215,7 @@
                     "value": "/config/srt-settings.json"
                   }
                 ],
-                "image": "cr.kagent.dev/kagent-dev/kagent/app@sha256:test-app-full",
+                "image": "ghcr.io/kagent-dev/kagent/app@sha256:test-app-full",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "kagent",
                 "ports": [
@@ -265,7 +265,7 @@
             ],
             "initContainers": [
               {
-                "image": "cr.kagent.dev/kagent-dev/kagent/skills-init:dev",
+                "image": "ghcr.io/kagent-dev/kagent/skills-init:dev",
                 "name": "skills-init",
                 "resources": {
                   "limits": {

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_streaming.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_streaming.json
@@ -187,7 +187,7 @@
                     "value": "http://kagent-controller.kagent:8083"
                   }
                 ],
-                "image": "cr.kagent.dev/kagent-dev/kagent/app@sha256:test-app",
+                "image": "ghcr.io/kagent-dev/kagent/app@sha256:test-app",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "kagent",
                 "ports": [

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_system_message_from_configmap.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_system_message_from_configmap.json
@@ -180,7 +180,7 @@
                     "value": "http://kagent-controller.kagent:8083"
                   }
                 ],
-                "image": "cr.kagent.dev/kagent-dev/kagent/app@sha256:test-app",
+                "image": "ghcr.io/kagent-dev/kagent/app@sha256:test-app",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "kagent",
                 "ports": [

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_system_message_from_secret.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_system_message_from_secret.json
@@ -180,7 +180,7 @@
                     "value": "http://kagent-controller.kagent:8083"
                   }
                 ],
-                "image": "cr.kagent.dev/kagent-dev/kagent/app@sha256:test-app",
+                "image": "ghcr.io/kagent-dev/kagent/app@sha256:test-app",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "kagent",
                 "ports": [

--- a/go/core/internal/controller/translator/agent/testdata/outputs/anthropic_agent.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/anthropic_agent.json
@@ -183,7 +183,7 @@
                     "value": "http://kagent-controller.kagent:8083"
                   }
                 ],
-                "image": "cr.kagent.dev/kagent-dev/kagent/app@sha256:test-app",
+                "image": "ghcr.io/kagent-dev/kagent/app@sha256:test-app",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "kagent",
                 "ports": [

--- a/go/core/internal/controller/translator/agent/testdata/outputs/basic_agent.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/basic_agent.json
@@ -187,7 +187,7 @@
                     "value": "http://kagent-controller.kagent:8083"
                   }
                 ],
-                "image": "cr.kagent.dev/kagent-dev/kagent/app@sha256:test-app",
+                "image": "ghcr.io/kagent-dev/kagent/app@sha256:test-app",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "kagent",
                 "ports": [

--- a/go/core/internal/controller/translator/agent/testdata/outputs/bedrock_agent.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/bedrock_agent.json
@@ -193,7 +193,7 @@
                     "value": "http://kagent-controller.kagent:8083"
                   }
                 ],
-                "image": "cr.kagent.dev/kagent-dev/kagent/app@sha256:test-app",
+                "image": "ghcr.io/kagent-dev/kagent/app@sha256:test-app",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "kagent",
                 "ports": [

--- a/go/core/internal/controller/translator/agent/testdata/outputs/ollama_agent.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/ollama_agent.json
@@ -182,7 +182,7 @@
                     "value": "http://kagent-controller.kagent:8083"
                   }
                 ],
-                "image": "cr.kagent.dev/kagent-dev/kagent/app@sha256:test-app",
+                "image": "ghcr.io/kagent-dev/kagent/app@sha256:test-app",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "kagent",
                 "ports": [

--- a/go/core/internal/controller/translator/agent/testdata/outputs/tls-with-custom-ca.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/tls-with-custom-ca.json
@@ -185,7 +185,7 @@
                     "value": "http://kagent-controller.kagent:8083"
                   }
                 ],
-                "image": "cr.kagent.dev/kagent-dev/kagent/app@sha256:test-app",
+                "image": "ghcr.io/kagent-dev/kagent/app@sha256:test-app",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "kagent",
                 "ports": [

--- a/go/core/internal/controller/translator/agent/testdata/outputs/tls-with-disabled-verify.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/tls-with-disabled-verify.json
@@ -184,7 +184,7 @@
                     "value": "http://kagent-controller.kagent:8083"
                   }
                 ],
-                "image": "cr.kagent.dev/kagent-dev/kagent/app@sha256:test-app",
+                "image": "ghcr.io/kagent-dev/kagent/app@sha256:test-app",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "kagent",
                 "ports": [

--- a/go/core/internal/controller/translator/agent/testdata/outputs/tls-with-system-cas-disabled.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/tls-with-system-cas-disabled.json
@@ -185,7 +185,7 @@
                     "value": "http://kagent-controller.kagent:8083"
                   }
                 ],
-                "image": "cr.kagent.dev/kagent-dev/kagent/app@sha256:test-app",
+                "image": "ghcr.io/kagent-dev/kagent/app@sha256:test-app",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "kagent",
                 "ports": [

--- a/go/core/pkg/sandboxbackend/substrate/constants.go
+++ b/go/core/pkg/sandboxbackend/substrate/constants.go
@@ -12,7 +12,7 @@ import (
 // from the just-pushed images. The registry and repository are composed at
 // runtime from --image-registry/--image-repository (the same DefaultImageConfig
 // values used for declarative agent images), so the same controller binary
-// works against ghcr.io, cr.kagent.dev, localhost:5001, or a private/mirrored
+// works against ghcr.io, localhost:5001, or a private/mirrored
 // registry without editing this file (kagent-dev/kagent#2055).
 const (
 	acpSandboxOpenClawImageName = "acp-sandbox-openclaw"

--- a/go/core/pkg/sandboxbackend/substrate/constants_test.go
+++ b/go/core/pkg/sandboxbackend/substrate/constants_test.go
@@ -34,12 +34,12 @@ func TestAcpSandboxImageResolve(t *testing.T) {
 	const digest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
 	t.Run("composes registry repo name digest", func(t *testing.T) {
-		cfg := acpSandboxImageConfig{Registry: "cr.kagent.dev", Repository: "kagent-dev/kagent/app"}
+		cfg := acpSandboxImageConfig{Registry: "ghcr.io", Repository: "kagent-dev/kagent/app"}
 		got, err := cfg.resolve("acp-sandbox-openclaw", digest)
 		if err != nil {
 			t.Fatalf("resolve: %v", err)
 		}
-		want := "cr.kagent.dev/kagent-dev/kagent/acp-sandbox-openclaw@" + digest
+		want := "ghcr.io/kagent-dev/kagent/acp-sandbox-openclaw@" + digest
 		if got != want {
 			t.Fatalf("resolve = %q, want %q", got, want)
 		}
@@ -58,19 +58,19 @@ func TestAcpSandboxImageResolve(t *testing.T) {
 	})
 
 	t.Run("adds sha256 prefix when missing", func(t *testing.T) {
-		cfg := acpSandboxImageConfig{Registry: "cr.kagent.dev", Repository: "kagent-dev/kagent/app"}
+		cfg := acpSandboxImageConfig{Registry: "ghcr.io", Repository: "kagent-dev/kagent/app"}
 		got, err := cfg.resolve("acp-sandbox-openclaw", strings.TrimPrefix(digest, "sha256:"))
 		if err != nil {
 			t.Fatalf("resolve: %v", err)
 		}
-		want := "cr.kagent.dev/kagent-dev/kagent/acp-sandbox-openclaw@" + digest
+		want := "ghcr.io/kagent-dev/kagent/acp-sandbox-openclaw@" + digest
 		if got != want {
 			t.Fatalf("resolve = %q, want %q", got, want)
 		}
 	})
 
 	t.Run("errors when digest missing", func(t *testing.T) {
-		cfg := acpSandboxImageConfig{Registry: "cr.kagent.dev", Repository: "kagent-dev/kagent/app"}
+		cfg := acpSandboxImageConfig{Registry: "ghcr.io", Repository: "kagent-dev/kagent/app"}
 		if _, err := cfg.resolve("acp-sandbox-openclaw", "  "); err == nil {
 			t.Fatal("expected error for missing digest")
 		}
@@ -84,7 +84,7 @@ func TestAcpSandboxImageResolve(t *testing.T) {
 	})
 
 	t.Run("errors when repository missing", func(t *testing.T) {
-		cfg := acpSandboxImageConfig{Registry: "cr.kagent.dev"}
+		cfg := acpSandboxImageConfig{Registry: "ghcr.io"}
 		if _, err := cfg.resolve("acp-sandbox-openclaw", digest); err == nil {
 			t.Fatal("expected error for missing repository")
 		}

--- a/helm/kagent/tests/controller-deployment_test.yaml
+++ b/helm/kagent/tests/controller-deployment_test.yaml
@@ -36,7 +36,7 @@ tests:
           value: controller
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: "^cr\\.kagent\\.dev/kagent-dev/kagent/controller:.+"
+          pattern: "^ghcr\\.io/kagent-dev/kagent/controller:.+"
 
   - it: should use global tag when set
     template: controller-deployment.yaml
@@ -45,7 +45,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: cr.kagent.dev/kagent-dev/kagent/controller:v1.0.0
+          value: ghcr.io/kagent-dev/kagent/controller:v1.0.0
 
   - it: should have correct controller resources
     template: controller-deployment.yaml

--- a/helm/kagent/tests/ui-deployment_test.yaml
+++ b/helm/kagent/tests/ui-deployment_test.yaml
@@ -35,7 +35,7 @@ tests:
           value: ui
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: "^cr\\.kagent\\.dev/kagent-dev/kagent/ui:.+"
+          pattern: "^ghcr\\.io/kagent-dev/kagent/ui:.+"
 
   - it: should use global tag when set
     template: ui-deployment.yaml
@@ -44,7 +44,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: cr.kagent.dev/kagent-dev/kagent/ui:v1.0.0
+          value: ghcr.io/kagent-dev/kagent/ui:v1.0.0
 
   - it: should have correct ui resources
     template: ui-deployment.yaml

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -15,7 +15,7 @@ ipv6:
   enabled: false
 
 tag: ""
-registry: "cr.kagent.dev"
+registry: "ghcr.io"
 
 imagePullSecrets: []
 imagePullPolicy: IfNotPresent

--- a/scripts/get-kagent
+++ b/scripts/get-kagent
@@ -143,7 +143,7 @@ checkKagentInstalledVersion() {
 # for that binary.
 downloadFile() {
   KAGENT_DIST="kagent-$OS-$ARCH"
-  DOWNLOAD_URL="https://cr.kagent.dev/$TAG/$KAGENT_DIST"
+  DOWNLOAD_URL="https://github.com/kagent-dev/kagent/releases/download/$TAG/$KAGENT_DIST"
   CHECKSUM_URL="$DOWNLOAD_URL.sha256"
   KAGENT_TMP_ROOT="$(mktemp -dt kagent-installer-XXXXXX)"
   KAGENT_TMP_FILE="$KAGENT_TMP_ROOT/$KAGENT_DIST"


### PR DESCRIPTION
## Summary
- replace cr.kagent.dev image defaults and test expectations with ghcr.io
- download CLI install assets from GitHub releases instead of the cr.kagent.dev alias
- update release docs and generated translator golden outputs

## Testing
- go test ./core/internal/controller/translator/agent ./core/pkg/sandboxbackend/substrate
- helm unittest -f 'tests/*deployment*' helm/kagent
- git diff --check

Note: full helm unittest helm/kagent still fails on the existing agent-nodeselector_test.yaml suite unrelated to this change.