### PR TITLE
fix: decouple skills from the privileged sandbox and default to restricted PSS

### DIFF
--- a/go/core/internal/controller/translator/agent/manifest_builder.go
+++ b/go/core/internal/controller/translator/agent/manifest_builder.go
@@ -303,7 +303,7 @@ func buildPodRuntime(
 	volumeMounts = append(volumeMounts, manifestCtx.deployment.VolumeMounts...)
 
 	needCodeExecIsolation := cfg != nil && cfg.GetExecuteCode()
-	initContainers, skillsInitCM, err := buildSkillsRuntime(manifestCtx, &sharedEnv, &volumes, &volumeMounts, &needCodeExecIsolation)
+	initContainers, skillsInitCM, err := buildSkillsRuntime(manifestCtx, &sharedEnv, &volumes, &volumeMounts)
 	if err != nil {
 		return nil, err
 	}
@@ -399,7 +399,6 @@ func buildSkillsRuntime(
 	sharedEnv *[]corev1.EnvVar,
 	volumes *[]corev1.Volume,
 	volumeMounts *[]corev1.VolumeMount,
-	needCodeExecIsolation *bool,
 ) ([]corev1.Container, *corev1.ConfigMap, error) {
 	spec := manifestCtx.agent.GetAgentSpec()
 	if spec.Skills == nil {
@@ -412,7 +411,6 @@ func buildSkillsRuntime(
 		return nil, nil, nil
 	}
 
-	*needCodeExecIsolation = true
 	*sharedEnv = append(*sharedEnv, corev1.EnvVar{
 		Name:  env.KagentSkillsFolder.Name(),
 		Value: "/skills",
@@ -445,7 +443,7 @@ func buildSkillsRuntime(
 		spec.Skills.GitAuthSecretRef,
 		skills,
 		spec.Skills.InsecureSkipVerify,
-		manifestCtx.deployment.SecurityContext,
+		buildContainerSecurityContext(manifestCtx.deployment.SecurityContext, false),
 		initEnv,
 		getDefaultResources(initResources),
 		spec.Skills.ImagePullSecrets,
@@ -488,10 +486,26 @@ func buildContainerSecurityContext(
 	}
 
 	if !needCodeExecIsolation {
-		return nil
+		return restrictedSecurityContext()
 	}
 
 	return &corev1.SecurityContext{Privileged: new(true)}
+}
+
+// restrictedSecurityContext satisfies the Pod Security Standards "restricted"
+// profile, so agents are admitted on clusters enforcing it without a
+// per-agent securityContext override.
+func restrictedSecurityContext() *corev1.SecurityContext {
+	return &corev1.SecurityContext{
+		AllowPrivilegeEscalation: new(false),
+		RunAsNonRoot:             new(true),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
 }
 
 func buildPodTemplate(

--- a/go/core/internal/controller/translator/agent/security_context_test.go
+++ b/go/core/internal/controller/translator/agent/security_context_test.go
@@ -195,9 +195,11 @@ func TestSecurityContext_OnlyPodSecurityContext(t *testing.T) {
 	assert.Equal(t, int64(2000), *podSecurityContext.RunAsUser)
 	assert.Equal(t, int64(2000), *podSecurityContext.RunAsGroup)
 
-	// Container security context should be nil if not specified
+	// Container security context defaults to the restricted-PSS profile when
+	// not specified; the pod-level settings are preserved alongside.
 	containerSecurityContext := podTemplate.Spec.Containers[0].SecurityContext
-	assert.Nil(t, containerSecurityContext, "Container securityContext should be nil when not specified")
+	require.NotNil(t, containerSecurityContext)
+	assertRestrictedSecurityContext(t, containerSecurityContext)
 }
 
 func TestSecurityContext_OnlyContainerSecurityContext(t *testing.T) {
@@ -278,7 +280,11 @@ func TestSecurityContext_OnlyContainerSecurityContext(t *testing.T) {
 // TestSecurityContext_SkillsDefaultPrivilegedSandbox verifies that when skills are
 // configured and the user has NOT set any securityContext (i.e., no PSS restriction),
 // the controller sets Privileged=true so that srt/bubblewrap can fully sandbox the BashTool.
-func TestSecurityContext_SkillsDefaultPrivilegedSandbox(t *testing.T) {
+// TestSecurityContext_SkillsDefaultNotPrivileged verifies that skills alone do
+// not trigger Privileged=true: skills loading needs no elevated privileges, and
+// only an explicit executeCodeBlocks opt-in requests the srt sandbox. Without a
+// user-provided securityContext the containers get the restricted-PSS defaults.
+func TestSecurityContext_SkillsDefaultNotPrivileged(t *testing.T) {
 	ctx := context.Background()
 
 	agent := &v1alpha2.Agent{
@@ -339,11 +345,120 @@ func TestSecurityContext_SkillsDefaultPrivilegedSandbox(t *testing.T) {
 	podTemplate := &deployment.Spec.Template
 
 	containerSecurityContext := podTemplate.Spec.Containers[0].SecurityContext
-	require.NotNil(t, containerSecurityContext, "SecurityContext should be created for sandbox")
-	// Without an explicit AllowPrivilegeEscalation=false constraint, skills trigger Privileged=true
-	// so that srt/bubblewrap can use kernel namespaces for full BashTool sandboxing.
-	require.NotNil(t, containerSecurityContext.Privileged, "Privileged should be set when no securityContext restriction")
-	assert.True(t, *containerSecurityContext.Privileged, "Privileged should be true for skills without PSS restrictions")
+	require.NotNil(t, containerSecurityContext)
+	assert.Nil(t, containerSecurityContext.Privileged, "skills alone must not trigger Privileged")
+	assertRestrictedSecurityContext(t, containerSecurityContext)
+
+	require.NotEmpty(t, podTemplate.Spec.InitContainers, "skills agent must have the skills-init container")
+	initSecurityContext := podTemplate.Spec.InitContainers[0].SecurityContext
+	require.NotNil(t, initSecurityContext, "skills-init must get the restricted defaults too")
+	assert.Nil(t, initSecurityContext.Privileged)
+	assertRestrictedSecurityContext(t, initSecurityContext)
+}
+
+func assertRestrictedSecurityContext(t *testing.T, securityContext *corev1.SecurityContext) {
+	t.Helper()
+	require.NotNil(t, securityContext.AllowPrivilegeEscalation)
+	assert.False(t, *securityContext.AllowPrivilegeEscalation)
+	require.NotNil(t, securityContext.RunAsNonRoot)
+	assert.True(t, *securityContext.RunAsNonRoot)
+	require.NotNil(t, securityContext.Capabilities)
+	assert.Equal(t, []corev1.Capability{"ALL"}, securityContext.Capabilities.Drop)
+	require.NotNil(t, securityContext.SeccompProfile)
+	assert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, securityContext.SeccompProfile.Type)
+}
+
+// TestSecurityContext_ExecuteCodeBlocksKeepsPrivileged verifies that the
+// explicit executeCodeBlocks opt-in still requests the privileged srt sandbox
+// when the user did not restrict the securityContext.
+func TestSecurityContext_ExecuteCodeBlocksKeepsPrivileged(t *testing.T) {
+	ctx := context.Background()
+
+	executeCode := true
+	agent := &v1alpha2.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-agent",
+			Namespace: "test",
+		},
+		Spec: v1alpha2.AgentSpec{
+			Type: v1alpha2.AgentType_Declarative,
+			Declarative: &v1alpha2.DeclarativeAgentSpec{
+				SystemMessage:     "Test agent",
+				ModelConfig:       "test-model",
+				ExecuteCodeBlocks: &executeCode,
+			},
+		},
+	}
+
+	deployment := translateToDeployment(ctx, t, agent)
+	containerSecurityContext := deployment.Spec.Template.Spec.Containers[0].SecurityContext
+	require.NotNil(t, containerSecurityContext)
+	require.NotNil(t, containerSecurityContext.Privileged)
+	assert.True(t, *containerSecurityContext.Privileged, "executeCodeBlocks is the explicit sandbox opt-in")
+}
+
+// TestSecurityContext_DefaultIsRestricted verifies that a plain agent (no
+// skills, no code execution, no user securityContext) renders restricted-PSS
+// compliant container security contexts.
+func TestSecurityContext_DefaultIsRestricted(t *testing.T) {
+	ctx := context.Background()
+
+	agent := &v1alpha2.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-agent",
+			Namespace: "test",
+		},
+		Spec: v1alpha2.AgentSpec{
+			Type: v1alpha2.AgentType_Declarative,
+			Declarative: &v1alpha2.DeclarativeAgentSpec{
+				SystemMessage: "Test agent",
+				ModelConfig:   "test-model",
+			},
+		},
+	}
+
+	deployment := translateToDeployment(ctx, t, agent)
+	containerSecurityContext := deployment.Spec.Template.Spec.Containers[0].SecurityContext
+	require.NotNil(t, containerSecurityContext, "default securityContext must be rendered")
+	assert.Nil(t, containerSecurityContext.Privileged)
+	assertRestrictedSecurityContext(t, containerSecurityContext)
+}
+
+func translateToDeployment(ctx context.Context, t *testing.T, agent *v1alpha2.Agent) *appsv1.Deployment {
+	t.Helper()
+
+	modelConfig := &v1alpha2.ModelConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-model",
+			Namespace: "test",
+		},
+		Spec: v1alpha2.ModelConfigSpec{
+			Provider: "OpenAI",
+			Model:    "gpt-4o",
+		},
+	}
+
+	scheme := schemev1.Scheme
+	require.NoError(t, v1alpha2.AddToScheme(scheme))
+
+	kubeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(agent, modelConfig).
+		Build()
+
+	translatorInstance := translator.NewAdkApiTranslator(kubeClient,
+		types.NamespacedName{Namespace: "test", Name: "test-model"}, nil, "", nil)
+
+	result, err := translator.TranslateAgent(ctx, translatorInstance, agent)
+	require.NoError(t, err)
+
+	for _, obj := range result.Manifest {
+		if dep, ok := obj.(*appsv1.Deployment); ok {
+			return dep
+		}
+	}
+	t.Fatal("no Deployment in translated manifest")
+	return nil
 }
 
 // TestSecurityContext_SkillsPSSRestricted verifies that when a user explicitly sets

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_a2a_config.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_a2a_config.json
@@ -214,6 +214,18 @@
                     "memory": "384Mi"
                   }
                 },
+                "securityContext": {
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "mountPath": "/config",

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_allowed_headers.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_allowed_headers.json
@@ -224,6 +224,18 @@
                     "memory": "384Mi"
                   }
                 },
+                "securityContext": {
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "mountPath": "/config",

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_context_config.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_context_config.json
@@ -235,6 +235,18 @@
                     "memory": "684Mi"
                   }
                 },
+                "securityContext": {
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "mountPath": "/config",

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_cross_namespace_tools.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_cross_namespace_tools.json
@@ -230,6 +230,18 @@
                     "memory": "384Mi"
                   }
                 },
