### PR TITLE
chore: add @Charlesthebird as CODEOWNER for .github/

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,5 @@
 /*      @kagent-dev/maintainers
+.github/ @kagent-dev/maintainers @Charlesthebird
 python/ @kagent-dev/maintainers @kagent-dev/developers
 go/     @kagent-dev/maintainers
 ui/     @peterj @Charlesthebird


### PR DESCRIPTION
---
*🤖 written by Claude (start)*

Adds `@Charlesthebird` as a code owner for the `.github/` directory, alongside `@kagent-dev/maintainers`.

**Changelog:** Add @Charlesthebird as a CODEOWNER for the `.github/` directory.

```release-note
NONE
```

---
*🤖 written by Claude (end)*
