### PR TITLE
feat(helm): bump bundled oauth2-proxy subchart to ~10.7.0

### DIFF
--- a/helm/kagent/Chart-template.yaml
+++ b/helm/kagent/Chart-template.yaml
@@ -65,6 +65,6 @@ dependencies:
     repository: file://../agents/cilium-debug
     condition: cilium-debug-agent.enabled
   - name: oauth2-proxy
-    version: "~7.0.0"
+    version: "~10.7.0"
     repository: "https://oauth2-proxy.github.io/manifests"
     condition: oauth2-proxy.enabled

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -799,9 +799,8 @@ querydoc:
 oauth2-proxy:
   enabled: false
 
-  # Disable Redis - use cookie-based sessions
-  redis:
-    enabled: false
+  # Cookie-based sessions (the redis-ha sub-chart is disabled by default;
+  # enable `redis-ha.enabled` + `sessionStorage.type: redis` to switch)
   sessionStorage:
     type: cookie
 


### PR DESCRIPTION
Fixes #2239.

## What
Bump the bundled oauth2-proxy subchart `~7.0.0` → `~10.7.0` (app v7.6.0 → **v7.15.3**).

## Why
Chart 7.0.0 hardcodes a `v` prefix on the image tag (`image: repo:v<tag>`), mangling any custom `image.tag` that doesn't follow the `vX.Y.Z` convention — e.g. a private-registry mirror tag `my-reg/kagent:oauth2-proxy-v7.6.0` renders as `:voauth2-proxy-v7.6.0` → ImagePullBackOff. Orgs whose admission policies forbid quay.io must mirror the image, so tag overrides are common. Chart 10.x renders the tag without the hardcoded prefix, and brings ~3 years of chart fixes.

## Compatibility — every key the kagent chart sets, verified by render
| kagent sets | 10.7.0 status |
|---|---|
| `config.existingSecret` | ✅ same `client-id`/`client-secret`/`cookie-secret` keys (now gated on `config.requiredSecretKeys`, defaults to all three) |
| `extraArgs` map / `extraEnv` / `extraVolumes(+Mounts)` | ✅ unchanged |
| `sessionStorage.type: cookie` | ✅ unchanged (bitnami `redis` sub-chart replaced by `redis-ha`, disabled by default — dropped the stale `redis.enabled: false` from values) |
| `service.portNumber: 4180` | ✅ still supported (upstream default moved to 80; kagent pins 4180) |

## Verified renders
- default: `quay.io/oauth2-proxy/oauth2-proxy:v7.15.3`
- **the #2239 scenario**: `--set image.registry=my-reg.example.com --set image.repository=mirrors/kagent --set image.tag=oauth2-proxy-v7.6.0` → renders **verbatim** ✅
- kagent's `extraArgs` (custom-templates-dir, skip-jwt-bearer-tokens, ...) and `existingSecret` env refs intact ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)