+                "securityContext": {
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "mountPath": "/config",

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_custom_sa.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_custom_sa.json
@@ -183,6 +183,18 @@
                     "memory": "384Mi"
                   }
                 },
+                "securityContext": {
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "mountPath": "/config",

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_default_sa.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_default_sa.json
@@ -183,6 +183,18 @@
                     "memory": "384Mi"
                   }
                 },
+                "securityContext": {
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "mountPath": "/config",

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_embedding_provider.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_embedding_provider.json
@@ -230,6 +230,18 @@
                     "memory": "384Mi"
                   }
                 },
+                "securityContext": {
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "mountPath": "/config",

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_extra_containers.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_extra_containers.json
@@ -208,6 +208,18 @@
                     "memory": "384Mi"
                   }
                 },
+                "securityContext": {
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "mountPath": "/config",

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_git_skills.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_git_skills.json
@@ -244,7 +244,16 @@
                   }
                 },
                 "securityContext": {
-                  "privileged": true
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
+                  }
                 },
                 "volumeMounts": [
                   {
@@ -275,6 +284,18 @@
                   "requests": {
                     "cpu": "100m",
                     "memory": "384Mi"
+                  }
+                },
+                "securityContext": {
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
                   }
                 },
                 "volumeMounts": [

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_http_toolserver.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_http_toolserver.json
@@ -223,6 +223,18 @@
                     "memory": "384Mi"
                   }
                 },
