### PR TITLE
feat: add deploymentAnnotations to agent deployment spec

### DIFF
--- a/go/api/config/crd/bases/kagent.dev_agents.yaml
+++ b/go/api/config/crd/bases/kagent.dev_agents.yaml
@@ -3415,6 +3415,16 @@ spec:
                         description: Cmd overrides the container entrypoint (the container's
                           command).
                         type: string
+                      deploymentAnnotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          DeploymentAnnotations are additional annotations added to the agent Deployment
+                          object itself. Unlike Annotations, which apply to the agent pods, these apply to
+                          the Deployment metadata. Keys set here take precedence over annotations inherited
+                          from the agent resource metadata. This has no effect when the agent runs with the
+                          Sandbox workload mode, as no Deployment is created in that mode.
+                        type: object
                       env:
                         description: Env are additional environment variables set
                           on the agent container.
@@ -8810,6 +8820,16 @@ spec:
                           type: string
                         description: Annotations are additional annotations added
                           to the agent pods.
+                        type: object
+                      deploymentAnnotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          DeploymentAnnotations are additional annotations added to the agent Deployment
+                          object itself. Unlike Annotations, which apply to the agent pods, these apply to
+                          the Deployment metadata. Keys set here take precedence over annotations inherited
+                          from the agent resource metadata. This has no effect when the agent runs with the
+                          Sandbox workload mode, as no Deployment is created in that mode.
                         type: object
                       env:
                         description: Env are additional environment variables set

--- a/go/api/config/crd/bases/kagent.dev_sandboxagents.yaml
+++ b/go/api/config/crd/bases/kagent.dev_sandboxagents.yaml
@@ -1072,6 +1072,16 @@ spec:
                         description: Cmd overrides the container entrypoint (the container's
                           command).
                         type: string
+                      deploymentAnnotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          DeploymentAnnotations are additional annotations added to the agent Deployment
+                          object itself. Unlike Annotations, which apply to the agent pods, these apply to
+                          the Deployment metadata. Keys set here take precedence over annotations inherited
+                          from the agent resource metadata. This has no effect when the agent runs with the
+                          Sandbox workload mode, as no Deployment is created in that mode.
+                        type: object
                       env:
                         description: Env are additional environment variables set
                           on the agent container.
@@ -6467,6 +6477,16 @@ spec:
                           type: string
                         description: Annotations are additional annotations added
                           to the agent pods.
+                        type: object
+                      deploymentAnnotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          DeploymentAnnotations are additional annotations added to the agent Deployment
+                          object itself. Unlike Annotations, which apply to the agent pods, these apply to
+                          the Deployment metadata. Keys set here take precedence over annotations inherited
+                          from the agent resource metadata. This has no effect when the agent runs with the
+                          Sandbox workload mode, as no Deployment is created in that mode.
                         type: object
                       env:
                         description: Env are additional environment variables set

