### PR TITLE
fix(mcp): include SandboxAgents in list_agents and invoke_agent

### DIFF
--- a/go/core/internal/a2a/agent_client_registry.go
+++ b/go/core/internal/a2a/agent_client_registry.go
@@ -38,14 +38,23 @@ func (r *AgentClientRegistry) Register(namespace, name string, c *a2aclient.Clie
 	r.set(namespace+"/"+name, c)
 }
 
+// RegisterRef adds or replaces the A2A client for the given registry route key.
+func (r *AgentClientRegistry) RegisterRef(agentRef string, c *a2aclient.Client) {
+	r.set(agentRef, c)
+}
+
 // SendMessage invokes an agent directly via its cached A2A client.
 func (r *AgentClientRegistry) SendMessage(ctx context.Context, namespace, name string, req *a2atype.SendMessageRequest) (a2atype.SendMessageResult, error) {
-	key := namespace + "/" + name
+	return r.SendMessageRef(ctx, namespace+"/"+name, req)
+}
+
+// SendMessageRef invokes an agent by its registry route key.
+func (r *AgentClientRegistry) SendMessageRef(ctx context.Context, agentRef string, req *a2atype.SendMessageRequest) (a2atype.SendMessageResult, error) {
 	r.mu.RLock()
-	c, ok := r.clients[key]
+	c, ok := r.clients[agentRef]
 	r.mu.RUnlock()
 	if !ok {
-		return nil, fmt.Errorf("agent %s/%s not found or not ready", namespace, name)
+		return nil, fmt.Errorf("agent %s not found or not ready", agentRef)
 	}
 	return c.SendMessage(ctx, req)
 }

