### PR TITLE
feat: support responses api in kagent harness

### DIFF
--- a/go/adk/pkg/agent/agent.go
+++ b/go/adk/pkg/agent/agent.go
@@ -233,6 +233,7 @@ func CreateLLM(ctx context.Context, m adk.Model, log logr.Logger) (adkmodel.LLM,
 			Seed:                m.Seed,
 			Temperature:         m.Temperature,
 			TopP:                m.TopP,
+			APIFormat:           m.APIFormat,
 		}
 		return models.NewOpenAIModelWithLogger(cfg, log)
 

--- a/go/adk/pkg/models/openai.go
+++ b/go/adk/pkg/models/openai.go
@@ -16,6 +16,12 @@ import (
 	"github.com/openai/openai-go/v3/option"
 )
 
+// OpenAI API format values (ModelConfig openAI.apiFormat).
+const (
+	OpenAIAPIFormatChatCompletions = "chatCompletions"
+	OpenAIAPIFormatResponses       = "responses"
+)
+
 // OpenAIConfig holds OpenAI configuration
 type OpenAIConfig struct {
 	TransportConfig
@@ -30,6 +36,8 @@ type OpenAIConfig struct {
 	Seed                *int
 	Temperature         *float64
 	TopP                *float64
+	// APIFormat selects chatCompletions (default) or responses.
+	APIFormat string
 }
 
 // AzureOpenAIConfig holds Azure OpenAI configuration

--- a/go/adk/pkg/models/openai_adk.go
+++ b/go/adk/pkg/models/openai_adk.go
@@ -128,7 +128,6 @@ func (m *OpenAIModel) Name() string {
 // GenerateContent implements model.LLM. Uses only ADK/genai types.
 func (m *OpenAIModel) GenerateContent(ctx context.Context, req *model.LLMRequest, stream bool) iter.Seq2[*model.LLMResponse, error] {
 	return func(yield func(*model.LLMResponse, error) bool) {
-		messages, systemInstruction := genaiContentsToOpenAIMessages(req.Contents, req.Config)
 		modelName := req.Model
 		if modelName == "" {
 			modelName = m.Config.Model
@@ -138,6 +137,12 @@ func (m *OpenAIModel) GenerateContent(ctx context.Context, req *model.LLMRequest
 		}
 		telemetry.SetLLMRequestAttributes(ctx, modelName, req)
 
+		if m.Config != nil && m.Config.APIFormat == OpenAIAPIFormatResponses {
+			generateContentResponses(ctx, m, req, modelName, stream, yield)
+			return
+		}
+
+		messages, systemInstruction := genaiContentsToOpenAIMessages(req.Contents, req.Config)
 		params := openai.ChatCompletionNewParams{
 			Model:    shared.ChatModel(modelName),
 			Messages: messages,

--- a/go/adk/pkg/models/openai_adk.go
+++ b/go/adk/pkg/models/openai_adk.go
@@ -125,6 +125,13 @@ func (m *OpenAIModel) Name() string {
 	return m.Config.Model
 }
 
+func (m *OpenAIModel) apiFormat() string {
+	if m.Config != nil && m.Config.APIFormat != "" {
+		return m.Config.APIFormat
+	}
+	return OpenAIAPIFormatChatCompletions
+}
+
 // GenerateContent implements model.LLM. Uses only ADK/genai types.
 func (m *OpenAIModel) GenerateContent(ctx context.Context, req *model.LLMRequest, stream bool) iter.Seq2[*model.LLMResponse, error] {
 	return func(yield func(*model.LLMResponse, error) bool) {
@@ -137,35 +144,46 @@ func (m *OpenAIModel) GenerateContent(ctx context.Context, req *model.LLMRequest
 		}
 		telemetry.SetLLMRequestAttributes(ctx, modelName, req)
 
-		if m.Config != nil && m.Config.APIFormat == OpenAIAPIFormatResponses {
+		switch m.apiFormat() {
+		case OpenAIAPIFormatResponses:
 			generateContentResponses(ctx, m, req, modelName, stream, yield)
-			return
+		default:
+			generateContentChatCompletions(ctx, m, req, modelName, stream, yield)
 		}
+	}
+}
 
-		messages, systemInstruction := genaiContentsToOpenAIMessages(req.Contents, req.Config)
-		params := openai.ChatCompletionNewParams{
-			Model:    shared.ChatModel(modelName),
-			Messages: messages,
-		}
-		if systemInstruction != "" {
-			params.Messages = append([]openai.ChatCompletionMessageParamUnion{
-				openai.SystemMessage(systemInstruction),
-			}, params.Messages...)
-		}
-		applyOpenAIConfig(&params, m.Config)
+func generateContentChatCompletions(
+	ctx context.Context,
+	m *OpenAIModel,
+	req *model.LLMRequest,
+	modelName string,
+	stream bool,
+	yield func(*model.LLMResponse, error) bool,
+) {
+	messages, systemInstruction := genaiContentsToOpenAIMessages(req.Contents, req.Config)
+	params := openai.ChatCompletionNewParams{
+		Model:    shared.ChatModel(modelName),
+		Messages: messages,
+	}
+	if systemInstruction != "" {
+		params.Messages = append([]openai.ChatCompletionMessageParamUnion{
+			openai.SystemMessage(systemInstruction),
+		}, params.Messages...)
+	}
+	applyOpenAIConfig(&params, m.Config)
 
-		if req.Config != nil && len(req.Config.Tools) > 0 {
-			params.Tools = genaiToolsToOpenAITools(req.Config.Tools)
-			params.ToolChoice = openai.ChatCompletionToolChoiceOptionUnionParam{
-				OfAuto: openai.String("auto"),
-			}
+	if req.Config != nil && len(req.Config.Tools) > 0 {
+		params.Tools = genaiToolsToOpenAITools(req.Config.Tools)
+		params.ToolChoice = openai.ChatCompletionToolChoiceOptionUnionParam{
+			OfAuto: openai.String("auto"),
 		}
+	}
 
-		if stream {
-			runStreaming(ctx, m, params, yield)
-		} else {
-			runNonStreaming(ctx, m, params, yield)
-		}
+	if stream {
+		runStreaming(ctx, m, params, yield)
+	} else {
+		runNonStreaming(ctx, m, params, yield)
 	}
 }
 

--- a/go/adk/pkg/models/openai_responses.go
+++ b/go/adk/pkg/models/openai_responses.go
@@ -1,0 +1,363 @@
+// Package models: OpenAI Responses API path for OpenAIModel.
+package models
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/kagent-dev/kagent/go/adk/pkg/telemetry"
+	"github.com/openai/openai-go/v3/packages/param"
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/openai/openai-go/v3/shared"
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/genai"
+)
+
+func generateContentResponses(
+	ctx context.Context,
+	m *OpenAIModel,
+	req *model.LLMRequest,
+	modelName string,
+	stream bool,
+	yield func(*model.LLMResponse, error) bool,
+) {
+	input, instructions := genaiContentsToResponsesInput(req.Contents, req.Config)
+	params := responses.ResponseNewParams{
+		Model: shared.ResponsesModel(modelName),
+		Input: responses.ResponseNewParamsInputUnion{
+			OfInputItemList: input,
+		},
+	}
+	if instructions != "" {
+		params.Instructions = param.NewOpt(instructions)
+	}
+	applyOpenAIResponsesConfig(&params, m.Config)
+
+	if req.Config != nil && len(req.Config.Tools) > 0 {
+		params.Tools = genaiToolsToResponsesTools(req.Config.Tools)
+		params.ToolChoice = responses.ResponseNewParamsToolChoiceUnion{
+			OfToolChoiceMode: param.NewOpt(responses.ToolChoiceOptionsAuto),
+		}
+	}
+
+	if stream {
+		runResponsesStreaming(ctx, m, params, yield)
+	} else {
+		runResponsesNonStreaming(ctx, m, params, yield)
+	}
+}
+
+func applyOpenAIResponsesConfig(params *responses.ResponseNewParams, cfg *OpenAIConfig) {
+	if cfg == nil {
+		return
+	}
+	if cfg.Temperature != nil {
+		params.Temperature = param.NewOpt(*cfg.Temperature)
+	}
+	// Responses uses max_output_tokens (same semantics as max_completion_tokens).
+	if cfg.MaxCompletionTokens != nil {
+		params.MaxOutputTokens = param.NewOpt(int64(*cfg.MaxCompletionTokens))
+	} else if cfg.MaxTokens != nil {
+		params.MaxOutputTokens = param.NewOpt(int64(*cfg.MaxTokens))
+	}
+	if cfg.TopP != nil {
+		params.TopP = param.NewOpt(*cfg.TopP)
+	}
+	if cfg.ReasoningEffort != nil {
+		params.Reasoning = shared.ReasoningParam{
+			Effort: shared.ReasoningEffort(*cfg.ReasoningEffort),
+		}
+	}
+}
+
+func genaiContentsToResponsesInput(contents []*genai.Content, config *genai.GenerateContentConfig) (responses.ResponseInputParam, string) {
+	instructions := mergeSystemInstructionFromConfig("", config)
+
+	functionResponses := make(map[string]*genai.FunctionResponse)
+	for _, c := range contents {
+		if c == nil || c.Parts == nil {
+			continue
+		}
+		for _, p := range c.Parts {
+			if p != nil && p.FunctionResponse != nil {
+				functionResponses[p.FunctionResponse.ID] = p.FunctionResponse
+			}
+		}
+	}
+
+	var input responses.ResponseInputParam
+	for _, content := range contents {
+		if content == nil || strings.TrimSpace(content.Role) == openAIRoleSystem {
+			continue
+		}
+		role := strings.TrimSpace(content.Role)
+		var textParts []string
+		var functionCalls []*genai.FunctionCall
+		var imageURLs []string
+
+		for _, part := range content.Parts {
+			if part == nil {
+				continue
+			}
+			if part.Text != "" {
+				textParts = append(textParts, part.Text)
+			} else if part.FunctionCall != nil {
+				functionCalls = append(functionCalls, part.FunctionCall)
+			} else if part.InlineData != nil && strings.HasPrefix(part.InlineData.MIMEType, "image/") {
+				imageURLs = append(imageURLs, fmt.Sprintf(
+					"data:%s;base64,%s",
+					part.InlineData.MIMEType,
+					base64.StdEncoding.EncodeToString(part.InlineData.Data),
+				))
+			}
+		}
+
+		if len(functionCalls) > 0 && (role == openAIRoleModel || role == openAIRoleAssistant) {
+			if len(textParts) > 0 {
+				input = append(input, responses.ResponseInputItemParamOfMessage(
+					strings.Join(textParts, "\n"),
+					responses.EasyInputMessageRoleAssistant,
+				))
+			}
+			for _, fc := range functionCalls {
+				argsJSON, _ := json.Marshal(fc.Args)
+				input = append(input, responses.ResponseInputItemParamOfFunctionCall(
+					string(argsJSON),
+					fc.ID,
+					fc.Name,
+				))
+				output := "No response available for this function call."
+				if fr := functionResponses[fc.ID]; fr != nil {
+					output = extractFunctionResponseContent(fr.Response)
+				}
+				input = append(input, responses.ResponseInputItemParamOfFunctionCallOutput(fc.ID, output))
+			}
+			continue
+		}
+
+		if len(textParts) == 0 && len(imageURLs) == 0 {
+			continue
+		}
+
+		msgRole := responses.EasyInputMessageRoleUser
+		if role == openAIRoleModel || role == openAIRoleAssistant {
+			msgRole = responses.EasyInputMessageRoleAssistant
+		}
+
+		if len(imageURLs) > 0 {
+			parts := make(responses.ResponseInputMessageContentListParam, 0, len(textParts)+len(imageURLs))
+			for _, t := range textParts {
+				parts = append(parts, responses.ResponseInputContentParamOfInputText(t))
+			}
+			for _, url := range imageURLs {
+				img := responses.ResponseInputContentParamOfInputImage(responses.ResponseInputImageDetailAuto)
+				img.OfInputImage.ImageURL = param.NewOpt(url)
+				parts = append(parts, img)
+			}
+			input = append(input, responses.ResponseInputItemParamOfMessage(parts, msgRole))
+		} else {
+			input = append(input, responses.ResponseInputItemParamOfMessage(strings.Join(textParts, "\n"), msgRole))
+		}
+	}
+	return input, instructions
+}
+
+func genaiToolsToResponsesTools(tools []*genai.Tool) []responses.ToolUnionParam {
+	var out []responses.ToolUnionParam
+	for _, t := range tools {
+		if t == nil || t.FunctionDeclarations == nil {
+			continue
+		}
+		for _, fd := range t.FunctionDeclarations {
+			if fd == nil {
+				continue
+			}
+			paramsMap := make(map[string]any)
+			if fd.ParametersJsonSchema != nil {
+				if m := parametersJsonSchemaToMap(fd.ParametersJsonSchema); m != nil {
+					for k, v := range m {
+						paramsMap[k] = v
+					}
+				}
+			} else if fd.Parameters != nil {
+				if m := genaiSchemaToMap(fd.Parameters); m != nil {
+					for k, v := range m {
+						paramsMap[k] = v
+					}
+				}
+			}
+			if _, ok := paramsMap["type"]; !ok {
+				paramsMap["type"] = "object"
+			}
+			if paramsMap["type"] == "object" {
+				if _, ok := paramsMap["properties"]; !ok {
+					paramsMap["properties"] = map[string]any{}
+				}
+			}
+			ft := responses.FunctionToolParam{
+				Name:        fd.Name,
+				Parameters:  paramsMap,
+				Description: param.NewOpt(fd.Description),
+				Strict:      param.NewOpt(false),
+			}
+			out = append(out, responses.ToolUnionParam{OfFunction: &ft})
+		}
+	}
+	return out
+}
+
+func runResponsesNonStreaming(
+	ctx context.Context,
+	m *OpenAIModel,
+	params responses.ResponseNewParams,
+	yield func(*model.LLMResponse, error) bool,
+) {
+	resp, err := m.Client.Responses.New(ctx, params, openAIPassthroughOpts(ctx, m)...)
+	if err != nil {
+		yield(nil, fmt.Errorf("OpenAI responses request failed: %w", err))
+		return
+	}
+	out := responseToLLMResponse(resp)
+	telemetry.SetLLMResponseAttributes(ctx, out)
+	yield(out, nil)
+}
+
+func runResponsesStreaming(
+	ctx context.Context,
+	m *OpenAIModel,
+	params responses.ResponseNewParams,
+	yield func(*model.LLMResponse, error) bool,
+) {
+	stream := m.Client.Responses.NewStreaming(ctx, params, openAIPassthroughOpts(ctx, m)...)
+	defer stream.Close()
+
+	var aggregatedText strings.Builder
+	toolCalls := make(map[string]*genai.Part) // call_id -> part
+	var toolCallOrder []string
+	var usage *genai.GenerateContentResponseUsageMetadata
+	var finishReason genai.FinishReason = genai.FinishReasonStop
+
+	for stream.Next() {
+		event := stream.Current()
+		switch v := event.AsAny().(type) {
+		case responses.ResponseTextDeltaEvent:
+			if v.Delta == "" {
+				continue
+			}
+			aggregatedText.WriteString(v.Delta)
+			if !yield(&model.LLMResponse{
+				Partial:      true,
+				TurnComplete: false,
+				Content: &genai.Content{
+					Role:  string(genai.RoleModel),
+					Parts: []*genai.Part{{Text: v.Delta}},
+				},
+			}, nil) {
+				return
+			}
+		case responses.ResponseOutputItemDoneEvent:
+			if fc, ok := v.Item.AsAny().(responses.ResponseFunctionToolCall); ok {
+				var args map[string]any
+				if fc.Arguments != "" {
+					_ = json.Unmarshal([]byte(fc.Arguments), &args)
+				}
+				callID := fc.CallID
+				if callID == "" {
+					callID = fc.ID
+				}
+				if _, seen := toolCalls[callID]; !seen {
+					toolCallOrder = append(toolCallOrder, callID)
+				}
+				toolCalls[callID] = newFunctionCallPart(fc.Name, args, callID, nil)
+			}
+		case responses.ResponseCompletedEvent:
+			usage = responsesUsageToGenai(v.Response.Usage)
+			finishReason = responsesStatusToFinishReason(v.Response.Status)
+		case responses.ResponseIncompleteEvent:
+			usage = responsesUsageToGenai(v.Response.Usage)
+			finishReason = genai.FinishReasonMaxTokens
+		}
+	}
+
+	if err := stream.Err(); err != nil {
+		if ctx.Err() == context.Canceled {
+			return
+		}
+		_ = yield(&model.LLMResponse{ErrorCode: "STREAM_ERROR", ErrorMessage: err.Error()}, nil)
+		return
+	}
+
+	finalParts := make([]*genai.Part, 0, 1+len(toolCallOrder))
+	if text := aggregatedText.String(); text != "" {
+		finalParts = append(finalParts, &genai.Part{Text: text})
+	}
+	for _, id := range toolCallOrder {
+		finalParts = append(finalParts, toolCalls[id])
+	}
+
+	out := &model.LLMResponse{
+		Partial:       false,
+		TurnComplete:  true,
+		FinishReason:  finishReason,
+		UsageMetadata: usage,
+		Content:       &genai.Content{Role: string(genai.RoleModel), Parts: finalParts},
+	}
+	telemetry.SetLLMResponseAttributes(ctx, out)
+	_ = yield(out, nil)
+}
+
+func responseToLLMResponse(resp *responses.Response) *model.LLMResponse {
+	parts := make([]*genai.Part, 0, len(resp.Output))
+	for _, item := range resp.Output {
+		switch v := item.AsAny().(type) {
+		case responses.ResponseOutputMessage:
+			for _, c := range v.Content {
+				if ot, ok := c.AsAny().(responses.ResponseOutputText); ok && ot.Text != "" {
+					parts = append(parts, &genai.Part{Text: ot.Text})
+				}
+			}
+		case responses.ResponseFunctionToolCall:
+			var args map[string]any
+			if v.Arguments != "" {
+				_ = json.Unmarshal([]byte(v.Arguments), &args)
+			}
+			callID := v.CallID
+			if callID == "" {
+				callID = v.ID
+			}
+			parts = append(parts, newFunctionCallPart(v.Name, args, callID, nil))
+		}
+	}
+
+	return &model.LLMResponse{
+		Partial:       false,
+		TurnComplete:  true,
+		FinishReason:  responsesStatusToFinishReason(resp.Status),
+		UsageMetadata: responsesUsageToGenai(resp.Usage),
+		Content:       &genai.Content{Role: string(genai.RoleModel), Parts: parts},
+	}
+}
+
+func responsesUsageToGenai(u responses.ResponseUsage) *genai.GenerateContentResponseUsageMetadata {
+	if u.InputTokens == 0 && u.OutputTokens == 0 {
+		return nil
+	}
+	return &genai.GenerateContentResponseUsageMetadata{
+		PromptTokenCount:     int32(u.InputTokens),
+		CandidatesTokenCount: int32(u.OutputTokens),
+	}
+}
+
+func responsesStatusToFinishReason(status responses.ResponseStatus) genai.FinishReason {
+	switch status {
+	case responses.ResponseStatusIncomplete:
+		return genai.FinishReasonMaxTokens
+	case responses.ResponseStatusFailed:
+		return genai.FinishReasonOther
+	default:
+		return genai.FinishReasonStop
+	}
+}

--- a/go/adk/pkg/models/openai_responses.go
+++ b/go/adk/pkg/models/openai_responses.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"strings"
 
 	"github.com/kagent-dev/kagent/go/adk/pkg/telemetry"
@@ -178,15 +179,11 @@ func genaiToolsToResponsesTools(tools []*genai.Tool) []responses.ToolUnionParam 
 			paramsMap := make(map[string]any)
 			if fd.ParametersJsonSchema != nil {
 				if m := parametersJsonSchemaToMap(fd.ParametersJsonSchema); m != nil {
-					for k, v := range m {
-						paramsMap[k] = v
-					}
+					maps.Copy(paramsMap, m)
 				}
 			} else if fd.Parameters != nil {
 				if m := genaiSchemaToMap(fd.Parameters); m != nil {
-					for k, v := range m {
-						paramsMap[k] = v
-					}
+					maps.Copy(paramsMap, m)
 				}
 			}
 			if _, ok := paramsMap["type"]; !ok {
@@ -238,7 +235,7 @@ func runResponsesStreaming(
 	toolCalls := make(map[string]*genai.Part) // call_id -> part
 	var toolCallOrder []string
 	var usage *genai.GenerateContentResponseUsageMetadata
-	var finishReason genai.FinishReason = genai.FinishReasonStop
+	var finishReason = genai.FinishReasonStop
 
 	for stream.Next() {
 		event := stream.Current()

--- a/go/adk/pkg/models/openai_responses_test.go
+++ b/go/adk/pkg/models/openai_responses_test.go
@@ -1,0 +1,268 @@
+package models
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/responses"
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/genai"
+)
+
+func TestGenaiContentsToResponsesInput(t *testing.T) {
+	t.Run("user text and system instruction", func(t *testing.T) {
+		input, instructions := genaiContentsToResponsesInput([]*genai.Content{
+			{Role: "user", Parts: []*genai.Part{{Text: "hello"}}},
+		}, &genai.GenerateContentConfig{
+			SystemInstruction: &genai.Content{Parts: []*genai.Part{{Text: "be helpful"}}},
+		})
+		if instructions != "be helpful" {
+			t.Fatalf("instructions = %q, want be helpful", instructions)
+		}
+		if len(input) != 1 || input[0].OfMessage == nil {
+			t.Fatalf("input = %#v, want 1 message", input)
+		}
+		if input[0].OfMessage.Role != responses.EasyInputMessageRoleUser {
+			t.Fatalf("role = %q, want user", input[0].OfMessage.Role)
+		}
+	})
+
+	t.Run("function call and output paired", func(t *testing.T) {
+		fc := genai.NewPartFromFunctionCall("add", map[string]any{"a": 1, "b": 2})
+		fc.FunctionCall.ID = "call_1"
+		fr := genai.NewPartFromFunctionResponse("add", map[string]any{"result": "3"})
+		fr.FunctionResponse.ID = "call_1"
+
+		input, _ := genaiContentsToResponsesInput([]*genai.Content{
+			{Role: "model", Parts: []*genai.Part{fc}},
+			{Role: "user", Parts: []*genai.Part{fr}},
+		}, nil)
+		if len(input) != 2 {
+			t.Fatalf("len(input) = %d, want 2", len(input))
+		}
+		if input[0].OfFunctionCall == nil || input[0].OfFunctionCall.CallID != "call_1" {
+			t.Fatalf("function_call = %#v", input[0].OfFunctionCall)
+		}
+		if input[1].OfFunctionCallOutput == nil || input[1].OfFunctionCallOutput.CallID != "call_1" {
+			t.Fatalf("function_call_output = %#v", input[1].OfFunctionCallOutput)
+		}
+		if got := input[1].OfFunctionCallOutput.Output.OfString.Value; got != "3" {
+			t.Fatalf("output = %q, want 3", got)
+		}
+	})
+}
+
+func TestGenaiToolsToResponsesTools(t *testing.T) {
+	out := genaiToolsToResponsesTools([]*genai.Tool{{
+		FunctionDeclarations: []*genai.FunctionDeclaration{{
+			Name:        "get_weather",
+			Description: "weather",
+			ParametersJsonSchema: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{"city": map[string]any{"type": "string"}},
+			},
+		}},
+	}})
+	if len(out) != 1 || out[0].OfFunction == nil {
+		t.Fatalf("out = %#v, want 1 function tool", out)
+	}
+	if out[0].OfFunction.Name != "get_weather" {
+		t.Fatalf("name = %q", out[0].OfFunction.Name)
+	}
+	if out[0].OfFunction.Parameters["type"] != "object" {
+		t.Fatalf("parameters = %#v", out[0].OfFunction.Parameters)
+	}
+}
+
+func TestApplyOpenAIResponsesConfig(t *testing.T) {
+	temp := 0.5
+	mct := 128
+	effort := "low"
+	var params responses.ResponseNewParams
+	applyOpenAIResponsesConfig(&params, &OpenAIConfig{
+		Temperature:         &temp,
+		MaxCompletionTokens: &mct,
+		ReasoningEffort:     &effort,
+	})
+	if !params.Temperature.Valid() || params.Temperature.Value != 0.5 {
+		t.Fatalf("Temperature = %#v", params.Temperature)
+	}
+	if !params.MaxOutputTokens.Valid() || params.MaxOutputTokens.Value != 128 {
+		t.Fatalf("MaxOutputTokens = %#v", params.MaxOutputTokens)
+	}
+	if params.Reasoning.Effort != "low" {
+		t.Fatalf("Reasoning.Effort = %q", params.Reasoning.Effort)
+	}
+}
+
+func TestResponseToLLMResponse(t *testing.T) {
+	raw := []byte(`{
+		"id":"resp_1",
+		"object":"response",
+		"created_at":1,
+		"status":"completed",
+		"model":"gpt-4o",
+		"output":[
+			{
+				"type":"message",
+				"id":"msg_1",
+				"role":"assistant",
+				"status":"completed",
+				"content":[{"type":"output_text","text":"hi","annotations":[]}]
+			},
+			{
+				"type":"function_call",
+				"id":"fc_1",
+				"call_id":"call_1",
+				"name":"add",
+				"arguments":"{\"a\":1}",
+				"status":"completed"
+			}
+		],
+		"usage":{"input_tokens":10,"output_tokens":5,"total_tokens":15,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}
+	}`)
+	var resp responses.Response
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	out := responseToLLMResponse(&resp)
+	if out.Content == nil || len(out.Content.Parts) != 2 {
+		t.Fatalf("parts = %#v", out.Content)
+	}
+	if out.Content.Parts[0].Text != "hi" {
+		t.Fatalf("text = %q", out.Content.Parts[0].Text)
+	}
+	if out.Content.Parts[1].FunctionCall == nil || out.Content.Parts[1].FunctionCall.ID != "call_1" {
+		t.Fatalf("function call = %#v", out.Content.Parts[1].FunctionCall)
+	}
+	if out.UsageMetadata == nil || out.UsageMetadata.PromptTokenCount != 10 {
+		t.Fatalf("usage = %#v", out.UsageMetadata)
+	}
+}
+
+func TestOpenAIModel_GenerateContent_Responses(t *testing.T) {
+	var gotPath string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"resp_1","object":"response","created_at":1,"status":"completed","model":"gpt-4o",
+			"output":[{"type":"message","id":"msg_1","role":"assistant","status":"completed",
+				"content":[{"type":"output_text","text":"pong","annotations":[]}]}],
+			"usage":{"input_tokens":3,"output_tokens":1,"total_tokens":4,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}
+		}`))
+	}))
+	defer srv.Close()
+
+	client := openai.NewClient(
+		option.WithAPIKey("test"),
+		option.WithBaseURL(srv.URL),
+		option.WithHTTPClient(srv.Client()),
+	)
+	m := &OpenAIModel{
+		Config: &OpenAIConfig{Model: "gpt-4o", APIFormat: OpenAIAPIFormatResponses},
+		Client: client,
+		Logger: logr.Discard(),
+	}
+
+	var got *model.LLMResponse
+	for resp, err := range m.GenerateContent(context.Background(), &model.LLMRequest{
+		Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "ping"}}}},
+	}, false) {
+		if err != nil {
+			t.Fatalf("GenerateContent error: %v", err)
+		}
+		got = resp
+	}
+	if !strings.HasSuffix(gotPath, "/responses") {
+		t.Fatalf("path = %q, want .../responses", gotPath)
+	}
+	if gotBody["model"] != "gpt-4o" {
+		t.Fatalf("body model = %#v", gotBody["model"])
+	}
+	if got == nil || got.Content == nil || len(got.Content.Parts) != 1 || got.Content.Parts[0].Text != "pong" {
+		t.Fatalf("response = %#v", got)
+	}
+}
+
+func TestOpenAIModel_GenerateContent_ResponsesStreaming(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, _ := w.(http.Flusher)
+		write := func(payload string) {
+			_, _ = io.WriteString(w, "data: "+payload+"\n\n")
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+		write(`{"type":"response.output_text.delta","content_index":0,"delta":"hel","item_id":"msg_1","output_index":0,"sequence_number":1,"logprobs":[]}`)
+		write(`{"type":"response.output_text.delta","content_index":0,"delta":"lo","item_id":"msg_1","output_index":0,"sequence_number":2,"logprobs":[]}`)
+		write(`{"type":"response.completed","sequence_number":3,"response":{"id":"resp_1","object":"response","created_at":1,"status":"completed","model":"gpt-4o","output":[],"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}}}`)
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	client := openai.NewClient(
+		option.WithAPIKey("test"),
+		option.WithBaseURL(srv.URL),
+		option.WithHTTPClient(srv.Client()),
+	)
+	m := &OpenAIModel{
+		Config: &OpenAIConfig{Model: "gpt-4o", APIFormat: OpenAIAPIFormatResponses},
+		Client: client,
+		Logger: logr.Discard(),
+	}
+
+	var partials []string
+	var final *model.LLMResponse
+	for resp, err := range m.GenerateContent(context.Background(), &model.LLMRequest{
+		Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "hi"}}}},
+	}, true) {
+		if err != nil {
+			t.Fatalf("GenerateContent error: %v", err)
+		}
+		if resp.Partial {
+			partials = append(partials, resp.Content.Parts[0].Text)
+		} else {
+			final = resp
+		}
+	}
+	if strings.Join(partials, "") != "hello" {
+		t.Fatalf("partials = %#v", partials)
+	}
+	if final == nil || final.Content.Parts[0].Text != "hello" {
+		t.Fatalf("final = %#v", final)
+	}
+}
+
+func TestGenaiContentsToResponsesInput_Image(t *testing.T) {
+	input, _ := genaiContentsToResponsesInput([]*genai.Content{{
+		Role: "user",
+		Parts: []*genai.Part{
+			{Text: "what is this?"},
+			{InlineData: &genai.Blob{MIMEType: "image/png", Data: []byte{0x89, 0x50}}},
+		},
+	}}, nil)
+	if len(input) != 1 || input[0].OfMessage == nil {
+		t.Fatalf("input = %#v", input)
+	}
+	// Content is a union; ensure image URL made it into marshaled JSON.
+	b, err := json.Marshal(input[0].OfMessage)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(b), "input_image") || !strings.Contains(string(b), "data:image/png;base64,") {
+		t.Fatalf("marshaled message missing image: %s", b)
+	}
+}

--- a/go/api/adk/types.go
+++ b/go/api/adk/types.go
@@ -90,6 +90,8 @@ type OpenAI struct {
 	Temperature         *float64 `json:"temperature,omitempty"`
 	Timeout             *int     `json:"timeout,omitempty"`
 	TopP                *float64 `json:"top_p,omitempty"`
+	// APIFormat selects chatCompletions (default) or responses.
+	APIFormat string `json:"api_format,omitempty"`
 
 	// TokenExchange configures dynamic bearer token acquisition
 	TokenExchange *TokenExchangeConfig `json:"token_exchange,omitempty"`

--- a/go/api/config/crd/bases/kagent.dev_modelconfigs.yaml
+++ b/go/api/config/crd/bases/kagent.dev_modelconfigs.yaml
@@ -640,6 +640,21 @@ spec:
               openAI:
                 description: OpenAI-specific configuration
                 properties:
+                  apiFormat:
+                    allOf:
+                    - enum:
+                      - chatCompletions
+                      - responses
+                    - enum:
+                      - chatCompletions
+                      - responses
+                    default: chatCompletions
+                    description: |-
+                      APIFormat selects which OpenAI HTTP API the runtime uses for this model.
+                      chatCompletions (default) posts to /v1/chat/completions.
+                      responses posts to /v1/responses. Use responses for OpenAI-compatible
+                      gateways or models that require the Responses API.
+                    type: string
                   baseUrl:
                     description: Base URL for the OpenAI API (overrides default)
                     type: string

--- a/go/api/config/crd/bases/kagent.dev_modelconfigs.yaml
+++ b/go/api/config/crd/bases/kagent.dev_modelconfigs.yaml
@@ -641,19 +641,15 @@ spec:
                 description: OpenAI-specific configuration
                 properties:
                   apiFormat:
-                    allOf:
-                    - enum:
-                      - chatCompletions
-                      - responses
-                    - enum:
-                      - chatCompletions
-                      - responses
                     default: chatCompletions
                     description: |-
                       APIFormat selects which OpenAI HTTP API the runtime uses for this model.
                       chatCompletions (default) posts to /v1/chat/completions.
                       responses posts to /v1/responses. Use responses for OpenAI-compatible
                       gateways or models that require the Responses API.
+                    enum:
+                    - chatCompletions
+                    - responses
                     type: string
                   baseUrl:
                     description: Base URL for the OpenAI API (overrides default)

--- a/go/api/v1alpha2/modelconfig_types.go
+++ b/go/api/v1alpha2/modelconfig_types.go
@@ -199,11 +199,29 @@ type OpenAIConfig struct {
 	// +optional
 	ReasoningEffort *OpenAIReasoningEffort `json:"reasoningEffort,omitempty"`
 
+	// APIFormat selects which OpenAI HTTP API the runtime uses for this model.
+	// chatCompletions (default) posts to /v1/chat/completions.
+	// responses posts to /v1/responses. Use responses for OpenAI-compatible
+	// gateways or models that require the Responses API.
+	// +optional
+	// +kubebuilder:validation:Enum=chatCompletions;responses
+	// +kubebuilder:default=chatCompletions
+	APIFormat *OpenAIAPIFormat `json:"apiFormat,omitempty"`
+
 	// TokenExchange configures dynamic bearer token acquisition via credential exchange.
 	// Requires apiKeySecret (used as the service account secret) and is mutually exclusive with apiKeyPassthrough.
 	// +optional
 	TokenExchange *TokenExchangeConfig `json:"tokenExchange,omitempty"`
 }
+
+// OpenAIAPIFormat selects the OpenAI HTTP API shape used by the Go ADK runtime.
+// +kubebuilder:validation:Enum=chatCompletions;responses
+type OpenAIAPIFormat string
+
+const (
+	OpenAIAPIFormatChatCompletions OpenAIAPIFormat = "chatCompletions"
+	OpenAIAPIFormatResponses       OpenAIAPIFormat = "responses"
+)
 
 // OpenAIReasoningEffort represents how many reasoning tokens the model generates before producing a response.
 // Supported values vary by model. Set to "none" to disable reasoning; some models (e.g. gpt-5.6-terra)

--- a/go/api/v1alpha2/modelconfig_types.go
+++ b/go/api/v1alpha2/modelconfig_types.go
@@ -204,7 +204,6 @@ type OpenAIConfig struct {
 	// responses posts to /v1/responses. Use responses for OpenAI-compatible
 	// gateways or models that require the Responses API.
 	// +optional
-	// +kubebuilder:validation:Enum=chatCompletions;responses
 	// +kubebuilder:default=chatCompletions
 	APIFormat *OpenAIAPIFormat `json:"apiFormat,omitempty"`
 

--- a/go/api/v1alpha2/zz_generated.deepcopy.go
+++ b/go/api/v1alpha2/zz_generated.deepcopy.go
@@ -1377,6 +1377,11 @@ func (in *OpenAIConfig) DeepCopyInto(out *OpenAIConfig) {
 		*out = new(OpenAIReasoningEffort)
 		**out = **in
 	}
+	if in.APIFormat != nil {
+		in, out := &in.APIFormat, &out.APIFormat
+		*out = new(OpenAIAPIFormat)
+		**out = **in
+	}
 	if in.TokenExchange != nil {
 		in, out := &in.TokenExchange, &out.TokenExchange
 		*out = new(TokenExchangeConfig)

--- a/go/core/internal/controller/translator/agent/adk_api_translator.go
+++ b/go/core/internal/controller/translator/agent/adk_api_translator.go
@@ -523,6 +523,9 @@ func (a *adkApiTranslator) translateModel(ctx context.Context, namespace, modelC
 				effort := string(*model.Spec.OpenAI.ReasoningEffort)
 				openai.ReasoningEffort = &effort
 			}
+			if model.Spec.OpenAI.APIFormat != nil && *model.Spec.OpenAI.APIFormat != "" {
+				openai.APIFormat = string(*model.Spec.OpenAI.APIFormat)
+			}
 
 			if model.Spec.OpenAI.Organization != "" {
 				modelDeploymentData.EnvVars = append(modelDeploymentData.EnvVars, corev1.EnvVar{

--- a/go/core/internal/controller/translator/agent/adk_api_translator_test.go
+++ b/go/core/internal/controller/translator/agent/adk_api_translator_test.go
@@ -523,6 +523,46 @@ func Test_AdkApiTranslator_AzureOpenAINoAPIKeySecret(t *testing.T) {
 	assert.Contains(t, envNames, "AZURE_AD_TOKEN")
 }
 
+func Test_AdkApiTranslator_OpenAIAPIFormat(t *testing.T) {
+	scheme := schemev1.Scheme
+	require.NoError(t, v1alpha2.AddToScheme(scheme))
+
+	apiFormat := v1alpha2.OpenAIAPIFormatResponses
+	modelConfig := &v1alpha2.ModelConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "ns"},
+		Spec: v1alpha2.ModelConfigSpec{
+			Model:             "gpt-4o",
+			Provider:          v1alpha2.ModelProviderOpenAI,
+			APIKeyPassthrough: true,
+			OpenAI: &v1alpha2.OpenAIConfig{
+				APIFormat: &apiFormat,
+			},
+		},
+	}
+	agent := &v1alpha2.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns"},
+		Spec: v1alpha2.AgentSpec{
+			Type: v1alpha2.AgentType_Declarative,
+			Declarative: &v1alpha2.DeclarativeAgentSpec{
+				SystemMessage: "x",
+				ModelConfig:   "m",
+				Runtime:       v1alpha2.DeclarativeRuntime_Go,
+			},
+		},
+	}
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns"}}
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns, modelConfig, agent).Build()
+	trans := translator.NewAdkApiTranslator(kubeClient, types.NamespacedName{Namespace: "ns", Name: "m"}, nil, "", nil)
+
+	outputs, err := translator.TranslateAgent(context.Background(), trans, agent)
+	require.NoError(t, err)
+
+	m, ok := outputs.Config.Model.(*adk.OpenAI)
+	require.True(t, ok)
+	assert.Equal(t, "responses", m.APIFormat)
+}
+
 func Test_AdkApiTranslator_OpenAIMaxCompletionTokens(t *testing.T) {
 	scheme := schemev1.Scheme
 	require.NoError(t, v1alpha2.AddToScheme(scheme))

--- a/helm/kagent-crds/templates/kagent.dev_modelconfigs.yaml
+++ b/helm/kagent-crds/templates/kagent.dev_modelconfigs.yaml
@@ -640,6 +640,21 @@ spec:
               openAI:
                 description: OpenAI-specific configuration
                 properties:
+                  apiFormat:
+                    allOf:
+                    - enum:
+                      - chatCompletions
+                      - responses
+                    - enum:
+                      - chatCompletions
+                      - responses
+                    default: chatCompletions
+                    description: |-
+                      APIFormat selects which OpenAI HTTP API the runtime uses for this model.
+                      chatCompletions (default) posts to /v1/chat/completions.
+                      responses posts to /v1/responses. Use responses for OpenAI-compatible
+                      gateways or models that require the Responses API.
+                    type: string
                   baseUrl:
                     description: Base URL for the OpenAI API (overrides default)
                     type: string

--- a/helm/kagent-crds/templates/kagent.dev_modelconfigs.yaml
+++ b/helm/kagent-crds/templates/kagent.dev_modelconfigs.yaml
@@ -641,19 +641,15 @@ spec:
                 description: OpenAI-specific configuration
                 properties:
                   apiFormat:
-                    allOf:
-                    - enum:
-                      - chatCompletions
-                      - responses
-                    - enum:
-                      - chatCompletions
-                      - responses
                     default: chatCompletions
                     description: |-
                       APIFormat selects which OpenAI HTTP API the runtime uses for this model.
                       chatCompletions (default) posts to /v1/chat/completions.
                       responses posts to /v1/responses. Use responses for OpenAI-compatible
                       gateways or models that require the Responses API.
+                    enum:
+                    - chatCompletions
+                    - responses
                     type: string
                   baseUrl:
                     description: Base URL for the OpenAI API (overrides default)


### PR DESCRIPTION
Users can now use the Responses API either directly with OpenAI or via a gateway like AgentGateway. Here's an example with agent gateway.

```yaml
apiVersion: kagent.dev/v1alpha2
kind: ModelConfig
metadata:
  name: openai-responses
  namespace: kagent
spec:
  provider: OpenAI
  model: gpt-5.4-mini
  apiKeyPassthrough: true
  openAI:
    baseUrl: http://agentgateway-proxy.agentgateway-system.svc/openai
    apiFormat: responses # NEW! <- If not provided, uses chat completions API
```

Note that certain features from Responses API like native tools and stateful chaining are not supported for now since they're only available when using with OpenAI's servers. For those interested, it can be a follow up to add those features in kagent harness.