+                "securityContext": {
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "mountPath": "/config",

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_mcp_service.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_mcp_service.json
@@ -219,6 +219,18 @@
                     "memory": "384Mi"
                   }
                 },
+                "securityContext": {
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "mountPath": "/config",

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_memory.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_memory.json
@@ -219,6 +219,18 @@
                     "memory": "684Mi"
                   }
                 },
+                "securityContext": {
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "mountPath": "/config",

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_nested_agent.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_nested_agent.json
@@ -217,6 +217,18 @@
                     "memory": "384Mi"
                   }
                 },
+                "securityContext": {
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "mountPath": "/config",

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_passthrough.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_passthrough.json
@@ -201,6 +201,18 @@
                     "memory": "384Mi"
                   }
                 },
+                "securityContext": {
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "mountPath": "/config",

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_prompt_template.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_prompt_template.json
@@ -221,6 +221,18 @@
                     "memory": "384Mi"
                   }
                 },
+                "securityContext": {
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "mountPath": "/config",

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_proxy.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_proxy.json
@@ -230,6 +230,18 @@
                     "memory": "384Mi"
                   }
                 },
+                "securityContext": {
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "mountPath": "/config",

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_proxy_external_remotemcp.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_proxy_external_remotemcp.json
@@ -219,6 +219,18 @@
                     "memory": "384Mi"
                   }
                 },
