### PR TITLE
fix(skills-init): clean stale dest before cloning

### DIFF
--- a/go/core/internal/skillsinit/clonegit_stale_dest_test.go
+++ b/go/core/internal/skillsinit/clonegit_stale_dest_test.go
@@ -1,0 +1,52 @@
+package skillsinit
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Test_CloneGit_cleansStaleDest guards against a regression of the bug where
+// a prior failed attempt (e.g. killed between the clone/checkout and
+// applySubPath's final rename) leaves ref.Dest non-empty on disk. Without
+// cleanup, every subsequent retry fails git's own pre-flight
+// "already exists and is not an empty directory" check forever, even though
+// the container is documented to retry from scratch on failure.
+func Test_CloneGit_cleansStaleDest(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	origin := t.TempDir()
+	runIn(t, origin, "init", "--initial-branch=main")
+	runIn(t, origin, "config", "user.email", "test@example.com")
+	runIn(t, origin, "config", "user.name", "test")
+	require.NoError(t, os.WriteFile(filepath.Join(origin, "README.md"), []byte("hi"), 0o644))
+	runIn(t, origin, "add", "README.md")
+	runIn(t, origin, "commit", "-m", "init")
+
+	dest := filepath.Join(t.TempDir(), "dest")
+	// Simulate the leftover from an interrupted prior attempt: a non-empty
+	// dest that was never cleaned up.
+	require.NoError(t, os.MkdirAll(dest, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dest, "stale.txt"), []byte("leftover"), 0o644))
+
+	err := CloneGit(GitRef{URL: origin, Ref: "main", Dest: dest})
+	require.NoError(t, err, "CloneGit must clean a stale dest and retry successfully")
+
+	_, err = os.Stat(filepath.Join(dest, "README.md"))
+	require.NoError(t, err, "dest should contain the freshly cloned content")
+	_, err = os.Stat(filepath.Join(dest, "stale.txt"))
+	require.True(t, os.IsNotExist(err), "stale leftover content must not survive the clone")
+}
+
+func runIn(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v: %s", args, out)
+}

--- a/go/core/internal/skillsinit/git.go
+++ b/go/core/internal/skillsinit/git.go
@@ -18,7 +18,18 @@ import (
 //
 // SubPath, if set, rewrites the destination so the final layout matches the
 // requested in-repo subdirectory.
+//
+// ref.Dest is removed before cloning: a prior failed attempt (e.g. killed
+// between the clone/checkout and applySubPath's final rename) can leave a
+// non-empty dest behind, which would otherwise make every subsequent retry
+// fail git's own "already exists and is not an empty directory" pre-flight
+// check forever, even though the container is expected to retry from
+// scratch on failure.
 func CloneGit(ref GitRef) error {
+	if err := os.RemoveAll(ref.Dest); err != nil {
+		return fmt.Errorf("clean stale dest %q: %w", ref.Dest, err)
+	}
+
 	if ref.Full {
 		if err := runGit("clone", "--", ref.URL, ref.Dest); err != nil {
 			return err


### PR DESCRIPTION
## Summary
`CloneGit` never removes a pre-existing `ref.Dest` before starting a clone, so a leftover from any prior failed attempt permanently poisons every retry with `destination path already exists and is not an empty directory` — the pre-flight check in git's own `clone` fails before any network I/O.

**Note on how this was hit:** in our case the *original* trigger of that first failed attempt was a separate bug in this same file — `Full: true`'s `git checkout -- <ref.Ref>` treats a 40-hex SHA as a pathspec (because of the `--` separator) and always exits 1, so the clone (step 1) succeeds and leaves `dest` fully populated, but the checkout (step 2) fails every time and `applySubPath` never runs. I'm not fixing that pathspec bug here (worked around it operationally by switching to a branch/tag ref, avoiding the `Full: true` path entirely) but wanted to flag it separately since it's the more common way to end up in the stuck state this PR fixes. Filing this PR for the general idempotency gap regardless: *any* interrupted attempt (OOM, node preemption, unrelated pod restart) leaves the same poisoned `dest`, not just the pathspec case.

## Fix
`os.RemoveAll(ref.Dest)` at the top of `CloneGit`, before any clone attempt, so every invocation genuinely starts from scratch — matching what `Run`'s own doc comment already claims happens ("the container restarts and re-runs from scratch").

## Test plan
- Added `Test_CloneGit_cleansStaleDest`: seeds `dest` with leftover content from a simulated interrupted attempt, then asserts `CloneGit` against a local git fixture repo succeeds and the stale content is gone.
- `go test ./core/internal/skillsinit/...` — all passing (including pre-existing tests, no regressions).