### PR TITLE
ci: improve build caching and cancel stale runs

### DIFF
--- a/.github/actions/upgrade-test-setup/action.yaml
+++ b/.github/actions/upgrade-test-setup/action.yaml
@@ -79,11 +79,6 @@ runs:
       shell: bash
       run: |
         sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
-    - name: Set up QEMU
-      if: steps.resolve.outputs.skip != 'true'
-      uses: docker/setup-qemu-action@v4
-      with:
-        platforms: linux/amd64,linux/arm64
     - name: Set up Docker Buildx
       if: steps.resolve.outputs.skip != 'true'
       uses: docker/setup-buildx-action@v4
@@ -92,7 +87,7 @@ runs:
         # workflows (e.g. tag.yaml); kept as literals for consistency.
         name: kagent-builder-v0.23.0
         version: v0.23.0
-        platforms: linux/amd64,linux/arm64
+        platforms: linux/amd64
         use: "true"
         driver-opts: network=host
     - name: Set up Helm

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,10 @@ on:
       - "**/*.md"
   workflow_dispatch:
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   # Cache key components for better organization
   CACHE_KEY_PREFIX: kagent-v2
@@ -49,16 +53,12 @@ jobs:
         # See https://github.com/openai/codex/issues/14919
         run: |
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-        with:
-          platforms: linux/amd64,linux/arm64
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
         with:
           name: ${{ env.BUILDX_BUILDER_NAME }}
           version: ${{ env.BUILDX_VERSION }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           use: "true"
           driver-opts: network=host
 

--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -13,6 +13,10 @@ on:
 
   workflow_dispatch:
 
+concurrency:
+  group: image-scan-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   # Cache key components for better organization
   CACHE_KEY_PREFIX: kagent-v2
@@ -73,8 +77,9 @@ jobs:
         env:
           DOCKER_BUILDER: "docker buildx build"
           DOCKER_BUILD_ARGS: >-
+            --cache-from=type=gha,scope=${{ env.CACHE_KEY_PREFIX }}-${{ matrix.build_target }}
             --cache-from=type=gha
-            --cache-to=type=gha,mode=max
+            --cache-to=type=gha,scope=${{ env.CACHE_KEY_PREFIX }}-${{ matrix.build_target }},mode=max
             --build-arg=VERSION=${{ steps.vars.outputs.version }}
             --push
         run: |

--- a/.github/workflows/ui-chromatic.yaml
+++ b/.github/workflows/ui-chromatic.yaml
@@ -14,6 +14,10 @@ on:
       - "ui/**"
   workflow_dispatch:
 
+concurrency:
+  group: ui-chromatic-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   chromatic:
     runs-on: ubuntu-latest

--- a/.github/workflows/ui-playwright.yaml
+++ b/.github/workflows/ui-playwright.yaml
@@ -15,6 +15,10 @@ on:
       - "ui/**"
   workflow_dispatch:
 
+concurrency:
+  group: ui-playwright-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   playwright:
     runs-on: ubuntu-latest

--- a/docker/acp-sandbox/Dockerfile
+++ b/docker/acp-sandbox/Dockerfile
@@ -44,7 +44,7 @@ ARG LDFLAGS
 RUN --mount=type=cache,target=/root/go/pkg/mod,rw \
     --mount=type=cache,target=/root/.cache/go-build,rw \
     CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
-    go build -a -trimpath -ldflags "$LDFLAGS" -o /acp-shim ./core/cmd/acp-shim
+    go build -trimpath -ldflags "$LDFLAGS" -o /acp-shim ./core/cmd/acp-shim
 
 ### Stage 1: kagent-owned sandbox base — shim only, no agent.
 FROM debian:trixie-slim AS base

--- a/docker/skills-init/Dockerfile
+++ b/docker/skills-init/Dockerfile
@@ -20,7 +20,7 @@ ARG LDFLAGS
 RUN --mount=type=cache,target=/root/go/pkg/mod,rw \
     --mount=type=cache,target=/root/.cache/go-build,rw \
     CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
-    go build -a -trimpath -ldflags "$LDFLAGS" -o /skills-init ./core/cmd/skills-init
+    go build -trimpath -ldflags "$LDFLAGS" -o /skills-init ./core/cmd/skills-init
 
 ### Stage 1: runtime
 FROM alpine:3.24

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -27,7 +27,7 @@ ARG LDFLAGS
 RUN --mount=type=cache,target=/root/go/pkg/mod,rw             \
     --mount=type=cache,target=/root/.cache/go-build,rw        \
     echo "Building on $BUILDPLATFORM -> linux/$TARGETARCH" && \
-    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags "$LDFLAGS" -o /app "$BUILD_PACKAGE"
+    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -ldflags "$LDFLAGS" -o /app "$BUILD_PACKAGE"
 
 ### STAGE 2: final image
 # Use distroless as minimal base image to package the manager binary

--- a/go/Dockerfile.full
+++ b/go/Dockerfile.full
@@ -20,7 +20,7 @@ ARG LDFLAGS
 RUN --mount=type=cache,target=/root/go/pkg/mod,rw \
     --mount=type=cache,target=/root/.cache/go-build,rw \
     echo "Building on $BUILDPLATFORM -> linux/$TARGETARCH" && \
-    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags "$LDFLAGS" -o /app "$BUILD_PACKAGE"
+    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -ldflags "$LDFLAGS" -o /app "$BUILD_PACKAGE"
 
 FROM $BASE_IMAGE_REGISTRY/chainguard/wolfi-base:latest AS srt-builder
 ARG TOOLS_PYTHON_VERSION=3.13


### PR DESCRIPTION
## Summary

Improve CI resource usage without changing test or build coverage:

- allow Go image builds to reuse the compilation cache
- remove unused QEMU setup from amd64-only jobs
- isolate image-scan caches by build target
- cancel superseded CI and UI workflow runs

The existing job set, test conditions, image matrix, and multi-architecture validation remain unchanged.

## Impact

Normal runs should see a modest improvement, primarily when Go build layers are invalidated but cached compilation artifacts remain available. Larger savings occur when stale runs are canceled after new commits are pushed.

## Validation

- verified binaries built with and without `go build -a` are byte-identical
- confirmed E2E and upgrade Docker builds target only amd64
- verified CI job sets, matrices, and conditions match the existing workflow
- ran `actionlint` on all modified workflows