### PR TITLE
feat(api): add topologySpreadConstraints to SharedDeploymentSpec

### DIFF
--- a/go/api/config/crd/bases/kagent.dev_agents.yaml
+++ b/go/api/config/crd/bases/kagent.dev_agents.yaml
@@ -5778,6 +5778,182 @@ spec:
                               type: string
                           type: object
                         type: array
+                      topologySpreadConstraints:
+                        description: |-
+                          TopologySpreadConstraints describes how a group of pods ought to spread across topology
+                          domains. All topologySpreadConstraints are ANDed.
+                        items:
+                          description: TopologySpreadConstraint specifies how to spread
+                            matching pods among the given topology.
+                          properties:
+                            labelSelector:
+                              description: |-
+                                LabelSelector is used to find matching pods.
+                                Pods that match this label selector are counted to determine the number of pods
+                                in their corresponding topology domain.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              description: |-
+                                MatchLabelKeys is a set of pod label keys to select the pods over which
+                                spreading will be calculated. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are ANDed with labelSelector
+                                to select the group of existing pods over which spreading will be calculated
+                                for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                Keys that don't exist in the incoming pod labels will
+                                be ignored. A null or empty list means only match against labelSelector.
+
+                                This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            maxSkew:
+                              description: |-
+                                MaxSkew describes the degree to which pods may be unevenly distributed.
+                                When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                                between the number of matching pods in the target topology and the global minimum.
+                                The global minimum is the minimum number of matching pods in an eligible domain
+                                or zero if the number of eligible domains is less than MinDomains.
+                                For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                labelSelector spread as 2/2/1:
+                                In this case, the global minimum is 1.
+                                | zone1 | zone2 | zone3 |
+                                |  P P  |  P P  |   P   |
+                                - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                                scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                                violate MaxSkew(1).
+                                - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                                When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                                to topologies that satisfy it.
+                                It's a required field. Default value is 1 and 0 is not allowed.
+                              format: int32
+                              type: integer
+                            minDomains:
+                              description: |-
+                                MinDomains indicates a minimum number of eligible domains.
+                                When the number of eligible domains with matching topology keys is less than minDomains,
+                                Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                                And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                                this value has no effect on scheduling.
+                                As a result, when the number of eligible domains is less than minDomains,
+                                scheduler won't schedule more than maxSkew Pods to those domains.
+                                If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                                Valid values are integers greater than 0.
+                                When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                                For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                                labelSelector spread as 2/2/2:
+                                | zone1 | zone2 | zone3 |
+                                |  P P  |  P P  |  P P  |
+                                The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                                In this situation, new pod with the same labelSelector cannot be scheduled,
+                                because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                                it will violate MaxSkew.
+                              format: int32
+                              type: integer
+                            nodeAffinityPolicy:
+                              description: |-
+                                NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                                when calculating pod topology spread skew. Options are:
+                                - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                                - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                                If this value is nil, the behavior is equivalent to the Honor policy.
+                              type: string
+                            nodeTaintsPolicy:
+                              description: |-
+                                NodeTaintsPolicy indicates how we will treat node taints when calculating
+                                pod topology spread skew. Options are:
+                                - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                                has a toleration, are included.
+                                - Ignore: node taints are ignored. All nodes are included.
+
+                                If this value is nil, the behavior is equivalent to the Ignore policy.
+                              type: string
+                            topologyKey:
+                              description: |-
+                                TopologyKey is the key of node labels. Nodes that have a label with this key
+                                and identical values are considered to be in the same topology.
+                                We consider each <key, value> as a "bucket", and try to put balanced number
+                                of pods into each bucket.
+                                We define a domain as a particular instance of a topology.
+                                Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                                nodeAffinityPolicy and nodeTaintsPolicy.
+                                e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                                And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                                It's a required field.
+                              type: string
+                            whenUnsatisfiable:
+                              description: |-
+                                WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                                the spread constraint.
+                                - DoNotSchedule (default) tells the scheduler not to schedule it.
+                                - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                  but giving higher precedence to topologies that would help reduce the
+                                  skew.
+                                A constraint is considered "Unsatisfiable" for an incoming pod
+                                if and only if every possible node assignment for that pod would violate
+                                "MaxSkew" on some topology.
+                                For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                labelSelector spread as 3/1/1:
+                                | zone1 | zone2 | zone3 |
+                                | P P P |   P   |   P   |
+                                If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                                to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                                MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                                won't make it *more* imbalanced.
+                                It's a required field.
+                              type: string
+                          required:
+                          - maxSkew
+                          - topologyKey
+                          - whenUnsatisfiable
+                          type: object
+                        type: array
                       volumeMounts:
                         description: VolumeMounts are additional volume mounts added
                           to the agent container.
@@ -11178,6 +11354,182 @@ spec:
                                 Value is the taint value the toleration matches to.
                                 If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
+                          type: object
+                        type: array
+                      topologySpreadConstraints:
+                        description: |-
+                          TopologySpreadConstraints describes how a group of pods ought to spread across topology
+                          domains. All topologySpreadConstraints are ANDed.
+                        items:
+                          description: TopologySpreadConstraint specifies how to spread
+                            matching pods among the given topology.
+                          properties:
+                            labelSelector:
+                              description: |-
+                                LabelSelector is used to find matching pods.
+                                Pods that match this label selector are counted to determine the number of pods
+                                in their corresponding topology domain.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              description: |-
+                                MatchLabelKeys is a set of pod label keys to select the pods over which
+                                spreading will be calculated. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are ANDed with labelSelector
+                                to select the group of existing pods over which spreading will be calculated
+                                for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                Keys that don't exist in the incoming pod labels will
+                                be ignored. A null or empty list means only match against labelSelector.
+
+                                This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            maxSkew:
+                              description: |-
+                                MaxSkew describes the degree to which pods may be unevenly distributed.
+                                When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                                between the number of matching pods in the target topology and the global minimum.
+                                The global minimum is the minimum number of matching pods in an eligible domain
+                                or zero if the number of eligible domains is less than MinDomains.
+                                For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                labelSelector spread as 2/2/1:
+                                In this case, the global minimum is 1.
+                                | zone1 | zone2 | zone3 |
+                                |  P P  |  P P  |   P   |
+                                - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                                scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                                violate MaxSkew(1).
+                                - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                                When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                                to topologies that satisfy it.
+                                It's a required field. Default value is 1 and 0 is not allowed.
+                              format: int32
+                              type: integer
+                            minDomains:
+                              description: |-
+                                MinDomains indicates a minimum number of eligible domains.
+                                When the number of eligible domains with matching topology keys is less than minDomains,
+                                Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                                And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                                this value has no effect on scheduling.
+                                As a result, when the number of eligible domains is less than minDomains,
+                                scheduler won't schedule more than maxSkew Pods to those domains.
+                                If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                                Valid values are integers greater than 0.
+                                When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                                For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                                labelSelector spread as 2/2/2:
+                                | zone1 | zone2 | zone3 |
+                                |  P P  |  P P  |  P P  |
+                                The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                                In this situation, new pod with the same labelSelector cannot be scheduled,
+                                because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                                it will violate MaxSkew.
+                              format: int32
+                              type: integer
+                            nodeAffinityPolicy:
+                              description: |-
+                                NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                                when calculating pod topology spread skew. Options are:
+                                - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                                - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                                If this value is nil, the behavior is equivalent to the Honor policy.
+                              type: string
+                            nodeTaintsPolicy:
+                              description: |-
+                                NodeTaintsPolicy indicates how we will treat node taints when calculating
+                                pod topology spread skew. Options are:
+                                - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                                has a toleration, are included.
+                                - Ignore: node taints are ignored. All nodes are included.
+
+                                If this value is nil, the behavior is equivalent to the Ignore policy.
+                              type: string
+                            topologyKey:
+                              description: |-
+                                TopologyKey is the key of node labels. Nodes that have a label with this key
+                                and identical values are considered to be in the same topology.
+                                We consider each <key, value> as a "bucket", and try to put balanced number
+                                of pods into each bucket.
+                                We define a domain as a particular instance of a topology.
+                                Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                                nodeAffinityPolicy and nodeTaintsPolicy.
+                                e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                                And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                                It's a required field.
+                              type: string
+                            whenUnsatisfiable:
+                              description: |-
+                                WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                                the spread constraint.
+                                - DoNotSchedule (default) tells the scheduler not to schedule it.
+                                - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                  but giving higher precedence to topologies that would help reduce the
+                                  skew.
+                                A constraint is considered "Unsatisfiable" for an incoming pod
+                                if and only if every possible node assignment for that pod would violate
+                                "MaxSkew" on some topology.
+                                For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                labelSelector spread as 3/1/1:
+                                | zone1 | zone2 | zone3 |
+                                | P P P |   P   |   P   |
+                                If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                                to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                                MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                                won't make it *more* imbalanced.
+                                It's a required field.
+                              type: string
+                          required:
+                          - maxSkew
+                          - topologyKey
+                          - whenUnsatisfiable
                           type: object
                         type: array
                       volumeMounts:

