### PR TITLE
perf(database): batch checkpoint writes to remove N+1 query

### DIFF
--- a/go/core/internal/database/client_langgraph_test.go
+++ b/go/core/internal/database/client_langgraph_test.go
@@ -1,0 +1,137 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	dbpkg "github.com/kagent-dev/kagent/go/api/database"
+	"github.com/stretchr/testify/require"
+)
+
+// countingTracer is a pgx.QueryTracer that counts how many executed statements
+// contain a given SQL substring. It is used to guard against the N+1 query
+// pattern in ListCheckpoints.
+type countingTracer struct {
+	substr string
+	mu     sync.Mutex
+	count  int
+}
+
+func (t *countingTracer) TraceQueryStart(ctx context.Context, _ *pgx.Conn, data pgx.TraceQueryStartData) context.Context {
+	if strings.Contains(data.SQL, t.substr) {
+		t.mu.Lock()
+		t.count++
+		t.mu.Unlock()
+	}
+	return ctx
+}
+
+func (t *countingTracer) TraceQueryEnd(context.Context, *pgx.Conn, pgx.TraceQueryEndData) {}
+
+func (t *countingTracer) reset() {
+	t.mu.Lock()
+	t.count = 0
+	t.mu.Unlock()
+}
+
+func (t *countingTracer) value() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.count
+}
+
+// newCountingClient opens a single-connection pool against the shared test
+// database with a query-counting tracer attached, so a test can assert how many
+// times a particular query runs.
+func newCountingClient(t *testing.T, tracer *countingTracer) dbpkg.Client {
+	t.Helper()
+
+	config, err := pgxpool.ParseConfig(sharedConnStr)
+	require.NoError(t, err)
+	config.MaxConns = 1
+	config.ConnConfig.Tracer = tracer
+
+	pool, err := pgxpool.NewWithConfig(context.Background(), config)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+
+	return NewClient(pool)
+}
+
+// TestListCheckpointsBatchesWrites verifies that reading a thread's checkpoint
+// history fetches all checkpoint writes in a single query instead of one query
+// per checkpoint (the N+1 pattern). It also checks the writes are grouped onto
+// the correct checkpoints and keep their per-checkpoint ordering.
+func TestListCheckpointsBatchesWrites(t *testing.T) {
+	setupTestDB(t)
+
+	tracer := &countingTracer{substr: "FROM lg_checkpoint_write"}
+	client := newCountingClient(t, tracer)
+	ctx := context.Background()
+
+	const (
+		userID       = "test-user"
+		threadID     = "test-thread"
+		checkpointNS = ""
+		numCP        = 5
+		writesPerCP  = 3
+	)
+
+	// Seed several checkpoints, each with multiple writes.
+	for i := range numCP {
+		cpID := fmt.Sprintf("cp-%02d", i)
+		err := client.StoreCheckpoint(ctx, &dbpkg.LangGraphCheckpoint{
+			UserID:       userID,
+			ThreadID:     threadID,
+			CheckpointNS: checkpointNS,
+			CheckpointID: cpID,
+			Metadata:     "{}",
+			Checkpoint:   "{}",
+			Version:      1,
+		})
+		require.NoError(t, err)
+
+		writes := make([]*dbpkg.LangGraphCheckpointWrite, writesPerCP)
+		for j := range writesPerCP {
+			writes[j] = &dbpkg.LangGraphCheckpointWrite{
+				UserID:       userID,
+				ThreadID:     threadID,
+				CheckpointNS: checkpointNS,
+				CheckpointID: cpID,
+				WriteIdx:     int64(j),
+				Value:        fmt.Sprintf("value-%d", j),
+				ValueType:    "json",
+				Channel:      fmt.Sprintf("channel-%d", j),
+				TaskID:       "task-0",
+			}
+		}
+		require.NoError(t, client.StoreCheckpointWrites(ctx, writes))
+	}
+
+	// Read the whole thread history (checkpointID nil, limit 0 -> unbounded).
+	tracer.reset()
+	tuples, err := client.ListCheckpoints(ctx, userID, threadID, checkpointNS, nil, 0)
+	require.NoError(t, err)
+
+	// Exactly one query against lg_checkpoint_write, regardless of how many
+	// checkpoints the thread has. Before batching this was one query per
+	// checkpoint (numCP).
+	writeQueries := tracer.value()
+	require.Equal(t, 1, writeQueries,
+		"expected a single checkpoint-writes query, got %d (N+1 regression)", writeQueries)
+
+	// Every checkpoint's writes are attached, in write_idx order.
+	require.Len(t, tuples, numCP)
+	for _, tuple := range tuples {
+		require.Len(t, tuple.Writes, writesPerCP, "checkpoint %s", tuple.Checkpoint.CheckpointID)
+		for j, w := range tuple.Writes {
+			require.Equal(t, int64(j), w.WriteIdx)
+			require.Equal(t, tuple.Checkpoint.CheckpointID, w.CheckpointID)
+		}
+	}
+}