--- a/go/api/v1alpha2/agent_types.go
+++ b/go/api/v1alpha2/agent_types.go
@@ -450,6 +450,13 @@ type SharedDeploymentSpec struct {
 	// Annotations are additional annotations added to the agent pods.
 	// +optional
 	Annotations map[string]string `json:"annotations,omitempty"`
+	// DeploymentAnnotations are additional annotations added to the agent Deployment
+	// object itself. Unlike Annotations, which apply to the agent pods, these apply to
+	// the Deployment metadata. Keys set here take precedence over annotations inherited
+	// from the agent resource metadata. This has no effect when the agent runs with the
+	// Sandbox workload mode, as no Deployment is created in that mode.
+	// +optional
+	DeploymentAnnotations map[string]string `json:"deploymentAnnotations,omitempty"`
 	// Env are additional environment variables set on the agent container.
 	// +optional
 	Env []corev1.EnvVar `json:"env,omitempty"`

--- a/go/api/v1alpha2/zz_generated.deepcopy.go
+++ b/go/api/v1alpha2/zz_generated.deepcopy.go
@@ -1794,6 +1794,13 @@ func (in *SharedDeploymentSpec) DeepCopyInto(out *SharedDeploymentSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.DeploymentAnnotations != nil {
+		in, out := &in.DeploymentAnnotations, &out.DeploymentAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env
 		*out = make([]v1.EnvVar, len(*in))

--- a/go/core/internal/controller/translator/agent/deployment_annotations_test.go
+++ b/go/core/internal/controller/translator/agent/deployment_annotations_test.go
@@ -1,0 +1,145 @@
+package agent_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kagent-dev/kagent/go/api/v1alpha2"
+	translator "github.com/kagent-dev/kagent/go/core/internal/controller/translator/agent"
+	"github.com/kagent-dev/kagent/go/core/pkg/consts"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	schemev1 "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// translateAgentWithDeployment runs the translator against a declarative agent whose
+// deployment spec is supplied by the caller, and returns the resulting manifest.
+func translateAgentWithDeployment(
+	t *testing.T,
+	agentAnnotations map[string]string,
+	deploymentSpec v1alpha2.SharedDeploymentSpec,
+) *translator.AgentOutputs {
+	t.Helper()
+
+	agent := &v1alpha2.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-agent",
+			Namespace:   "test",
+			Annotations: agentAnnotations,
+		},
+		Spec: v1alpha2.AgentSpec{
+			Type: v1alpha2.AgentType_Declarative,
+			Declarative: &v1alpha2.DeclarativeAgentSpec{
+				SystemMessage: "Test agent",
+				ModelConfig:   "test-model",
+				Deployment: &v1alpha2.DeclarativeDeploymentSpec{
+					SharedDeploymentSpec: deploymentSpec,
+				},
+			},
+		},
+	}
+	modelConfig := &v1alpha2.ModelConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-model", Namespace: "test"},
+		Spec:       v1alpha2.ModelConfigSpec{Provider: "OpenAI", Model: "gpt-4o"},
+	}
+
+	scheme := schemev1.Scheme
+	require.NoError(t, v1alpha2.AddToScheme(scheme))
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(agent, modelConfig).Build()
+	defaultModel := types.NamespacedName{Namespace: "test", Name: "test-model"}
+	translatorInstance := translator.NewAdkApiTranslator(kubeClient, defaultModel, nil, "", nil)
+
+	result, err := translator.TranslateAgent(context.Background(), translatorInstance, agent)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	return result
+}
+
+// TestDeploymentAnnotations_LandOnDeploymentOnly asserts deploymentAnnotations reach the
+// Deployment metadata while annotations reach the pod template, and that neither leaks
+// onto the other objects the translator emits.
+func TestDeploymentAnnotations_LandOnDeploymentOnly(t *testing.T) {
+	result := translateAgentWithDeployment(t, nil, v1alpha2.SharedDeploymentSpec{
+		Annotations:           map[string]string{"pod.example.com/inject": "pod-value"},
+		DeploymentAnnotations: map[string]string{"deployment.example.com/owner": "platform-team"},
+	})
+
+	deployment := findDeployment(t, result)
+
+	// deploymentAnnotations land on the Deployment object metadata.
+	assert.Equal(t, "platform-team", deployment.Annotations["deployment.example.com/owner"])
+	// ...and not on the pod template.
+	assert.NotContains(t, deployment.Spec.Template.Annotations, "deployment.example.com/owner")
+
+	// annotations stay scoped to the pod template, alongside the config hash the
+	// translator always writes there.
+	assert.Equal(t, "pod-value", deployment.Spec.Template.Annotations["pod.example.com/inject"])
+	assert.Contains(t, deployment.Spec.Template.Annotations, consts.ConfigHashAnnotation)
+	assert.NotContains(t, deployment.Annotations, "pod.example.com/inject")
+
+	// Every other emitted object keeps the plain object metadata.
+	for _, obj := range result.Manifest {
+		if _, ok := obj.(*appsv1.Deployment); ok {
+			continue
+		}
+		assert.NotContains(t, obj.GetAnnotations(), "deployment.example.com/owner",
+			"deploymentAnnotations leaked onto %T %s", obj, obj.GetName())
+		assert.NotContains(t, obj.GetAnnotations(), "pod.example.com/inject",
+			"pod annotations leaked onto %T %s", obj, obj.GetName())
+	}
+
+	// The Service and ServiceAccount are the objects most likely to regress here,
+	// since they share the same object metadata helper as the Deployment.
+	var sawService, sawServiceAccount bool
+	for _, obj := range result.Manifest {
+		switch obj.(type) {
+		case *corev1.Service:
+			sawService = true
+		case *corev1.ServiceAccount:
+			sawServiceAccount = true
+		}
+	}
+	assert.True(t, sawService, "Service should be in manifest")
+	assert.True(t, sawServiceAccount, "ServiceAccount should be in manifest")
+}
+
+// TestDeploymentAnnotations_MergeWithAgentMetadata asserts inherited agent metadata
+// annotations survive on the Deployment and that a colliding deploymentAnnotations key
+// wins, without mutating the agent object itself.
+func TestDeploymentAnnotations_MergeWithAgentMetadata(t *testing.T) {
+	agentAnnotations := map[string]string{
+		"inherited.example.com/keep": "from-agent",
+		"shared.example.com/key":     "from-agent",
+	}
+
+	result := translateAgentWithDeployment(t, agentAnnotations, v1alpha2.SharedDeploymentSpec{
+		DeploymentAnnotations: map[string]string{"shared.example.com/key": "from-spec"},
+	})
+
+	deployment := findDeployment(t, result)
+	assert.Equal(t, "from-agent", deployment.Annotations["inherited.example.com/keep"])
+	assert.Equal(t, "from-spec", deployment.Annotations["shared.example.com/key"])
+
+	// The inherited map must be cloned before merging, so the agent object held by the
+	// client cache is never rewritten.
+	assert.Equal(t, "from-agent", agentAnnotations["shared.example.com/key"])
+}
+
+// TestDeploymentAnnotations_UnsetKeepsInheritedMetadata asserts the no-op path leaves
+// the Deployment metadata exactly as it was before this field existed.
+func TestDeploymentAnnotations_UnsetKeepsInheritedMetadata(t *testing.T) {
+	result := translateAgentWithDeployment(t,
+		map[string]string{"inherited.example.com/keep": "from-agent"},
+		v1alpha2.SharedDeploymentSpec{},
+	)
+
+	deployment := findDeployment(t, result)
+	assert.Equal(t, "from-agent", deployment.Annotations["inherited.example.com/keep"])
+}

