### PR TITLE
fix: parse migration filenames the same way golang-migrate does

### DIFF
--- a/go/core/pkg/cli/db/migrate/migrate.go
+++ b/go/core/pkg/cli/db/migrate/migrate.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	"github.com/golang-migrate/migrate/v4"
+	"github.com/golang-migrate/migrate/v4/source"
 	"github.com/spf13/cobra"
 
 	"github.com/kagent-dev/kagent/go/core/pkg/migrations"
@@ -217,8 +218,9 @@ func ensureClean(src migrations.Source, mg *migrate.Migrate) error {
 	return nil
 }
 
-// sourceFileVersions returns the (ascending-sorted) NNN versions parsed from
-// every NNN_name.up.sql file in src.FS/src.Dir.
+// sourceFileVersions returns the (ascending-sorted) versions parsed from
+// every up migration file in src.FS/src.Dir, using golang-migrate's own
+// filename parser so a file it would silently skip is never counted here.
 //
 // The set isn't required to be contiguous — gaps (e.g. a deleted 005) are
 // real and the missing numbers are treated as not-applicable-to-this-binary.
@@ -234,19 +236,11 @@ func sourceFileVersions(src migrations.Source) ([]int, error) {
 		if e.IsDir() {
 			continue
 		}
-		name := e.Name()
-		if !strings.HasSuffix(name, ".up.sql") {
+		m, err := source.DefaultParse(e.Name())
+		if err != nil || m.Direction != source.Up {
 			continue
 		}
-		parts := strings.SplitN(name, "_", 2)
-		if len(parts) != 2 {
-			continue
-		}
-		v, err := strconv.Atoi(parts[0])
-		if err != nil {
-			continue
-		}
-		versions = append(versions, v)
+		versions = append(versions, int(m.Version))
 	}
 	slices.Sort(versions)
 	return versions, nil

--- a/go/core/pkg/cli/db/migrate/migrate_test.go
+++ b/go/core/pkg/cli/db/migrate/migrate_test.go
@@ -362,3 +362,36 @@ func markDirty(t *testing.T, dsn, table string) {
 		t.Fatalf("mark %s dirty: %v", table, err)
 	}
 }
+
+func TestSourceFileVersions(t *testing.T) {
+	tests := []struct {
+		name  string
+		files []string
+		want  []int
+	}{
+		{"standard format", []string{"000001_create.up.sql", "000002_alter.up.sql"}, []int{1, 2}},
+		{"no underscore ignored", []string{"000003foo.up.sql"}, nil},
+		{"no leading digits ignored", []string{"notes.up.sql"}, nil},
+		{"down files ignored", []string{"000001_create.down.sql", "000001_create.up.sql"}, []int{1}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mfs := fstest.MapFS{}
+			for _, f := range tt.files {
+				mfs["m/"+f] = &fstest.MapFile{Data: []byte("-- sql")}
+			}
+			got, err := sourceFileVersions(migrations.Source{FS: mfs, Dir: "m"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("[%d] got %d, want %d", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/go/core/pkg/migrations/runner.go
+++ b/go/core/pkg/migrations/runner.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/golang-migrate/migrate/v4"
 	migratepgx "github.com/golang-migrate/migrate/v4/database/pgx/v5"
+	"github.com/golang-migrate/migrate/v4/source"
 	"github.com/golang-migrate/migrate/v4/source/iofs"
 	_ "github.com/jackc/pgx/v5/stdlib"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -653,13 +654,13 @@ func maxEmbeddedVersion(migrationsFS fs.FS, dir string) (uint, error) {
 			continue
 		}
 		foundUpSQL = true
-		var v uint
-		if _, scanErr := fmt.Sscanf(e.Name(), "%d", &v); scanErr != nil {
+		m, parseErr := source.DefaultParse(e.Name())
+		if parseErr != nil || m.Direction != source.Up {
 			continue
 		}
 		foundVersioned = true
-		if v > highest {
-			highest = v
+		if m.Version > highest {
+			highest = m.Version
 		}
 	}
 	if !foundUpSQL {

--- a/go/core/pkg/migrations/runner_test.go
+++ b/go/core/pkg/migrations/runner_test.go
@@ -351,6 +351,12 @@ func TestMaxEmbeddedVersion(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "no underscore returns error, matches golang-migrate",
+			fs:      fstest.MapFS{"core/000003foo.up.sql": {}},
+			dir:     "core",
+			wantErr: true,
+		},
+		{
 			name:    "empty dir returns error",
 			fs:      fstest.MapFS{"core/.keep": {}},
 			dir:     "core",


### PR DESCRIPTION
sourceFileVersions and maxEmbeddedVersion both used custom parsing that accepted filenames golang-migrate would skip, like one with no underscore after the number. Both now use source.DefaultParse so they can't drift from what golang-migrate actually runs.