### PR TITLE
fix: correct package comment in v1alpha2 groupversion_info

### DIFF
--- a/go/api/v1alpha2/groupversion_info.go
+++ b/go/api/v1alpha2/groupversion_info.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1alpha1 contains API Schema definitions for the agent v1alpha1 API group.
+// Package v1alpha2 contains API Schema definitions for the kagent.dev v1alpha2 API group.
 // +kubebuilder:object:generate=true
 // +groupName=kagent.dev
 package v1alpha2


### PR DESCRIPTION
Package doc comment said `v1alpha1` but the package is `v1alpha2`. Fixes the godoc output for this package.