### PR TITLE
helm: add annotations support to controller and UI ServiceAccounts

### DIFF
--- a/helm/kagent/templates/controller-serviceaccount.yaml
+++ b/helm/kagent/templates/controller-serviceaccount.yaml
@@ -5,3 +5,7 @@ metadata:
   namespace: {{ include "kagent.namespace" . }}
   labels:
     {{- include "kagent.labels" . | nindent 4 }}
+  {{- with .Values.controller.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/helm/kagent/templates/ui-serviceaccount.yaml
+++ b/helm/kagent/templates/ui-serviceaccount.yaml
@@ -5,3 +5,7 @@ metadata:
   namespace: {{ include "kagent.namespace" . }}
   labels:
     {{- include "kagent.labels" . | nindent 4 }}
+  {{- with .Values.ui.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/helm/kagent/tests/serviceaccount-annotations_test.yaml
+++ b/helm/kagent/tests/serviceaccount-annotations_test.yaml
@@ -1,0 +1,111 @@
+suite: test ServiceAccount annotations
+templates:
+  - controller-serviceaccount.yaml
+  - ui-serviceaccount.yaml
+tests:
+  # =============================================================================
+  # Controller ServiceAccount Annotation Tests
+  # =============================================================================
+  - it: should not render annotations on controller ServiceAccount by default
+    template: controller-serviceaccount.yaml
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - isNull:
+          path: metadata.annotations
+
+  - it: should render annotations on controller ServiceAccount when set
+    template: controller-serviceaccount.yaml
+    set:
+      controller:
+        serviceAccount:
+          annotations:
+            iam.gke.io/gcp-service-account: my-sa@my-project.iam.gserviceaccount.com
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.annotations["iam.gke.io/gcp-service-account"]
+          value: my-sa@my-project.iam.gserviceaccount.com
+
+  - it: should render multiple annotations on controller ServiceAccount
+    template: controller-serviceaccount.yaml
+    set:
+      controller:
+        serviceAccount:
+          annotations:
+            iam.gke.io/gcp-service-account: my-sa@my-project.iam.gserviceaccount.com
+            eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/my-role
+    asserts:
+      - equal:
+          path: metadata.annotations["iam.gke.io/gcp-service-account"]
+          value: my-sa@my-project.iam.gserviceaccount.com
+      - equal:
+          path: metadata.annotations["eks.amazonaws.com/role-arn"]
+          value: arn:aws:iam::123456789012:role/my-role
+
+  # =============================================================================
+  # UI ServiceAccount Annotation Tests
+  # =============================================================================
+  - it: should not render annotations on UI ServiceAccount by default
+    template: ui-serviceaccount.yaml
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - isNull:
+          path: metadata.annotations
+
+  - it: should render annotations on UI ServiceAccount when set
+    template: ui-serviceaccount.yaml
+    set:
+      ui:
+        serviceAccount:
+          annotations:
+            iam.gke.io/gcp-service-account: ui-sa@my-project.iam.gserviceaccount.com
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.annotations["iam.gke.io/gcp-service-account"]
+          value: ui-sa@my-project.iam.gserviceaccount.com
+
+  - it: should render multiple annotations on UI ServiceAccount
+    template: ui-serviceaccount.yaml
+    set:
+      ui:
+        serviceAccount:
+          annotations:
+            iam.gke.io/gcp-service-account: ui-sa@my-project.iam.gserviceaccount.com
+            eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/ui-role
+    asserts:
+      - equal:
+          path: metadata.annotations["iam.gke.io/gcp-service-account"]
+          value: ui-sa@my-project.iam.gserviceaccount.com
+      - equal:
+          path: metadata.annotations["eks.amazonaws.com/role-arn"]
+          value: arn:aws:iam::123456789012:role/ui-role
+
+  # =============================================================================
+  # Independence Tests
+  # =============================================================================
+  - it: controller annotations should not affect UI ServiceAccount
+    template: ui-serviceaccount.yaml
+    set:
+      controller:
+        serviceAccount:
+          annotations:
+            iam.gke.io/gcp-service-account: controller-sa@my-project.iam.gserviceaccount.com
+    asserts:
+      - isNull:
+          path: metadata.annotations
+
+  - it: UI annotations should not affect controller ServiceAccount
+    template: controller-serviceaccount.yaml
+    set:
+      ui:
+        serviceAccount:
+          annotations:
+            iam.gke.io/gcp-service-account: ui-sa@my-project.iam.gserviceaccount.com
+    asserts:
+      - isNull:
+          path: metadata.annotations

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -151,6 +151,12 @@ rbac:
 # ==============================================================================
 
 controller:
+  # -- ServiceAccount settings for the controller pod
+  serviceAccount:
+    # -- Annotations to add to the controller ServiceAccount.
+    # Useful for GCP Workload Identity, AWS IRSA, or Azure Workload Identity.
+    # @default -- {} (no extra annotations)
+    annotations: {}
   replicas: 1
   loglevel: "info"
   # Authentication mode: "unsecure" (default) or "trusted-proxy"
@@ -374,6 +380,12 @@ substrateWorkerPool:
 # ==============================================================================
 
 ui:
+  # -- ServiceAccount settings for the UI pod
+  serviceAccount:
+    # -- Annotations to add to the UI ServiceAccount.
+    # Useful for GCP Workload Identity, AWS IRSA, or Azure Workload Identity.
+    # @default -- {} (no extra annotations)
+    annotations: {}
   # -- Additional annotations to add to the UI Deployment metadata
   annotations: {}
 


### PR DESCRIPTION
## Summary

- Adds `controller.serviceAccount.annotations` and `ui.serviceAccount.annotations` to `values.yaml`
- Updates `controller-serviceaccount.yaml` and `ui-serviceaccount.yaml` templates to render annotations when provided

## Motivation

Cloud provider workload identity integrations (GCP Workload Identity, AWS IRSA, Azure Workload Identity) require annotations on Kubernetes ServiceAccounts. Without chart-level support, users must either maintain wrapper charts that render duplicate SA resources (which causes ArgoCD `ServerSideApply` conflicts) or annotate out-of-band via `kubectl`.

This is a standard pattern used by most Helm charts (ingress-nginx, cert-manager, external-dns, etc.).

## Example

```yaml
controller:
  serviceAccount:
    annotations:
      iam.gke.io/gcp-service-account: kagent@my-project.iam.gserviceaccount.com

ui:
  serviceAccount:
    annotations:
      iam.gke.io/gcp-service-account: kagent@my-project.iam.gserviceaccount.com
```

Fixes #2318