### PR TITLE
feat(helm): add optional networking.k8s.io/v1 Ingress for the UI

### DIFF
--- a/helm/kagent/templates/ui-ingress.yaml
+++ b/helm/kagent/templates/ui-ingress.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.ui.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "kagent.fullname" . }}-ui
+  namespace: {{ include "kagent.namespace" . }}
+  labels:
+    {{- include "kagent.ui.labels" . | nindent 4 }}
+    {{- with .Values.ui.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.ui.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ui.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ui.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ui.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ (.backend).name | default (printf "%s-ui" (include "kagent.fullname" $)) }}
+                port:
+                  number: {{ (.backend).port | default $.Values.ui.service.ports.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/kagent/tests/ui-ingress_test.yaml
+++ b/helm/kagent/tests/ui-ingress_test.yaml
@@ -1,0 +1,81 @@
+suite: test UI ingress
+templates:
+  - ui-ingress.yaml
+tests:
+  - it: should not render an Ingress by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render an Ingress with host, class and default UI backend
+    set:
+      ui:
+        ingress:
+          enabled: true
+          className: nginx
+          hosts:
+            - host: kagent.example.com
+              paths:
+                - path: /
+                  pathType: Prefix
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+      - equal:
+          path: spec.rules[0].host
+          value: kagent.example.com
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: RELEASE-NAME-ui
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 8080
+
+  - it: should allow a per-path backend override
+    set:
+      ui:
+        ingress:
+          enabled: true
+          hosts:
+            - host: kagent.example.com
+              paths:
+                - path: /
+                  pathType: ImplementationSpecific
+                  backend:
+                    name: kagent-oauth2-proxy
+                    port: 4180
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: kagent-oauth2-proxy
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 4180
+      - equal:
+          path: spec.rules[0].http.paths[0].pathType
+          value: ImplementationSpecific
+
+  - it: should pass tls and annotations through
+    set:
+      ui:
+        ingress:
+          enabled: true
+          annotations:
+            cert-manager.io/cluster-issuer: letsencrypt
+          hosts:
+            - host: kagent.example.com
+              paths:
+                - path: /
+          tls:
+            - hosts: [kagent.example.com]
+              secretName: kagent-tls
+    asserts:
+      - equal:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+          value: letsencrypt
+      - equal:
+          path: spec.tls[0].secretName
+          value: kagent-tls

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -504,6 +504,35 @@ ui:
     #       request: "0s"
     #       backendRequest: "0s"
 
+  # -- Optional `networking.k8s.io/v1` Ingress for the UI, for clusters using
+  # classic ingress controllers (AWS ALB, ingress-nginx, etc.) instead of the
+  # Gateway API `httpRoute` above. Each path may override `backend` (name/port)
+  # to front the UI with something else, e.g. the bundled oauth2-proxy.
+  ingress:
+    enabled: false
+    # -- IngressClass name (e.g. `alb`, `nginx`). Omitted when empty.
+    className: ""
+    # -- Extra labels to add to the `Ingress` (merged with the chart labels).
+    labels: {}
+    # -- Annotations to add to the `Ingress` (controller-specific settings).
+    annotations: {}
+    # -- Hosts and their paths. When a path omits `backend`, it defaults to
+    # the UI `Service` on `ui.service.ports.port`.
+    hosts: []
+    #   - host: kagent.example.com
+    #     paths:
+    #       - path: /
+    #         pathType: Prefix
+    #       - path: /
+    #         pathType: Prefix
+    #         backend:
+    #           name: kagent-oauth2-proxy
+    #           port: 4180
+    # -- TLS configuration, passed through verbatim.
+    tls: []
+    #   - hosts: [kagent.example.com]
+    #     secretName: kagent-tls
+
 # ==============================================================================
 # LLM PROVIDERS CONFIGURATION
 # ==============================================================================


### PR DESCRIPTION
## What
Adds an optional classic `networking.k8s.io/v1` **Ingress** for the UI (`ui.ingress`, disabled by default) — className, labels/annotations, hosts/paths with **per-path backend override**, and `tls` passthrough.

## Why
The chart currently exposes the UI via Gateway API `HTTPRoute` and OpenShift `Route`, but clusters on classic ingress controllers (AWS ALB, ingress-nginx, Traefik) have no built-in option and must hand-roll an Ingress out-of-band. We hit this deploying kagent 0.9.11 on EKS behind an internal ALB.

The per-path `backend` override covers the common auth pattern of pointing the Ingress at the bundled **oauth2-proxy** instead of the UI Service:

```yaml
ui:
  ingress:
    enabled: true
    className: alb
    hosts:
      - host: kagent.example.com
        paths:
          - path: /
            pathType: Prefix
            backend:
              name: kagent-oauth2-proxy
              port: 4180
```

## Notes
- Disabled by default; no behavior change.
- Follows the `ui.httpRoute` conventions (labels merged with chart labels, annotations passthrough, backend defaults to the UI Service on `ui.service.ports.port`).
- helm-unittest coverage: default off, class/host/default-backend, per-path backend override, tls+annotations passthrough (4 tests).

Related: #2237 (podLabels for controller/UI pods) — together these let the chart run unmodified behind cluster admission policies + classic ingress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)