### PR TITLE
feat(helm): optional Vault Secrets Operator integration

### DIFF
--- a/helm/kagent/templates/vault-secrets.yaml
+++ b/helm/kagent/templates/vault-secrets.yaml
@@ -1,0 +1,57 @@
+{{- /*
+Optional HashiCorp Vault Secrets Operator (VSO) integration, disabled by
+default and fully value-driven. Materializes chart secrets (model API keys,
+oauth2-proxy credentials, ...) as REAL Kubernetes Secrets sourced from Vault —
+required when secrets are consumed via the Kubernetes API (e.g. ModelConfig
+apiKeySecretRef), where pod-level injection webhooks cannot intercept.
+Requires the Vault Secrets Operator to be installed in the cluster.
+*/}}
+{{- if .Values.vault.enabled }}
+{{- if .Values.vault.auth.create }}
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultAuth
+metadata:
+  name: {{ include "kagent.fullname" . }}-vault-auth
+  namespace: {{ include "kagent.namespace" . }}
+  labels:
+    {{- include "kagent.labels" . | nindent 4 }}
+spec:
+  method: {{ .Values.vault.auth.method }}
+  mount: {{ .Values.vault.auth.mount }}
+  {{- with .Values.vault.auth.vaultConnectionRef }}
+  vaultConnectionRef: {{ . }}
+  {{- end }}
+  {{- if eq .Values.vault.auth.method "kubernetes" }}
+  kubernetes:
+    role: {{ required "vault.auth.kubernetes.role is required" .Values.vault.auth.kubernetes.role }}
+    serviceAccount: {{ .Values.vault.auth.kubernetes.serviceAccount | default (printf "%s-controller" (include "kagent.fullname" .)) }}
+    {{- with .Values.vault.auth.kubernetes.audiences }}
+    audiences:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- range .Values.vault.staticSecrets }}
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: {{ include "kagent.fullname" $ }}-{{ .name }}
+  namespace: {{ include "kagent.namespace" $ }}
+  labels:
+    {{- include "kagent.labels" $ | nindent 4 }}
+spec:
+  type: {{ .type | default "kv-v2" }}
+  mount: {{ .mount | default $.Values.vault.mount }}
+  path: {{ .path }}
+  vaultAuthRef: {{ $.Values.vault.auth.ref | default (printf "%s-vault-auth" (include "kagent.fullname" $)) }}
+  refreshAfter: {{ .refreshAfter | default "60s" }}
+  destination:
+    name: {{ .destination | default .name }}
+    create: {{ if hasKey . "createDestination" }}{{ .createDestination }}{{ else }}true{{ end }}
+    {{- with .transformation }}
+    transformation:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/helm/kagent/tests/vault-secrets_test.yaml
+++ b/helm/kagent/tests/vault-secrets_test.yaml
@@ -1,0 +1,103 @@
+suite: test optional vault (VSO) resources
+templates:
+  - vault-secrets.yaml
+tests:
+  - it: should render nothing by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a VaultAuth with kubernetes auth and default SA
+    set:
+      vault:
+        enabled: true
+        auth:
+          kubernetes:
+            role: svcs-my-namespace
+            audiences: [vault]
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: VaultAuth
+      - equal:
+          path: spec.method
+          value: kubernetes
+      - equal:
+          path: spec.kubernetes.role
+          value: svcs-my-namespace
+      - equal:
+          path: spec.kubernetes.serviceAccount
+          value: RELEASE-NAME-controller
+      - contains:
+          path: spec.kubernetes.audiences
+          content: vault
+
+  - it: should render VaultStaticSecrets with defaults and transformation passthrough
+    set:
+      vault:
+        enabled: true
+        auth:
+          kubernetes:
+            role: svcs-my-namespace
+        staticSecrets:
+          - name: model-api-key
+            path: teams/ai/kagent
+            destination: kagent-openai
+            transformation:
+              excludes: [".*"]
+              templates:
+                OPENAI_API_KEY:
+                  text: '{{- get .Secrets "OPENAI_API_KEY" -}}'
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: VaultStaticSecret
+        documentIndex: 1
+      - equal:
+          path: spec.mount
+          value: secret
+        documentIndex: 1
+      - equal:
+          path: spec.path
+          value: teams/ai/kagent
+        documentIndex: 1
+      - equal:
+          path: spec.vaultAuthRef
+          value: RELEASE-NAME-vault-auth
+        documentIndex: 1
+      - equal:
+          path: spec.destination.name
+          value: kagent-openai
+        documentIndex: 1
+      - equal:
+          path: spec.destination.create
+          value: true
+        documentIndex: 1
+      - equal:
+          path: spec.destination.transformation.templates.OPENAI_API_KEY.text
+          value: '{{- get .Secrets "OPENAI_API_KEY" -}}'
+        documentIndex: 1
+
+  - it: should reuse an existing VaultAuth when create is false
+    set:
+      vault:
+        enabled: true
+        auth:
+          create: false
+          ref: my-shared-vault-auth
+        staticSecrets:
+          - name: creds
+            path: teams/ai/creds
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: VaultStaticSecret
+      - equal:
+          path: spec.vaultAuthRef
+          value: my-shared-vault-auth
+      - equal:
+          path: spec.destination.name
+          value: creds

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -905,3 +905,47 @@ otel:
         endpoint: ""
         timeout: 15000 # milliseconds
         insecure: true
