### PR TITLE
fix: deflake TestNewClientPreemptsStale slot-ownership race

### DIFF
--- a/go/core/pkg/acpshim/server_test.go
+++ b/go/core/pkg/acpshim/server_test.go
@@ -113,6 +113,19 @@ func TestNewClientPreemptsStale(t *testing.T) {
 	conn1 := dial(t, url, "")
 	defer conn1.Close()
 
+	// A completed handshake does not mean the handler goroutine has taken the
+	// single-client slot yet; if the second connection races ahead, the first
+	// handler would "preempt" the newcomer instead. An echo round-trip through
+	// the cat child proves conn1 is the established incumbent.
+	ping := `{"jsonrpc":"2.0","id":0,"method":"ping"}`
+	if err := conn1.WriteMessage(websocket.TextMessage, []byte(ping)); err != nil {
+		t.Fatalf("write on first conn: %v", err)
+	}
+	_ = conn1.SetReadDeadline(time.Now().Add(5 * time.Second))
+	if _, _, err := conn1.ReadMessage(); err != nil {
+		t.Fatalf("echo on first conn: %v", err)
+	}
+
 	// A browser refresh opens a new connection while the stale one lingers.
 	// The newcomer must preempt the incumbent rather than being rejected with
 	// 409, otherwise the user is locked out behind a half-open connection.


### PR DESCRIPTION
## What

Adds an echo round-trip on the first connection in `TestNewClientPreemptsStale` before dialing the second one.

## Why

The test is flaky (observed on https://github.com/kagent-dev/kagent/actions/runs/29563789318/job/87831751214, reproducible locally within ~30 runs of `go test -race -count=30 -run TestNewClientPreemptsStale ./core/pkg/acpshim`).

A completed WebSocket handshake only means the HTTP upgrade finished; the handler goroutine may not have taken the single-client slot yet. When the second dial races ahead, the slot ordering inverts: the first handler finds the second connection as the incumbent and preempts it, so the connection the test expects to win reads `close 1006 (abnormal closure)` at `server_test.go:139`.

The echo through the `cat` child proves the first connection's handler owns the slot and is pumping before the preempting dial happens, which is the scenario the test is about (an established stale client being preempted by a refresh).

Shim behavior is unchanged; under a genuinely simultaneous connect the winner is arbitrary either way and the loser's bridge reconnects. 100/100 passes with `-race` after the fix.