### PR TITLE
feat: default nodeSelector for agent deployments (--default-agent-node-selector)

### DIFF
--- a/go/core/internal/controller/translator/agent/adk_api_translator.go
+++ b/go/core/internal/controller/translator/agent/adk_api_translator.go
@@ -142,6 +142,10 @@ var DefaultServiceAccountName string
 // Per-agent labels from the Agent CRD spec take precedence over these defaults.
 var DefaultAgentPodLabels map[string]string
 
+// DefaultAgentNodeSelector is a node selector applied to all agent deployments.
+// A per-agent nodeSelector from the Agent CRD spec takes precedence over these defaults.
+var DefaultAgentNodeSelector map[string]string
+
 // DefaultAgentBindHost is the host address agent pods bind to.
 // Defaults to "0.0.0.0" (IPv4 only). Set to "::" for dual-stack (IPv4+IPv6) support.
 var DefaultAgentBindHost = "0.0.0.0"

--- a/go/core/internal/controller/translator/agent/deployments.go
+++ b/go/core/internal/controller/translator/agent/deployments.go
@@ -80,6 +80,18 @@ func getDefaultLabels(agentName string, incoming map[string]string) map[string]s
 	return defaultLabels
 }
 
+func getDefaultNodeSelector(incoming map[string]string) map[string]string {
+	// No global default (from --default-agent-node-selector flag): keep the
+	// per-agent value as-is (nil stays nil).
+	if len(DefaultAgentNodeSelector) == 0 {
+		return maps.Clone(incoming)
+	}
+	nodeSelector := maps.Clone(DefaultAgentNodeSelector)
+	// Per-agent nodeSelector overrides global defaults
+	maps.Copy(nodeSelector, incoming)
+	return nodeSelector
+}
+
 // getRuntimeImageRepository returns the image repository for a given runtime.
 // It respects DefaultImageConfig.Repository for the Python runtime, and derives
 // the Go runtime repository by replacing the last path segment with "golang-adk".
@@ -237,7 +249,7 @@ func resolveInlineDeployment(agent v1alpha2.AgentObject, mdd *modelDeploymentDat
 		Resources:            getDefaultResources(spec.Resources), // Set default resources if not specified
 		Tolerations:          slices.Clone(spec.Tolerations),
 		Affinity:             spec.Affinity,
-		NodeSelector:         maps.Clone(spec.NodeSelector),
+		NodeSelector:         getDefaultNodeSelector(spec.NodeSelector),
 		SecurityContext:      spec.SecurityContext,
 		PodSecurityContext:   spec.PodSecurityContext,
 		ServiceAccountName:   spec.ServiceAccountName,
@@ -321,7 +333,7 @@ func resolveByoDeployment(agent v1alpha2.AgentObject) (*resolvedDeployment, erro
 		Resources:            getDefaultResources(spec.Resources), // Set default resources if not specified
 		Tolerations:          slices.Clone(spec.Tolerations),
 		Affinity:             spec.Affinity,
-		NodeSelector:         maps.Clone(spec.NodeSelector),
+		NodeSelector:         getDefaultNodeSelector(spec.NodeSelector),
 		SecurityContext:      spec.SecurityContext,
 		PodSecurityContext:   spec.PodSecurityContext,
 		ServiceAccountName:   spec.ServiceAccountName,

--- a/go/core/internal/controller/translator/agent/deployments_test.go
+++ b/go/core/internal/controller/translator/agent/deployments_test.go
@@ -85,3 +85,43 @@ func TestValidateExtraContainers(t *testing.T) {
 		})
 	}
 }
