### PR TITLE
fix(bedrock): degrade to empty args on malformed streamed tool JSON

### DIFF
--- a/python/packages/kagent-adk/src/kagent/adk/models/_bedrock.py
+++ b/python/packages/kagent-adk/src/kagent/adk/models/_bedrock.py
@@ -421,7 +421,10 @@ class KAgentBedrockLlm(KAgentTLSMixin, BaseLlm):
                 if aggregated_text:
                     final_parts.append(types.Part.from_text(text=aggregated_text))
                 for tool_id, tool in tool_uses.items():
-                    args = json.loads(tool["input_json"]) if tool["input_json"] else {}
+                    try:
+                        args = json.loads(tool["input_json"]) if tool["input_json"] else {}
+                    except json.JSONDecodeError:
+                        args = {}
                     part = types.Part.from_function_call(name=tool["name"], args=args)
                     if part.function_call:
                         part.function_call.id = tool_id

--- a/python/packages/kagent-adk/src/kagent/adk/models/_bedrock.py
+++ b/python/packages/kagent-adk/src/kagent/adk/models/_bedrock.py
@@ -434,7 +434,10 @@ class KAgentBedrockLlm(KAgentTLSMixin, BaseLlm):
                 if aggregated_text:
                     final_parts.append(types.Part.from_text(text=aggregated_text))
                 for tool_id, tool in tool_uses.items():
-                    args = json.loads(tool["input_json"]) if tool["input_json"] else {}
+                    try:
+                        args = json.loads(tool["input_json"]) if tool["input_json"] else {}
+                    except json.JSONDecodeError:
+                        args = {}
                     part = types.Part.from_function_call(name=tool["name"], args=args)
                     if part.function_call:
                         part.function_call.id = tool_id

--- a/python/packages/kagent-adk/tests/unittests/models/test_bedrock.py
+++ b/python/packages/kagent-adk/tests/unittests/models/test_bedrock.py
@@ -358,6 +358,36 @@ class TestKAgentBedrockLlm:
         tool_names = [t["toolSpec"]["name"] for t in call_kwargs["toolConfig"]["tools"]]
         assert tool_names == ["fetch_get_url"]
 
+    @pytest.mark.asyncio
+    async def test_streaming_malformed_tool_input_degrades_to_empty_args(self):
+        """A truncated/malformed streamed tool-argument JSON must not abort the
+        turn: it degrades to empty args, matching the OpenAI and SAP AI Core
+        streaming paths."""
+        llm = KAgentBedrockLlm(model="us.anthropic.claude-sonnet-4-20250514-v1:0")
+
+        stream_events = [
+            {"contentBlockStart": {"start": {"toolUse": {"toolUseId": "call-xyz", "name": "get_weather"}}}},
+            {"contentBlockDelta": {"delta": {"toolUse": {"input": '{"city": "Paris"'}}}},
+            {"messageStop": {"stopReason": "tool_use"}},
+        ]
+        mock_client = mock.MagicMock()
+        mock_client.converse_stream.return_value = {"stream": stream_events}
+
+        request = mock.MagicMock()
+        request.model = "us.anthropic.claude-sonnet-4-20250514-v1:0"
+        request.contents = []
+        request.config = None
+
+        with mock.patch("kagent.adk.models._bedrock._get_bedrock_client", return_value=mock_client):
+            responses = [r async for r in llm.generate_content_async(request, stream=True)]
+
+        final = responses[-1]
+        assert final.error_code is None
+        fc = final.content.parts[0].function_call
+        assert fc.name == "get_weather"
+        assert fc.id == "call-xyz"
+        assert fc.args == {}
+
     def test_create_llm_from_bedrock_model_config(self):
         from kagent.adk.types import Bedrock, _create_llm_from_model_config
 

--- a/python/packages/kagent-adk/tests/unittests/models/test_bedrock.py
+++ b/python/packages/kagent-adk/tests/unittests/models/test_bedrock.py
@@ -306,6 +306,36 @@ class TestKAgentBedrockLlm:
         tool_names = [t["toolSpec"]["name"] for t in call_kwargs["toolConfig"]["tools"]]
         assert tool_names == ["fetch_get_url"]
 