+
+# ==============================================================================
+# --------------------- HashiCorp Vault via VSO (optional) --------------------
+# ==============================================================================
+# -- Optional HashiCorp Vault integration through the Vault Secrets Operator
+# (must be installed in the cluster). Materializes chart secrets — model API
+# keys (`ModelConfig` `apiKeySecretRef`), oauth2-proxy credentials, etc. — as
+# real Kubernetes Secrets sourced from Vault. Disabled by default and fully
+# value-driven.
+vault:
+  enabled: false
+  # -- Default KV mount for `staticSecrets` entries that don't set their own.
+  mount: secret
+  auth:
+    # -- Create a `VaultAuth` for the secrets below. Set to `false` and set
+    # `auth.ref` to reuse an existing VaultAuth instead.
+    create: true
+    # -- Existing VaultAuth name to reference when `create` is `false`.
+    ref: ""
+    method: kubernetes
+    # -- Auth mount path in Vault.
+    mount: kubernetes
+    # -- Optional VaultConnection name (omitted = operator default).
+    vaultConnectionRef: ""
+    kubernetes:
+      # -- Vault Kubernetes-auth role (required when enabled with `create`).
+      role: ""
+      # -- ServiceAccount to authenticate as.
+      # @default -- `<fullname>-controller`
+      serviceAccount: ""
+      audiences: []
+      #   - vault
+  # -- Secrets to materialize from Vault. `transformation` is passed through
+  # verbatim (VSO templates/excludes) — useful to remap Vault keys to the key
+  # names consumers expect.
+  staticSecrets: []
+  #   - name: model-api-key          # VaultStaticSecret name suffix
+  #     path: teams/ai/kagent        # KV path under `mount`
+  #     destination: kagent-openai   # Secret to create (defaults to `name`)
+  #     transformation:
+  #       excludes: [".*"]
+  #       templates:
+  #         OPENAI_API_KEY:
+  #           text: '{{- get .Secrets "OPENAI_API_KEY" -}}'


### PR DESCRIPTION
## What
A generic, fully value-driven `vault` block (**disabled by default**) that materializes chart secrets as **real Kubernetes Secrets** sourced from HashiCorp Vault via the [Vault Secrets Operator](https://github.com/hashicorp/vault-secrets-operator):

- **`VaultAuth`** — kubernetes auth (`role`/`serviceAccount`/`audiences`), or reuse an existing VaultAuth via `auth.ref`
- **`VaultStaticSecret` list** — per-entry `path`/`destination`/`refreshAfter`, with verbatim `transformation` passthrough to remap Vault keys to the key names consumers expect (e.g. oauth2-proxy's `client-id`/`client-secret`/`cookie-secret`)

```yaml
vault:
  enabled: true
  auth:
    kubernetes:
      role: svcs-ai-platform
  staticSecrets:
    - name: model-api-key
      path: teams/ai/kagent
      destination: kagent-openai
      transformation:
        excludes: [".*"]
        templates:
          OPENAI_API_KEY:
            text: '{{- get .Secrets "OPENAI_API_KEY" -}}'
```

## Why
Secrets like the model API key are consumed through the **Kubernetes API** (`ModelConfig` `apiKeySecretRef`) — pod-level Vault injection (agent sidecars / env rewriting webhooks) can't intercept that path, so the Secret object itself must hold real values. We hit exactly this in production: the controller passed a literal `vault:...` ref string to the model gateway as an API key. VSO closes the gap declaratively, and the chart-level integration means orgs don't need a wrapper chart for it.

## Notes
- Disabled by default; requires VSO installed when enabled.
- helm-unittest coverage: default off, VaultAuth defaults, static-secret defaults + transformation passthrough, existing-VaultAuth reuse (4 tests).
- From the same production deployment as #2237, #2238, #2239, #2240.

🤖 Generated with [Claude Code](https://claude.com/claude-code)