### PR TITLE
docs: fix broken file links

### DIFF
--- a/docs/OIDC_PROXY_AUTH_ARCHITECTURE.md
+++ b/docs/OIDC_PROXY_AUTH_ARCHITECTURE.md
@@ -90,8 +90,8 @@ flowchart TB
 
 | Component | File | Purpose |
 |-----------|------|---------|
-| **ProxyAuthenticator** | `go/internal/httpserver/auth/proxy_authn.go` | Extract user identity from JWT Bearer tokens, pass through raw claims |
-| **CurrentUserHandler** | `go/internal/httpserver/handlers/current_user.go` | Returns raw JWT claims (or `{"sub": userId}` for non-JWT auth) |
+| **ProxyAuthenticator** | `go/core/internal/httpserver/auth/proxy_authn.go` | Extract user identity from JWT Bearer tokens, pass through raw claims |
+| **CurrentUserHandler** | `go/core/internal/httpserver/handlers/current_user.go` | Returns raw JWT claims (or `{"sub": userId}` for non-JWT auth) |
 
 ## Authentication Modes
 

--- a/docs/architecture/controller-reconciliation.md
+++ b/docs/architecture/controller-reconciliation.md
@@ -84,7 +84,7 @@ This filtering prevents unnecessary reconciliations when only the agent's status
 
 ## Related Files
 
-- [reconciler.go](../../go/internal/controller/reconciler/reconciler.go) - Shared reconciler implementation
-- [agent_controller.go](../../go/internal/controller/agent_controller.go) - Agent controller setup
-- [service.go](../../go/internal/database/service.go) - Database helpers with atomic upserts
-- [client.go](../../go/internal/database/client.go) - Database client implementation
+- [reconciler.go](../../go/core/internal/controller/reconciler/reconciler.go) - Shared reconciler implementation
+- [agent_controller.go](../../go/core/internal/controller/agent_controller.go) - Agent controller setup
+- [connect.go](../../go/core/internal/database/connect.go) - Database connection setup
+- [client_postgres.go](../../go/core/internal/database/client_postgres.go) - Database client implementation with atomic upserts

--- a/docs/architecture/human-in-the-loop.md
+++ b/docs/architecture/human-in-the-loop.md
@@ -1,6 +1,6 @@
 # Human-in-the-Loop
 
-Kagent implements Human-in-the-Loop (HITL) tool approval by combining a custom extension on top of A2A Task-driven communication and Google ADK's built-in `ToolContext.request_confirmation()` mechanism. When an agent or a subagent calls a tool marked with `requireApproval` the system pauses execution and asks the user to approve or reject the call before proceeding. This design avoids as much homebrewed Kagent constants and HITL logic as possible.
+Kagent implements Human-in-the-Loop (HITL) tool approval by combining a custom extension on top of A2A Task-driven communication and Google ADK's built-in `ToolContext.request_confirmation()` mechanism. When an agent or a subagent calls a tool marked with `requireApproval` the system pauses execution and asks the user to approve or reject the call before proceeding. This design avoids as much homebrewed HITL logic as possible.
 
 Below documents, in depth, how the HITL logic works in Kagent, and how relevant features are designed.
 
@@ -86,7 +86,7 @@ sequenceDiagram
 ### Detailed Sequence Diagrams
 
 You should only review the following diagrams if you are developing HITL features in Kagent. 
-They are extremely specific and you can almost find exact function representing each step in kagent / ADK code.
+They are extremely specific and you can almost find the exact function representing each step in kagent / ADK code.
 
 #### Direct HITL Flow
 

--- a/docs/architecture/prompt-templates.md
+++ b/docs/architecture/prompt-templates.md
@@ -283,8 +283,8 @@ kubectl get agent my-agent -o jsonpath='{.status.conditions[?(@.type=="Accepted"
 ## Related Files
 
 - [agent_types.go](../../go/api/v1alpha2/agent_types.go) — `PromptTemplateSpec`, `PromptSource` types
-- [template.go](../../go/internal/controller/translator/agent/template.go) — Template resolution logic
-- [template_test.go](../../go/internal/controller/translator/agent/template_test.go) — Unit tests
-- [adk_api_translator.go](../../go/internal/controller/translator/agent/adk_api_translator.go) — Template integration in `translateInlineAgent()`
-- [agent_controller.go](../../go/internal/controller/agent_controller.go) — ConfigMap watch setup
+- [template.go](../../go/core/internal/controller/translator/agent/template.go) — Template resolution logic
+- [template_test.go](../../go/core/internal/controller/translator/agent/template_test.go) — Unit tests
+- [adk_api_translator.go](../../go/core/internal/controller/translator/agent/adk_api_translator.go) — Template integration in `translateInlineAgent()`
+- [agent_controller.go](../../go/core/internal/controller/agent_controller.go) — ConfigMap watch setup
 - [builtin-prompts-configmap.yaml](../../helm/kagent/templates/builtin-prompts-configmap.yaml) — Built-in prompt templates


### PR DESCRIPTION
Some docs still point to go/internal/... paths from before the code moved to go/core/internal/.

Fixes links in:
- docs/architecture/prompt-templates.md
- docs/architecture/controller-reconciliation.md
- docs/OIDC_PROXY_AUTH_ARCHITECTURE.md

Also fixes two small grammar issues in docs/architecture/human-in-the-loop.md.

Checked every path in the diff resolves to a real file in the repo.