### PR TITLE
Backport 2387 to 0.10.x release branch

### DIFF
--- a/.github/workflows/ui-playwright.yaml
+++ b/.github/workflows/ui-playwright.yaml
@@ -10,12 +10,8 @@ name: UI Playwright E2E
 on:
   push:
     branches: [main, "release/**"]
-    paths:
-      - "ui/**"
   pull_request:
     branches: [main, "release/**"]
-    paths:
-      - "ui/**"
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Description

---
*🤖 written by Claude (start)*

Backport of #2387 to `release/v0.10.x` — same 4-line change, cherry-picked cleanly.

## Changelog

NONE

## Testing

1. On this PR (no `ui/**` files changed), confirm a `playwright` check is reported — before this change it was absent entirely, so the required check could never be satisfied on this branch either.
2. On a PR into `release/v0.10.x` that does touch `ui/**`, confirm the suite still runs as it did.

## Additional Notes

The branch ruleset requiring `playwright` applies to `refs/heads/release/*` as well as the default branch, so this branch had the same merge blocker: a path-filtered workflow reports no status at all on a PR that misses the filter. Dropping the filter also reflects what the suite exercises — it drives a live in-cluster controller, so backend changes can break it. The existing `concurrency` block still cancels superseded runs.

---
*🤖 written by Claude (end)*