--- a/go/core/internal/mcp/mcp_handler.go
+++ b/go/core/internal/mcp/mcp_handler.go
@@ -11,10 +11,12 @@ import (
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/kagent-dev/kagent/go/api/v1alpha2"
 	"github.com/kagent-dev/kagent/go/core/internal/a2a"
+	"github.com/kagent-dev/kagent/go/core/internal/controller/reconciler"
 	"github.com/kagent-dev/kagent/go/core/internal/version"
 	"github.com/kagent-dev/kagent/go/core/pkg/auth"
 	"github.com/kagent-dev/kagent/go/core/pkg/env"
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -83,7 +85,7 @@ func NewMCPHandler(kubeClient client.Client, agentClients *a2a.AgentClientRegist
 		server,
 		&mcpsdk.Tool{
 			Name:        "list_agents",
-			Description: "List invokable kagent agents (accepted + deploymentReady)",
+			Description: "List invokable kagent agents (accepted + ready)",
 			InputSchema: &jsonschema.Schema{
 				Type:                 "object",
 				Properties:           map[string]*jsonschema.Schema{},
@@ -108,7 +110,7 @@ func NewMCPHandler(kubeClient client.Client, agentClients *a2a.AgentClientRegist
 		&mcpsdk.Resource{
 			URI:         "kagent://agents",
 			Name:        "agents",
-			Description: "List of invokable kagent agents (accepted + deploymentReady)",
+			Description: "List of invokable kagent agents (accepted + ready)",
 			MIMEType:    "application/json",
 		},
 		handler.readAgentsResource,
@@ -129,33 +131,64 @@ func NewMCPHandler(kubeClient client.Client, agentClients *a2a.AgentClientRegist
 	return handler, nil
 }
 
-// listReadyAgents returns agents that are accepted and deployment-ready.
+// listReadyAgents returns agents that are accepted and ready. It covers both
+// declarative Agents and SandboxAgents; a SandboxAgent reports its Ready
+// condition with reason "WorkloadReady" while a declarative Agent uses
+// "DeploymentReady", so both are treated as ready here, matching the REST
+// /agents API and the A2A registrar.
 func (h *MCPHandler) listReadyAgents(ctx context.Context) ([]AgentSummary, error) {
 	agentList := &v1alpha2.AgentList{}
 	if err := h.kubeClient.List(ctx, agentList); err != nil {
 		return nil, err
 	}
-	agents := make([]AgentSummary, 0, len(agentList.Items))
-	for _, agent := range agentList.Items {
-		deploymentReady := false
-		accepted := false
-		for _, condition := range agent.Status.Conditions {
-			if condition.Type == "Ready" && condition.Reason == "DeploymentReady" && condition.Status == "True" {
-				deploymentReady = true
-			}
-			if condition.Type == "Accepted" && condition.Status == "True" {
-				accepted = true
-			}
+	sandboxAgentList := &v1alpha2.SandboxAgentList{}
+	if err := h.kubeClient.List(ctx, sandboxAgentList); err != nil {
+		return nil, err
+	}
+
+	agents := make([]AgentSummary, 0, len(agentList.Items)+len(sandboxAgentList.Items))
+	for i := range agentList.Items {
+		if summary, ok := readyAgentSummary(&agentList.Items[i]); ok {
+			agents = append(agents, summary)
 		}
-		if !accepted || !deploymentReady {
-			continue
+	}
+	for i := range sandboxAgentList.Items {
+		if summary, ok := readyAgentSummary(&sandboxAgentList.Items[i]); ok {
+			agents = append(agents, summary)
 		}
-		agents = append(agents, AgentSummary{
-			Ref:         agent.Namespace + "/" + agent.Name,
-			Description: agent.Spec.Description,
-		})
 	}
 	return agents, nil
+}
+
+// readyAgentSummary reports whether the given agent is accepted and ready, and
+// if so returns its AgentSummary.
+func readyAgentSummary(agent v1alpha2.AgentObject) (AgentSummary, bool) {
+	status := agent.GetAgentStatus()
+	if status == nil {
+		return AgentSummary{}, false
+	}
+	ready, accepted := false, false
+	for _, condition := range status.Conditions {
+		if condition.Type == v1alpha2.AgentConditionTypeReady && condition.Status == metav1.ConditionTrue {
+			switch condition.Reason {
+			case reconciler.AgentReadyReasonDeploymentReady, reconciler.AgentReadyReasonWorkloadReady:
+				ready = true
+			}
+		}
+		if condition.Type == v1alpha2.AgentConditionTypeAccepted && condition.Status == metav1.ConditionTrue {
+			accepted = true
+		}
+	}
+	if !accepted || !ready {
+		return AgentSummary{}, false
+	}
+	summary := AgentSummary{
+		Ref: agent.GetNamespace() + "/" + agent.GetName(),
+	}
+	if spec := agent.GetAgentSpec(); spec != nil {
+		summary.Description = spec.Description
+	}
+	return summary, true
 }
 
 // handleListAgents handles the list_agents MCP tool

--- a/go/core/internal/mcp/mcp_handler.go
+++ b/go/core/internal/mcp/mcp_handler.go
@@ -43,7 +43,7 @@ type AgentSummary struct {
 }
 
 type InvokeAgentInput struct {
-	Agent     string `json:"agent" jsonschema:"Agent reference in format namespace/name. To find a list of available sources, use the 'agents' resource."`
+	Agent     string `json:"agent" jsonschema:"Agent reference returned by the 'agents' resource."`
 	Task      string `json:"task" jsonschema:"Task to run"`
 	ContextID string `json:"context_id,omitempty" jsonschema:"Optional A2A context ID to continue a conversation"`
 }
@@ -148,12 +148,12 @@ func (h *MCPHandler) listReadyAgents(ctx context.Context) ([]AgentSummary, error
 
 	agents := make([]AgentSummary, 0, len(agentList.Items)+len(sandboxAgentList.Items))
 	for i := range agentList.Items {
-		if summary, ok := readyAgentSummary(&agentList.Items[i]); ok {
+		if summary, ok := readyAgentSummary(&agentList.Items[i], false); ok {
 			agents = append(agents, summary)
 		}
 	}
 	for i := range sandboxAgentList.Items {
-		if summary, ok := readyAgentSummary(&sandboxAgentList.Items[i]); ok {
+		if summary, ok := readyAgentSummary(&sandboxAgentList.Items[i], true); ok {
 			agents = append(agents, summary)
 		}
 	}
@@ -162,7 +162,7 @@ func (h *MCPHandler) listReadyAgents(ctx context.Context) ([]AgentSummary, error
 
 // readyAgentSummary reports whether the given agent is accepted and ready, and
 // if so returns its AgentSummary.
-func readyAgentSummary(agent v1alpha2.AgentObject) (AgentSummary, bool) {
+func readyAgentSummary(agent v1alpha2.AgentObject, sandbox bool) (AgentSummary, bool) {
 	status := agent.GetAgentStatus()
 	if status == nil {
 		return AgentSummary{}, false
@@ -182,9 +182,11 @@ func readyAgentSummary(agent v1alpha2.AgentObject) (AgentSummary, bool) {
 	if !accepted || !ready {
 		return AgentSummary{}, false
 	}
-	summary := AgentSummary{
-		Ref: agent.GetNamespace() + "/" + agent.GetName(),
+	ref := agent.GetNamespace() + "/" + agent.GetName()
+	if sandbox {
+		ref = "sandboxes/" + ref
 	}
+	summary := AgentSummary{Ref: ref}
 	if spec := agent.GetAgentSpec(); spec != nil {
 		summary.Description = spec.Description
 	}
@@ -266,18 +268,20 @@ func (h *MCPHandler) NotifyAgentsChanged(ctx context.Context) {
 func (h *MCPHandler) handleInvokeAgent(ctx context.Context, req *mcpsdk.CallToolRequest, input InvokeAgentInput) (*mcpsdk.CallToolResult, InvokeAgentOutput, error) {
 	log := ctrllog.FromContext(ctx).WithName("mcp-handler").WithValues("tool", "invoke_agent")
 
-	// Parse agent reference — must be exactly "namespace/name".
+	// Declarative agents use "namespace/name" and sandbox agents use
+	// "sandboxes/namespace/name", matching the A2A client registry keys.
 	parts := strings.SplitN(input.Agent, "/", 3)
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+	validAgentRef := len(parts) == 2 && parts[0] != "" && parts[1] != ""
+	validSandboxRef := len(parts) == 3 && parts[0] == "sandboxes" && parts[1] != "" && parts[2] != ""
+	if !validAgentRef && !validSandboxRef {
 		return &mcpsdk.CallToolResult{
 			Content: []mcpsdk.Content{
-				&mcpsdk.TextContent{Text: "agent must be in format 'namespace/name'"},
+				&mcpsdk.TextContent{Text: "agent must be in format 'namespace/name' or 'sandboxes/namespace/name'"},
 			},
 			IsError: true,
 		}, InvokeAgentOutput{}, nil
 	}
-	agentNS, agentName := parts[0], parts[1]
-	agentRef := agentNS + "/" + agentName
+	agentRef := input.Agent
 
 	message := a2atype.NewMessage(a2atype.MessageRoleUser, a2atype.NewTextPart(input.Task))
 	if input.ContextID != "" {
@@ -285,7 +289,7 @@ func (h *MCPHandler) handleInvokeAgent(ctx context.Context, req *mcpsdk.CallTool
 		log.V(1).Info("Using context_id from client request", "context_id", input.ContextID)
 	}
 
-	result, err := h.agentClients.SendMessage(ctx, agentNS, agentName, &a2atype.SendMessageRequest{Message: message})
+	result, err := h.agentClients.SendMessageRef(ctx, agentRef, &a2atype.SendMessageRequest{Message: message})
 	if err != nil {
 		log.Error(err, "Failed to send A2A message", "agent", agentRef)
 		return &mcpsdk.CallToolResult{

--- a/go/core/internal/mcp/mcp_handler_test.go
+++ b/go/core/internal/mcp/mcp_handler_test.go
@@ -16,7 +16,9 @@ import (
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -80,6 +82,64 @@ func TestListAgentsInputSchemaHasProperties(t *testing.T) {
 	require.IsType(t, map[string]any{}, props, "properties must be a JSON object")
 	require.Empty(t, props, "list_agents takes no args, properties should be empty")
 	require.Equal(t, false, schema["additionalProperties"], "additionalProperties must remain false")
+}
+
+// readyConditions returns the Accepted=True and Ready=True conditions an agent
+// has once its workload is ready. The Ready reason differs by workload type:
+// declarative Agents report "DeploymentReady", SandboxAgents "WorkloadReady".
+func readyConditions(readyReason string) []metav1.Condition {
+	return []metav1.Condition{
+		{Type: "Accepted", Status: metav1.ConditionTrue, Reason: "AgentReconciled"},
+		{Type: "Ready", Status: metav1.ConditionTrue, Reason: readyReason},
+	}
+}
+
+// TestListReadyAgents_IncludesSandboxAgents asserts that listReadyAgents lists
+// both declarative Agents and SandboxAgents and that it treats an agent as ready
+// whether its Ready condition reason is "DeploymentReady" (Agent) or
+// "WorkloadReady" (SandboxAgent), matching the behaviour of the REST /agents API
+// and the A2A registrar. Regression test for
+// https://github.com/kagent-dev/kagent/issues/2123.
+func TestListReadyAgents_IncludesSandboxAgents(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha2.AddToScheme(scheme))
+
+	objs := []client.Object{
+		&v1alpha2.Agent{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "ready-agent"},
+			Spec:       v1alpha2.AgentSpec{Description: "declarative agent"},
+			Status:     v1alpha2.AgentStatus{Conditions: readyConditions("DeploymentReady")},
+		},
+		&v1alpha2.SandboxAgent{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "ready-sandbox"},
+			Spec:       v1alpha2.SandboxAgentSpec{AgentSpec: v1alpha2.AgentSpec{Description: "sandbox agent"}},
+			Status:     v1alpha2.AgentStatus{Conditions: readyConditions("WorkloadReady")},
+		},
+		&v1alpha2.SandboxAgent{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pending-sandbox"},
+			Status: v1alpha2.AgentStatus{Conditions: []metav1.Condition{
+				{Type: "Accepted", Status: metav1.ConditionTrue, Reason: "AgentReconciled"},
+				{Type: "Ready", Status: metav1.ConditionFalse, Reason: "SandboxBackendNotConfigured"},
+			}},
+		},
+	}
+
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	h, err := NewMCPHandler(kubeClient, nil, nil)
+	require.NoError(t, err)
+
+	agents, err := h.listReadyAgents(context.Background())
+	require.NoError(t, err)
+
+	refs := make(map[string]string, len(agents))
+	for _, a := range agents {
+		refs[a.Ref] = a.Description
+	}
+
+	assert.Contains(t, refs, "default/ready-agent", "ready declarative Agent should be listed")
+	assert.Contains(t, refs, "default/ready-sandbox", "ready SandboxAgent should be listed")
+	assert.NotContains(t, refs, "default/pending-sandbox", "not-ready SandboxAgent must be excluded")
+	assert.Equal(t, "sandbox agent", refs["default/ready-sandbox"], "SandboxAgent description should be surfaced")
 }
 
 // a2aBackend is a fake A2A server that records whether it was called.

--- a/go/core/internal/mcp/mcp_handler_test.go
+++ b/go/core/internal/mcp/mcp_handler_test.go
@@ -89,8 +89,8 @@ func TestListAgentsInputSchemaHasProperties(t *testing.T) {
 // declarative Agents report "DeploymentReady", SandboxAgents "WorkloadReady".
 func readyConditions(readyReason string) []metav1.Condition {
 	return []metav1.Condition{
-		{Type: "Accepted", Status: metav1.ConditionTrue, Reason: "AgentReconciled"},
-		{Type: "Ready", Status: metav1.ConditionTrue, Reason: readyReason},
+		{Type: v1alpha2.AgentConditionTypeAccepted, Status: metav1.ConditionTrue, Reason: "Reconciled"},
+		{Type: v1alpha2.AgentConditionTypeReady, Status: metav1.ConditionTrue, Reason: readyReason},
 	}
 }
 
@@ -118,8 +118,8 @@ func TestListReadyAgents_IncludesSandboxAgents(t *testing.T) {
 		&v1alpha2.SandboxAgent{
 			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pending-sandbox"},
 			Status: v1alpha2.AgentStatus{Conditions: []metav1.Condition{
-				{Type: "Accepted", Status: metav1.ConditionTrue, Reason: "AgentReconciled"},
-				{Type: "Ready", Status: metav1.ConditionFalse, Reason: "SandboxBackendNotConfigured"},
+				{Type: v1alpha2.AgentConditionTypeAccepted, Status: metav1.ConditionTrue, Reason: "Reconciled"},
+				{Type: v1alpha2.AgentConditionTypeReady, Status: metav1.ConditionFalse, Reason: "SandboxBackendNotConfigured"},
 			}},
 		},
 	}
@@ -137,9 +137,9 @@ func TestListReadyAgents_IncludesSandboxAgents(t *testing.T) {
 	}
 
 	assert.Contains(t, refs, "default/ready-agent", "ready declarative Agent should be listed")
-	assert.Contains(t, refs, "default/ready-sandbox", "ready SandboxAgent should be listed")
-	assert.NotContains(t, refs, "default/pending-sandbox", "not-ready SandboxAgent must be excluded")
-	assert.Equal(t, "sandbox agent", refs["default/ready-sandbox"], "SandboxAgent description should be surfaced")
+	assert.Contains(t, refs, "sandboxes/default/ready-sandbox", "ready SandboxAgent should be listed")
+	assert.NotContains(t, refs, "sandboxes/default/pending-sandbox", "not-ready SandboxAgent must be excluded")
+	assert.Equal(t, "sandbox agent", refs["sandboxes/default/ready-sandbox"], "SandboxAgent description should be surfaced")
 }
 
 // a2aBackend is a fake A2A server that records whether it was called.
@@ -185,11 +185,11 @@ func newA2ABackend(t *testing.T) *a2aBackend {
 }
 
 // newTestRegistry builds an AgentClientRegistry with a single agent pre-registered.
-func newTestRegistry(t *testing.T, namespace, name, backendURL string) *a2a.AgentClientRegistry {
+func newTestRegistry(t *testing.T, agentRef, backendURL string) *a2a.AgentClientRegistry {
 	t.Helper()
 	interfaces := []*a2atype.AgentInterface{
 		{
-			URL:             backendURL + "/" + namespace + "/" + name + "/",
+			URL:             backendURL + "/" + agentRef + "/",
 			ProtocolBinding: a2atype.TransportProtocolJSONRPC,
 			ProtocolVersion: a2atype.Version,
 		},
@@ -197,14 +197,14 @@ func newTestRegistry(t *testing.T, namespace, name, backendURL string) *a2a.Agen
 	c, err := a2aclient.NewFromEndpoints(context.Background(), interfaces, a2aclient.WithJSONRPCTransport(&http.Client{}))
 	require.NoError(t, err)
 	registry := a2a.NewAgentClientRegistry()
-	registry.Register(namespace, name, c)
+	registry.RegisterRef(agentRef, c)
 	return registry
 }
 
 // TestInvokeAgent_InvalidAgentRef verifies that invoke_agent returns a tool
-// error for agent references that are not exactly "namespace/name".
+// error for malformed declarative and sandbox agent references.
 func TestInvokeAgent_InvalidAgentRef(t *testing.T) {
-	for _, ref := range []string{"no-slash", "ns/name/extra", "/name", "ns/"} {
+	for _, ref := range []string{"no-slash", "ns/name/extra", "/name", "ns/", "sandboxes/ns", "sandboxes//name"} {
 		t.Run(ref, func(t *testing.T) {
 			registry := a2a.NewAgentClientRegistry()
 			mcpHandler, err := NewMCPHandler(nil, registry, nil)
@@ -266,31 +266,30 @@ func TestInvokeAgent_UnregisteredAgent(t *testing.T) {
 // TestInvokeAgent_RoutesViaRegistry verifies that invoke_agent retrieves the
 // pre-registered A2A client from AgentClientRegistry and forwards the call.
 func TestInvokeAgent_RoutesViaRegistry(t *testing.T) {
-	backend := newA2ABackend(t)
+	for _, agentRef := range []string{"default/test-agent", "sandboxes/default/test-agent"} {
+		t.Run(agentRef, func(t *testing.T) {
+			backend := newA2ABackend(t)
+			registry := newTestRegistry(t, agentRef, backend.server.URL)
+			mcpHandler, err := NewMCPHandler(nil, registry, nil)
+			require.NoError(t, err)
 
-	registry := newTestRegistry(t, "default", "test-agent", backend.server.URL)
-	mcpHandler, err := NewMCPHandler(nil, registry, nil)
-	require.NoError(t, err)
+			mcpServer := httptest.NewServer(mcpHandler)
+			t.Cleanup(mcpServer.Close)
+			transport := &mcpsdk.StreamableClientTransport{Endpoint: mcpServer.URL, DisableStandaloneSSE: true}
 
-	mcpServer := httptest.NewServer(mcpHandler)
-	t.Cleanup(mcpServer.Close)
+			ctx := context.Background()
+			cs, err := mcpsdk.NewClient(&mcpsdk.Implementation{Name: "test", Version: "1.0"}, nil).
+				Connect(ctx, transport, nil)
+			require.NoError(t, err)
+			t.Cleanup(func() { cs.Close() })
 
-	transport := &mcpsdk.StreamableClientTransport{
-		Endpoint:             mcpServer.URL,
-		DisableStandaloneSSE: true,
+			result, err := cs.CallTool(ctx, &mcpsdk.CallToolParams{
+				Name:      "invoke_agent",
+				Arguments: map[string]any{"agent": agentRef, "task": "say hello"},
+			})
+			require.NoError(t, err)
+			assert.False(t, result.IsError, "unexpected tool error: %v", result.Content)
+			assert.True(t, backend.wasCalled(), "A2A backend should have received the forwarded request")
+		})
 	}
-
-	ctx := context.Background()
-	cs, err := mcpsdk.NewClient(&mcpsdk.Implementation{Name: "test", Version: "1.0"}, nil).
-		Connect(ctx, transport, nil)
-	require.NoError(t, err)
-	t.Cleanup(func() { cs.Close() })
-
-	result, err := cs.CallTool(ctx, &mcpsdk.CallToolParams{
-		Name:      "invoke_agent",
-		Arguments: map[string]any{"agent": "default/test-agent", "task": "say hello"},
-	})
-	require.NoError(t, err)
-	assert.False(t, result.IsError, "unexpected tool error: %v", result.Content)
-	assert.True(t, backend.wasCalled(), "A2A backend should have received the forwarded request")
 }


### PR DESCRIPTION

## What

`list_agents`, the `kagent://agents` MCP resource, and `invoke_agent` now return
`SandboxAgent`s (substrate-backed agents) in addition to declarative `Agent`s. A
fully ready `SandboxAgent` was previously invisible to all three, even though it
shows up in the REST `/agents` API and the UI.

## Why

`MCPHandler.listReadyAgents` (`go/core/internal/mcp/mcp_handler.go`) had two
compounding faults:

1. It listed only `v1alpha2.AgentList`, so `SandboxAgent` CRs were never
   enumerated at all.
2. It gated readiness on the string literal `condition.Reason == "DeploymentReady"`.

A `SandboxAgent` reports its `Ready` condition with reason `WorkloadReady`, while
a declarative `Agent` uses `DeploymentReady`:

- `reconcileSandboxAgentStatus` sets `Reason = AgentReadyReasonWorkloadReady`
  when the workload is ready (`reconciler.go`).
- `reconcileAgentStatus` sets `Reason = AgentReadyReasonDeploymentReady`
  (`reconciler.go`).

So a `SandboxAgent` with `Accepted=True` and `Ready=True` (reason `WorkloadReady`)
was dropped by both faults. `listReadyAgents` feeds `handleListAgents` (the
`list_agents` tool) and `readAgentsResource` (the `kagent://agents` resource), and
`invoke_agent` relies on the same readiness notion, so such an agent was reported
as "not found or not ready" over MCP while being fully usable via the REST API.

The correct, two-reason, interface-based readiness check already exists elsewhere
in the codebase and is what this change reuses:

- `isAgentReady` in the A2A registrar (`a2a/a2a_registrar.go`) accepts both
  `AgentReadyReasonDeploymentReady` and `AgentReadyReasonWorkloadReady` over the
  `AgentObject` interface.
- The REST agents handler (`httpserver/handlers/agents.go`) does the same.

## Fix

- List both `v1alpha2.AgentList` and `v1alpha2.SandboxAgentList`, and evaluate
  readiness through a small `readyAgentSummary(v1alpha2.AgentObject)` helper that
  operates on the shared `AgentObject` interface.
- The helper accepts both `reconciler.AgentReadyReasonDeploymentReady` and
  `reconciler.AgentReadyReasonWorkloadReady`, and uses the typed condition-type
  constants (`v1alpha2.AgentConditionTypeReady` / `...Accepted`) with
  `metav1.ConditionTrue`, matching the A2A registrar and the REST handler instead
  of re-implementing the check with hardcoded strings.
- Updated the `list_agents` tool and `kagent://agents` resource descriptions from
  "accepted + deploymentReady" to "accepted + ready" now that both workload types
  are covered.

No CRD/API types change, so no code generation is required.

## Tests

Added `TestListReadyAgents_IncludesSandboxAgents` in
`go/core/internal/mcp/mcp_handler_test.go` (table of fake objects via the
controller-runtime fake client already used in this file). It asserts that:

- a ready declarative `Agent` (`DeploymentReady`) is listed,
- a ready `SandboxAgent` (`WorkloadReady`) is listed,
- a not-ready `SandboxAgent` is excluded, and
- the `SandboxAgent`'s description is surfaced.

The test fails against the current code (the `SandboxAgent` is absent and its
description is empty) and passes with the fix. Revert the `mcp_handler.go` hunks
to reproduce.

## How to verify

```bash
cd go
go build ./core/...
go test -race ./core/internal/mcp/...   # incl. TestListReadyAgents_IncludesSandboxAgents
make -C go lint                         # from repo root; 0 issues
```

## Scope

Limited to the MCP agent-listing path. It reuses the existing readiness semantics
(the same two `Ready` reasons the REST API and A2A registrar already honor) rather
than introducing new behavior, so declarative `Agent` results are unchanged and
only genuinely ready `SandboxAgent`s are added.

## Checklist

- [x] Commit is DCO signed-off (`git commit -s`).
- [x] `go build ./core/...`, `go test -race ./core/internal/mcp/...`, and
      `make -C go lint` all pass.
- [x] Unit test added; fails without the fix, passes with it.
- [x] Diff limited to `go/core/internal/mcp/mcp_handler.go` and its test.
