### PR TITLE
contrib: add ratatosk-mcp (CNCF release intelligence)

### DIFF
--- a/contrib/tools/ratatosk-mcp/README.md
+++ b/contrib/tools/ratatosk-mcp/README.md
@@ -1,0 +1,44 @@
+# Ratatosk MCP server
+
+[Ratatosk](https://ratatosk.io) reads every CNCF graduated/incubating project's
+release notes daily and extracts typed facts — security fixes, breaking
+changes, removals, deprecations, default changes — each with a verbatim quote
+and a source URL. This MCP server exposes those facts to in-cluster agents.
+
+Privacy: the `check_stack` tool compares your running versions locally, inside
+this process. Only project slugs are sent to the ratatosk server; versions
+never leave your cluster. The upstream API is public, read-only, and needs no
+credentials (rate limit 60 req/min per IP).
+
+## Tools
+
+| Tool | Purpose |
+| --- | --- |
+| `list_projects` | The tracked-project roster — resolve slugs here first |
+| `check_stack` | Compare running versions against known facts (local comparison) |
+| `get_release` | One reviewed release with all facts and the source URL |
+| `facts_by_entity` | Reverse index: every fact touching one CVE/flag/CRD |
+| `list_facts` | Incremental fact feed with a `since` cursor |
+
+## Install
+
+```bash
+kubectl apply -f ratatosk-deploy.yaml            # Deployment + Service (no RBAC needed)
+kubectl apply -f ratatosk-remote-mcpserver.yaml  # register with kagent
+kubectl apply -f ratatosk-agent.yaml             # optional: release-triage example agent
+```
+
+Or with the Helm chart from the repository:
+
+```bash
+git clone https://github.com/garlicKim21/ratatosk-mcp
+helm install ratatosk-mcp ./ratatosk-mcp/charts/ratatosk-mcp -n kagent
+```
+
+Ask the example agent things like:
+
+> "We run kubernetes v1.36.0, cilium v1.17.18 and envoy v1.38.3 — anything
+> that needs action before we upgrade?"
+
+The agent answers with severity-ranked facts, each backed by a quote from the
+release note and a link to the source.

--- a/contrib/tools/ratatosk-mcp/ratatosk-agent.yaml
+++ b/contrib/tools/ratatosk-mcp/ratatosk-agent.yaml
@@ -1,0 +1,44 @@
+apiVersion: kagent.dev/v1alpha2
+kind: Agent
+metadata:
+  name: release-triage-agent
+  namespace: kagent
+spec:
+  declarative:
+    modelConfig: default-model-config
+    stream: true
+    systemMessage: |-
+      You triage CNCF component upgrades for this cluster using ratatosk tools.
+
+      # Instructions
+          - Resolve project slugs with list_projects first — never guess a slug.
+          - Use check_stack with the component versions the user gives you (or
+            that you discover from the cluster). Versions are compared locally
+            by the tool; they are never sent to the ratatosk server.
+          - A component with tracked:false is NOT covered by ratatosk — say so
+            explicitly; never present the absence of facts as safety.
+          - Every fact carries a verbatim quote and a source URL via
+            get_release; cite the quote when you recommend action, and link
+            the source for anything critical.
+          - facts=[] with coverage=full_reviewed means the release was read
+            and is routine — it is safe to report "no action needed".
+          - If a question is unclear, ask before running tools.
+
+      # Response format:
+          - ALWAYS format your response as Markdown
+          - Lead with what needs action (severity first), then what does not
+          - Include the upgrade target version per component when relevant
+    tools:
+    - mcpServer:
+        apiGroup: kagent.dev
+        kind: RemoteMCPServer
+        name: ratatosk-mcp
+        toolNames:
+        - list_projects
+        - check_stack
+        - get_release
+        - facts_by_entity
+        - list_facts
+      type: McpServer
+  description: Flags which CNCF components in the cluster need action, with quoted evidence
+  type: Declarative

--- a/contrib/tools/ratatosk-mcp/ratatosk-deploy.yaml
+++ b/contrib/tools/ratatosk-mcp/ratatosk-deploy.yaml
@@ -1,0 +1,51 @@
+# ratatosk-mcp in-cluster deployment (streamable HTTP mode).
+# Read-only client of the public ratatosk.io API — no RBAC, no credentials,
+# no cluster permissions. Alternatively install via the Helm chart in
+# https://github.com/garlicKim21/ratatosk-mcp/tree/main/charts/ratatosk-mcp
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ratatosk-mcp
+  namespace: kagent
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ratatosk-mcp
+  template:
+    metadata:
+      labels:
+        app: ratatosk-mcp
+    spec:
+      containers:
+        - name: ratatosk-mcp
+          image: ghcr.io/garlickim21/ratatosk-mcp:0.3.4
+          env:
+            - name: MCP_HTTP_ADDR
+              value: ":8080"
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ratatosk-mcp
+  namespace: kagent
+spec:
+  selector:
+    app: ratatosk-mcp
+  ports:
+    - port: 8080
+      targetPort: 8080

--- a/contrib/tools/ratatosk-mcp/ratatosk-remote-mcpserver.yaml
+++ b/contrib/tools/ratatosk-mcp/ratatosk-remote-mcpserver.yaml
@@ -1,0 +1,12 @@
+## Ratatosk MCP server — CNCF release intelligence
+## https://github.com/garlicKim21/ratatosk-mcp
+apiVersion: kagent.dev/v1alpha2
+kind: RemoteMCPServer
+metadata:
+  name: ratatosk-mcp
+  namespace: kagent
+spec:
+  url: "http://ratatosk-mcp:8080/mcp"
+  timeout: 30s
+  sseReadTimeout: 5m0s
+  description: "Typed, quoted facts from CNCF release notes; check_stack compares running versions locally"


### PR DESCRIPTION
Adds [ratatosk-mcp](https://github.com/garlicKim21/ratatosk-mcp) to `contrib/tools`, following the layout of the existing k8sgpt entry (README + Deployment/Service + RemoteMCPServer + example Agent).

**What it is**: a read-only MCP server for [Ratatosk](https://ratatosk.io), which reads every CNCF graduated/incubating project's release notes daily and extracts typed facts (security fixes, breaking changes, removals, deprecations) — each with a verbatim quote and source URL. Five tools: `list_projects`, `check_stack`, `get_release`, `facts_by_entity`, `list_facts`.

**Why it fits kagent**: the included `release-triage-agent` answers "we run kubernetes vX, cilium vY — anything that needs action?" with severity-ranked, quoted evidence. `check_stack` compares running versions locally, so cluster versions never leave the process; the upstream API is public and needs no credentials. The Deployment needs no RBAC and runs clean under PSS `restricted`.

**Verification**: applied unmodified on a live kagent cluster — RemoteMCPServer `Accepted=True` with all five tools discovered, example agent Ready and answering with quoted facts, untracked components reported honestly as not covered. Also listed in the official MCP registry as `io.github.garlicKim21/ratatosk-mcp`.