--- a/go/core/internal/controller/translator/agent/deployment_annotations_test.go
+++ b/go/core/internal/controller/translator/agent/deployment_annotations_test.go
@@ -143,3 +143,43 @@ func TestDeploymentAnnotations_UnsetKeepsInheritedMetadata(t *testing.T) {
 	deployment := findDeployment(t, result)
 	assert.Equal(t, "from-agent", deployment.Annotations["inherited.example.com/keep"])
 }
+
+// TestObjectMeta_DoesNotMutateAgentAnnotations asserts that building the ServiceAccount
+// does not write serviceAccountConfig annotations back into the agent's own annotations.
+// The ServiceAccount extends the shared object metadata in place, so unless the inherited
+// map is cloned it is the very map owned by the agent object in the client cache, and the
+// extra keys leak onto every other object built from that metadata.
+func TestObjectMeta_DoesNotMutateAgentAnnotations(t *testing.T) {
+	agentAnnotations := map[string]string{"inherited.example.com/keep": "from-agent"}
+
+	result := translateAgentWithDeployment(t, agentAnnotations, v1alpha2.SharedDeploymentSpec{
+		ServiceAccountConfig: &v1alpha2.ServiceAccountConfig{
+			Annotations: map[string]string{"sa.example.com/role": "reader"},
+		},
+	})
+
+	var serviceAccount *corev1.ServiceAccount
+	for _, obj := range result.Manifest {
+		if sa, ok := obj.(*corev1.ServiceAccount); ok {
+			serviceAccount = sa
+			break
+		}
+	}
+	require.NotNil(t, serviceAccount, "ServiceAccount should be in manifest")
+
+	// The ServiceAccount carries both the inherited and the configured annotations.
+	assert.Equal(t, "from-agent", serviceAccount.Annotations["inherited.example.com/keep"])
+	assert.Equal(t, "reader", serviceAccount.Annotations["sa.example.com/role"])
+
+	// The agent's own annotations are untouched.
+	assert.Equal(t, map[string]string{"inherited.example.com/keep": "from-agent"}, agentAnnotations)
+
+	// ...and the ServiceAccount-only annotation reaches no other object.
+	for _, obj := range result.Manifest {
+		if _, ok := obj.(*corev1.ServiceAccount); ok {
+			continue
+		}
+		assert.NotContains(t, obj.GetAnnotations(), "sa.example.com/role",
+			"serviceAccountConfig annotations leaked onto %T %s", obj, obj.GetName())
+	}
+}

