### PR TITLE
docs: list bash in get_skill_tools Returns docstring

### DIFF
--- a/python/packages/kagent-openai/src/kagent/openai/tools/_tools.py
+++ b/python/packages/kagent-openai/src/kagent/openai/tools/_tools.py
@@ -180,6 +180,6 @@ def get_skill_tools(skills_directory: str | Path = "/skills") -> list[FunctionTo
         skills_directory: Path to the directory containing skills.
 
     Returns:
-        A list of FunctionTool instances: skills tool, read_file, write_file, edit_file
+        A list of FunctionTool instances: skills tool, read_file, write_file, edit_file, and bash
     """
     return [get_skill_tool(skills_directory), read_file, write_file, edit_file, bash]


### PR DESCRIPTION

```
## What

`get_skill_tools` in `python/packages/kagent-openai/src/kagent/openai/tools/_tools.py`
returns five tools:

    return [get_skill_tool(skills_directory), read_file, write_file, edit_file, bash]

but its `Returns:` docstring only listed the first four, omitting `bash`:

    A list of FunctionTool instances: skills tool, read_file, write_file, edit_file

This updates the docstring to enumerate all five tools so it matches what the
function actually returns.

## Why

`get_skill_tools` is the entry point that assembles the toolset granted to a
skills-enabled agent. `bash` is a real tool (`@function_tool(name_override="bash")`)
that executes shell commands, so leaving it out of the docstring understates the
capability, and security, surface: a reader relying on the docstring would not
realize a shell-execution tool is included in the returned set.

## Change

    -        A list of FunctionTool instances: skills tool, read_file, write_file, edit_file
    +        A list of FunctionTool instances: skills tool, read_file, write_file, edit_file, and bash

## Testing

Documentation-only change; no behavior is affected. `ruff check` and
`ruff format --check` pass on the file.
```
