### PR TITLE
ci: always run the UI Playwright suite

### DIFF
--- a/.github/workflows/ui-playwright.yaml
+++ b/.github/workflows/ui-playwright.yaml
@@ -10,12 +10,8 @@ name: UI Playwright E2E
 on:
   push:
     branches: [main, "release/**"]
-    paths:
-      - "ui/**"
   pull_request:
     branches: [main, "release/**"]
-    paths:
-      - "ui/**"
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Description

---
*🤖 written by Claude (start)*

## Changelog

NONE

## Testing

1. On this PR (no `ui/**` files changed), confirm a `playwright` check is reported — before this change it was absent entirely, so the required check could never be satisfied.
2. On a PR that does touch `ui/**`, confirm the suite still runs as it did.

## Additional Notes

This trades CI time for an unblockable required check: the suite now runs on every PR rather than only `ui/**` ones. That also reflects what it actually exercises — it drives a live in-cluster controller, so backend changes can break it. The existing `concurrency` block still cancels superseded runs.

---
*🤖 written by Claude (end)*
