### PR TITLE
docs: fix stale architecture references

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -128,7 +128,7 @@ This installs the following components into your cluster:
 
 PostgreSQL is deployed automatically as part of `make helm-install` via the bundled Helm chart. The optional addons above provide observability components.
 
-> **pgvector:** The default bundled PostgreSQL image (`postgres:18`) does not include the pgvector extension. If you need vector features (e.g. long-term memory), either use an external PostgreSQL instance with pgvector installed, or override the bundled image to `pgvector/pgvector:pg18-trixie` and set `database.postgres.vectorEnabled=true`. The `make helm-install` target does this automatically for local development.
+> **pgvector:** The default bundled PostgreSQL image (`postgres:18.3-alpine`) does not include the pgvector extension. If you need vector features (e.g. long-term memory), either use an external PostgreSQL instance with pgvector installed, or override the bundled image to `pgvector/pgvector:pg18-trixie` and set `database.postgres.vectorEnabled=true`. The `make helm-install` target does this automatically for local development.
 
 Verify the database connection by checking the controller logs:
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -391,22 +391,23 @@ Agents connect to tool servers using the [MCP protocol](https://modelcontextprot
 
 ## Go Module Structure
 
-The Go code is organized as a Go workspace (`go.work`) with three modules:
+The Go code is a single module (`github.com/kagent-dev/kagent/go`) with three top-level package trees:
 
 ```
 go/
-├── go.work
-├── api/        # github.com/kagent-dev/kagent/go/api
+├── api/        # Shared types
 │   ├── v1alpha2/         # CRD type definitions
+│   ├── adk/              # ADK config types (shared with Python)
 │   ├── database/         # database models
 │   ├── httpapi/          # HTTP API request/response types
 │   ├── client/           # REST client SDK for the HTTP API
 │   └── config/crd/       # Generated CRD manifests
 │
-├── core/       # github.com/kagent-dev/kagent/go/core
+├── core/       # Infrastructure
 │   ├── cmd/
-│   │   ├── controller/   # Main controller binary entry point
-│   │   └── kagent/       # CLI tool entry point
+│   │   └── controller/   # Main controller binary entry point
+│   ├── cli/
+│   │   └── cmd/kagent/   # CLI tool entry point
 │   ├── internal/
 │   │   ├── controller/   # K8s controllers and reconciler
 │   │   │   ├── reconciler/   # Shared kagentReconciler
@@ -416,8 +417,7 @@ go/
 │   │   └── database/     # Database client implementation
 │   └── test/e2e/         # E2E tests
 │
-└── adk/        # github.com/kagent-dev/kagent/go/adk
-    ├── types.go          # ADK config types (shared with Python)
+└── adk/        # Go Agent Development Kit
     ├── pkg/
     │   ├── app/          # KAgentApp - main application wiring
     │   ├── a2a/server/   # A2A HTTP server with health endpoints

--- a/docs/architecture/crds-and-types.md
+++ b/docs/architecture/crds-and-types.md
@@ -252,8 +252,8 @@ The same configuration data flows through three type systems:
 
 ```
 CRD Types (Go)                    Go ADK Types              Python ADK Types
-go/api/v1alpha2/                  go/adk/types.go           kagent/adk/types.py
-────────────────                  ──────────────            ────────────────────
+go/api/v1alpha2/                  go/api/adk/types.go       kagent/adk/types.py
+────────────────                  ───────────────────       ────────────────────
 AgentSpec                    ──▶  AgentConfig          ──▶  AgentConfig
 DeclarativeAgentSpec         ──▶  AgentConfig.Agent    ──▶  AgentConfig.agent
 ModelConfigSpec              ──▶  ModelConfig          ──▶  ModelConfig
@@ -342,7 +342,7 @@ When adding a field to an existing CRD, update all layers:
 1. **CRD type** — `go/api/v1alpha2/*_types.go` (add field with kubebuilder markers)
 2. **Code generation** — `make -C go generate` (DeepCopy, CRD manifests)
 3. **Helm CRD chart** — `cp go/api/config/crd/bases/*.yaml helm/kagent-crds/templates/`
-4. **Go ADK types** — `go/adk/types.go` (if field affects agent config)
+4. **Go ADK types** — `go/api/adk/types.go` (if field affects agent config)
 5. **Translator** — `go/core/internal/controller/translator/agent/adk_api_translator.go` (wire field into config)
 6. **Python ADK types** — `python/packages/kagent-adk/src/kagent/adk/types.py` (mirror Go types)
 7. **Python runtime** — Use the field in agent setup if it affects runtime behavior

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -208,7 +208,7 @@ Agent Pod reads /config/config.json at startup
 AgentConfig → creates ADK Agent with tools, callbacks, session service
 ```
 
-**config.json structure** (Go types in `go/adk/types.go`, Python types in `python/packages/kagent-adk/src/kagent/adk/types.py`):
+**config.json structure** (Go types in `go/api/adk/types.go`, Python types in `python/packages/kagent-adk/src/kagent/adk/types.py`):
 
 ```json
 {


### PR DESCRIPTION
The architecture guide described the Go code as a go.work workspace with three modules. It is a single module with three package trees, as go/README.md already says. The module tree also listed the CLI under core/cmd/kagent, the real path is core/cli/cmd/kagent.

Four references pointed to go/adk/types.go for the ADK config types. The file lives at go/api/adk/types.go.

DEVELOPMENT.md called the bundled PostgreSQL image postgres:18, the actual default in values.yaml is postgres:18.3-alpine.