--- a/go/api/config/crd/bases/kagent.dev_sandboxagents.yaml
+++ b/go/api/config/crd/bases/kagent.dev_sandboxagents.yaml
@@ -3435,6 +3435,182 @@ spec:
                               type: string
                           type: object
                         type: array
+                      topologySpreadConstraints:
+                        description: |-
+                          TopologySpreadConstraints describes how a group of pods ought to spread across topology
+                          domains. All topologySpreadConstraints are ANDed.
+                        items:
+                          description: TopologySpreadConstraint specifies how to spread
+                            matching pods among the given topology.
+                          properties:
+                            labelSelector:
+                              description: |-
+                                LabelSelector is used to find matching pods.
+                                Pods that match this label selector are counted to determine the number of pods
+                                in their corresponding topology domain.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              description: |-
+                                MatchLabelKeys is a set of pod label keys to select the pods over which
+                                spreading will be calculated. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are ANDed with labelSelector
+                                to select the group of existing pods over which spreading will be calculated
+                                for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                Keys that don't exist in the incoming pod labels will
+                                be ignored. A null or empty list means only match against labelSelector.
+
+                                This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            maxSkew:
+                              description: |-
+                                MaxSkew describes the degree to which pods may be unevenly distributed.
+                                When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                                between the number of matching pods in the target topology and the global minimum.
+                                The global minimum is the minimum number of matching pods in an eligible domain
+                                or zero if the number of eligible domains is less than MinDomains.
+                                For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                labelSelector spread as 2/2/1:
+                                In this case, the global minimum is 1.
+                                | zone1 | zone2 | zone3 |
+                                |  P P  |  P P  |   P   |
+                                - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                                scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                                violate MaxSkew(1).
+                                - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                                When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                                to topologies that satisfy it.
+                                It's a required field. Default value is 1 and 0 is not allowed.
+                              format: int32
+                              type: integer
+                            minDomains:
+                              description: |-
+                                MinDomains indicates a minimum number of eligible domains.
+                                When the number of eligible domains with matching topology keys is less than minDomains,
+                                Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                                And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                                this value has no effect on scheduling.
+                                As a result, when the number of eligible domains is less than minDomains,
+                                scheduler won't schedule more than maxSkew Pods to those domains.
+                                If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                                Valid values are integers greater than 0.
+                                When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                                For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                                labelSelector spread as 2/2/2:
+                                | zone1 | zone2 | zone3 |
+                                |  P P  |  P P  |  P P  |
+                                The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                                In this situation, new pod with the same labelSelector cannot be scheduled,
+                                because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                                it will violate MaxSkew.
+                              format: int32
+                              type: integer
+                            nodeAffinityPolicy:
+                              description: |-
+                                NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                                when calculating pod topology spread skew. Options are:
+                                - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                                - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                                If this value is nil, the behavior is equivalent to the Honor policy.
+                              type: string
+                            nodeTaintsPolicy:
+                              description: |-
+                                NodeTaintsPolicy indicates how we will treat node taints when calculating
+                                pod topology spread skew. Options are:
+                                - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                                has a toleration, are included.
+                                - Ignore: node taints are ignored. All nodes are included.
+
+                                If this value is nil, the behavior is equivalent to the Ignore policy.
+                              type: string
+                            topologyKey:
+                              description: |-
+                                TopologyKey is the key of node labels. Nodes that have a label with this key
+                                and identical values are considered to be in the same topology.
+                                We consider each <key, value> as a "bucket", and try to put balanced number
+                                of pods into each bucket.
+                                We define a domain as a particular instance of a topology.
+                                Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                                nodeAffinityPolicy and nodeTaintsPolicy.
+                                e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                                And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                                It's a required field.
+                              type: string
+                            whenUnsatisfiable:
+                              description: |-
+                                WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                                the spread constraint.
+                                - DoNotSchedule (default) tells the scheduler not to schedule it.
+                                - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                  but giving higher precedence to topologies that would help reduce the
+                                  skew.
+                                A constraint is considered "Unsatisfiable" for an incoming pod
+                                if and only if every possible node assignment for that pod would violate
+                                "MaxSkew" on some topology.
+                                For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                labelSelector spread as 3/1/1:
+                                | zone1 | zone2 | zone3 |
+                                | P P P |   P   |   P   |
+                                If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                                to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                                MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                                won't make it *more* imbalanced.
+                                It's a required field.
+                              type: string
+                          required:
+                          - maxSkew
+                          - topologyKey
+                          - whenUnsatisfiable
+                          type: object
+                        type: array
                       volumeMounts:
                         description: VolumeMounts are additional volume mounts added
                           to the agent container.
@@ -8835,6 +9011,182 @@ spec:
                                 Value is the taint value the toleration matches to.
                                 If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