+    @pytest.mark.asyncio
+    async def test_streaming_malformed_tool_input_degrades_to_empty_args(self):
+        """A truncated/malformed streamed tool-argument JSON must not abort the
+        turn: it degrades to empty args, matching the OpenAI and SAP AI Core
+        streaming paths."""
+        llm = KAgentBedrockLlm(model="us.anthropic.claude-sonnet-4-20250514-v1:0")
+
+        stream_events = [
+            {"contentBlockStart": {"start": {"toolUse": {"toolUseId": "call-xyz", "name": "get_weather"}}}},
+            {"contentBlockDelta": {"delta": {"toolUse": {"input": '{"city": "Paris"'}}}},
+            {"messageStop": {"stopReason": "tool_use"}},
+        ]
+        mock_client = mock.MagicMock()
+        mock_client.converse_stream.return_value = {"stream": stream_events}
+
+        request = mock.MagicMock()
+        request.model = "us.anthropic.claude-sonnet-4-20250514-v1:0"
+        request.contents = []
+        request.config = None
+
+        with mock.patch("kagent.adk.models._bedrock._get_bedrock_client", return_value=mock_client):
+            responses = [r async for r in llm.generate_content_async(request, stream=True)]
+
+        final = responses[-1]
+        assert final.error_code is None
+        fc = final.content.parts[0].function_call
+        assert fc.name == "get_weather"
+        assert fc.id == "call-xyz"
+        assert fc.args == {}
+
     def test_create_llm_from_bedrock_model_config(self):
         from kagent.adk.types import Bedrock, _create_llm_from_model_config
 


### PR DESCRIPTION

### What
In the Bedrock streaming path, tool-call arguments are accumulated across
`contentBlockDelta` chunks and then parsed with `json.loads`, but without the
`json.JSONDecodeError` guard that every other provider uses. When a streamed
tool-argument JSON is truncated or malformed, the `json.loads` raises inside the
response generator, gets caught by the broad `except Exception` that wraps the
whole method, and the entire turn is returned as an `API_ERROR`.

This PR wraps that single `json.loads` in `try/except json.JSONDecodeError` and
falls back to `{}`, so a recoverable-but-malformed streamed tool call degrades to
empty args instead of aborting the turn.

### Why
Every sibling provider already handles this exact situation gracefully, so
Bedrock streaming is the odd one out:

- OpenAI, non-streaming: `_openai.py` (`try/except json.JSONDecodeError: args = {}`)
- OpenAI, streaming: `_openai.py` (same guard on the accumulated tool call)
- SAP AI Core, streaming: `_sap_ai_core.py` (same guard)
- Bedrock, non-streaming: `_bedrock.py` reads an already-parsed dict
  (`tool.get("input", {})`), so it never raises here.

Only the Bedrock streaming branch parsed the accumulated `input_json` with a bare
`json.loads`. Streamed tool arguments are a realistic place for truncation (early
stream termination, or a model emitting slightly malformed JSON), so the
inconsistency is user-visible: the same partial tool call that recovers on
OpenAI/SAP fails the whole turn on Bedrock streaming. This change restores the
behavior the rest of the models package already standardized on.

### How
`python/packages/kagent-adk/src/kagent/adk/models/_bedrock.py`:

```python
for tool_id, tool in tool_uses.items():
    try:
        args = json.loads(tool["input_json"]) if tool["input_json"] else {}
    except json.JSONDecodeError:
        args = {}
    part = types.Part.from_function_call(name=tool["name"], args=args)
```

The `try/except` is copied verbatim from the sibling providers so the behavior is
identical across the package.

### Testing
Added a colocated regression test,
`test_streaming_malformed_tool_input_degrades_to_empty_args`, in
`python/packages/kagent-adk/tests/unittests/models/test_bedrock.py`. It drives the
real `generate_content_async(..., stream=True)` path with a mocked
`converse_stream` that emits a `toolUse` whose accumulated input is truncated
(`{"city": "Paris"`), and asserts the turn completes cleanly:
`error_code is None`, the function-call `name`/`id` are preserved, and
`args == {}`. Bedrock (AWS) is fully mocked, so no live credentials are needed.

- Before the fix, this test fails: the turn comes back as `API_ERROR`
  ("Expecting ',' delimiter").
- After the fix, it passes.

```
cd python
uv run pytest packages/kagent-adk/tests/unittests/models/test_bedrock.py   # 34 passed
uv run pytest packages/kagent-adk/tests/unittests/models/                  # 159 passed, 1 skipped
make lint                                                                   # clean
```

No CRD or Go API change, so no `make generate` and no E2E changes are required.