--- a/go/core/internal/database/client_postgres.go
+++ b/go/core/internal/database/client_postgres.go
@@ -584,17 +584,33 @@ func (c *postgresClient) ListCheckpoints(ctx context.Context, userID, threadID, 
 			}
 		}
 
-		tuples = make([]*dbpkg.LangGraphCheckpointTuple, 0, len(checkpoints))
-		for _, cp := range checkpoints {
-			writes, err := q.ListCheckpointWrites(ctx, dbgen.ListCheckpointWritesParams{
-				UserID: userID, ThreadID: threadID, CheckpointNs: checkpointNS, CheckpointID: cp.CheckpointID,
+		// Fetch all writes for the returned checkpoints in a single query and
+		// bucket them by checkpoint ID, instead of issuing one query per
+		// checkpoint (which turned reading a thread's history into 1+N round
+		// trips that grew with the conversation length).
+		checkpointIDs := make([]string, len(checkpoints))
+		for i, cp := range checkpoints {
+			checkpointIDs[i] = cp.CheckpointID
+		}
+
+		writesByCheckpoint := make(map[string][]*dbpkg.LangGraphCheckpointWrite, len(checkpoints))
+		if len(checkpointIDs) > 0 {
+			writes, err := q.ListCheckpointWritesForCheckpoints(ctx, dbgen.ListCheckpointWritesForCheckpointsParams{
+				UserID: userID, ThreadID: threadID, CheckpointNs: checkpointNS, Column4: checkpointIDs,
 			})
 			if err != nil {
 				return fmt.Errorf("failed to get checkpoint writes: %w", err)
 			}
-			dbWrites := make([]*dbpkg.LangGraphCheckpointWrite, len(writes))
-			for i, w := range writes {
-				dbWrites[i] = toCheckpointWrite(w)
+			for _, w := range writes {
+				writesByCheckpoint[w.CheckpointID] = append(writesByCheckpoint[w.CheckpointID], toCheckpointWrite(w))
+			}
+		}
+
+		tuples = make([]*dbpkg.LangGraphCheckpointTuple, 0, len(checkpoints))
+		for _, cp := range checkpoints {
+			dbWrites := writesByCheckpoint[cp.CheckpointID]
+			if dbWrites == nil {
+				dbWrites = []*dbpkg.LangGraphCheckpointWrite{}
 			}
 			tuples = append(tuples, &dbpkg.LangGraphCheckpointTuple{
 				Checkpoint: toCheckpoint(cp),

--- a/go/core/internal/database/client_postgres.go
+++ b/go/core/internal/database/client_postgres.go
@@ -596,7 +596,7 @@ func (c *postgresClient) ListCheckpoints(ctx context.Context, userID, threadID, 
 		writesByCheckpoint := make(map[string][]*dbpkg.LangGraphCheckpointWrite, len(checkpoints))
 		if len(checkpointIDs) > 0 {
 			writes, err := q.ListCheckpointWritesForCheckpoints(ctx, dbgen.ListCheckpointWritesForCheckpointsParams{
-				UserID: userID, ThreadID: threadID, CheckpointNs: checkpointNS, Column4: checkpointIDs,
+				UserID: userID, ThreadID: threadID, CheckpointNs: checkpointNS, CheckpointIds: checkpointIDs,
 			})
 			if err != nil {
 				return fmt.Errorf("failed to get checkpoint writes: %w", err)

--- a/go/core/internal/database/gen/langgraph.sql.go
+++ b/go/core/internal/database/gen/langgraph.sql.go
@@ -100,6 +100,58 @@ func (q *Queries) ListCheckpointWrites(ctx context.Context, arg ListCheckpointWr
 	return items, nil
 }
 
+const listCheckpointWritesForCheckpoints = `-- name: ListCheckpointWritesForCheckpoints :many
+SELECT user_id, thread_id, checkpoint_ns, checkpoint_id, write_idx, value, value_type, channel, task_id, created_at, updated_at, deleted_at FROM lg_checkpoint_write
+WHERE user_id = $1 AND thread_id = $2 AND checkpoint_ns = $3
+  AND checkpoint_id = ANY($4::text[]) AND deleted_at IS NULL
+ORDER BY checkpoint_id, task_id, write_idx
+`
+
+type ListCheckpointWritesForCheckpointsParams struct {
+	UserID       string
+	ThreadID     string
+	CheckpointNs string
+	Column4      []string
+}
+
+func (q *Queries) ListCheckpointWritesForCheckpoints(ctx context.Context, arg ListCheckpointWritesForCheckpointsParams) ([]LgCheckpointWrite, error) {
+	rows, err := q.db.Query(ctx, listCheckpointWritesForCheckpoints,
+		arg.UserID,
+		arg.ThreadID,
+		arg.CheckpointNs,
+		arg.Column4,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []LgCheckpointWrite
+	for rows.Next() {
+		var i LgCheckpointWrite
+		if err := rows.Scan(
+			&i.UserID,
+			&i.ThreadID,
+			&i.CheckpointNs,
+			&i.CheckpointID,
+			&i.WriteIdx,
+			&i.Value,
+			&i.ValueType,
+			&i.Channel,
+			&i.TaskID,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.DeletedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listCheckpoints = `-- name: ListCheckpoints :many
 SELECT user_id, thread_id, checkpoint_ns, checkpoint_id, parent_checkpoint_id, created_at, updated_at, deleted_at, metadata, checkpoint, checkpoint_type, version FROM lg_checkpoint
 WHERE user_id = $1 AND thread_id = $2 AND checkpoint_ns = $3

--- a/go/core/internal/database/gen/langgraph.sql.go
+++ b/go/core/internal/database/gen/langgraph.sql.go
@@ -48,58 +48,6 @@ func (q *Queries) GetCheckpoint(ctx context.Context, arg GetCheckpointParams) (L
 	return i, err
 }
 
-const listCheckpointWrites = `-- name: ListCheckpointWrites :many
-SELECT user_id, thread_id, checkpoint_ns, checkpoint_id, write_idx, value, value_type, channel, task_id, created_at, updated_at, deleted_at FROM lg_checkpoint_write
-WHERE user_id = $1 AND thread_id = $2 AND checkpoint_ns = $3
-  AND checkpoint_id = $4 AND deleted_at IS NULL
-ORDER BY task_id, write_idx
-`
-
-type ListCheckpointWritesParams struct {
-	UserID       string
-	ThreadID     string
-	CheckpointNs string
-	CheckpointID string
-}
-
-func (q *Queries) ListCheckpointWrites(ctx context.Context, arg ListCheckpointWritesParams) ([]LgCheckpointWrite, error) {
-	rows, err := q.db.Query(ctx, listCheckpointWrites,
-		arg.UserID,
-		arg.ThreadID,
-		arg.CheckpointNs,
-		arg.CheckpointID,
-	)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []LgCheckpointWrite
-	for rows.Next() {
-		var i LgCheckpointWrite
-		if err := rows.Scan(
-			&i.UserID,
-			&i.ThreadID,
-			&i.CheckpointNs,
-			&i.CheckpointID,
-			&i.WriteIdx,
-			&i.Value,
-			&i.ValueType,
-			&i.Channel,
-			&i.TaskID,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.DeletedAt,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const listCheckpointWritesForCheckpoints = `-- name: ListCheckpointWritesForCheckpoints :many
 SELECT user_id, thread_id, checkpoint_ns, checkpoint_id, write_idx, value, value_type, channel, task_id, created_at, updated_at, deleted_at FROM lg_checkpoint_write
 WHERE user_id = $1 AND thread_id = $2 AND checkpoint_ns = $3
@@ -108,10 +56,10 @@ ORDER BY checkpoint_id, task_id, write_idx
 `
 
 type ListCheckpointWritesForCheckpointsParams struct {
-	UserID       string
-	ThreadID     string
-	CheckpointNs string
-	Column4      []string
+	UserID        string
+	ThreadID      string
+	CheckpointNs  string
+	CheckpointIds []string
 }
 
 func (q *Queries) ListCheckpointWritesForCheckpoints(ctx context.Context, arg ListCheckpointWritesForCheckpointsParams) ([]LgCheckpointWrite, error) {
@@ -119,7 +67,7 @@ func (q *Queries) ListCheckpointWritesForCheckpoints(ctx context.Context, arg Li
 		arg.UserID,
 		arg.ThreadID,
 		arg.CheckpointNs,
-		arg.Column4,
+		arg.CheckpointIds,
 	)
 	if err != nil {
 		return nil, err

--- a/go/core/internal/database/gen/querier.go
+++ b/go/core/internal/database/gen/querier.go
@@ -47,6 +47,7 @@ type Querier interface {
 	ListAgentMemories(ctx context.Context, arg ListAgentMemoriesParams) ([]Memory, error)
 	ListAgents(ctx context.Context) ([]Agent, error)
 	ListCheckpointWrites(ctx context.Context, arg ListCheckpointWritesParams) ([]LgCheckpointWrite, error)
+	ListCheckpointWritesForCheckpoints(ctx context.Context, arg ListCheckpointWritesForCheckpointsParams) ([]LgCheckpointWrite, error)
 	ListCheckpoints(ctx context.Context, arg ListCheckpointsParams) ([]LgCheckpoint, error)
 	ListCheckpointsLimit(ctx context.Context, arg ListCheckpointsLimitParams) ([]LgCheckpoint, error)
 	ListEventsByContextID(ctx context.Context, sessionID *string) ([]Event, error)

--- a/go/core/internal/database/gen/querier.go
+++ b/go/core/internal/database/gen/querier.go
@@ -46,7 +46,6 @@ type Querier interface {
 	InsertMemory(ctx context.Context, arg InsertMemoryParams) (string, error)
 	ListAgentMemories(ctx context.Context, arg ListAgentMemoriesParams) ([]Memory, error)
 	ListAgents(ctx context.Context) ([]Agent, error)
-	ListCheckpointWrites(ctx context.Context, arg ListCheckpointWritesParams) ([]LgCheckpointWrite, error)
 	ListCheckpointWritesForCheckpoints(ctx context.Context, arg ListCheckpointWritesForCheckpointsParams) ([]LgCheckpointWrite, error)
 	ListCheckpoints(ctx context.Context, arg ListCheckpointsParams) ([]LgCheckpoint, error)
 	ListCheckpointsLimit(ctx context.Context, arg ListCheckpointsLimitParams) ([]LgCheckpoint, error)

--- a/go/core/internal/database/queries/langgraph.sql
+++ b/go/core/internal/database/queries/langgraph.sql
@@ -37,6 +37,12 @@ WHERE user_id = $1 AND thread_id = $2 AND checkpoint_ns = $3
   AND checkpoint_id = $4 AND deleted_at IS NULL
 ORDER BY task_id, write_idx;
 
+-- name: ListCheckpointWritesForCheckpoints :many
+SELECT * FROM lg_checkpoint_write
+WHERE user_id = $1 AND thread_id = $2 AND checkpoint_ns = $3
+  AND checkpoint_id = ANY($4::text[]) AND deleted_at IS NULL
+ORDER BY checkpoint_id, task_id, write_idx;
+
 -- name: UpsertCheckpointWrite :exec
 INSERT INTO lg_checkpoint_write (
     user_id, thread_id, checkpoint_ns, checkpoint_id, write_idx,

--- a/go/core/internal/database/queries/langgraph.sql
+++ b/go/core/internal/database/queries/langgraph.sql
@@ -31,16 +31,10 @@ WHERE user_id = $1 AND thread_id = $2 AND checkpoint_ns = $3
   AND checkpoint_id = $4 AND deleted_at IS NULL
 LIMIT 1;
 
--- name: ListCheckpointWrites :many
-SELECT * FROM lg_checkpoint_write
-WHERE user_id = $1 AND thread_id = $2 AND checkpoint_ns = $3
-  AND checkpoint_id = $4 AND deleted_at IS NULL
-ORDER BY task_id, write_idx;
-
 -- name: ListCheckpointWritesForCheckpoints :many
 SELECT * FROM lg_checkpoint_write
 WHERE user_id = $1 AND thread_id = $2 AND checkpoint_ns = $3
-  AND checkpoint_id = ANY($4::text[]) AND deleted_at IS NULL
+  AND checkpoint_id = ANY(sqlc.arg(checkpoint_ids)::text[]) AND deleted_at IS NULL
 ORDER BY checkpoint_id, task_id, write_idx;
 
 -- name: UpsertCheckpointWrite :exec


### PR DESCRIPTION

### What

Reading a LangGraph thread's checkpoint history through
`postgresClient.ListCheckpoints`
(`go/core/internal/database/client_postgres.go`) issued 1+N database queries.
After loading the thread's checkpoints, it looped over each one and ran a
separate `ListCheckpointWrites` query per checkpoint:

```go
for _, cp := range checkpoints {
    writes, err := q.ListCheckpointWrites(ctx, dbgen.ListCheckpointWritesParams{
        UserID: userID, ThreadID: threadID, CheckpointNs: checkpointNS, CheckpointID: cp.CheckpointID,
    })
    ...
}
```

All of these run inside the single transaction opened at the top of
`ListCheckpoints`, so they are serialized on one pooled connection.

This is the normal history-read path, not an edge case:

- `GET /api/langgraph/checkpoints` (route in
  `go/core/internal/httpserver/server.go`) calls `HandleListCheckpoints`
  (`go/core/internal/httpserver/handlers/checkpoints.go`), which reads the
  `limit` query param defaulting to `0` and passes it straight through.
- When no single `checkpointID` is requested and `limit` is not `> 0`,
  `ListCheckpoints` takes the unbounded list branch (`q.ListCheckpoints`, whose
  SQL has no `LIMIT`).
- The Python LangGraph checkpointer sends `limit=-1` whenever no limit is set
  (`python/packages/kagent-langgraph/src/kagent/langgraph/_checkpointer.py`:
  `limit = limit if limit else -1`), which is not `> 0`, so it hits that branch.

A LangGraph thread accumulates one checkpoint per superstep, so `N` grows with
conversation length. Reading a long thread's history therefore issues `1+N`
queries and holds the connection for the whole fan-out.

### Fix

Add a single `:many` query that loads the writes for all returned checkpoints
at once, using `checkpoint_id = ANY(...)`
(`go/core/internal/database/queries/langgraph.sql`):

```sql
-- name: ListCheckpointWritesForCheckpoints :many
SELECT * FROM lg_checkpoint_write
WHERE user_id = $1 AND thread_id = $2 AND checkpoint_ns = $3
  AND checkpoint_id = ANY($4::text[]) AND deleted_at IS NULL
ORDER BY checkpoint_id, task_id, write_idx;
```

`ListCheckpoints` now runs that one query, buckets the rows into a
`map[checkpointID][]write` in a single pass, and attaches each slice to its
tuple. This turns the write fan-out into one query regardless of history length
(so the whole call is 2 queries instead of `1+N`).

Behavior is preserved:

- The `ANY(...)` pattern already exists in this codebase (see
  `IncrementMemoryAccessCount` in `queries/memory.sql`, which uses
  `ANY($1::text[])`).
- Per-checkpoint write ordering is unchanged: the original singular query
  ordered by `task_id, write_idx`; the batched query orders by
  `checkpoint_id, task_id, write_idx`, so within each checkpoint the relative
  order is identical.
- The non-nil empty-slice contract is kept: a checkpoint with no writes still
  gets `[]*LangGraphCheckpointWrite{}`, matching the previous
  `make(..., len(writes))` result.
- The single-checkpoint path (`GetCheckpoint`) flows through the same code with
  a one-element batch and yields the same result.

The generated code (`gen/langgraph.sql.go`, `gen/querier.go`) is the committed
output of `sqlc` v1.30.0 (`make -C go sqlc-generate` produces no diff).

### Tests

Added `TestListCheckpointsBatchesWrites` in
`go/core/internal/database/client_langgraph_test.go`. It seeds a thread with 5
checkpoints (3 writes each), reads the full history, and asserts:

- exactly one `lg_checkpoint_write` query runs (a `pgx.QueryTracer` counts
  statements containing `FROM lg_checkpoint_write`) - this is the N+1 guard, and
  it was `numCP` before the change, and
- the writes are grouped onto the correct checkpoints in `write_idx` order.

The test uses the same `testcontainers`-backed Postgres as the existing
database tests, so it skips under `go test -short` and runs in CI.

Locally (this change):

- `make -C go sqlc-generate` -> no diff
- `go build ./...`, `go vet ./core/internal/database/...` -> pass
- `make -C go lint` (`golangci-lint` on the database package) -> 0 issues
- `go test -short ./core/internal/database/... ./core/internal/httpserver/...`
  -> pass

### Note

The pre-existing singular `ListCheckpointWrites` query (and its generated
method) is left in place: it is no longer called from Go after this change, but
removing it would enlarge the generated interface diff. Happy to drop it in a
follow-up (or in this PR) if you prefer.
