### PR TITLE
fix: point currency sample at the new Frankfurter API endpoint

### DIFF
--- a/python/samples/langgraph/currency/currency/agent.py
+++ b/python/samples/langgraph/currency/currency/agent.py
@@ -36,8 +36,10 @@ def _get_exchange_rate(
     """
     try:
         response = httpx.get(
-            f"https://api.frankfurter.app/{currency_date}",
+            f"https://api.frankfurter.dev/v1/{currency_date}",
             params={"from": currency_from, "to": currency_to},
+            follow_redirects=True,
+            timeout=10.0,
         )
         response.raise_for_status()
 


### PR DESCRIPTION
## What

The currency LangGraph sample calls the Frankfurter API to fetch exchange rates. The API has migrated hosts: `api.frankfurter.app` now returns a **301 redirect** to `api.frankfurter.dev/v1/...`. This updates the sample's exchange-rate tool to call the new canonical endpoint directly.

## Changes (`currency/agent.py`)

- Point the request at `https://api.frankfurter.dev/v1/{date}` (was `https://api.frankfurter.app/{date}`).
- Add a **10s timeout** — the call previously had none and could hang indefinitely.
- Add `follow_redirects=True` as a safeguard against any future host/path moves.

## Verification

Confirmed against the live API:

| Request | Result |
|---|---|
| Old `api.frankfurter.app/latest?from=USD&to=EUR` | `HTTP 301` → `api.frankfurter.dev/v1/latest` |
| New `api.frankfurter.dev/v1/latest?from=USD&to=EUR` | `HTTP 200`, valid JSON (`{"base":"USD","rates":{"EUR":...}}`) |

The existing `from`/`to` query params are accepted unchanged by the new endpoint, so no other code changes are needed.

Before:
<img width="1237" height="711" alt="Screenshot 2026-07-30 at 10 30 37 PM" src="https://github.com/user-attachments/assets/fe0f20f7-1d30-4eeb-a812-da899785e37f" />
After:
<img width="1237" height="711" alt="Screenshot 2026-07-30 at 10 31 11 PM" src="https://github.com/user-attachments/assets/89c3e626-5e11-4c85-b3fd-36d277ce5411" />

## Testing

Docs/sample fix; behavior verified via direct API calls as shown above.