### PR TITLE
test(adk): assert real tls_insecure_skip_verify tag in omitempty test

### DIFF
--- a/go/api/adk/types_test.go
+++ b/go/api/adk/types_test.go
@@ -53,12 +53,12 @@ func TestMarshalJSON_OmitemptyFields(t *testing.T) {
 		{
 			name:       "OpenAI zero-valued omitempty fields omitted",
 			model:      &OpenAI{BaseModel: BaseModel{Model: "gpt-4o"}},
-			wantAbsent: []string{"headers", "tls_disable_verify", "tls_ca_cert_path", "tls_disable_system_cas", "api_key_passthrough", "frequency_penalty", "max_tokens", "temperature"},
+			wantAbsent: []string{"headers", "tls_insecure_skip_verify", "tls_ca_cert_path", "tls_disable_system_cas", "api_key_passthrough", "frequency_penalty", "max_tokens", "temperature"},
 		},
 		{
 			name:       "Anthropic zero-valued omitempty fields omitted",
 			model:      &Anthropic{BaseModel: BaseModel{Model: "claude-3"}},
-			wantAbsent: []string{"headers", "tls_disable_verify", "tls_ca_cert_path", "tls_disable_system_cas", "api_key_passthrough"},
+			wantAbsent: []string{"headers", "tls_insecure_skip_verify", "tls_ca_cert_path", "tls_disable_system_cas", "api_key_passthrough"},
 		},
 		{
 			name:       "Bedrock zero-valued omitempty fields omitted",


### PR DESCRIPTION

### What

`TestMarshalJSON_OmitemptyFields` (`go/api/adk/types_test.go`) checks that
zero-valued `omitempty` fields are omitted from the marshalled model JSON by
listing the expected-absent JSON keys in `wantAbsent`. The OpenAI and Anthropic
cases listed `"tls_disable_verify"`, but no Go struct field serializes to that
key: the TLS-verify field on `BaseModel` is

```go
TLSInsecureSkipVerify *bool `json:"tls_insecure_skip_verify,omitempty"`
```

so it marshals to `tls_insecure_skip_verify`. Because the marshaller never emits
`tls_disable_verify`, `raw["tls_disable_verify"]` was always absent and the
assertion was vacuously true, it could never fail. As a result the `omitempty`
behavior of the TLS-verify pointer was not actually covered by this test.
`tls_disable_verify` is a Python-only legacy validation alias
(`python/packages/kagent-adk/.../types.py`, via `AliasChoices`) and has never
been a Go json tag.

This changes the two `wantAbsent` entries to the real json tag
`tls_insecure_skip_verify` so the assertion exercises the intended omission
behavior. No production code is touched; the `,omitempty` tag is already correct,
so the corrected test stays green on the current code.

### Why it is correct

The sibling presence test `TestMarshalJSON_BaseModelFields` already asserts on
`raw["tls_insecure_skip_verify"]`, confirming that is the tag the marshaller
emits and that the absent-key form was a copy/paste slip from the Python field
name.

### How it was verified

Temporarily dropping `,omitempty` from `BaseModel.TLSInsecureSkipVerify` makes the
corrected test fail:

```
field "tls_insecure_skip_verify" should be omitted when zero-valued, but was present
```

while the previous `tls_disable_verify` assertion still passed under the same
broken condition, demonstrating the old check was a no-op. Restoring `,omitempty`
makes the corrected test pass again.

Local checks (module `github.com/kagent-dev/kagent/go`, go 1.26):

- `go test ./api/adk/ -run TestMarshalJSON_OmitemptyFields -v` -> PASS (4/4)
- `go test -race ./api/adk/` -> PASS
- `gofmt -l`, `go vet ./api/adk/`, `golangci-lint run ./api/adk/...` -> clean / 0 issues
