### PR TITLE
docs: fix currency LangGraph sample README to match OpenAI implementation

### DIFF
--- a/python/samples/langgraph/currency/README.md
+++ b/python/samples/langgraph/currency/README.md
@@ -4,7 +4,7 @@ This is a currency LangGraph agent that demonstrates KAgent integration with ses
 
 ## Features
 
-- Currency conversion agent using Google Gemini
+- Currency conversion agent using OpenAI
 - LangGraph state management with KAgent checkpointer
 - A2A protocol compatibility
 - Session persistence via KAgent REST API
@@ -26,11 +26,11 @@ make basic-langchain-sample
 docker push localhost:5001/langgraph-currency:latest
 ```
 
-3. Create a secret with the Google API key:
+3. Create a secret with the OpenAI API key:
 
 ```bash
-kubectl create secret generic kagent-google -n kagent \
-  --from-literal=GOOGLE_API_KEY=$GOOGLE_API_KEY \
+kubectl create secret generic kagent-openai -n kagent \
+  --from-literal=OPENAI_API_KEY=$OPENAI_API_KEY \
   --dry-run=client -o yaml | kubectl apply -f -
 ```
 
@@ -51,7 +51,7 @@ uv sync
 2. Set environment variables:
 
 ```bash
-export GOOGLE_API_KEY=your_api_key_here
+export OPENAI_API_KEY=your_api_key_here
 export KAGENT_URL=http://localhost:8083
 ```
 
@@ -82,7 +82,7 @@ The agent maintains conversation history across sessions using the KAgent REST A
 
 The agent can be configured via environment variables:
 
-- `GOOGLE_API_KEY`: Required for Gemini API access
+- `OPENAI_API_KEY`: Required for OpenAI API access
 - `KAGENT_URL`: Required. KAgent server URL; for local development, the controller commonly runs at `http://localhost:8083`
 - `PORT`: Server port (default: 8080)
 - `HOST`: Server host (default: 0.0.0.0)


### PR DESCRIPTION
## What

The currency LangGraph sample's README described the agent as using **Google Gemini**, but the actual implementation uses **OpenAI**. This PR corrects the README to match the code.

## Why

Everything except the README already uses OpenAI, consistently:

| File | Provider |
|------|----------|
| `currency/agent.py` | `ChatOpenAI(model="gpt-4o-mini")` |
| `agent.yaml` | `OPENAI_API_KEY` from secret `kagent-openai` |
| `pyproject.toml` | `langchain-openai>=0.3.0` |
| Sibling samples (`kebab`, `hitl-tools`) | `ChatOpenAI("gpt-4o-mini")` |

The README was the only outlier, referencing Google Gemini, `GOOGLE_API_KEY`, and a `kagent-google` secret.

## Changes

Documentation-only. Updated the README's provider name, the Kubernetes secret (`kagent-openai` / `OPENAI_API_KEY`), and the environment-variable docs to match the actual implementation. No code, deployment config, or dependencies were touched.

## Testing

Docs-only change; no code paths affected.