+                          type: object
+                        type: array
+                      topologySpreadConstraints:
+                        description: |-
+                          TopologySpreadConstraints describes how a group of pods ought to spread across topology
+                          domains. All topologySpreadConstraints are ANDed.
+                        items:
+                          description: TopologySpreadConstraint specifies how to spread
+                            matching pods among the given topology.
+                          properties:
+                            labelSelector:
+                              description: |-
+                                LabelSelector is used to find matching pods.
+                                Pods that match this label selector are counted to determine the number of pods
+                                in their corresponding topology domain.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              description: |-
+                                MatchLabelKeys is a set of pod label keys to select the pods over which
+                                spreading will be calculated. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are ANDed with labelSelector
+                                to select the group of existing pods over which spreading will be calculated
+                                for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                Keys that don't exist in the incoming pod labels will
+                                be ignored. A null or empty list means only match against labelSelector.
+
+                                This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            maxSkew:
+                              description: |-
+                                MaxSkew describes the degree to which pods may be unevenly distributed.
+                                When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                                between the number of matching pods in the target topology and the global minimum.
+                                The global minimum is the minimum number of matching pods in an eligible domain
+                                or zero if the number of eligible domains is less than MinDomains.
+                                For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                labelSelector spread as 2/2/1:
+                                In this case, the global minimum is 1.
+                                | zone1 | zone2 | zone3 |
+                                |  P P  |  P P  |   P   |
+                                - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                                scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                                violate MaxSkew(1).
+                                - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                                When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                                to topologies that satisfy it.
+                                It's a required field. Default value is 1 and 0 is not allowed.
+                              format: int32
+                              type: integer
+                            minDomains:
+                              description: |-
+                                MinDomains indicates a minimum number of eligible domains.
+                                When the number of eligible domains with matching topology keys is less than minDomains,
+                                Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                                And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                                this value has no effect on scheduling.
+                                As a result, when the number of eligible domains is less than minDomains,
+                                scheduler won't schedule more than maxSkew Pods to those domains.
+                                If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                                Valid values are integers greater than 0.
+                                When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                                For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                                labelSelector spread as 2/2/2:
+                                | zone1 | zone2 | zone3 |
+                                |  P P  |  P P  |  P P  |
+                                The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                                In this situation, new pod with the same labelSelector cannot be scheduled,
+                                because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                                it will violate MaxSkew.
+                              format: int32
+                              type: integer
+                            nodeAffinityPolicy:
+                              description: |-
+                                NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                                when calculating pod topology spread skew. Options are:
+                                - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                                - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                                If this value is nil, the behavior is equivalent to the Honor policy.
+                              type: string
+                            nodeTaintsPolicy:
+                              description: |-
+                                NodeTaintsPolicy indicates how we will treat node taints when calculating
+                                pod topology spread skew. Options are:
+                                - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                                has a toleration, are included.
+                                - Ignore: node taints are ignored. All nodes are included.
+
+                                If this value is nil, the behavior is equivalent to the Ignore policy.
+                              type: string
+                            topologyKey:
+                              description: |-
+                                TopologyKey is the key of node labels. Nodes that have a label with this key
+                                and identical values are considered to be in the same topology.
+                                We consider each <key, value> as a "bucket", and try to put balanced number
+                                of pods into each bucket.
+                                We define a domain as a particular instance of a topology.
+                                Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                                nodeAffinityPolicy and nodeTaintsPolicy.
+                                e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                                And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                                It's a required field.
+                              type: string
+                            whenUnsatisfiable:
+                              description: |-
+                                WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                                the spread constraint.
+                                - DoNotSchedule (default) tells the scheduler not to schedule it.
+                                - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                  but giving higher precedence to topologies that would help reduce the
+                                  skew.
+                                A constraint is considered "Unsatisfiable" for an incoming pod
+                                if and only if every possible node assignment for that pod would violate
+                                "MaxSkew" on some topology.
+                                For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                labelSelector spread as 3/1/1:
+                                | zone1 | zone2 | zone3 |
+                                | P P P |   P   |   P   |
+                                If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                                to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                                MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                                won't make it *more* imbalanced.
+                                It's a required field.
+                              type: string
+                          required:
+                          - maxSkew
+                          - topologyKey
+                          - whenUnsatisfiable
                           type: object
                         type: array
                       volumeMounts:

