### PR TITLE
fix(go-adk): truncate A2A session name on rune boundaries

### DIFF
--- a/go/adk/pkg/a2a/executor.go
+++ b/go/adk/pkg/a2a/executor.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"os"
 	"strings"
+	"unicode/utf8"
 
 	a2atype "github.com/a2aproject/a2a-go/a2a"
 	"github.com/a2aproject/a2a-go/a2asrv"
@@ -424,14 +425,17 @@ func (e *KAgentExecutor) Cancel(ctx context.Context, reqCtx *a2asrv.RequestConte
 }
 
 // extractSessionName extracts session name from the first text part of a message.
+// Truncation is rune-aware: cutting on a byte boundary can split a multi-byte
+// UTF-8 rune and yield an invalid-UTF-8 name, which the Postgres session store
+// rejects on session create. sessionNameMaxLength is therefore counted in runes.
 func extractSessionName(message *a2atype.Message) string {
 	if message == nil {
 		return ""
 	}
 	for _, part := range message.Parts {
 		if tp, ok := part.(a2atype.TextPart); ok && tp.Text != "" {
-			if len(tp.Text) > sessionNameMaxLength {
-				return tp.Text[:sessionNameMaxLength] + "..."
+			if utf8.RuneCountInString(tp.Text) > sessionNameMaxLength {
+				return string([]rune(tp.Text)[:sessionNameMaxLength]) + "..."
 			}
 			return tp.Text
 		}

--- a/go/adk/pkg/a2a/executor.go
+++ b/go/adk/pkg/a2a/executor.go
@@ -6,7 +6,6 @@ import (
 	"maps"
 	"os"
 	"strings"
-	"unicode/utf8"
 
 	a2atype "github.com/a2aproject/a2a-go/a2a"
 	"github.com/a2aproject/a2a-go/a2asrv"
@@ -434,10 +433,15 @@ func extractSessionName(message *a2atype.Message) string {
 	}
 	for _, part := range message.Parts {
 		if tp, ok := part.(a2atype.TextPart); ok && tp.Text != "" {
-			if utf8.RuneCountInString(tp.Text) > sessionNameMaxLength {
-				return string([]rune(tp.Text)[:sessionNameMaxLength]) + "..."
+			text := strings.TrimSpace(tp.Text)
+			runeCount := 0
+			for byteIndex := range text {
+				if runeCount == sessionNameMaxLength {
+					return text[:byteIndex] + "..."
+				}
+				runeCount++
 			}
-			return tp.Text
+			return text
 		}
 	}
 	return ""

--- a/go/adk/pkg/a2a/executor.go
+++ b/go/adk/pkg/a2a/executor.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"iter"
 	"strings"
-	"unicode/utf8"
 
 	a2atype "github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/a2aproject/a2a-go/v2/a2asrv"
@@ -243,8 +242,13 @@ func extractSessionName(message *a2atype.Message) string {
 			continue
 		}
 		if text := part.Text(); text != "" {
-			if utf8.RuneCountInString(text) > sessionNameMaxLength {
-				return string([]rune(text)[:sessionNameMaxLength]) + "..."
+			text = strings.TrimSpace(text)
+			runeCount := 0
+			for byteIndex := range text {
+				if runeCount == sessionNameMaxLength {
+					return text[:byteIndex] + "..."
+				}
+				runeCount++
 			}
 			return text
 		}

--- a/go/adk/pkg/a2a/executor.go
+++ b/go/adk/pkg/a2a/executor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"iter"
 	"strings"
+	"unicode/utf8"
 
 	a2atype "github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/a2aproject/a2a-go/v2/a2asrv"
@@ -230,6 +231,9 @@ func (e *KAgentExecutor) Cleanup(ctx context.Context, reqCtx *a2asrv.ExecutorCon
 }
 
 // extractSessionName extracts session name from the first text part of a message.
+// Truncation is rune-aware: cutting on a byte boundary can split a multi-byte
+// UTF-8 rune and yield an invalid-UTF-8 name, which the Postgres session store
+// rejects on session create. sessionNameMaxLength is therefore counted in runes.
 func extractSessionName(message *a2atype.Message) string {
 	if message == nil {
 		return ""
@@ -239,8 +243,8 @@ func extractSessionName(message *a2atype.Message) string {
 			continue
 		}
 		if text := part.Text(); text != "" {
-			if len(text) > sessionNameMaxLength {
-				return text[:sessionNameMaxLength] + "..."
+			if utf8.RuneCountInString(text) > sessionNameMaxLength {
+				return string([]rune(text)[:sessionNameMaxLength]) + "..."
 			}
 			return text
 		}

--- a/go/adk/pkg/a2a/executor_test.go
+++ b/go/adk/pkg/a2a/executor_test.go
@@ -2,6 +2,7 @@ package a2a
 
 import (
 	"testing"
+	"unicode/utf8"
 
 	a2atype "github.com/a2aproject/a2a-go/a2a"
 	"github.com/a2aproject/a2a-go/a2asrv"
@@ -63,5 +64,66 @@ func TestNewAgentStatusEvent_MessageCarriesIDs(t *testing.T) {
 	}
 	if ev.TaskID != a2atype.TaskID("task-xyz") {
 		t.Errorf("event TaskID = %q, want %q", ev.TaskID, a2atype.TaskID("task-xyz"))
+	}
+}
+
+// TestExtractSessionName verifies session names are truncated on rune boundaries.
+// A byte-wise cut can split a multi-byte UTF-8 rune and produce an invalid-UTF-8
+// name, which the Postgres session store rejects on session create. The result
+// must always be valid UTF-8, and pure-ASCII behavior must be unchanged.
+func TestExtractSessionName(t *testing.T) {
+	textMsg := func(s string) *a2atype.Message {
+		return &a2atype.Message{Parts: []a2atype.Part{a2atype.TextPart{Text: s}}}
+	}
+
+	tests := []struct {
+		name string
+		msg  *a2atype.Message
+		want string
+	}{
+		{name: "nil message", msg: nil, want: ""},
+		{name: "no parts", msg: &a2atype.Message{}, want: ""},
+		{name: "short ascii", msg: textMsg("hello"), want: "hello"},
+		{
+			name: "ascii at limit is not truncated",
+			msg:  textMsg("01234567890123456789"), // exactly 20 runes
+			want: "01234567890123456789",
+		},
+		{
+			name: "long ascii is truncated with ellipsis",
+			msg:  textMsg("012345678901234567890"), // 21 runes
+			want: "01234567890123456789...",
+		},
+		{
+			// 7 CJK runes = 21 bytes: byte-slicing at 20 splits the 7th rune.
+			name: "multibyte over byte limit stays valid utf8",
+			msg:  textMsg("こんにちは世界"),
+			want: "こんにちは世界",
+		},
+		{
+			name: "long multibyte truncated on rune boundary",
+			msg:  textMsg("あいうえおかきくけこさしすせそたちつてとな"), // 21 runes
+			want: "あいうえおかきくけこさしすせそたちつてと...",
+		},
+		{
+			name: "skips empty text part and uses first non-empty",
+			msg: &a2atype.Message{Parts: []a2atype.Part{
+				a2atype.TextPart{Text: ""},
+				a2atype.TextPart{Text: "hi"},
+			}},
+			want: "hi",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractSessionName(tt.msg)
+			if got != tt.want {
+				t.Errorf("extractSessionName() = %q, want %q", got, tt.want)
+			}
+			if !utf8.ValidString(got) {
+				t.Errorf("extractSessionName() returned invalid UTF-8: %q", got)
+			}
+		})
 	}
 }

--- a/go/adk/pkg/a2a/executor_test.go
+++ b/go/adk/pkg/a2a/executor_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"iter"
 	"testing"
+	"unicode/utf8"
 
 	a2atype "github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/a2aproject/a2a-go/v2/a2asrv"
@@ -363,5 +364,66 @@ func TestKAgentExecutor_HITLPauseAndResumeFlow(t *testing.T) {
 	}
 	if resumedText != "resumed" || invocations != 2 {
 		t.Fatalf("resumed text = %q, invocations = %d", resumedText, invocations)
+	}
+}
+
+// TestExtractSessionName verifies session names are truncated on rune boundaries.
+// A byte-wise cut can split a multi-byte UTF-8 rune and produce an invalid-UTF-8
+// name, which the Postgres session store rejects on session create. The result
+// must always be valid UTF-8, and pure-ASCII behavior must be unchanged.
+func TestExtractSessionName(t *testing.T) {
+	textMsg := func(s string) *a2atype.Message {
+		return &a2atype.Message{Parts: []a2atype.Part{a2atype.TextPart{Text: s}}}
+	}
+
+	tests := []struct {
+		name string
+		msg  *a2atype.Message
+		want string
+	}{
+		{name: "nil message", msg: nil, want: ""},
+		{name: "no parts", msg: &a2atype.Message{}, want: ""},
+		{name: "short ascii", msg: textMsg("hello"), want: "hello"},
+		{
+			name: "ascii at limit is not truncated",
+			msg:  textMsg("01234567890123456789"), // exactly 20 runes
+			want: "01234567890123456789",
+		},
+		{
+			name: "long ascii is truncated with ellipsis",
+			msg:  textMsg("012345678901234567890"), // 21 runes
+			want: "01234567890123456789...",
+		},
+		{
+			// 7 CJK runes = 21 bytes: byte-slicing at 20 splits the 7th rune.
+			name: "multibyte over byte limit stays valid utf8",
+			msg:  textMsg("こんにちは世界"),
+			want: "こんにちは世界",
+		},
+		{
+			name: "long multibyte truncated on rune boundary",
+			msg:  textMsg("あいうえおかきくけこさしすせそたちつてとな"), // 21 runes
+			want: "あいうえおかきくけこさしすせそたちつてと...",
+		},
+		{
+			name: "skips empty text part and uses first non-empty",
+			msg: &a2atype.Message{Parts: []a2atype.Part{
+				a2atype.TextPart{Text: ""},
+				a2atype.TextPart{Text: "hi"},
+			}},
+			want: "hi",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractSessionName(tt.msg)
+			if got != tt.want {
+				t.Errorf("extractSessionName() = %q, want %q", got, tt.want)
+			}
+			if !utf8.ValidString(got) {
+				t.Errorf("extractSessionName() returned invalid UTF-8: %q", got)
+			}
+		})
 	}
 }

--- a/go/adk/pkg/a2a/executor_test.go
+++ b/go/adk/pkg/a2a/executor_test.go
@@ -373,7 +373,7 @@ func TestKAgentExecutor_HITLPauseAndResumeFlow(t *testing.T) {
 // must always be valid UTF-8, and pure-ASCII behavior must be unchanged.
 func TestExtractSessionName(t *testing.T) {
 	textMsg := func(s string) *a2atype.Message {
-		return &a2atype.Message{Parts: []a2atype.Part{a2atype.TextPart{Text: s}}}
+		return a2atype.NewMessage(a2atype.MessageRoleUser, a2atype.NewTextPart(s))
 	}
 
 	tests := []struct {
@@ -413,10 +413,7 @@ func TestExtractSessionName(t *testing.T) {
 		},
 		{
 			name: "skips empty text part and uses first non-empty",
-			msg: &a2atype.Message{Parts: []a2atype.Part{
-				a2atype.TextPart{Text: ""},
-				a2atype.TextPart{Text: "hi"},
-			}},
+			msg:  a2atype.NewMessage(a2atype.MessageRoleUser, a2atype.NewTextPart(""), a2atype.NewTextPart("hi")),
 			want: "hi",
 		},
 	}

--- a/go/adk/pkg/a2a/executor_test.go
+++ b/go/adk/pkg/a2a/executor_test.go
@@ -384,6 +384,7 @@ func TestExtractSessionName(t *testing.T) {
 		{name: "nil message", msg: nil, want: ""},
 		{name: "no parts", msg: &a2atype.Message{}, want: ""},
 		{name: "short ascii", msg: textMsg("hello"), want: "hello"},
+		{name: "surrounding whitespace is trimmed", msg: textMsg("  hello\n"), want: "hello"},
 		{
 			name: "ascii at limit is not truncated",
 			msg:  textMsg("01234567890123456789"), // exactly 20 runes
@@ -404,6 +405,11 @@ func TestExtractSessionName(t *testing.T) {
 			name: "long multibyte truncated on rune boundary",
 			msg:  textMsg("あいうえおかきくけこさしすせそたちつてとな"), // 21 runes
 			want: "あいうえおかきくけこさしすせそたちつてと...",
+		},
+		{
+			name: "whitespace is trimmed before truncation",
+			msg:  textMsg("  012345678901234567890  "),
+			want: "01234567890123456789...",
 		},
 		{
 			name: "skips empty text part and uses first non-empty",

--- a/go/adk/pkg/a2a/executor_test.go
+++ b/go/adk/pkg/a2a/executor_test.go
@@ -84,6 +84,7 @@ func TestExtractSessionName(t *testing.T) {
 		{name: "nil message", msg: nil, want: ""},
 		{name: "no parts", msg: &a2atype.Message{}, want: ""},
 		{name: "short ascii", msg: textMsg("hello"), want: "hello"},
+		{name: "surrounding whitespace is trimmed", msg: textMsg("  hello\n"), want: "hello"},
 		{
 			name: "ascii at limit is not truncated",
 			msg:  textMsg("01234567890123456789"), // exactly 20 runes
@@ -104,6 +105,11 @@ func TestExtractSessionName(t *testing.T) {
 			name: "long multibyte truncated on rune boundary",
 			msg:  textMsg("あいうえおかきくけこさしすせそたちつてとな"), // 21 runes
 			want: "あいうえおかきくけこさしすせそたちつてと...",
+		},
+		{
+			name: "whitespace is trimmed before truncation",
+			msg:  textMsg("  012345678901234567890  "),
+			want: "01234567890123456789...",
 		},
 		{
 			name: "skips empty text part and uses first non-empty",


### PR DESCRIPTION

### What

`extractSessionName` in `go/adk/pkg/a2a/executor.go` derives a session name from the
first text part of an inbound A2A message and caps it at `sessionNameMaxLength` (20).
The cap used a byte-wise slice:

```go
if len(tp.Text) > sessionNameMaxLength {
    return tp.Text[:sessionNameMaxLength] + "..."
}
```

Both `len()` and the `[:20]` slice operate on bytes, not runes. A first message longer
than 20 bytes that begins with multi-byte UTF-8 (CJK, emoji, accented Latin) gets cut
in the middle of a rune, producing an invalid-UTF-8 string.

This is only ~6-7 non-ASCII characters, so it is easy to hit for non-English users.
For example `こんにちは世界` (7 CJK runes = 21 bytes) truncates to
`こんにちは世\xe7\x95...`, which is not valid UTF-8.

### Why it matters

The derived name flows into `state[StateKeySessionName]` and is persisted via
`CreateSession`:

- On the **Postgres** session store, a `text` column rejects invalid UTF-8, so the
  session-create call fails and the whole turn is aborted with an error, a valid
  non-English first message can break the conversation.
- On **SQLite**, the invalid bytes are stored as mojibake and shown in the UI.

### The fix

Count the cap in runes and slice on a rune boundary, so the result is always valid
UTF-8:

```go
if utf8.RuneCountInString(tp.Text) > sessionNameMaxLength {
    return string([]rune(tp.Text)[:sessionNameMaxLength]) + "..."
}
```

Pure-ASCII behavior is unchanged (for ASCII, byte count == rune count), and the `"..."`
suffix is kept. The only additions are the `unicode/utf8` import and a short doc comment
explaining why truncation is rune-aware.

### Tests

Adds a table-driven `TestExtractSessionName` colocated in
`go/adk/pkg/a2a/executor_test.go` covering:

- nil message / no parts / short ASCII (unchanged behavior)
- ASCII exactly at the 20-rune limit (not truncated)
- ASCII over the limit (truncated with `...`)
- multi-byte over the 20-**byte** limit but under the rune limit (must stay valid UTF-8)
- long multi-byte truncated on a rune boundary
- skipping an empty text part and using the first non-empty one

Each case asserts both the exact result and `utf8.ValidString(got)`. The multi-byte
cases fail against the old byte-slice code (they return invalid UTF-8) and pass with the
fix; the ASCII cases pass either way.

Verified locally:

```
cd go && go test -race -run TestExtractSessionName -v ./adk/pkg/a2a/   # PASS (8/8)
cd go && go test -race -skip 'TestE2E.*' ./adk/...                     # ok, no regressions
cd go && go build ./adk/... && go vet ./adk/pkg/a2a/                   # clean
```

This is a small (<100 LoC) bug fix with unit coverage and no CRD/API change, so no E2E
change is needed.