+                "securityContext": {
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "mountPath": "/config",

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_proxy_mcpserver.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_proxy_mcpserver.json
@@ -222,6 +222,18 @@
                     "memory": "384Mi"
                   }
                 },
+                "securityContext": {
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "mountPath": "/config",

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_proxy_mcpserver_custom_timeout.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_proxy_mcpserver_custom_timeout.json
@@ -222,6 +222,18 @@
                     "memory": "384Mi"
                   }
                 },
+                "securityContext": {
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "mountPath": "/config",

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_proxy_service.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_proxy_service.json
@@ -221,6 +221,18 @@
                     "memory": "384Mi"
                   }
                 },
+                "securityContext": {
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "mountPath": "/config",

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_require_approval.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_require_approval.json
@@ -225,6 +225,18 @@
                     "memory": "384Mi"
                   }
                 },
+                "securityContext": {
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "mountPath": "/config",

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_scheduling_attributes.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_scheduling_attributes.json
@@ -234,6 +234,18 @@
                     "memory": "684Mi"
                   }
                 },
+                "securityContext": {
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "mountPath": "/config",

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_skills.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_skills.json
@@ -244,7 +244,16 @@
                   }
                 },
                 "securityContext": {
-                  "privileged": true
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
+                  }
                 },
                 "volumeMounts": [
                   {
@@ -275,6 +284,18 @@
                   "requests": {
                     "cpu": "100m",
                     "memory": "384Mi"
+                  }
+                },
+                "securityContext": {
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
                   }
                 },
                 "volumeMounts": [

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_streaming.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_streaming.json
@@ -215,6 +215,18 @@
                     "memory": "684Mi"
                   }
                 },
+                "securityContext": {
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "mountPath": "/config",

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_system_message_from_configmap.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_system_message_from_configmap.json
@@ -208,6 +208,18 @@
                     "memory": "384Mi"
                   }
                 },
+                "securityContext": {
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "mountPath": "/config",

--- a/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_system_message_from_secret.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/agent_with_system_message_from_secret.json
@@ -208,6 +208,18 @@
                     "memory": "384Mi"
                   }
                 },
+                "securityContext": {
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "mountPath": "/config",

--- a/go/core/internal/controller/translator/agent/testdata/outputs/anthropic_agent.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/anthropic_agent.json
@@ -211,6 +211,18 @@
                     "memory": "384Mi"
                   }
                 },
+                "securityContext": {
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "mountPath": "/config",

--- a/go/core/internal/controller/translator/agent/testdata/outputs/basic_agent.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/basic_agent.json
@@ -215,6 +215,18 @@
                     "memory": "684Mi"
                   }
                 },
+                "securityContext": {
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "mountPath": "/config",

--- a/go/core/internal/controller/translator/agent/testdata/outputs/bedrock_agent.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/bedrock_agent.json
@@ -221,6 +221,18 @@
                     "memory": "384Mi"
                   }
                 },