--- a/go/api/v1alpha2/agent_types.go
+++ b/go/api/v1alpha2/agent_types.go
@@ -473,6 +473,10 @@ type SharedDeploymentSpec struct {
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 	// +optional
 	Affinity *corev1.Affinity `json:"affinity,omitempty"`
+	// TopologySpreadConstraints describes how a group of pods ought to spread across topology
+	// domains. All topologySpreadConstraints are ANDed.
+	// +optional
+	TopologySpreadConstraints []corev1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
 	// NodeSelector restricts the nodes the agent pods can be scheduled on.
 	// +optional
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`

--- a/go/api/v1alpha2/zz_generated.deepcopy.go
+++ b/go/api/v1alpha2/zz_generated.deepcopy.go
@@ -1862,6 +1862,13 @@ func (in *SharedDeploymentSpec) DeepCopyInto(out *SharedDeploymentSpec) {
 		*out = new(v1.Affinity)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.TopologySpreadConstraints != nil {
+		in, out := &in.TopologySpreadConstraints, &out.TopologySpreadConstraints
+		*out = make([]v1.TopologySpreadConstraint, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
 		*out = make(map[string]string, len(*in))

--- a/go/core/internal/controller/translator/agent/deployments.go
+++ b/go/core/internal/controller/translator/agent/deployments.go
@@ -31,24 +31,25 @@ type resolvedDeployment struct {
 	ImagePullPolicy corev1.PullPolicy
 
 	// SharedDeploymentSpec merged
-	Replicas              *int32
-	ImagePullSecrets      []corev1.LocalObjectReference
-	Volumes               []corev1.Volume
-	VolumeMounts          []corev1.VolumeMount
-	Labels                map[string]string
-	Annotations           map[string]string
-	DeploymentAnnotations map[string]string
-	Env                   []corev1.EnvVar
-	EnvFrom               []corev1.EnvFromSource
-	Resources             corev1.ResourceRequirements
-	Tolerations           []corev1.Toleration
-	Affinity              *corev1.Affinity
-	NodeSelector          map[string]string
-	SecurityContext       *corev1.SecurityContext
-	PodSecurityContext    *corev1.PodSecurityContext
-	ServiceAccountName    *string
-	ServiceAccountConfig  *v1alpha2.ServiceAccountConfig
-	ExtraContainers       []corev1.Container
+	Replicas                  *int32
+	ImagePullSecrets          []corev1.LocalObjectReference
+	Volumes                   []corev1.Volume
+	VolumeMounts              []corev1.VolumeMount
+	Labels                    map[string]string
+	Annotations               map[string]string
+	DeploymentAnnotations     map[string]string
+	Env                       []corev1.EnvVar
+	EnvFrom                   []corev1.EnvFromSource
+	Resources                 corev1.ResourceRequirements
+	Tolerations               []corev1.Toleration
+	Affinity                  *corev1.Affinity
+	NodeSelector              map[string]string
+	TopologySpreadConstraints []corev1.TopologySpreadConstraint
+	SecurityContext           *corev1.SecurityContext
+	PodSecurityContext        *corev1.PodSecurityContext
+	ServiceAccountName        *string
+	ServiceAccountConfig      *v1alpha2.ServiceAccountConfig
+	ExtraContainers           []corev1.Container
 }
 
 // getDefaultResources sets default resource requirements if not specified
@@ -245,28 +246,29 @@ func resolveInlineDeployment(agent v1alpha2.AgentObject, mdd *modelDeploymentDat
 	}
 
 	dep := &resolvedDeployment{
-		Image:                 image,
-		Args:                  args,
-		Port:                  port,
-		ImagePullPolicy:       imagePullPolicy,
-		Replicas:              spec.Replicas,
-		ImagePullSecrets:      slices.Clone(spec.ImagePullSecrets),
-		Volumes:               append(slices.Clone(spec.Volumes), mdd.Volumes...),
-		VolumeMounts:          append(slices.Clone(spec.VolumeMounts), mdd.VolumeMounts...),
-		Labels:                getDefaultLabels(agent.GetName(), spec.Labels),
-		Annotations:           maps.Clone(spec.Annotations),
-		DeploymentAnnotations: maps.Clone(spec.DeploymentAnnotations),
-		Env:                   append(slices.Clone(spec.Env), mdd.EnvVars...),
-		EnvFrom:               slices.Clone(spec.EnvFrom),
-		Resources:             getDefaultResources(spec.Resources), // Set default resources if not specified
-		Tolerations:           slices.Clone(spec.Tolerations),
-		Affinity:              spec.Affinity,
-		NodeSelector:          getDefaultNodeSelector(spec.NodeSelector),
-		SecurityContext:       spec.SecurityContext,
-		PodSecurityContext:    spec.PodSecurityContext,
-		ServiceAccountName:    spec.ServiceAccountName,
-		ServiceAccountConfig:  spec.ServiceAccountConfig,
-		ExtraContainers:       slices.Clone(spec.ExtraContainers),
+		Image:                     image,
+		Args:                      args,
+		Port:                      port,
+		ImagePullPolicy:           imagePullPolicy,
+		Replicas:                  spec.Replicas,
+		ImagePullSecrets:          slices.Clone(spec.ImagePullSecrets),
+		Volumes:                   append(slices.Clone(spec.Volumes), mdd.Volumes...),
+		VolumeMounts:              append(slices.Clone(spec.VolumeMounts), mdd.VolumeMounts...),
+		Labels:                    getDefaultLabels(agent.GetName(), spec.Labels),
+		Annotations:               maps.Clone(spec.Annotations),
+		DeploymentAnnotations:     maps.Clone(spec.DeploymentAnnotations),
+		Env:                       append(slices.Clone(spec.Env), mdd.EnvVars...),
+		EnvFrom:                   slices.Clone(spec.EnvFrom),
+		Resources:                 getDefaultResources(spec.Resources), // Set default resources if not specified
+		Tolerations:               slices.Clone(spec.Tolerations),
+		Affinity:                  spec.Affinity,
+		TopologySpreadConstraints: slices.Clone(spec.TopologySpreadConstraints),
+		NodeSelector:              getDefaultNodeSelector(spec.NodeSelector),
+		SecurityContext:           spec.SecurityContext,
+		PodSecurityContext:        spec.PodSecurityContext,
+		ServiceAccountName:        spec.ServiceAccountName,
+		ServiceAccountConfig:      spec.ServiceAccountConfig,
+		ExtraContainers:           slices.Clone(spec.ExtraContainers),
 	}
 
 	// Precedence: agent-level serviceAccountName > global default > auto-created SA (agent name)
@@ -329,30 +331,31 @@ func resolveByoDeployment(agent v1alpha2.AgentObject) (*resolvedDeployment, erro
 	}
 
 	dep := &resolvedDeployment{
-		Image:                 image,
-		Cmd:                   cmd,
-		Args:                  args,
-		WorkingDir:            spec.WorkingDir,
-		Port:                  port,
-		ImagePullPolicy:       imagePullPolicy,
-		Replicas:              replicas,
-		ImagePullSecrets:      slices.Clone(spec.ImagePullSecrets),
-		Volumes:               slices.Clone(spec.Volumes),
-		VolumeMounts:          slices.Clone(spec.VolumeMounts),
-		Labels:                getDefaultLabels(agent.GetName(), spec.Labels),
-		Annotations:           maps.Clone(spec.Annotations),
-		DeploymentAnnotations: maps.Clone(spec.DeploymentAnnotations),
-		Env:                   slices.Clone(spec.Env),
-		EnvFrom:               slices.Clone(spec.EnvFrom),
-		Resources:             getDefaultResources(spec.Resources), // Set default resources if not specified
-		Tolerations:           slices.Clone(spec.Tolerations),
-		Affinity:              spec.Affinity,
-		NodeSelector:          getDefaultNodeSelector(spec.NodeSelector),
-		SecurityContext:       spec.SecurityContext,
-		PodSecurityContext:    spec.PodSecurityContext,
-		ServiceAccountName:    spec.ServiceAccountName,
-		ServiceAccountConfig:  spec.ServiceAccountConfig,
-		ExtraContainers:       slices.Clone(spec.ExtraContainers),
+		Image:                     image,
+		Cmd:                       cmd,
+		Args:                      args,
+		WorkingDir:                spec.WorkingDir,
+		Port:                      port,
+		ImagePullPolicy:           imagePullPolicy,
+		Replicas:                  replicas,
+		ImagePullSecrets:          slices.Clone(spec.ImagePullSecrets),
+		Volumes:                   slices.Clone(spec.Volumes),
+		VolumeMounts:              slices.Clone(spec.VolumeMounts),
+		Labels:                    getDefaultLabels(agent.GetName(), spec.Labels),
+		Annotations:               maps.Clone(spec.Annotations),
+		DeploymentAnnotations:     maps.Clone(spec.DeploymentAnnotations),
+		Env:                       slices.Clone(spec.Env),
+		EnvFrom:                   slices.Clone(spec.EnvFrom),
+		Resources:                 getDefaultResources(spec.Resources), // Set default resources if not specified
+		Tolerations:               slices.Clone(spec.Tolerations),
+		Affinity:                  spec.Affinity,
+		TopologySpreadConstraints: slices.Clone(spec.TopologySpreadConstraints),
+		NodeSelector:              getDefaultNodeSelector(spec.NodeSelector),
+		SecurityContext:           spec.SecurityContext,
+		PodSecurityContext:        spec.PodSecurityContext,
+		ServiceAccountName:        spec.ServiceAccountName,
+		ServiceAccountConfig:      spec.ServiceAccountConfig,
+		ExtraContainers:           slices.Clone(spec.ExtraContainers),
 	}
 
 	// Precedence: agent-level serviceAccountName > global default > auto-created SA (agent name)

--- a/go/core/internal/controller/translator/agent/deployments_test.go
+++ b/go/core/internal/controller/translator/agent/deployments_test.go
@@ -172,6 +172,109 @@ func TestResolveByoDeployment_DeploymentAnnotationsCloned(t *testing.T) {
 	}
 }
 
+func TestResolveByoDeployment_TopologySpreadConstraintsPropagated(t *testing.T) {
+	tsc := []corev1.TopologySpreadConstraint{
+		{
+			MaxSkew:           1,
+			TopologyKey:       "kubernetes.io/hostname",
+			WhenUnsatisfiable: corev1.DoNotSchedule,
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test"},
+			},
+		},
+	}
+	agent := &v1alpha2.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec: v1alpha2.AgentSpec{
+			Type: v1alpha2.AgentType_BYO,
+			BYO: &v1alpha2.BYOAgentSpec{
+				Deployment: &v1alpha2.ByoDeploymentSpec{
+					Image: "my-image:latest",
+					SharedDeploymentSpec: v1alpha2.SharedDeploymentSpec{
+						TopologySpreadConstraints: tsc,
+					},
+				},
+			},
+		},
+	}
+	dep, err := resolveByoDeployment(agent)
+	if err != nil {
+		t.Fatalf("resolveByoDeployment() error = %v", err)
+	}
+	if !reflect.DeepEqual(dep.TopologySpreadConstraints, tsc) {
+		t.Errorf("TopologySpreadConstraints = %v, want %v", dep.TopologySpreadConstraints, tsc)
+	}
+}
+
+func TestResolveInlineDeployment_TopologySpreadConstraintsPropagated(t *testing.T) {
+	tsc := []corev1.TopologySpreadConstraint{
+		{
+			MaxSkew:           1,
+			TopologyKey:       "topology.kubernetes.io/zone",
+			WhenUnsatisfiable: corev1.ScheduleAnyway,
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test"},
+			},
+		},
+	}
+	agent := &v1alpha2.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec: v1alpha2.AgentSpec{
+			Type: v1alpha2.AgentType_Declarative,
+			Declarative: &v1alpha2.DeclarativeAgentSpec{
+				Deployment: &v1alpha2.DeclarativeDeploymentSpec{
+					SharedDeploymentSpec: v1alpha2.SharedDeploymentSpec{
+						TopologySpreadConstraints: tsc,
+					},
+				},
+			},
+		},
+	}
+	dep, err := resolveInlineDeployment(agent, &modelDeploymentData{})
+	if err != nil {
+		t.Fatalf("resolveInlineDeployment() error = %v", err)
+	}
+	if !reflect.DeepEqual(dep.TopologySpreadConstraints, tsc) {
+		t.Errorf("TopologySpreadConstraints = %v, want %v", dep.TopologySpreadConstraints, tsc)
+	}
+}
+
+// TestResolveByoDeployment_TopologySpreadConstraintsCloned asserts the resolver
+// copies the spec slice so later mutation of the resolved deployment cannot write
+// back into the agent object held by the client cache.
+func TestResolveByoDeployment_TopologySpreadConstraintsCloned(t *testing.T) {
+	tsc := []corev1.TopologySpreadConstraint{
+		{
+			MaxSkew:           1,
+			TopologyKey:       "kubernetes.io/hostname",
+			WhenUnsatisfiable: corev1.DoNotSchedule,
+			LabelSelector:     &metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}},
+		},
+	}
+	agent := &v1alpha2.Agent{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec: v1alpha2.AgentSpec{
+			Type: v1alpha2.AgentType_BYO,
+			BYO: &v1alpha2.BYOAgentSpec{
+				Deployment: &v1alpha2.ByoDeploymentSpec{
+					Image: "my-image:latest",
+					SharedDeploymentSpec: v1alpha2.SharedDeploymentSpec{
+						TopologySpreadConstraints: tsc,
+					},
+				},
+			},
+		},
+	}
+	dep, err := resolveByoDeployment(agent)
+	if err != nil {
+		t.Fatalf("resolveByoDeployment() error = %v", err)
+	}
+	dep.TopologySpreadConstraints[0].MaxSkew = 99
+	if tsc[0].MaxSkew != 1 {
+		t.Errorf("spec TopologySpreadConstraints mutated to %d, want the resolver to clone the slice", tsc[0].MaxSkew)
+	}
+}
+
 func TestValidateExtraContainers(t *testing.T) {
 	t.Parallel()
 

--- a/go/core/internal/controller/translator/agent/manifest_builder.go
+++ b/go/core/internal/controller/translator/agent/manifest_builder.go
@@ -575,10 +575,11 @@ func buildPodTemplate(
 				SecurityContext: runtimeInputs.securityContext,
 				VolumeMounts:    runtimeInputs.volumeMounts,
 			}}, dep.ExtraContainers...),
-			Volumes:      runtimeInputs.volumes,
-			Tolerations:  dep.Tolerations,
-			Affinity:     dep.Affinity,
-			NodeSelector: dep.NodeSelector,
+			Volumes:                   runtimeInputs.volumes,
+			Tolerations:               dep.Tolerations,
+			Affinity:                  dep.Affinity,
+			NodeSelector:              dep.NodeSelector,
+			TopologySpreadConstraints: dep.TopologySpreadConstraints,
 		},
 	}
 }

--- a/go/core/internal/controller/translator/agent/topology_spread_constraints_test.go
+++ b/go/core/internal/controller/translator/agent/topology_spread_constraints_test.go
@@ -1,0 +1,115 @@
+package agent_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	schemev1 "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kagent-dev/kagent/go/api/v1alpha2"
+	translator "github.com/kagent-dev/kagent/go/core/internal/controller/translator/agent"
+)
+
+// TestTopologySpreadConstraints_AppliedToPodSpec asserts a declarative agent's
+// topologySpreadConstraints reach the rendered Deployment pod template spec.
+func TestTopologySpreadConstraints_AppliedToPodSpec(t *testing.T) {
+	ctx := context.Background()
+
+	tsc := []corev1.TopologySpreadConstraint{
+		{
+			MaxSkew:           1,
+			TopologyKey:       "kubernetes.io/hostname",
+			WhenUnsatisfiable: corev1.DoNotSchedule,
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test-agent"},
+			},
+		},
+		{
+			MaxSkew:           2,
+			TopologyKey:       "topology.kubernetes.io/zone",
+			WhenUnsatisfiable: corev1.ScheduleAnyway,
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test-agent"},
+			},
+		},
+	}
+
+	agent := &v1alpha2.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-agent",
+			Namespace: "test",
+		},
+		Spec: v1alpha2.AgentSpec{
+			Type: v1alpha2.AgentType_Declarative,
+			Declarative: &v1alpha2.DeclarativeAgentSpec{
+				SystemMessage: "Test agent",
+				ModelConfig:   "test-model",
+				Deployment: &v1alpha2.DeclarativeDeploymentSpec{
+					SharedDeploymentSpec: v1alpha2.SharedDeploymentSpec{
+						TopologySpreadConstraints: tsc,
+					},
+				},
+			},
+		},
+	}
+
+	modelConfig := &v1alpha2.ModelConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-model",
+			Namespace: "test",
+		},
+		Spec: v1alpha2.ModelConfigSpec{
+			Provider: "OpenAI",
+			Model:    "gpt-4o",
+		},
+	}
+
+	scheme := schemev1.Scheme
+	require.NoError(t, v1alpha2.AddToScheme(scheme))
+
+	kubeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(agent, modelConfig).
+		Build()
+
+	defaultModel := types.NamespacedName{
+		Namespace: "test",
+		Name:      "test-model",
+	}
+	translatorInstance := translator.NewAdkApiTranslator(kubeClient, defaultModel, nil, "", nil)
+
+	result, err := translator.TranslateAgent(ctx, translatorInstance, agent)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	var deployment *appsv1.Deployment
+	for _, obj := range result.Manifest {
+		if dep, ok := obj.(*appsv1.Deployment); ok {
+			deployment = dep
+			break
+		}
+	}
+	require.NotNil(t, deployment, "Deployment should be in manifest")
+
+	podTemplate := &deployment.Spec.Template
+	require.Equal(t, tsc, podTemplate.Spec.TopologySpreadConstraints,
+		"topologySpreadConstraints from the agent spec should land on the pod template")
+}
+
+// TestTopologySpreadConstraints_UnsetOmittedFromPodSpec asserts the no-op path
+// leaves the pod template without any topologySpreadConstraints, matching the
+// pre-field behavior.
+func TestTopologySpreadConstraints_UnsetOmittedFromPodSpec(t *testing.T) {
+	result := translateAgentWithDeployment(t, nil, v1alpha2.SharedDeploymentSpec{})
+
+	deployment := findDeployment(t, result)
+	assert.Empty(t, deployment.Spec.Template.Spec.TopologySpreadConstraints,
+		"no topologySpreadConstraints should be set when the field is unset")
+}

--- a/go/core/test/e2e/invoke_api_test.go
+++ b/go/core/test/e2e/invoke_api_test.go
@@ -174,6 +174,9 @@ type AgentOptions struct {
 	DocumentationURL string
 	Version          string
 	Provider         *v1alpha2.AgentProvider
+
+	// TopologySpreadConstraints propagated to the Deployment pod template.
+	TopologySpreadConstraints []corev1.TopologySpreadConstraint
 }
 
 func pythonRuntime() *v1alpha2.DeclarativeRuntime {
@@ -531,6 +534,10 @@ func generateAgent(modelConfigName string, tools []*v1alpha2.Tool, opts AgentOpt
 	agent.Spec.DocumentationURL = opts.DocumentationURL
 	agent.Spec.Version = opts.Version
 	agent.Spec.Provider = opts.Provider
+
+	if len(opts.TopologySpreadConstraints) > 0 {
+		agent.Spec.Declarative.Deployment.TopologySpreadConstraints = opts.TopologySpreadConstraints
+	}
 
 	return agent
 }

--- a/go/core/test/e2e/invoke_api_topologyspread_test.go
+++ b/go/core/test/e2e/invoke_api_topologyspread_test.go
@@ -1,0 +1,43 @@
+package e2e_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TestE2ETopologySpreadConstraints asserts a declarative agent's
+// topologySpreadConstraints reach the rendered Deployment pod template spec
+// unchanged.
+func TestE2ETopologySpreadConstraints(t *testing.T) {
+	baseURL, stopServer := setupMockServer(t, "mocks/invoke_inline_agent.json")
+	defer stopServer()
+
+	cli := setupK8sClient(t, false)
+	modelCfg := setupModelConfig(t, cli, baseURL)
+
+	tsc := []corev1.TopologySpreadConstraint{
+		{
+			MaxSkew:           1,
+			TopologyKey:       "kubernetes.io/hostname",
+			WhenUnsatisfiable: corev1.DoNotSchedule,
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app.kubernetes.io/instance": "test-tsc"},
+			},
+		},
+	}
+
+	agent := setupAgentWithOptions(t, cli, modelCfg.Name, nil, AgentOptions{
+		Name:                      "test-tsc",
+		TopologySpreadConstraints: tsc,
+	})
+
+	deployment := &appsv1.Deployment{}
+	require.NoError(t, cli.Get(t.Context(), client.ObjectKey{Name: agent.Name, Namespace: agent.Namespace}, deployment))
+	require.Equal(t, tsc, deployment.Spec.Template.Spec.TopologySpreadConstraints,
+		"topologySpreadConstraints from the agent spec should land on the rendered Deployment")
+}

--- a/helm/kagent-crds/templates/kagent.dev_agents.yaml
+++ b/helm/kagent-crds/templates/kagent.dev_agents.yaml
@@ -5778,6 +5778,182 @@ spec:
                               type: string
                           type: object
                         type: array
+                      topologySpreadConstraints:
+                        description: |-
+                          TopologySpreadConstraints describes how a group of pods ought to spread across topology
+                          domains. All topologySpreadConstraints are ANDed.
+                        items:
+                          description: TopologySpreadConstraint specifies how to spread
+                            matching pods among the given topology.
+                          properties:
+                            labelSelector:
+                              description: |-
+                                LabelSelector is used to find matching pods.
+                                Pods that match this label selector are counted to determine the number of pods
+                                in their corresponding topology domain.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              description: |-
+                                MatchLabelKeys is a set of pod label keys to select the pods over which
+                                spreading will be calculated. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are ANDed with labelSelector
+                                to select the group of existing pods over which spreading will be calculated
+                                for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                Keys that don't exist in the incoming pod labels will
+                                be ignored. A null or empty list means only match against labelSelector.
+
+                                This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            maxSkew:
+                              description: |-
+                                MaxSkew describes the degree to which pods may be unevenly distributed.
+                                When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                                between the number of matching pods in the target topology and the global minimum.
+                                The global minimum is the minimum number of matching pods in an eligible domain
+                                or zero if the number of eligible domains is less than MinDomains.
+                                For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                labelSelector spread as 2/2/1:
+                                In this case, the global minimum is 1.
+                                | zone1 | zone2 | zone3 |
+                                |  P P  |  P P  |   P   |
+                                - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                                scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                                violate MaxSkew(1).
+                                - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                                When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                                to topologies that satisfy it.
+                                It's a required field. Default value is 1 and 0 is not allowed.
+                              format: int32
+                              type: integer
+                            minDomains:
+                              description: |-
+                                MinDomains indicates a minimum number of eligible domains.
+                                When the number of eligible domains with matching topology keys is less than minDomains,
+                                Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                                And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                                this value has no effect on scheduling.
+                                As a result, when the number of eligible domains is less than minDomains,
+                                scheduler won't schedule more than maxSkew Pods to those domains.
+                                If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                                Valid values are integers greater than 0.
+                                When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                                For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                                labelSelector spread as 2/2/2:
+                                | zone1 | zone2 | zone3 |
+                                |  P P  |  P P  |  P P  |
+                                The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                                In this situation, new pod with the same labelSelector cannot be scheduled,
+                                because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                                it will violate MaxSkew.
+                              format: int32
+                              type: integer
+                            nodeAffinityPolicy:
+                              description: |-
+                                NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                                when calculating pod topology spread skew. Options are:
+                                - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                                - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                                If this value is nil, the behavior is equivalent to the Honor policy.
+                              type: string
+                            nodeTaintsPolicy:
+                              description: |-
+                                NodeTaintsPolicy indicates how we will treat node taints when calculating
+                                pod topology spread skew. Options are:
+                                - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                                has a toleration, are included.
+                                - Ignore: node taints are ignored. All nodes are included.
+
+                                If this value is nil, the behavior is equivalent to the Ignore policy.
+                              type: string
+                            topologyKey:
+                              description: |-
+                                TopologyKey is the key of node labels. Nodes that have a label with this key
+                                and identical values are considered to be in the same topology.
+                                We consider each <key, value> as a "bucket", and try to put balanced number
+                                of pods into each bucket.
+                                We define a domain as a particular instance of a topology.
+                                Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                                nodeAffinityPolicy and nodeTaintsPolicy.
+                                e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                                And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                                It's a required field.
+                              type: string
+                            whenUnsatisfiable:
+                              description: |-
+                                WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                                the spread constraint.
+                                - DoNotSchedule (default) tells the scheduler not to schedule it.
+                                - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                  but giving higher precedence to topologies that would help reduce the
+                                  skew.
+                                A constraint is considered "Unsatisfiable" for an incoming pod
+                                if and only if every possible node assignment for that pod would violate
+                                "MaxSkew" on some topology.
+                                For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                labelSelector spread as 3/1/1:
+                                | zone1 | zone2 | zone3 |
+                                | P P P |   P   |   P   |
+                                If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                                to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                                MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                                won't make it *more* imbalanced.
+                                It's a required field.
+                              type: string
+                          required:
+                          - maxSkew
+                          - topologyKey
+                          - whenUnsatisfiable
+                          type: object
+                        type: array
                       volumeMounts:
                         description: VolumeMounts are additional volume mounts added
                           to the agent container.
@@ -11178,6 +11354,182 @@ spec:
                                 Value is the taint value the toleration matches to.
                                 If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
+                          type: object
+                        type: array
+                      topologySpreadConstraints:
+                        description: |-
+                          TopologySpreadConstraints describes how a group of pods ought to spread across topology
+                          domains. All topologySpreadConstraints are ANDed.
+                        items:
+                          description: TopologySpreadConstraint specifies how to spread
+                            matching pods among the given topology.
+                          properties:
+                            labelSelector:
+                              description: |-
+                                LabelSelector is used to find matching pods.
+                                Pods that match this label selector are counted to determine the number of pods
+                                in their corresponding topology domain.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              description: |-
+                                MatchLabelKeys is a set of pod label keys to select the pods over which
+                                spreading will be calculated. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are ANDed with labelSelector
+                                to select the group of existing pods over which spreading will be calculated
+                                for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                Keys that don't exist in the incoming pod labels will
+                                be ignored. A null or empty list means only match against labelSelector.
+
+                                This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            maxSkew:
+                              description: |-
+                                MaxSkew describes the degree to which pods may be unevenly distributed.
+                                When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                                between the number of matching pods in the target topology and the global minimum.
+                                The global minimum is the minimum number of matching pods in an eligible domain
+                                or zero if the number of eligible domains is less than MinDomains.
+                                For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                labelSelector spread as 2/2/1:
+                                In this case, the global minimum is 1.
+                                | zone1 | zone2 | zone3 |
+                                |  P P  |  P P  |   P   |
+                                - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                                scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                                violate MaxSkew(1).
+                                - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                                When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                                to topologies that satisfy it.
+                                It's a required field. Default value is 1 and 0 is not allowed.
+                              format: int32
+                              type: integer
+                            minDomains:
+                              description: |-
+                                MinDomains indicates a minimum number of eligible domains.
+                                When the number of eligible domains with matching topology keys is less than minDomains,
+                                Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                                And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                                this value has no effect on scheduling.
+                                As a result, when the number of eligible domains is less than minDomains,
+                                scheduler won't schedule more than maxSkew Pods to those domains.
+                                If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                                Valid values are integers greater than 0.
+                                When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                                For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                                labelSelector spread as 2/2/2:
+                                | zone1 | zone2 | zone3 |
+                                |  P P  |  P P  |  P P  |
+                                The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                                In this situation, new pod with the same labelSelector cannot be scheduled,
+                                because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                                it will violate MaxSkew.
+                              format: int32
+                              type: integer
+                            nodeAffinityPolicy:
+                              description: |-
+                                NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                                when calculating pod topology spread skew. Options are:
+                                - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                                - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                                If this value is nil, the behavior is equivalent to the Honor policy.
+                              type: string
+                            nodeTaintsPolicy:
+                              description: |-
+                                NodeTaintsPolicy indicates how we will treat node taints when calculating
+                                pod topology spread skew. Options are:
+                                - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                                has a toleration, are included.
+                                - Ignore: node taints are ignored. All nodes are included.
+
+                                If this value is nil, the behavior is equivalent to the Ignore policy.
+                              type: string
+                            topologyKey:
+                              description: |-
+                                TopologyKey is the key of node labels. Nodes that have a label with this key
+                                and identical values are considered to be in the same topology.
+                                We consider each <key, value> as a "bucket", and try to put balanced number
+                                of pods into each bucket.
+                                We define a domain as a particular instance of a topology.
+                                Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                                nodeAffinityPolicy and nodeTaintsPolicy.
+                                e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                                And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                                It's a required field.
+                              type: string
+                            whenUnsatisfiable:
+                              description: |-
+                                WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                                the spread constraint.
+                                - DoNotSchedule (default) tells the scheduler not to schedule it.
+                                - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                  but giving higher precedence to topologies that would help reduce the
+                                  skew.
+                                A constraint is considered "Unsatisfiable" for an incoming pod
+                                if and only if every possible node assignment for that pod would violate
+                                "MaxSkew" on some topology.
+                                For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                labelSelector spread as 3/1/1:
+                                | zone1 | zone2 | zone3 |
+                                | P P P |   P   |   P   |
+                                If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                                to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                                MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                                won't make it *more* imbalanced.
+                                It's a required field.
+                              type: string
+                          required:
+                          - maxSkew
+                          - topologyKey
+                          - whenUnsatisfiable
                           type: object
                         type: array
                       volumeMounts:

--- a/helm/kagent-crds/templates/kagent.dev_sandboxagents.yaml
+++ b/helm/kagent-crds/templates/kagent.dev_sandboxagents.yaml
@@ -3435,6 +3435,182 @@ spec:
                               type: string
                           type: object
                         type: array
+                      topologySpreadConstraints:
+                        description: |-
+                          TopologySpreadConstraints describes how a group of pods ought to spread across topology
+                          domains. All topologySpreadConstraints are ANDed.
+                        items:
+                          description: TopologySpreadConstraint specifies how to spread
+                            matching pods among the given topology.
+                          properties:
+                            labelSelector:
+                              description: |-
+                                LabelSelector is used to find matching pods.
+                                Pods that match this label selector are counted to determine the number of pods
+                                in their corresponding topology domain.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              description: |-
+                                MatchLabelKeys is a set of pod label keys to select the pods over which
+                                spreading will be calculated. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are ANDed with labelSelector
+                                to select the group of existing pods over which spreading will be calculated
+                                for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                Keys that don't exist in the incoming pod labels will
+                                be ignored. A null or empty list means only match against labelSelector.
+
+                                This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            maxSkew:
+                              description: |-
+                                MaxSkew describes the degree to which pods may be unevenly distributed.
+                                When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                                between the number of matching pods in the target topology and the global minimum.
+                                The global minimum is the minimum number of matching pods in an eligible domain
+                                or zero if the number of eligible domains is less than MinDomains.
+                                For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                labelSelector spread as 2/2/1:
+                                In this case, the global minimum is 1.
+                                | zone1 | zone2 | zone3 |
+                                |  P P  |  P P  |   P   |
+                                - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                                scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                                violate MaxSkew(1).
+                                - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                                When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                                to topologies that satisfy it.
+                                It's a required field. Default value is 1 and 0 is not allowed.
+                              format: int32
+                              type: integer
+                            minDomains:
+                              description: |-
+                                MinDomains indicates a minimum number of eligible domains.
+                                When the number of eligible domains with matching topology keys is less than minDomains,
+                                Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                                And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                                this value has no effect on scheduling.
+                                As a result, when the number of eligible domains is less than minDomains,
+                                scheduler won't schedule more than maxSkew Pods to those domains.
+                                If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                                Valid values are integers greater than 0.
+                                When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                                For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                                labelSelector spread as 2/2/2:
+                                | zone1 | zone2 | zone3 |
+                                |  P P  |  P P  |  P P  |
+                                The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                                In this situation, new pod with the same labelSelector cannot be scheduled,
+                                because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                                it will violate MaxSkew.
+                              format: int32
+                              type: integer
+                            nodeAffinityPolicy:
+                              description: |-
+                                NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                                when calculating pod topology spread skew. Options are:
+                                - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                                - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                                If this value is nil, the behavior is equivalent to the Honor policy.
+                              type: string
+                            nodeTaintsPolicy:
+                              description: |-
+                                NodeTaintsPolicy indicates how we will treat node taints when calculating
+                                pod topology spread skew. Options are:
+                                - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                                has a toleration, are included.
+                                - Ignore: node taints are ignored. All nodes are included.
+
+                                If this value is nil, the behavior is equivalent to the Ignore policy.
+                              type: string
+                            topologyKey:
+                              description: |-
+                                TopologyKey is the key of node labels. Nodes that have a label with this key
+                                and identical values are considered to be in the same topology.
+                                We consider each <key, value> as a "bucket", and try to put balanced number
+                                of pods into each bucket.
+                                We define a domain as a particular instance of a topology.
+                                Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                                nodeAffinityPolicy and nodeTaintsPolicy.
+                                e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                                And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                                It's a required field.
+                              type: string
+                            whenUnsatisfiable:
+                              description: |-
+                                WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                                the spread constraint.
+                                - DoNotSchedule (default) tells the scheduler not to schedule it.
+                                - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                  but giving higher precedence to topologies that would help reduce the
+                                  skew.
+                                A constraint is considered "Unsatisfiable" for an incoming pod
+                                if and only if every possible node assignment for that pod would violate
+                                "MaxSkew" on some topology.
+                                For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                labelSelector spread as 3/1/1:
+                                | zone1 | zone2 | zone3 |
+                                | P P P |   P   |   P   |
+                                If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                                to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                                MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                                won't make it *more* imbalanced.
+                                It's a required field.
+                              type: string
+                          required:
+                          - maxSkew
+                          - topologyKey
+                          - whenUnsatisfiable
+                          type: object
+                        type: array
                       volumeMounts:
                         description: VolumeMounts are additional volume mounts added
                           to the agent container.
@@ -8835,6 +9011,182 @@ spec:
                                 Value is the taint value the toleration matches to.
                                 If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
+                          type: object
+                        type: array
+                      topologySpreadConstraints:
+                        description: |-
+                          TopologySpreadConstraints describes how a group of pods ought to spread across topology
+                          domains. All topologySpreadConstraints are ANDed.
+                        items:
+                          description: TopologySpreadConstraint specifies how to spread
+                            matching pods among the given topology.
+                          properties:
+                            labelSelector:
+                              description: |-
+                                LabelSelector is used to find matching pods.
+                                Pods that match this label selector are counted to determine the number of pods
+                                in their corresponding topology domain.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              description: |-
+                                MatchLabelKeys is a set of pod label keys to select the pods over which
+                                spreading will be calculated. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are ANDed with labelSelector
+                                to select the group of existing pods over which spreading will be calculated
+                                for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                Keys that don't exist in the incoming pod labels will
+                                be ignored. A null or empty list means only match against labelSelector.
+
+                                This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            maxSkew:
+                              description: |-
+                                MaxSkew describes the degree to which pods may be unevenly distributed.
+                                When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                                between the number of matching pods in the target topology and the global minimum.
+                                The global minimum is the minimum number of matching pods in an eligible domain
+                                or zero if the number of eligible domains is less than MinDomains.
+                                For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                labelSelector spread as 2/2/1:
+                                In this case, the global minimum is 1.
+                                | zone1 | zone2 | zone3 |
+                                |  P P  |  P P  |   P   |
+                                - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                                scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                                violate MaxSkew(1).
+                                - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                                When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                                to topologies that satisfy it.
+                                It's a required field. Default value is 1 and 0 is not allowed.
+                              format: int32
+                              type: integer
+                            minDomains:
+                              description: |-
+                                MinDomains indicates a minimum number of eligible domains.
+                                When the number of eligible domains with matching topology keys is less than minDomains,
+                                Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                                And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                                this value has no effect on scheduling.
+                                As a result, when the number of eligible domains is less than minDomains,
+                                scheduler won't schedule more than maxSkew Pods to those domains.
+                                If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                                Valid values are integers greater than 0.
+                                When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                                For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                                labelSelector spread as 2/2/2:
+                                | zone1 | zone2 | zone3 |
+                                |  P P  |  P P  |  P P  |
+                                The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                                In this situation, new pod with the same labelSelector cannot be scheduled,
+                                because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                                it will violate MaxSkew.
+                              format: int32
+                              type: integer
+                            nodeAffinityPolicy:
+                              description: |-
+                                NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                                when calculating pod topology spread skew. Options are:
+                                - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                                - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                                If this value is nil, the behavior is equivalent to the Honor policy.
+                              type: string
+                            nodeTaintsPolicy:
+                              description: |-
+                                NodeTaintsPolicy indicates how we will treat node taints when calculating
+                                pod topology spread skew. Options are:
+                                - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                                has a toleration, are included.
+                                - Ignore: node taints are ignored. All nodes are included.
+
+                                If this value is nil, the behavior is equivalent to the Ignore policy.
+                              type: string
+                            topologyKey:
+                              description: |-
+                                TopologyKey is the key of node labels. Nodes that have a label with this key
+                                and identical values are considered to be in the same topology.
+                                We consider each <key, value> as a "bucket", and try to put balanced number
+                                of pods into each bucket.
+                                We define a domain as a particular instance of a topology.
+                                Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                                nodeAffinityPolicy and nodeTaintsPolicy.
+                                e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                                And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                                It's a required field.
+                              type: string
+                            whenUnsatisfiable:
+                              description: |-
+                                WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                                the spread constraint.
+                                - DoNotSchedule (default) tells the scheduler not to schedule it.
+                                - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                  but giving higher precedence to topologies that would help reduce the
+                                  skew.
+                                A constraint is considered "Unsatisfiable" for an incoming pod
+                                if and only if every possible node assignment for that pod would violate
+                                "MaxSkew" on some topology.
+                                For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                labelSelector spread as 3/1/1:
+                                | zone1 | zone2 | zone3 |
+                                | P P P |   P   |   P   |
+                                If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                                to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                                MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                                won't make it *more* imbalanced.
+                                It's a required field.
+                              type: string
+                          required:
+                          - maxSkew
+                          - topologyKey
+                          - whenUnsatisfiable
                           type: object
                         type: array
                       volumeMounts:


### PR DESCRIPTION
Users could set affinity/tolerations on agent pods but had no way to spread agent replicas across topology domains (zones, hosts, regions). 

Adds `topologySpreadConstraints` to SharedDeploymentSpec so it applies to both Declarative and BYO agents, plus SandboxAgent via its shared deployment embed
 Controller threads the field through resolvedDeployment into the rendered PodSpec.