--- a/go/core/internal/controller/translator/agent/deployments.go
+++ b/go/core/internal/controller/translator/agent/deployments.go
@@ -31,23 +31,24 @@ type resolvedDeployment struct {
 	ImagePullPolicy corev1.PullPolicy
 
 	// SharedDeploymentSpec merged
-	Replicas             *int32
-	ImagePullSecrets     []corev1.LocalObjectReference
-	Volumes              []corev1.Volume
-	VolumeMounts         []corev1.VolumeMount
-	Labels               map[string]string
-	Annotations          map[string]string
-	Env                  []corev1.EnvVar
-	EnvFrom              []corev1.EnvFromSource
-	Resources            corev1.ResourceRequirements
-	Tolerations          []corev1.Toleration
-	Affinity             *corev1.Affinity
-	NodeSelector         map[string]string
-	SecurityContext      *corev1.SecurityContext
-	PodSecurityContext   *corev1.PodSecurityContext
-	ServiceAccountName   *string
-	ServiceAccountConfig *v1alpha2.ServiceAccountConfig
-	ExtraContainers      []corev1.Container
+	Replicas              *int32
+	ImagePullSecrets      []corev1.LocalObjectReference
+	Volumes               []corev1.Volume
+	VolumeMounts          []corev1.VolumeMount
+	Labels                map[string]string
+	Annotations           map[string]string
+	DeploymentAnnotations map[string]string
+	Env                   []corev1.EnvVar
+	EnvFrom               []corev1.EnvFromSource
+	Resources             corev1.ResourceRequirements
+	Tolerations           []corev1.Toleration
+	Affinity              *corev1.Affinity
+	NodeSelector          map[string]string
+	SecurityContext       *corev1.SecurityContext
+	PodSecurityContext    *corev1.PodSecurityContext
+	ServiceAccountName    *string
+	ServiceAccountConfig  *v1alpha2.ServiceAccountConfig
+	ExtraContainers       []corev1.Container
 }
 
 // getDefaultResources sets default resource requirements if not specified
@@ -244,27 +245,28 @@ func resolveInlineDeployment(agent v1alpha2.AgentObject, mdd *modelDeploymentDat
 	}
 
 	dep := &resolvedDeployment{
-		Image:                image,
-		Args:                 args,
-		Port:                 port,
-		ImagePullPolicy:      imagePullPolicy,
-		Replicas:             spec.Replicas,
-		ImagePullSecrets:     slices.Clone(spec.ImagePullSecrets),
-		Volumes:              append(slices.Clone(spec.Volumes), mdd.Volumes...),
-		VolumeMounts:         append(slices.Clone(spec.VolumeMounts), mdd.VolumeMounts...),
-		Labels:               getDefaultLabels(agent.GetName(), spec.Labels),
-		Annotations:          maps.Clone(spec.Annotations),
-		Env:                  append(slices.Clone(spec.Env), mdd.EnvVars...),
-		EnvFrom:              slices.Clone(spec.EnvFrom),
-		Resources:            getDefaultResources(spec.Resources), // Set default resources if not specified
-		Tolerations:          slices.Clone(spec.Tolerations),
-		Affinity:             spec.Affinity,
-		NodeSelector:         getDefaultNodeSelector(spec.NodeSelector),
-		SecurityContext:      spec.SecurityContext,
-		PodSecurityContext:   spec.PodSecurityContext,
-		ServiceAccountName:   spec.ServiceAccountName,
-		ServiceAccountConfig: spec.ServiceAccountConfig,
-		ExtraContainers:      slices.Clone(spec.ExtraContainers),
+		Image:                 image,
+		Args:                  args,
+		Port:                  port,
+		ImagePullPolicy:       imagePullPolicy,
+		Replicas:              spec.Replicas,
+		ImagePullSecrets:      slices.Clone(spec.ImagePullSecrets),
+		Volumes:               append(slices.Clone(spec.Volumes), mdd.Volumes...),
+		VolumeMounts:          append(slices.Clone(spec.VolumeMounts), mdd.VolumeMounts...),
+		Labels:                getDefaultLabels(agent.GetName(), spec.Labels),
+		Annotations:           maps.Clone(spec.Annotations),
+		DeploymentAnnotations: maps.Clone(spec.DeploymentAnnotations),
+		Env:                   append(slices.Clone(spec.Env), mdd.EnvVars...),
+		EnvFrom:               slices.Clone(spec.EnvFrom),
+		Resources:             getDefaultResources(spec.Resources), // Set default resources if not specified
+		Tolerations:           slices.Clone(spec.Tolerations),
+		Affinity:              spec.Affinity,
+		NodeSelector:          getDefaultNodeSelector(spec.NodeSelector),
+		SecurityContext:       spec.SecurityContext,
+		PodSecurityContext:    spec.PodSecurityContext,
+		ServiceAccountName:    spec.ServiceAccountName,
+		ServiceAccountConfig:  spec.ServiceAccountConfig,
+		ExtraContainers:       slices.Clone(spec.ExtraContainers),
 	}
 
 	// Precedence: agent-level serviceAccountName > global default > auto-created SA (agent name)