+                "securityContext": {
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "mountPath": "/config",

--- a/go/core/internal/controller/translator/agent/testdata/outputs/byo_agent.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/byo_agent.json
@@ -186,6 +186,18 @@
                     "memory": "384Mi"
                   }
                 },
+                "securityContext": {
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "mountPath": "/config",

--- a/go/core/internal/controller/translator/agent/testdata/outputs/ollama_agent.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/ollama_agent.json
@@ -210,6 +210,18 @@
                     "memory": "384Mi"
                   }
                 },
+                "securityContext": {
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "mountPath": "/config",

--- a/go/core/internal/controller/translator/agent/testdata/outputs/tls-with-custom-ca.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/tls-with-custom-ca.json
@@ -213,6 +213,18 @@
                     "memory": "684Mi"
                   }
                 },
+                "securityContext": {
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "mountPath": "/config",

--- a/go/core/internal/controller/translator/agent/testdata/outputs/tls-with-disabled-verify.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/tls-with-disabled-verify.json
@@ -212,6 +212,18 @@
                     "memory": "684Mi"
                   }
                 },
+                "securityContext": {
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "mountPath": "/config",

--- a/go/core/internal/controller/translator/agent/testdata/outputs/tls-with-system-cas-disabled.json
+++ b/go/core/internal/controller/translator/agent/testdata/outputs/tls-with-system-cas-disabled.json
@@ -213,6 +213,18 @@
                     "memory": "684Mi"
                   }
                 },
+                "securityContext": {
+                  "allowPrivilegeEscalation": false,
+                  "capabilities": {
+                    "drop": [
+                      "ALL"
+                    ]
+                  },
+                  "runAsNonRoot": true,
+                  "seccompProfile": {
+                    "type": "RuntimeDefault"
+                  }
+                },
                 "volumeMounts": [
                   {
                     "mountPath": "/config",

--- a/python/Dockerfile.full
+++ b/python/Dockerfile.full
@@ -70,7 +70,8 @@ RUN --mount=type=cache,target=/root/.npm \
 
 ENV PATH="/opt/sandbox-runtime/node_modules/.bin:$PATH"
 
-USER python
+# Numeric USER so kubelet can verify runAsNonRoot without an explicit runAsUser.
+USER 1001:1001
 WORKDIR /.kagent
 
 ### STAGE 3: final (install project)


### PR DESCRIPTION
Fixes #1997. Fixes #2244.

## What

Two changes to how the controller renders agent pod security:

**Skills no longer imply `privileged: true`** (#1997). Skills loading (git clone / OCI pull in `skills-init`) needs no elevated privileges; `privileged` exists only for the srt/bubblewrap BashTool sandbox, and the controller conflated the two. Now only the explicit `declarative.executeCodeBlocks: true` opt-in requests the privileged sandbox (the existing `allowPrivilegeEscalation: false` guard still suppresses it), and `securityContext.privileged: true` remains the manual knob. This is safe rather than a silent downgrade: both runtimes always exec `srt`, which fails loudly per command when it cannot set up isolation — there is no unsandboxed fallback path.

**Restricted-PSS defaults** (#2244). When the user provides no `securityContext`, the agent container and the skills-init container now render the Pod Security Standards `restricted` profile (`allowPrivilegeEscalation: false`, `runAsNonRoot: true`, `capabilities.drop: [ALL]`, `seccompProfile: RuntimeDefault`) instead of nothing, so agents are admitted on `restricted`-enforcing clusters out of the box. A user-provided `securityContext` passes through unchanged. All first-party images already run as non-root; `python/Dockerfile.full` switches from `USER python` to the numeric `USER 1001:1001` so the kubelet can verify `runAsNonRoot` without an explicit `runAsUser`.

Behavior change for skills users who relied on the implicit privileged sandbox: bash commands on clusters without unprivileged user namespaces will return per-command sandbox errors until `executeCodeBlocks: true` (or `securityContext.privileged: true`) is set. BYO images that run as root now need an explicit `securityContext`.

## Tests

`TestSecurityContext_SkillsDefaultNotPrivileged` (flipped from the previous `SkillsDefaultPrivilegedSandbox`, incl. skills-init), `TestSecurityContext_ExecuteCodeBlocksKeepsPrivileged`, `TestSecurityContext_DefaultIsRestricted`; golden files regenerated.