### PR TITLE
feat(helm): optional Istio resources (Sidecar egress, ServiceEntries, JWT authn/authz)

### DIFF
--- a/helm/kagent/templates/istio.yaml
+++ b/helm/kagent/templates/istio.yaml
@@ -1,0 +1,81 @@
+{{- /*
+Optional Istio resources, all disabled by default and fully value-driven so
+each org can shape them to its own mesh policy. See the `istio` block in
+values.yaml.
+*/}}
+{{- if .Values.istio.sidecar.enabled }}
+apiVersion: networking.istio.io/v1
+kind: Sidecar
+metadata:
+  name: {{ include "kagent.fullname" . }}-sidecar
+  namespace: {{ include "kagent.namespace" . }}
+  labels:
+    {{- include "kagent.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.istio.sidecar.workloadSelector }}
+  workloadSelector:
+    labels:
+      {{- toYaml . | nindent 6 }}
+  {{- end }}
+  egress:
+    - hosts:
+        {{- toYaml .Values.istio.sidecar.egressHosts | nindent 8 }}
+  {{- with .Values.istio.sidecar.outboundTrafficPolicy }}
+  outboundTrafficPolicy:
+    mode: {{ . }}
+  {{- end }}
+{{- end }}
+{{- range .Values.istio.serviceEntries }}
+---
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: {{ include "kagent.fullname" $ }}-{{ .name }}
+  namespace: {{ include "kagent.namespace" $ }}
+  labels:
+    {{- include "kagent.labels" $ | nindent 4 }}
+spec:
+  hosts:
+    {{- toYaml .hosts | nindent 4 }}
+  location: {{ .location | default "MESH_EXTERNAL" }}
+  resolution: {{ .resolution | default "DNS" }}
+  ports:
+    {{- toYaml .ports | nindent 4 }}
+{{- end }}
+{{- if .Values.istio.requestAuthentication.enabled }}
+---
+apiVersion: security.istio.io/v1
+kind: RequestAuthentication
+metadata:
+  name: {{ include "kagent.fullname" . }}-jwt
+  namespace: {{ include "kagent.namespace" . }}
+  labels:
+    {{- include "kagent.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.istio.requestAuthentication.selector }}
+  selector:
+    matchLabels:
+      {{- toYaml . | nindent 6 }}
+  {{- end }}
+  jwtRules:
+    {{- toYaml .Values.istio.requestAuthentication.jwtRules | nindent 4 }}
+{{- end }}
+{{- if .Values.istio.authorizationPolicy.enabled }}
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ include "kagent.fullname" . }}-authz
+  namespace: {{ include "kagent.namespace" . }}
+  labels:
+    {{- include "kagent.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.istio.authorizationPolicy.selector }}
+  selector:
+    matchLabels:
+      {{- toYaml . | nindent 6 }}
+  {{- end }}
+  action: {{ .Values.istio.authorizationPolicy.action | default "ALLOW" }}
+  rules:
+    {{- toYaml .Values.istio.authorizationPolicy.rules | nindent 4 }}
+{{- end }}

--- a/helm/kagent/tests/istio_test.yaml
+++ b/helm/kagent/tests/istio_test.yaml
@@ -1,0 +1,99 @@
+suite: test optional istio resources
+templates:
+  - istio.yaml
+tests:
+  - it: should render nothing by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a Sidecar with selector, egress hosts and outbound policy
+    set:
+      istio:
+        sidecar:
+          enabled: true
+          workloadSelector:
+            app.kubernetes.io/instance: kagent
+          egressHosts:
+            - "./*"
+            - "istio-system/*"
+            - "monitoring/*"
+          outboundTrafficPolicy: REGISTRY_ONLY
+    asserts:
+      - isKind:
+          of: Sidecar
+      - equal:
+          path: spec.workloadSelector.labels["app.kubernetes.io/instance"]
+          value: kagent
+      - contains:
+          path: spec.egress[0].hosts
+          content: "monitoring/*"
+      - equal:
+          path: spec.outboundTrafficPolicy.mode
+          value: REGISTRY_ONLY
+
+  - it: should render ServiceEntries with defaults and explicit TCP ports
+    set:
+      istio:
+        serviceEntries:
+          - name: openai
+            hosts: [api.openai.com]
+            ports:
+              - number: 443
+                name: https
+                protocol: TLS
+          - name: postgres
+            hosts: [db.example.internal]
+            ports:
+              - number: 5432
+                name: tcp-postgres
+                protocol: TCP
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: ServiceEntry
+      - equal:
+          path: spec.location
+          value: MESH_EXTERNAL
+        documentIndex: 0
+      - equal:
+          path: spec.ports[0].number
+          value: 5432
+        documentIndex: 1
+
+  - it: should render JWT RequestAuthentication and AuthorizationPolicy
+    set:
+      istio:
+        requestAuthentication:
+          enabled: true
+          selector:
+            app.kubernetes.io/name: kagent
+          jwtRules:
+            - issuer: https://accounts.example.com
+              jwksUri: https://accounts.example.com/.well-known/jwks.json
+        authorizationPolicy:
+          enabled: true
+          selector:
+            app.kubernetes.io/name: kagent
+          rules:
+            - from:
+                - source:
+                    requestPrincipals: ["*"]
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: RequestAuthentication
+        documentIndex: 0
+      - equal:
+          path: spec.jwtRules[0].issuer
+          value: https://accounts.example.com
+        documentIndex: 0
+      - isKind:
+          of: AuthorizationPolicy
+        documentIndex: 1
+      - equal:
+          path: spec.rules[0].from[0].source.requestPrincipals[0]
+          value: "*"
+        documentIndex: 1

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -905,3 +905,59 @@ otel:
         endpoint: ""
         timeout: 15000 # milliseconds
         insecure: true
+
+# ==============================================================================
+# ------------------------------ Istio (optional) -----------------------------
+# ==============================================================================
+# -- Optional Istio resources for meshes. All disabled by default and fully
+# value-driven so each org can shape them to its own mesh policy. Sidecar
+# injection itself is controlled via `podAnnotations`
+# (e.g. `sidecar.istio.io/inject: "true"`).
+istio:
+  # -- `Sidecar` restricting egress for the chart's pods — useful under
+  # `REGISTRY_ONLY` meshes to allow-list what agents may reach.
+  sidecar:
+    enabled: false
+    # -- Pod labels the Sidecar applies to. Empty selects every pod in the
+    # namespace — set this on shared namespaces.
+    workloadSelector: {}
+    #   app.kubernetes.io/instance: kagent
+    # -- Egress hosts visible to the selected pods.
+    egressHosts:
+      - "./*"
+      - "istio-system/*"
+    # -- Outbound traffic mode (`REGISTRY_ONLY` / `ALLOW_ANY`). Omitted when empty.
+    outboundTrafficPolicy: ""
+  # -- `ServiceEntry` objects registering external hosts (LLM providers, OAuth
+  # issuers, databases, ...) in the mesh registry.
+  serviceEntries: []
+  #   - name: openai
+  #     hosts: [api.openai.com]
+  #     ports:
+  #       - number: 443
+  #         name: https
+  #         protocol: TLS
+  #   - name: postgres
+  #     hosts: [db.example.internal]
+  #     ports:
+  #       - number: 5432
+  #         name: tcp-postgres
+  #         protocol: TCP
+  # -- `RequestAuthentication` validating JWTs on the selected workloads
+  # (`jwtRules` passed through verbatim).
+  requestAuthentication:
+    enabled: false
+    selector: {}
+    jwtRules: []
+    #   - issuer: https://accounts.example.com
+    #     jwksUri: https://accounts.example.com/.well-known/jwks.json
+  # -- `AuthorizationPolicy` for the selected workloads (`rules` passed
+  # through verbatim, e.g. requiring a valid JWT principal).
+  authorizationPolicy:
+    enabled: false
+    selector: {}
+    action: ALLOW
+    rules: []
+    #   - from:
+    #       - source:
+    #           requestPrincipals: ["*"]


### PR DESCRIPTION
## What
A generic, fully value-driven `istio` block (everything **disabled by default**):

- **`Sidecar`** — restrict egress for the chart's pods (`workloadSelector`, `egressHosts`, `outboundTrafficPolicy`). This is the allow-list agent pods need under `REGISTRY_ONLY` meshes.
- **`ServiceEntry` list** — register the external hosts agents actually reach (LLM providers, OAuth issuers, databases) in the mesh registry; TLS or raw TCP ports.
- **`RequestAuthentication` + `AuthorizationPolicy`** — JWT validation / access rules on selected workloads, with `jwtRules` / `rules` passed through verbatim.

## Why
Agents are exactly the workload you want egress-fenced: they execute model-driven tool calls, so meshes running `REGISTRY_ONLY` need ServiceEntries for every LLM/OAuth/DB host and a Sidecar allow-list — today that all has to live in a wrapper chart. We run kagent 0.9.11 on EKS + Istio with this shape in production (LiteLLM + Okta + Postgres egress).

Nothing here is opinionated: no hosts or issuers are pre-filled, selectors are user-supplied, and sidecar injection itself stays where it already works (`podAnnotations`). Orgs not on Istio see zero change.

## Notes
- helm-unittest coverage: default off, Sidecar (selector/hosts/mode), ServiceEntries (TLS + TCP, defaults), JWT pair (4 tests).
- Related from the same deployment: #2237 (pod labels), #2238 (UI Ingress), #2239 (oauth2-proxy bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)