@@ -327,29 +329,30 @@ func resolveByoDeployment(agent v1alpha2.AgentObject) (*resolvedDeployment, erro
 	}
 
 	dep := &resolvedDeployment{
-		Image:                image,
-		Cmd:                  cmd,
-		Args:                 args,
-		WorkingDir:           spec.WorkingDir,
-		Port:                 port,
-		ImagePullPolicy:      imagePullPolicy,
-		Replicas:             replicas,
-		ImagePullSecrets:     slices.Clone(spec.ImagePullSecrets),
-		Volumes:              slices.Clone(spec.Volumes),
-		VolumeMounts:         slices.Clone(spec.VolumeMounts),
-		Labels:               getDefaultLabels(agent.GetName(), spec.Labels),
-		Annotations:          maps.Clone(spec.Annotations),
-		Env:                  slices.Clone(spec.Env),
-		EnvFrom:              slices.Clone(spec.EnvFrom),
-		Resources:            getDefaultResources(spec.Resources), // Set default resources if not specified
-		Tolerations:          slices.Clone(spec.Tolerations),
-		Affinity:             spec.Affinity,
-		NodeSelector:         getDefaultNodeSelector(spec.NodeSelector),
-		SecurityContext:      spec.SecurityContext,
-		PodSecurityContext:   spec.PodSecurityContext,
-		ServiceAccountName:   spec.ServiceAccountName,
-		ServiceAccountConfig: spec.ServiceAccountConfig,
-		ExtraContainers:      slices.Clone(spec.ExtraContainers),
+		Image:                 image,
+		Cmd:                   cmd,
+		Args:                  args,
+		WorkingDir:            spec.WorkingDir,
+		Port:                  port,
+		ImagePullPolicy:       imagePullPolicy,
+		Replicas:              replicas,
+		ImagePullSecrets:      slices.Clone(spec.ImagePullSecrets),
+		Volumes:               slices.Clone(spec.Volumes),
+		VolumeMounts:          slices.Clone(spec.VolumeMounts),
+		Labels:                getDefaultLabels(agent.GetName(), spec.Labels),
+		Annotations:           maps.Clone(spec.Annotations),
+		DeploymentAnnotations: maps.Clone(spec.DeploymentAnnotations),
+		Env:                   slices.Clone(spec.Env),
+		EnvFrom:               slices.Clone(spec.EnvFrom),
+		Resources:             getDefaultResources(spec.Resources), // Set default resources if not specified
+		Tolerations:           slices.Clone(spec.Tolerations),
+		Affinity:              spec.Affinity,
+		NodeSelector:          getDefaultNodeSelector(spec.NodeSelector),
+		SecurityContext:       spec.SecurityContext,
+		PodSecurityContext:    spec.PodSecurityContext,
+		ServiceAccountName:    spec.ServiceAccountName,
+		ServiceAccountConfig:  spec.ServiceAccountConfig,
+		ExtraContainers:       slices.Clone(spec.ExtraContainers),
 	}
 
 	// Precedence: agent-level serviceAccountName > global default > auto-created SA (agent name)

