### PR TITLE
fix(build): use AZURE_OPENAI_API_KEY env var name consistently

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,9 +177,9 @@ check-api-key: ## Validate required API key for the configured model provider
 			exit 1; \
 		fi; \
 	elif [ "$(KAGENT_DEFAULT_MODEL_PROVIDER)" = "azureOpenAI" ]; then \
-		if [ -z "$(AZUREOPENAI_API_KEY)" ]; then \
-			echo "Error: AZUREOPENAI_API_KEY environment variable is not set for Azure OpenAI provider"; \
-			echo "Please set it with: export AZUREOPENAI_API_KEY=your-api-key"; \
+		if [ -z "$(AZURE_OPENAI_API_KEY)" ]; then \
+			echo "Error: AZURE_OPENAI_API_KEY environment variable is not set for Azure OpenAI provider"; \
+			echo "Please set it with: export AZURE_OPENAI_API_KEY=your-api-key"; \
 			exit 1; \
 		fi; \
 	elif [ "$(KAGENT_DEFAULT_MODEL_PROVIDER)" = "gemini" ]; then \
@@ -497,7 +497,7 @@ helm-install-provider: helm-version check-api-key
 		--set ui.image.pullPolicy=Always \
 		--set controller.service.type=LoadBalancer \
 		--set providers.openAI.apiKey=$(OPENAI_API_KEY) \
-		--set providers.azureOpenAI.apiKey=$(AZUREOPENAI_API_KEY) \
+		--set providers.azureOpenAI.apiKey=$(AZURE_OPENAI_API_KEY) \
 		--set providers.anthropic.apiKey=$(ANTHROPIC_API_KEY) \
 		--set providers.gemini.apiKey=$(GOOGLE_API_KEY) \
 		--set providers.default=$(KAGENT_DEFAULT_MODEL_PROVIDER) \

--- a/helm/README.md
+++ b/helm/README.md
@@ -27,7 +27,7 @@ helm install kagent ./helm/kagent/ --namespace kagent --set providers.default=az
 # export your openAI key
 export OPENAI_API_KEY=your-openai-api-key
 export ANTHROPIC_API_KEY=your-anthropic-api-key
-export AZUREOPENAI_API_KEY=your-azure-api-key
+export AZURE_OPENAI_API_KEY=your-azure-api-key
 
 # install the kagent charts with openAI provider 
 make KAGENT_DEFAULT_MODEL_PROVIDER=openAI helm-install
@@ -48,7 +48,7 @@ make KAGENT_DEFAULT_MODEL_PROVIDER=ollama helm-install
 ## make sure have env variable with your API_KEY
 export OPENAI_API_KEY=your-openai-api-key
 export ANTHROPIC_API_KEY=your-anthropic-api-key
-export AZURE_API_KEY=your-azure-api-key
+export AZURE_OPENAI_API_KEY=your-azure-api-key
 
 #default provider is openAI but you can select from the list 
 export KAGENT_DEFAULT_MODEL_PROVIDER=ollama


### PR DESCRIPTION
The Makefile checked and passed AZUREOPENAI_API_KEY while the Go and Python code read AZURE_OPENAI_API_KEY, so the helm-install targets silently passed an empty Azure key. This renames the Makefile variable and the two helm README export examples to match the code. Split out of #2144 since it changes Makefile behavior rather than docs.