+
+func TestGetDefaultNodeSelector(t *testing.T) {
+	setGlobal := func(t *testing.T, v map[string]string) {
+		t.Helper()
+		prev := DefaultAgentNodeSelector
+		DefaultAgentNodeSelector = v
+		t.Cleanup(func() { DefaultAgentNodeSelector = prev })
+	}
+
+	t.Run("nil stays nil without a global default", func(t *testing.T) {
+		setGlobal(t, nil)
+		if got := getDefaultNodeSelector(nil); got != nil {
+			t.Errorf("getDefaultNodeSelector(nil) = %v, want nil", got)
+		}
+	})
+
+	t.Run("per-agent value kept without a global default", func(t *testing.T) {
+		setGlobal(t, nil)
+		got := getDefaultNodeSelector(map[string]string{"disktype": "ssd"})
+		if got["disktype"] != "ssd" || len(got) != 1 {
+			t.Errorf("getDefaultNodeSelector() = %v, want map[disktype:ssd]", got)
+		}
+	})
+
+	t.Run("global default applied when agent sets nothing", func(t *testing.T) {
+		setGlobal(t, map[string]string{"kubernetes.io/os": "linux"})
+		got := getDefaultNodeSelector(nil)
+		if got["kubernetes.io/os"] != "linux" || len(got) != 1 {
+			t.Errorf("getDefaultNodeSelector(nil) = %v, want the global default", got)
+		}
+	})
+
+	t.Run("per-agent nodeSelector overrides the global default", func(t *testing.T) {
+		setGlobal(t, map[string]string{"kubernetes.io/os": "linux", "pool": "default"})
+		got := getDefaultNodeSelector(map[string]string{"pool": "gpu"})
+		if got["pool"] != "gpu" || got["kubernetes.io/os"] != "linux" || len(got) != 2 {
+			t.Errorf("getDefaultNodeSelector() = %v, want merged map with per-agent pool=gpu", got)
+		}
+	})
+}

--- a/go/core/pkg/app/app.go
+++ b/go/core/pkg/app/app.go
@@ -217,6 +217,8 @@ func (cfg *Config) SetFlags(commandLine *flag.FlagSet) {
 
 	commandLine.Var(&MapValue{Target: &agent_translator.DefaultAgentPodLabels}, "default-agent-pod-labels", "Comma-separated key=value pairs of labels to apply to all agent pod templates (e.g. 'team=platform,env=prod'). Per-agent labels take precedence.")
 
+	commandLine.Var(&MapValue{Target: &agent_translator.DefaultAgentNodeSelector}, "default-agent-node-selector", "Comma-separated key=value pairs of node selector terms to apply to all agent deployments (e.g. 'kubernetes.io/os=linux'). A per-agent nodeSelector takes precedence.")
+
 	commandLine.StringVar(&agent_translator.DefaultAgentBindHost, "default-agent-bind-host", agent_translator.DefaultAgentBindHost, "Default host address for agent pods to bind to. Use '0.0.0.0' for IPv4 only or '::' for dual-stack (IPv4+IPv6).")
 }
 

--- a/go/core/pkg/app/app_test.go
+++ b/go/core/pkg/app/app_test.go
@@ -468,3 +468,15 @@ func TestLoadFromEnvIntegration(t *testing.T) {
 		t.Errorf("WatchNamespaces = %v, want ns1,ns2,ns3", cfg.WatchNamespaces)
 	}
 }
+
+func TestMapValueWithLoadFromEnvNodeSelector(t *testing.T) {
+	t.Setenv("DEFAULT_AGENT_NODE_SELECTOR", "kubernetes.io/os=linux,pool=agents")
+
+	var target map[string]string
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.Var(&MapValue{Target: &target}, "default-agent-node-selector", "test flag")
+
+	err := LoadFromEnv(fs)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"kubernetes.io/os": "linux", "pool": "agents"}, target)
+}

--- a/helm/kagent/templates/controller-configmap.yaml
+++ b/helm/kagent/templates/controller-configmap.yaml
@@ -83,3 +83,12 @@ data:
   DEFAULT_AGENT_POD_LABELS: {{ join "," $pairs | quote }}
   {{- end }}
   {{- end }}
+  {{- if and .Values.controller.agentDeployment .Values.controller.agentDeployment.nodeSelector }}
+  {{- $nsPairs := list }}
+  {{- range $k := keys .Values.controller.agentDeployment.nodeSelector | sortAlpha }}
+  {{- $nsPairs = append $nsPairs (printf "%s=%s" $k (index $.Values.controller.agentDeployment.nodeSelector $k | toString)) }}
+  {{- end }}
+  {{- if $nsPairs }}
+  DEFAULT_AGENT_NODE_SELECTOR: {{ join "," $nsPairs | quote }}
+  {{- end }}
+  {{- end }}