--- a/go/core/internal/controller/translator/agent/deployments_test.go
+++ b/go/core/internal/controller/translator/agent/deployments_test.go
@@ -84,6 +84,94 @@ func TestResolveInlineDeployment_EnvFromPropagated(t *testing.T) {
 	}
 }
 
+func TestResolveByoDeployment_DeploymentAnnotationsPropagated(t *testing.T) {
+	podAnnotations := map[string]string{"pod-only": "pod-value"}
+	deploymentAnnotations := map[string]string{"deployment-only": "deployment-value"}
+	agent := &v1alpha2.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec: v1alpha2.AgentSpec{
+			Type: v1alpha2.AgentType_BYO,
+			BYO: &v1alpha2.BYOAgentSpec{
+				Deployment: &v1alpha2.ByoDeploymentSpec{
+					Image: "my-image:latest",
+					SharedDeploymentSpec: v1alpha2.SharedDeploymentSpec{
+						Annotations:           podAnnotations,
+						DeploymentAnnotations: deploymentAnnotations,
+					},
+				},
+			},
+		},
+	}
+	dep, err := resolveByoDeployment(agent)
+	if err != nil {
+		t.Fatalf("resolveByoDeployment() error = %v", err)
+	}
+	if !reflect.DeepEqual(dep.DeploymentAnnotations, deploymentAnnotations) {
+		t.Errorf("DeploymentAnnotations = %v, want %v", dep.DeploymentAnnotations, deploymentAnnotations)
+	}
+	if !reflect.DeepEqual(dep.Annotations, podAnnotations) {
+		t.Errorf("Annotations = %v, want %v", dep.Annotations, podAnnotations)
+	}
+}
+
+func TestResolveInlineDeployment_DeploymentAnnotationsPropagated(t *testing.T) {
+	podAnnotations := map[string]string{"pod-only": "pod-value"}
+	deploymentAnnotations := map[string]string{"deployment-only": "deployment-value"}
+	agent := &v1alpha2.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec: v1alpha2.AgentSpec{
+			Type: v1alpha2.AgentType_Declarative,
+			Declarative: &v1alpha2.DeclarativeAgentSpec{
+				Deployment: &v1alpha2.DeclarativeDeploymentSpec{
+					SharedDeploymentSpec: v1alpha2.SharedDeploymentSpec{
+						Annotations:           podAnnotations,
+						DeploymentAnnotations: deploymentAnnotations,
+					},
+				},
+			},
+		},
+	}
+	dep, err := resolveInlineDeployment(agent, &modelDeploymentData{})
+	if err != nil {
+		t.Fatalf("resolveInlineDeployment() error = %v", err)
+	}
+	if !reflect.DeepEqual(dep.DeploymentAnnotations, deploymentAnnotations) {
+		t.Errorf("DeploymentAnnotations = %v, want %v", dep.DeploymentAnnotations, deploymentAnnotations)
+	}
+	if !reflect.DeepEqual(dep.Annotations, podAnnotations) {
+		t.Errorf("Annotations = %v, want %v", dep.Annotations, podAnnotations)
+	}
+}
+
+// TestResolveByoDeployment_DeploymentAnnotationsCloned asserts the resolver copies
+// the spec map so later mutation of the resolved deployment cannot write back into
+// the agent object held by the client cache.
+func TestResolveByoDeployment_DeploymentAnnotationsCloned(t *testing.T) {
+	deploymentAnnotations := map[string]string{"key": "value"}
+	agent := &v1alpha2.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec: v1alpha2.AgentSpec{
+			Type: v1alpha2.AgentType_BYO,
+			BYO: &v1alpha2.BYOAgentSpec{
+				Deployment: &v1alpha2.ByoDeploymentSpec{
+					Image: "my-image:latest",
+					SharedDeploymentSpec: v1alpha2.SharedDeploymentSpec{
+						DeploymentAnnotations: deploymentAnnotations,
+					},
+				},
+			},
+		},
+	}
+	dep, err := resolveByoDeployment(agent)
+	if err != nil {
+		t.Fatalf("resolveByoDeployment() error = %v", err)
+	}
+	dep.DeploymentAnnotations["key"] = "mutated"
+	if deploymentAnnotations["key"] != "value" {
+		t.Errorf("spec DeploymentAnnotations mutated to %q, want the resolver to clone the map", deploymentAnnotations["key"])
+	}
+}
+
 func TestValidateExtraContainers(t *testing.T) {
 	t.Parallel()
 

--- a/go/core/internal/controller/translator/agent/manifest_builder.go
+++ b/go/core/internal/controller/translator/agent/manifest_builder.go
@@ -167,6 +167,26 @@ func (m manifestContext) objectMeta() metav1.ObjectMeta {
 	}
 }
 
