### PR TITLE
fix(crewai): align memory storage save with LongTermMemory contract

### DIFF
--- a/python/packages/kagent-crewai/src/kagent/crewai/_memory.py
+++ b/python/packages/kagent-crewai/src/kagent/crewai/_memory.py
@@ -26,7 +26,7 @@ class KagentMemoryStorage:
         self.user_id = user_id
         self.base_url = base_url
 
-    def save(self, task_description: str, metadata: dict, timestamp: str, score: float) -> None:
+    def save(self, task_description: str, metadata: dict, datetime: str, score: float) -> None:
         """
         Saves a memory item to the Kagent backend.
         The agent_id is expected to be in the metadata.
@@ -39,7 +39,7 @@ class KagentMemoryStorage:
                 "task_description": task_description,
                 "score": score,
                 "metadata": metadata,
-                "datetime": timestamp,
+                "datetime": datetime,
             },
         )
 

--- a/python/packages/kagent-crewai/tests/test_memory.py
+++ b/python/packages/kagent-crewai/tests/test_memory.py
@@ -1,0 +1,54 @@
+import inspect
+from unittest.mock import MagicMock, patch
+
+from crewai.memory.long_term.long_term_memory import LongTermMemory
+from crewai.memory.long_term.long_term_memory_item import LongTermMemoryItem
+from crewai.memory.storage.ltm_sqlite_storage import LTMSQLiteStorage
+
+from kagent.crewai._memory import KagentMemoryStorage
+
+
+def test_save_signature_matches_crewai_storage_contract():
+    """KagentMemoryStorage.save must accept the same keyword arguments CrewAI's
+    LongTermMemory passes to its storage. CrewAI calls storage.save() with
+    datetime= as a keyword (see LongTermMemory.save), and the reference
+    LTMSQLiteStorage.save names that parameter 'datetime'."""
+    reference_params = list(inspect.signature(LTMSQLiteStorage.save).parameters)
+    kagent_params = list(inspect.signature(KagentMemoryStorage.save).parameters)
+    assert kagent_params == reference_params
+
+
+def test_long_term_memory_save_posts_datetime():
+    """A memory-enabled CrewAI crew wires KagentMemoryStorage as its
+    LongTermMemory backend. Saving must not raise and must forward the item's
+    datetime to the Kagent backend."""
+    storage = KagentMemoryStorage(
+        thread_id="thread-1",
+        user_id="user-1",
+        base_url="http://kagent.test",
+    )
+    long_term_memory = LongTermMemory(storage)
+    item = LongTermMemoryItem(
+        agent="researcher",
+        task="summarize the report",
+        expected_output="a summary",
+        datetime="2020-01-01T00:00:00",
+        quality=0.9,
+        metadata={"quality": 0.9},
+    )
+
+    with patch("kagent.crewai._memory.httpx.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client_cls.return_value.__enter__.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_client.post.return_value = mock_response
+
+        long_term_memory.save(item)
+
+        mock_client.post.assert_called_once()
+        _, kwargs = mock_client.post.call_args
+        memory_data = kwargs["json"]["memory_data"]
+        assert memory_data["datetime"] == "2020-01-01T00:00:00"
+        assert memory_data["task_description"] == "summarize the report"
+        assert memory_data["score"] == 0.9


### PR DESCRIPTION

### What

`KagentMemoryStorage.save` names its third parameter `timestamp`, but CrewAI's
`LongTermMemory` invokes its storage backend with that value passed as the
keyword argument `datetime`:

```python
# crewai/memory/long_term/long_term_memory.py (LongTermMemory.save)
self.storage.save(
    task_description=item.task,
    score=metadata["quality"],
    metadata=metadata,
    datetime=item.datetime,
)
```

The reference backend `LTMSQLiteStorage.save(self, task_description, metadata,
datetime, score)` names that parameter `datetime`, so any storage that plugs
into `LongTermMemory` has to use the same keyword. Because `KagentMemoryStorage`
uses `timestamp` instead, every long-term-memory write raises:

```
TypeError: KagentMemoryStorage.save() got an unexpected keyword argument 'datetime'
```

`_executor.py` wires `KagentMemoryStorage` as the crew's `LongTermMemory`
backend when memory is enabled, so this fires on any memory-enabled CrewAI crew
(`crew.memory=True`) the first time it persists a long-term-memory item. The
exception propagates out of `LongTermMemory.save` after a `MemorySaveFailedEvent`
is emitted.

### Fix

Rename the parameter from `timestamp` to `datetime` so the signature matches the
storage contract exactly. This is a two-line change and also aligns `save` with
the sibling `load`, which already reads and writes the `datetime` key.

### Tests

Added `packages/kagent-crewai/tests/test_memory.py`:

- `test_save_signature_matches_crewai_storage_contract` asserts
  `KagentMemoryStorage.save`'s parameters match the reference
  `LTMSQLiteStorage.save`.
- `test_long_term_memory_save_posts_datetime` drives a real
  `LongTermMemory(KagentMemoryStorage(...)).save(LongTermMemoryItem(...))` with
  the HTTP client mocked and asserts the item's datetime is forwarded to the
  backend in `memory_data["datetime"]`.

A new `tests/conftest.py` sets `KAGENT_URL` / `KAGENT_NAME` / `KAGENT_NAMESPACE`
defaults so the package imports without a running backend. Both tests fail on
`main` (the second with the exact upstream `TypeError`) and pass with the fix.

Run:

```
cd python
uv run pytest packages/kagent-crewai/tests/
```
