### PR TITLE
ci: read go version from go.mod in sqlc check

### DIFF
--- a/.github/workflows/sqlc-generate-check.yaml
+++ b/.github/workflows/sqlc-generate-check.yaml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version-file: go/go.mod
           cache: true
           cache-dependency-path: go/go.sum
 


### PR DESCRIPTION
Go version was hardcoded to 1.26 in sqlc-generate-check.yaml, so it drifts when go.mod changes. Now reads go-version-file from go/go.mod like the other workflows.