+// deploymentObjectMeta returns the object metadata for the agent Deployment. It extends
+// objectMeta with the user-supplied deploymentAnnotations, which take precedence over
+// annotations inherited from the agent resource metadata. The inherited map is cloned so
+// that the agent object held by the client cache is never mutated.
+func (m manifestContext) deploymentObjectMeta() metav1.ObjectMeta {
+	meta := m.objectMeta()
+	if len(m.deployment.DeploymentAnnotations) == 0 {
+		return meta
+	}
+
+	annotations := maps.Clone(meta.Annotations)
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	maps.Copy(annotations, m.deployment.DeploymentAnnotations)
+	meta.Annotations = annotations
+
+	return meta
+}
+
 func (a *adkApiTranslator) buildConfigSecret(
 	ctx context.Context,
 	manifestCtx manifestContext,
@@ -599,7 +619,7 @@ func (a *adkApiTranslator) buildWorkloadObjects(
 	return []client.Object{
 		&appsv1.Deployment{
 			TypeMeta:   metav1.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"},
-			ObjectMeta: manifestCtx.objectMeta(),
+			ObjectMeta: manifestCtx.deploymentObjectMeta(),
 			Spec: appsv1.DeploymentSpec{
 				Replicas: manifestCtx.deployment.Replicas,
 				Strategy: appsv1.DeploymentStrategy{

--- a/go/core/internal/controller/translator/agent/manifest_builder.go
+++ b/go/core/internal/controller/translator/agent/manifest_builder.go
@@ -158,31 +158,31 @@ func (m manifestContext) podLabels() map[string]string {
 	return podLabels
 }
 
+// objectMeta returns the metadata shared by every object emitted for an agent. The
+// annotations inherited from the agent resource are cloned, so that builders which
+// extend them never mutate the agent object held by the client cache.
 func (m manifestContext) objectMeta() metav1.ObjectMeta {
 	return metav1.ObjectMeta{
 		Name:        m.agent.GetName(),
 		Namespace:   m.agent.GetNamespace(),
-		Annotations: m.agent.GetAnnotations(),
+		Annotations: maps.Clone(m.agent.GetAnnotations()),
 		Labels:      m.podLabels(),
 	}
 }
 
 // deploymentObjectMeta returns the object metadata for the agent Deployment. It extends
 // objectMeta with the user-supplied deploymentAnnotations, which take precedence over
-// annotations inherited from the agent resource metadata. The inherited map is cloned so
-// that the agent object held by the client cache is never mutated.
+// annotations inherited from the agent resource metadata.
 func (m manifestContext) deploymentObjectMeta() metav1.ObjectMeta {
 	meta := m.objectMeta()
 	if len(m.deployment.DeploymentAnnotations) == 0 {
 		return meta
 	}
 
-	annotations := maps.Clone(meta.Annotations)
-	if annotations == nil {
-		annotations = map[string]string{}
+	if meta.Annotations == nil {
+		meta.Annotations = map[string]string{}
 	}
-	maps.Copy(annotations, m.deployment.DeploymentAnnotations)
-	meta.Annotations = annotations
+	maps.Copy(meta.Annotations, m.deployment.DeploymentAnnotations)
 
 	return meta
 }

--- a/helm/kagent-crds/templates/kagent.dev_agents.yaml
+++ b/helm/kagent-crds/templates/kagent.dev_agents.yaml
@@ -3415,6 +3415,16 @@ spec:
                         description: Cmd overrides the container entrypoint (the container's
                           command).
                         type: string
+                      deploymentAnnotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          DeploymentAnnotations are additional annotations added to the agent Deployment
+                          object itself. Unlike Annotations, which apply to the agent pods, these apply to
+                          the Deployment metadata. Keys set here take precedence over annotations inherited
+                          from the agent resource metadata. This has no effect when the agent runs with the
+                          Sandbox workload mode, as no Deployment is created in that mode.
+                        type: object
                       env:
                         description: Env are additional environment variables set
                           on the agent container.
@@ -8810,6 +8820,16 @@ spec:
                           type: string
                         description: Annotations are additional annotations added
                           to the agent pods.
+                        type: object
+                      deploymentAnnotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          DeploymentAnnotations are additional annotations added to the agent Deployment
+                          object itself. Unlike Annotations, which apply to the agent pods, these apply to
+                          the Deployment metadata. Keys set here take precedence over annotations inherited
+                          from the agent resource metadata. This has no effect when the agent runs with the
+                          Sandbox workload mode, as no Deployment is created in that mode.
                         type: object
                       env:
                         description: Env are additional environment variables set

--- a/helm/kagent-crds/templates/kagent.dev_sandboxagents.yaml
+++ b/helm/kagent-crds/templates/kagent.dev_sandboxagents.yaml
@@ -1072,6 +1072,16 @@ spec:
                         description: Cmd overrides the container entrypoint (the container's
                           command).
                         type: string
+                      deploymentAnnotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          DeploymentAnnotations are additional annotations added to the agent Deployment
+                          object itself. Unlike Annotations, which apply to the agent pods, these apply to
+                          the Deployment metadata. Keys set here take precedence over annotations inherited
+                          from the agent resource metadata. This has no effect when the agent runs with the
+                          Sandbox workload mode, as no Deployment is created in that mode.
+                        type: object
                       env:
                         description: Env are additional environment variables set
                           on the agent container.
@@ -6467,6 +6477,16 @@ spec:
                           type: string
                         description: Annotations are additional annotations added
                           to the agent pods.
+                        type: object
+                      deploymentAnnotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          DeploymentAnnotations are additional annotations added to the agent Deployment
+                          object itself. Unlike Annotations, which apply to the agent pods, these apply to
+                          the Deployment metadata. Keys set here take precedence over annotations inherited
+                          from the agent resource metadata. This has no effect when the agent runs with the
+                          Sandbox workload mode, as no Deployment is created in that mode.
                         type: object
                       env:
                         description: Env are additional environment variables set

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -419,6 +419,7 @@ export interface BYODeploymentSpec {
   volumeMounts?: unknown[];
   labels?: Record<string, string>;
   annotations?: Record<string, string>;
+  deploymentAnnotations?: Record<string, string>;
   env?: EnvVar[];
   envFrom?: EnvFromSource[];
   imagePullPolicy?: string;


### PR DESCRIPTION
## Summary
Adds a new `deploymentAnnotations` field to `SharedDeploymentSpec` so users can set annotations on the Deployment object metadata directly, independent of pod annotations.

## Motivation
The existing annotations field lands only on the pod template (`deployment.spec.template.metadata.annotations ).
GitOps and policy tooling that keys off Deployment-level metadata - Argo CD sync waves, Flux annotations, Kyverno policies, Datadog admission controller - had no declarative hook. 
Users had to manually patch Deployments or use post-render kustomizations.

## Usage
```
apiVersion: kagent.dev/v1alpha2
kind: Agent
metadata:
  name: my-agent
spec:
  type: Declarative
  declarative:
    deployment:
      deploymentAnnotations:
        argocd.argoproj.io/sync-wave: "5"
        notifications.argoproj.io/subscribe.on-degraded.slack: my-channel
      annotations:
        prometheus.io/scrape: "true"   # still goes to pods only
````

--
The Pull Request has been assisted by Claude Opus 5.