--- a/helm/kagent/tests/controller-deployment_test.yaml
+++ b/helm/kagent/tests/controller-deployment_test.yaml
@@ -269,6 +269,35 @@ tests:
           path: data.DEFAULT_AGENT_POD_LABELS
           value: "team=platform"
 
+  - it: should set DEFAULT_AGENT_NODE_SELECTOR when nodeSelector is configured
+    template: controller-configmap.yaml
+    set:
+      controller:
+        agentDeployment:
+          nodeSelector:
+            kubernetes.io/os: linux
+            pool: agents
+    asserts:
+      - equal:
+          path: data.DEFAULT_AGENT_NODE_SELECTOR
+          value: "kubernetes.io/os=linux,pool=agents"
+
+  - it: should not set DEFAULT_AGENT_NODE_SELECTOR when nodeSelector is empty
+    template: controller-configmap.yaml
+    set:
+      controller:
+        agentDeployment:
+          nodeSelector: {}
+    asserts:
+      - notExists:
+          path: data.DEFAULT_AGENT_NODE_SELECTOR
+
+  - it: should not set DEFAULT_AGENT_NODE_SELECTOR when nodeSelector is not configured
+    template: controller-configmap.yaml
+    asserts:
+      - notExists:
+          path: data.DEFAULT_AGENT_NODE_SELECTOR
+
   - it: should set DEFAULT_AGENT_BIND_HOST when host is configured
     template: controller-configmap.yaml
     set:

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -174,6 +174,15 @@ controller:
     #   podLabels:
     #     team: platform
     #     environment: production
+    # -- Default nodeSelector applied to all agent deployments.
+    # Useful when admission policies require a nodeSelector on every
+    # Deployment, since wizard-created Agents carry none. A per-agent
+    # nodeSelector in the Agent CRD takes precedence over these defaults.
+    # @default -- {} (no default nodeSelector)
+    nodeSelector: {}
+    # Example:
+    #   nodeSelector:
+    #     kubernetes.io/os: linux
     # -- Default host address for agent pods to bind to.
     # Leave empty to use the controller's default fallback of "0.0.0.0".
     # Automatically set to "::" when ipv6.enabled is true.


### PR DESCRIPTION
Fixes #2258

## Summary

Parallel to `--default-agent-pod-labels`: a global default **nodeSelector** applied to all agent Deployments, with a per-agent `spec.declarative.deployment.nodeSelector` taking precedence (per-key merge, agent wins).

## Motivation

In clusters where admission policies (Gatekeeper/Kyverno) require a nodeSelector on every Deployment — a common pattern for cost/scheduling governance — every dashboard-created Agent is denied at admission, because wizard-created Agents carry no nodeSelector and there is no global default. Operators currently need an external mutation webhook to work around it (we run a Gatekeeper `Assign` scoped to our agents namespace; this PR would let us delete it).

## Changes

**Controller**
- `DefaultAgentNodeSelector` in the agent translator, next to `DefaultAgentPodLabels`.
- `--default-agent-node-selector` flag (comma-separated `key=value`, same `MapValue` format as pod labels), reachable as `DEFAULT_AGENT_NODE_SELECTOR` via the existing flag→env mapping.
- Both declarative and BYO deployment resolution use the merge helper: no global default → per-agent value untouched (nil stays nil); global default set → merged with per-agent keys winning.

**Chart**
- `controller.agentDeployment.nodeSelector` renders `DEFAULT_AGENT_NODE_SELECTOR` into the controller ConfigMap, mirroring the `agentDeployment.podLabels` wiring (sorted keys for deterministic output).

## Testing

- Go: merge-semantics unit tests (nil/no-default, per-agent only, default only, per-agent overrides default) + env parsing test; `go build ./core/...` and both packages' tests pass.
- Helm: 3 new helm-unittest cases for the ConfigMap wiring; full `controller-deployment_test.yaml` suite passes (64 tests).