### PR TITLE
Backport 2409 (db session cleanup) to 0.10.x release

### DIFF
--- a/go/api/database/client.go
+++ b/go/api/database/client.go
@@ -94,4 +94,9 @@ type Client interface {
 	ListAgentMemories(ctx context.Context, agentName, userID string) ([]Memory, error)
 	DeleteAgentMemory(ctx context.Context, agentName, userID string) error
 	PruneExpiredMemories(ctx context.Context) error
+
+	// PruneExpiredSessions hard-deletes idle sessions older than retentionDays
+	// (sliding window on updated_at) and cascaded conversation state. No-op when
+	// retentionDays <= 0. Returns the number of sessions deleted.
+	PruneExpiredSessions(ctx context.Context, retentionDays int) (int64, error)
 }

--- a/go/core/internal/database/client_postgres.go
+++ b/go/core/internal/database/client_postgres.go
@@ -836,6 +836,37 @@ func (c *postgresClient) PruneExpiredMemories(ctx context.Context) error {
 	})
 }
 
+const sessionRetentionBatchSize int32 = 1000
+
+func (c *postgresClient) PruneExpiredSessions(ctx context.Context, retentionDays int) (int64, error) {
+	if retentionDays <= 0 {
+		return 0, nil
+	}
+	var total int64
+	for {
+		var n int64
+		err := c.withTx(ctx, func(q *dbgen.Queries) error {
+			var err error
+			n, err = q.DeleteExpiredSessionsBatch(ctx, dbgen.DeleteExpiredSessionsBatchParams{
+				RetentionDays: int32(retentionDays),
+				BatchSize:     sessionRetentionBatchSize,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to delete expired sessions batch: %w", err)
+			}
+			return nil
+		})
+		if err != nil {
+			return total, err
+		}
+		total += n
+		if n == 0 {
+			break
+		}
+	}
+	return total, nil
+}
+
 // ── Conversion helpers ────────────────────────────────────────────────────────
 
 func toAgent(r dbgen.Agent) *dbpkg.Agent {

--- a/go/core/internal/database/client_test.go
+++ b/go/core/internal/database/client_test.go
@@ -589,7 +589,8 @@ func setupTestDB(t *testing.T) *pgxpool.Pool {
 		TRUNCATE TABLE
 			agent, session, event, task, push_notification, feedback,
 			tool, toolserver, lg_checkpoint, lg_checkpoint_write,
-			crewai_agent_memory, crewai_flow_state, memory
+			crewai_agent_memory, crewai_flow_state, memory,
+			session_share, session_share_access
 		RESTART IDENTITY CASCADE
 	`)
 	require.NoError(t, err, "Failed to truncate test tables")
@@ -919,6 +920,122 @@ func TestPruneExpiredMemories(t *testing.T) {
 	assert.Contains(t, ids, hotMem.ID, "Expired popular memory should have TTL extended and be retained")
 	assert.Contains(t, ids, liveMem.ID, "Non-expired memory should be retained")
 }
+
+func countRows(t *testing.T, db *pgxpool.Pool, query string, args ...any) int64 {
+	t.Helper()
+	var n int64
+	require.NoError(t, db.QueryRow(context.Background(), query, args...).Scan(&n))
+	return n
+}
+
+func ageSession(t *testing.T, db *pgxpool.Pool, sessionID, userID string, updatedAt time.Time) {
+	t.Helper()
+	_, err := db.Exec(context.Background(),
+		`UPDATE session SET updated_at = $1 WHERE id = $2 AND user_id = $3`,
+		updatedAt, sessionID, userID)
+	require.NoError(t, err)
+}
+
+// TestPruneExpiredSessions verifies sliding-window hard-delete of idle sessions
+// and cascaded conversation state.
+func TestPruneExpiredSessions(t *testing.T) {
+	db := setupTestDB(t)
+	client := NewClient(db)
+	ctx := context.Background()
+
+	const (
+		userID     = "prune-sess-user"
+		oldSessID  = "old-session"
+		liveSessID = "live-session"
+		softSessID = "soft-deleted-session"
+	)
+
+	require.NoError(t, client.StoreSession(ctx, &dbpkg.Session{ID: oldSessID, UserID: userID, Name: strPtr("old")}))
+	require.NoError(t, client.StoreSession(ctx, &dbpkg.Session{ID: liveSessID, UserID: userID, Name: strPtr("live")}))
+	require.NoError(t, client.StoreSession(ctx, &dbpkg.Session{ID: softSessID, UserID: userID, Name: strPtr("soft")}))
+
+	require.NoError(t, client.StoreEvents(ctx, &dbpkg.Event{
+		ID: "ev-old", UserID: userID, SessionID: oldSessID, Data: `{"role":"user"}`,
+	}))
+	require.NoError(t, client.StoreEvents(ctx, &dbpkg.Event{
+		ID: "ev-live", UserID: userID, SessionID: liveSessID, Data: `{"role":"user"}`,
+	}))
+
+	require.NoError(t, client.StoreTask(ctx, &a2a.Task{ID: "task-old", ContextID: oldSessID}, userID))
+	require.NoError(t, client.StoreTask(ctx, &a2a.Task{ID: "task-live", ContextID: liveSessID}, userID))
+
+	_, err := db.Exec(ctx, `
+		INSERT INTO push_notification (id, task_id, data, created_at, updated_at)
+		VALUES ('push-old', 'task-old', '{}', NOW(), NOW()),
+		       ('push-live', 'task-live', '{}', NOW(), NOW())`)
+	require.NoError(t, err)
+
+	require.NoError(t, client.StoreCheckpoint(ctx, &dbpkg.LangGraphCheckpoint{
+		UserID: userID, ThreadID: oldSessID, CheckpointNS: "", CheckpointID: "cp-old",
+		Metadata: "{}", Checkpoint: "{}", CheckpointType: "json", Version: 1,
+	}))
+	require.NoError(t, client.StoreCheckpointWrites(ctx, []*dbpkg.LangGraphCheckpointWrite{{
+		UserID: userID, ThreadID: oldSessID, CheckpointNS: "", CheckpointID: "cp-old",
+		WriteIdx: 0, Value: "{}", ValueType: "json", Channel: "ch", TaskID: "t",
+	}}))
+	require.NoError(t, client.StoreCheckpoint(ctx, &dbpkg.LangGraphCheckpoint{
+		UserID: userID, ThreadID: liveSessID, CheckpointNS: "", CheckpointID: "cp-live",
+		Metadata: "{}", Checkpoint: "{}", CheckpointType: "json", Version: 1,
+	}))
+
+	require.NoError(t, client.StoreCrewAIMemory(ctx, &dbpkg.CrewAIAgentMemory{
+		UserID: userID, ThreadID: oldSessID, MemoryData: `{"task_description":"old"}`,
+	}))
+	require.NoError(t, client.StoreCrewAIFlowState(ctx, &dbpkg.CrewAIFlowState{
+		UserID: userID, ThreadID: oldSessID, MethodName: "start", StateData: `{}`,
+	}))
+
+	_, err = client.CreateSessionShare(ctx, &dbpkg.SessionShare{
+		Token: "share-old", SessionID: oldSessID, UserID: userID, ReadOnly: true,
+	})
+	require.NoError(t, err)
+
+	// Soft-delete one aged session — prune should still hard-delete it.
+	require.NoError(t, client.DeleteSession(ctx, softSessID, userID))
+
+	stale := time.Now().Add(-48 * time.Hour)
+	ageSession(t, db, oldSessID, userID, stale)
+	ageSession(t, db, softSessID, userID, stale)
+	// live session keeps a fresh updated_at from StoreEvents/StoreTask above
+
+	// retentionDays == 0 is a no-op
+	deleted, err := client.PruneExpiredSessions(ctx, 0)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), deleted)
+	assert.Equal(t, int64(1), countRows(t, db, `SELECT COUNT(*) FROM session WHERE id = $1`, oldSessID))
+
+	deleted, err = client.PruneExpiredSessions(ctx, 1)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), deleted, "old + soft-deleted sessions should be pruned")
+
+	assert.Equal(t, int64(0), countRows(t, db, `SELECT COUNT(*) FROM session WHERE id = $1`, oldSessID))
+	assert.Equal(t, int64(0), countRows(t, db, `SELECT COUNT(*) FROM session WHERE id = $1`, softSessID))
+	assert.Equal(t, int64(1), countRows(t, db, `SELECT COUNT(*) FROM session WHERE id = $1`, liveSessID))
+
+	assert.Equal(t, int64(0), countRows(t, db, `SELECT COUNT(*) FROM event WHERE session_id = $1`, oldSessID))
+	assert.Equal(t, int64(1), countRows(t, db, `SELECT COUNT(*) FROM event WHERE session_id = $1`, liveSessID))
+
+	assert.Equal(t, int64(0), countRows(t, db, `SELECT COUNT(*) FROM task WHERE id = $1`, "task-old"))
+	assert.Equal(t, int64(1), countRows(t, db, `SELECT COUNT(*) FROM task WHERE id = $1`, "task-live"))
+
+	assert.Equal(t, int64(0), countRows(t, db, `SELECT COUNT(*) FROM push_notification WHERE id = $1`, "push-old"))
+	assert.Equal(t, int64(1), countRows(t, db, `SELECT COUNT(*) FROM push_notification WHERE id = $1`, "push-live"))
+
+	assert.Equal(t, int64(0), countRows(t, db, `SELECT COUNT(*) FROM lg_checkpoint WHERE thread_id = $1`, oldSessID))
+	assert.Equal(t, int64(0), countRows(t, db, `SELECT COUNT(*) FROM lg_checkpoint_write WHERE thread_id = $1`, oldSessID))
+	assert.Equal(t, int64(1), countRows(t, db, `SELECT COUNT(*) FROM lg_checkpoint WHERE thread_id = $1`, liveSessID))
+
+	assert.Equal(t, int64(0), countRows(t, db, `SELECT COUNT(*) FROM crewai_agent_memory WHERE thread_id = $1`, oldSessID))
+	assert.Equal(t, int64(0), countRows(t, db, `SELECT COUNT(*) FROM crewai_flow_state WHERE thread_id = $1`, oldSessID))
+	assert.Equal(t, int64(0), countRows(t, db, `SELECT COUNT(*) FROM session_share WHERE session_id = $1`, oldSessID))
+}
+
+func strPtr(s string) *string { return &s }
 
 // TestSearchAgentMemoryConcurrentAccessCount verifies concurrent searches over
 // overlapping rows do not deadlock when incrementing access_count and still

--- a/go/core/internal/database/client_test.go
+++ b/go/core/internal/database/client_test.go
@@ -950,9 +950,9 @@ func TestPruneExpiredSessions(t *testing.T) {
 		softSessID = "soft-deleted-session"
 	)
 
-	require.NoError(t, client.StoreSession(ctx, &dbpkg.Session{ID: oldSessID, UserID: userID, Name: strPtr("old")}))
-	require.NoError(t, client.StoreSession(ctx, &dbpkg.Session{ID: liveSessID, UserID: userID, Name: strPtr("live")}))
-	require.NoError(t, client.StoreSession(ctx, &dbpkg.Session{ID: softSessID, UserID: userID, Name: strPtr("soft")}))
+	require.NoError(t, client.StoreSession(ctx, &dbpkg.Session{ID: oldSessID, UserID: userID, Name: new("old")}))
+	require.NoError(t, client.StoreSession(ctx, &dbpkg.Session{ID: liveSessID, UserID: userID, Name: new("live")}))
+	require.NoError(t, client.StoreSession(ctx, &dbpkg.Session{ID: softSessID, UserID: userID, Name: new("soft")}))
 
 	require.NoError(t, client.StoreEvents(ctx, &dbpkg.Event{
 		ID: "ev-old", UserID: userID, SessionID: oldSessID, Data: `{"role":"user"}`,
@@ -1034,8 +1034,6 @@ func TestPruneExpiredSessions(t *testing.T) {
 	assert.Equal(t, int64(0), countRows(t, db, `SELECT COUNT(*) FROM crewai_flow_state WHERE thread_id = $1`, oldSessID))
 	assert.Equal(t, int64(0), countRows(t, db, `SELECT COUNT(*) FROM session_share WHERE session_id = $1`, oldSessID))
 }
-
-func strPtr(s string) *string { return &s }
 
 // TestSearchAgentMemoryConcurrentAccessCount verifies concurrent searches over
 // overlapping rows do not deadlock when incrementing access_count and still

--- a/go/core/internal/database/gen/querier.go
+++ b/go/core/internal/database/gen/querier.go
@@ -14,6 +14,7 @@ type Querier interface {
 	DeleteExpiredMemories(ctx context.Context) error
 	// DeleteExpiredSessionsBatch hard-deletes up to batch_size idle sessions whose
 	// updated_at is older than retention_days, plus cascaded conversation state.
+	// Soft-deleted sessions are included so tombstones still reclaim disk.
 	DeleteExpiredSessionsBatch(ctx context.Context, arg DeleteExpiredSessionsBatchParams) (int64, error)
 	DeleteSessionShare(ctx context.Context, arg DeleteSessionShareParams) error
 	ExtendMemoryTTL(ctx context.Context) error

--- a/go/core/internal/database/gen/querier.go
+++ b/go/core/internal/database/gen/querier.go
@@ -12,6 +12,9 @@ type Querier interface {
 	CreateSessionShare(ctx context.Context, arg CreateSessionShareParams) (SessionShare, error)
 	DeleteAgentMemory(ctx context.Context, arg DeleteAgentMemoryParams) error
 	DeleteExpiredMemories(ctx context.Context) error
+	// DeleteExpiredSessionsBatch hard-deletes up to batch_size idle sessions whose
+	// updated_at is older than retention_days, plus cascaded conversation state.
+	DeleteExpiredSessionsBatch(ctx context.Context, arg DeleteExpiredSessionsBatchParams) (int64, error)
 	DeleteSessionShare(ctx context.Context, arg DeleteSessionShareParams) error
 	ExtendMemoryTTL(ctx context.Context) error
 	GetAgent(ctx context.Context, id string) (Agent, error)

--- a/go/core/internal/database/gen/sessions.sql.go
+++ b/go/core/internal/database/gen/sessions.sql.go
@@ -10,6 +10,80 @@ import (
 	"time"
 )
 
+const deleteExpiredSessionsBatch = `-- name: DeleteExpiredSessionsBatch :one
+WITH expired AS (
+    SELECT id, user_id
+    FROM session
+    WHERE updated_at < NOW() - make_interval(days => $1::int)
+    ORDER BY updated_at ASC
+    LIMIT $2
+),
+del_shares AS (
+    DELETE FROM session_share ss
+    USING expired e
+    WHERE ss.session_id = e.id AND ss.user_id = e.user_id
+),
+del_events AS (
+    DELETE FROM event ev
+    USING expired e
+    WHERE ev.session_id = e.id AND ev.user_id = e.user_id
+),
+del_push AS (
+    DELETE FROM push_notification pn
+    USING task t, expired e
+    WHERE pn.task_id = t.id
+      AND t.session_id = e.id
+      AND COALESCE(t.user_id, e.user_id) = e.user_id
+),
+del_tasks AS (
+    DELETE FROM task t
+    USING expired e
+    WHERE t.session_id = e.id
+      AND COALESCE(t.user_id, e.user_id) = e.user_id
+),
+del_cp_writes AS (
+    DELETE FROM lg_checkpoint_write w
+    USING expired e
+    WHERE w.user_id = e.user_id AND w.thread_id = e.id
+),
+del_cps AS (
+    DELETE FROM lg_checkpoint c
+    USING expired e
+    WHERE c.user_id = e.user_id AND c.thread_id = e.id
+),
+del_crewai_mem AS (
+    DELETE FROM crewai_agent_memory m
+    USING expired e
+    WHERE m.user_id = e.user_id AND m.thread_id = e.id
+),
+del_crewai_flow AS (
+    DELETE FROM crewai_flow_state f
+    USING expired e
+    WHERE f.user_id = e.user_id AND f.thread_id = e.id
+),
+del_sessions AS (
+    DELETE FROM session s
+    USING expired e
+    WHERE s.id = e.id AND s.user_id = e.user_id
+    RETURNING s.id
+)
+SELECT COUNT(*)::bigint AS deleted FROM del_sessions
+`
+
+type DeleteExpiredSessionsBatchParams struct {
+	RetentionDays int32
+	BatchSize     int32
+}
+
+// DeleteExpiredSessionsBatch hard-deletes up to batch_size idle sessions whose
+// updated_at is older than retention_days, plus cascaded conversation state.
+func (q *Queries) DeleteExpiredSessionsBatch(ctx context.Context, arg DeleteExpiredSessionsBatchParams) (int64, error) {
+	row := q.db.QueryRow(ctx, deleteExpiredSessionsBatch, arg.RetentionDays, arg.BatchSize)
+	var deleted int64
+	err := row.Scan(&deleted)
+	return deleted, err
+}
+
 const getSession = `-- name: GetSession :one
 SELECT id, user_id, name, created_at, updated_at, deleted_at, agent_id, source FROM session
 WHERE id = $1 AND user_id = $2 AND deleted_at IS NULL

--- a/go/core/internal/database/gen/sessions.sql.go
+++ b/go/core/internal/database/gen/sessions.sql.go
@@ -17,55 +17,56 @@ WITH expired AS (
     WHERE updated_at < NOW() - make_interval(days => $1::int)
     ORDER BY updated_at ASC
     LIMIT $2
-),
-del_shares AS (
-    DELETE FROM session_share ss
-    USING expired e
-    WHERE ss.session_id = e.id AND ss.user_id = e.user_id
-),
-del_events AS (
-    DELETE FROM event ev
-    USING expired e
-    WHERE ev.session_id = e.id AND ev.user_id = e.user_id
-),
-del_push AS (
-    DELETE FROM push_notification pn
-    USING task t, expired e
-    WHERE pn.task_id = t.id
-      AND t.session_id = e.id
-      AND COALESCE(t.user_id, e.user_id) = e.user_id
-),
-del_tasks AS (
-    DELETE FROM task t
-    USING expired e
-    WHERE t.session_id = e.id
-      AND COALESCE(t.user_id, e.user_id) = e.user_id
-),
-del_cp_writes AS (
-    DELETE FROM lg_checkpoint_write w
-    USING expired e
-    WHERE w.user_id = e.user_id AND w.thread_id = e.id
-),
-del_cps AS (
-    DELETE FROM lg_checkpoint c
-    USING expired e
-    WHERE c.user_id = e.user_id AND c.thread_id = e.id
-),
-del_crewai_mem AS (
-    DELETE FROM crewai_agent_memory m
-    USING expired e
-    WHERE m.user_id = e.user_id AND m.thread_id = e.id
-),
-del_crewai_flow AS (
-    DELETE FROM crewai_flow_state f
-    USING expired e
-    WHERE f.user_id = e.user_id AND f.thread_id = e.id
+    FOR UPDATE SKIP LOCKED
 ),
 del_sessions AS (
     DELETE FROM session s
     USING expired e
     WHERE s.id = e.id AND s.user_id = e.user_id
-    RETURNING s.id
+    RETURNING s.id, s.user_id
+),
+del_shares AS (
+    DELETE FROM session_share ss
+    USING del_sessions d
+    WHERE ss.session_id = d.id AND ss.user_id = d.user_id
+),
+del_events AS (
+    DELETE FROM event ev
+    USING del_sessions d
+    WHERE ev.session_id = d.id AND ev.user_id = d.user_id
+),
+del_push AS (
+    DELETE FROM push_notification pn
+    USING task t, del_sessions d
+    WHERE pn.task_id = t.id
+      AND t.session_id = d.id
+      AND COALESCE(t.user_id, d.user_id) = d.user_id
+),
+del_tasks AS (
+    DELETE FROM task t
+    USING del_sessions d
+    WHERE t.session_id = d.id
+      AND COALESCE(t.user_id, d.user_id) = d.user_id
+),
+del_cp_writes AS (
+    DELETE FROM lg_checkpoint_write w
+    USING del_sessions d
+    WHERE w.user_id = d.user_id AND w.thread_id = d.id
+),
+del_cps AS (
+    DELETE FROM lg_checkpoint c
+    USING del_sessions d
+    WHERE c.user_id = d.user_id AND c.thread_id = d.id
+),
+del_crewai_mem AS (
+    DELETE FROM crewai_agent_memory m
+    USING del_sessions d
+    WHERE m.user_id = d.user_id AND m.thread_id = d.id
+),
+del_crewai_flow AS (
+    DELETE FROM crewai_flow_state f
+    USING del_sessions d
+    WHERE f.user_id = d.user_id AND f.thread_id = d.id
 )
 SELECT COUNT(*)::bigint AS deleted FROM del_sessions
 `
@@ -77,6 +78,7 @@ type DeleteExpiredSessionsBatchParams struct {
 
 // DeleteExpiredSessionsBatch hard-deletes up to batch_size idle sessions whose
 // updated_at is older than retention_days, plus cascaded conversation state.
+// Soft-deleted sessions are included so tombstones still reclaim disk.
 func (q *Queries) DeleteExpiredSessionsBatch(ctx context.Context, arg DeleteExpiredSessionsBatchParams) (int64, error) {
 	row := q.db.QueryRow(ctx, deleteExpiredSessionsBatch, arg.RetentionDays, arg.BatchSize)
 	var deleted int64

--- a/go/core/internal/database/queries/sessions.sql
+++ b/go/core/internal/database/queries/sessions.sql
@@ -47,6 +47,7 @@ WHERE id = $1 AND user_id = $2 AND deleted_at IS NULL;
 
 -- DeleteExpiredSessionsBatch hard-deletes up to batch_size idle sessions whose
 -- updated_at is older than retention_days, plus cascaded conversation state.
+-- Soft-deleted sessions are included so tombstones still reclaim disk.
 -- name: DeleteExpiredSessionsBatch :one
 WITH expired AS (
     SELECT id, user_id
@@ -54,54 +55,55 @@ WITH expired AS (
     WHERE updated_at < NOW() - make_interval(days => sqlc.arg(retention_days)::int)
     ORDER BY updated_at ASC
     LIMIT sqlc.arg(batch_size)
-),
-del_shares AS (
-    DELETE FROM session_share ss
-    USING expired e
-    WHERE ss.session_id = e.id AND ss.user_id = e.user_id
-),
-del_events AS (
-    DELETE FROM event ev
-    USING expired e
-    WHERE ev.session_id = e.id AND ev.user_id = e.user_id
-),
-del_push AS (
-    DELETE FROM push_notification pn
-    USING task t, expired e
-    WHERE pn.task_id = t.id
-      AND t.session_id = e.id
-      AND COALESCE(t.user_id, e.user_id) = e.user_id
-),
-del_tasks AS (
-    DELETE FROM task t
-    USING expired e
-    WHERE t.session_id = e.id
-      AND COALESCE(t.user_id, e.user_id) = e.user_id
-),
-del_cp_writes AS (
-    DELETE FROM lg_checkpoint_write w
-    USING expired e
-    WHERE w.user_id = e.user_id AND w.thread_id = e.id
-),
-del_cps AS (
-    DELETE FROM lg_checkpoint c
-    USING expired e
-    WHERE c.user_id = e.user_id AND c.thread_id = e.id
-),
-del_crewai_mem AS (
-    DELETE FROM crewai_agent_memory m
-    USING expired e
-    WHERE m.user_id = e.user_id AND m.thread_id = e.id
-),
-del_crewai_flow AS (
-    DELETE FROM crewai_flow_state f
-    USING expired e
-    WHERE f.user_id = e.user_id AND f.thread_id = e.id
+    FOR UPDATE SKIP LOCKED
 ),
 del_sessions AS (
     DELETE FROM session s
     USING expired e
     WHERE s.id = e.id AND s.user_id = e.user_id
-    RETURNING s.id
+    RETURNING s.id, s.user_id
+),
+del_shares AS (
+    DELETE FROM session_share ss
+    USING del_sessions d
+    WHERE ss.session_id = d.id AND ss.user_id = d.user_id
+),
+del_events AS (
+    DELETE FROM event ev
+    USING del_sessions d
+    WHERE ev.session_id = d.id AND ev.user_id = d.user_id
+),
+del_push AS (
+    DELETE FROM push_notification pn
+    USING task t, del_sessions d
+    WHERE pn.task_id = t.id
+      AND t.session_id = d.id
+      AND COALESCE(t.user_id, d.user_id) = d.user_id
+),
+del_tasks AS (
+    DELETE FROM task t
+    USING del_sessions d
+    WHERE t.session_id = d.id
+      AND COALESCE(t.user_id, d.user_id) = d.user_id
+),
+del_cp_writes AS (
+    DELETE FROM lg_checkpoint_write w
+    USING del_sessions d
+    WHERE w.user_id = d.user_id AND w.thread_id = d.id
+),
+del_cps AS (
+    DELETE FROM lg_checkpoint c
+    USING del_sessions d
+    WHERE c.user_id = d.user_id AND c.thread_id = d.id
+),
+del_crewai_mem AS (
+    DELETE FROM crewai_agent_memory m
+    USING del_sessions d
+    WHERE m.user_id = d.user_id AND m.thread_id = d.id
+),
+del_crewai_flow AS (
+    DELETE FROM crewai_flow_state f
+    USING del_sessions d
+    WHERE f.user_id = d.user_id AND f.thread_id = d.id
 )
 SELECT COUNT(*)::bigint AS deleted FROM del_sessions;

--- a/go/core/internal/database/queries/sessions.sql
+++ b/go/core/internal/database/queries/sessions.sql
@@ -44,3 +44,64 @@ ON CONFLICT (id, user_id) DO UPDATE SET
 -- name: SoftDeleteSession :exec
 UPDATE session SET deleted_at = NOW()
 WHERE id = $1 AND user_id = $2 AND deleted_at IS NULL;
+
+-- DeleteExpiredSessionsBatch hard-deletes up to batch_size idle sessions whose
+-- updated_at is older than retention_days, plus cascaded conversation state.
+-- name: DeleteExpiredSessionsBatch :one
+WITH expired AS (
+    SELECT id, user_id
+    FROM session
+    WHERE updated_at < NOW() - make_interval(days => sqlc.arg(retention_days)::int)
+    ORDER BY updated_at ASC
+    LIMIT sqlc.arg(batch_size)
+),
+del_shares AS (
+    DELETE FROM session_share ss
+    USING expired e
+    WHERE ss.session_id = e.id AND ss.user_id = e.user_id
+),
+del_events AS (
+    DELETE FROM event ev
+    USING expired e
+    WHERE ev.session_id = e.id AND ev.user_id = e.user_id
+),
+del_push AS (
+    DELETE FROM push_notification pn
+    USING task t, expired e
+    WHERE pn.task_id = t.id
+      AND t.session_id = e.id
+      AND COALESCE(t.user_id, e.user_id) = e.user_id
+),
+del_tasks AS (
+    DELETE FROM task t
+    USING expired e
+    WHERE t.session_id = e.id
+      AND COALESCE(t.user_id, e.user_id) = e.user_id
+),
+del_cp_writes AS (
+    DELETE FROM lg_checkpoint_write w
+    USING expired e
+    WHERE w.user_id = e.user_id AND w.thread_id = e.id
+),
+del_cps AS (
+    DELETE FROM lg_checkpoint c
+    USING expired e
+    WHERE c.user_id = e.user_id AND c.thread_id = e.id
+),
+del_crewai_mem AS (
+    DELETE FROM crewai_agent_memory m
+    USING expired e
+    WHERE m.user_id = e.user_id AND m.thread_id = e.id
+),
+del_crewai_flow AS (
+    DELETE FROM crewai_flow_state f
+    USING expired e
+    WHERE f.user_id = e.user_id AND f.thread_id = e.id
+),
+del_sessions AS (
+    DELETE FROM session s
+    USING expired e
+    WHERE s.id = e.id AND s.user_id = e.user_id
+    RETURNING s.id
+)
+SELECT COUNT(*)::bigint AS deleted FROM del_sessions;

--- a/go/core/internal/httpserver/server.go
+++ b/go/core/internal/httpserver/server.go
@@ -159,31 +159,38 @@ func (s *HTTPServer) Start(ctx context.Context) error {
 	return nil
 }
 
-// MemoryCleanupRunnable is a controller-runtime Runnable that periodically
-// prunes expired memory entries. It implements NeedLeaderElection so that
-// the sweep only runs on the elected leader, preventing duplicate deletes
-// when multiple replicas are deployed.
-type MemoryCleanupRunnable struct {
-	DbClient dbpkg.Client
-	Interval time.Duration
+// DbCleanupRunnable is a controller-runtime Runnable that periodically
+// prunes expired DB rows (memory TTL, and when configured idle sessions).
+// It implements NeedLeaderElection so that the sweep only runs on the
+// elected leader, preventing duplicate deletes when multiple replicas are
+// deployed.
+type DbCleanupRunnable struct {
+	DbClient             dbpkg.Client
+	Interval             time.Duration
+	SessionRetentionDays int
 }
 
-func (m *MemoryCleanupRunnable) NeedLeaderElection() bool { return true }
+func (m *DbCleanupRunnable) NeedLeaderElection() bool { return true }
 
-// NewMemoryCleanupRunnable returns a MemoryCleanupRunnable with the given
-// database client. interval controls how often the cleanup runs; pass 0 to
-// use the default of 24 hours.
-func NewMemoryCleanupRunnable(dbClient dbpkg.Client, interval time.Duration) *MemoryCleanupRunnable {
+// NewDbCleanupRunnable returns a DbCleanupRunnable with the given database
+// client. interval controls how often the cleanup runs; pass 0 to use the
+// default of 24 hours. sessionRetentionDays is passed through to
+// PruneExpiredSessions (0 disables session cleanup).
+func NewDbCleanupRunnable(dbClient dbpkg.Client, interval time.Duration, sessionRetentionDays int) *DbCleanupRunnable {
 	if interval <= 0 {
 		interval = 24 * time.Hour
 	}
-	return &MemoryCleanupRunnable{DbClient: dbClient, Interval: interval}
+	return &DbCleanupRunnable{
+		DbClient:             dbClient,
+		Interval:             interval,
+		SessionRetentionDays: sessionRetentionDays,
+	}
 }
 
 // Start runs the periodic cleanup loop until ctx is cancelled.
-func (m *MemoryCleanupRunnable) Start(ctx context.Context) error {
-	log := ctrllog.FromContext(ctx).WithName("memory-cleanup")
-	log.Info("Starting memory TTL cleanup loop", "interval", m.Interval)
+func (m *DbCleanupRunnable) Start(ctx context.Context) error {
+	log := ctrllog.FromContext(ctx).WithName("db-cleanup")
+	log.Info("Starting DB TTL cleanup loop", "interval", m.Interval, "sessionRetentionDays", m.SessionRetentionDays)
 	ticker := time.NewTicker(m.Interval)
 	defer ticker.Stop()
 	for {
@@ -191,6 +198,11 @@ func (m *MemoryCleanupRunnable) Start(ctx context.Context) error {
 		case <-ticker.C:
 			if err := m.DbClient.PruneExpiredMemories(ctx); err != nil {
 				log.Error(err, "Failed to prune expired memories")
+			}
+			if deleted, err := m.DbClient.PruneExpiredSessions(ctx, m.SessionRetentionDays); err != nil {
+				log.Error(err, "Failed to prune expired sessions")
+			} else if deleted > 0 {
+				log.Info("Pruned expired sessions", "deleted", deleted)
 			}
 		case <-ctx.Done():
 			return nil

--- a/go/core/pkg/app/app.go
+++ b/go/core/pkg/app/app.go
@@ -137,14 +137,15 @@ type Config struct {
 	// that originates TLS upstream. Off by default;
 	MCPEgressPlaintext bool
 	Database           struct {
-		Url             string
-		UrlFile         string
-		VectorEnabled   bool
-		SkipMigrations  bool
-		MaxConns        int           // 0 = unset (pgx default)
-		MinConns        int           // -1 = unset (pgx default); 0 is a valid value
-		MaxConnIdleTime time.Duration // 0 = unset (pgx default)
-		MaxConnLifetime time.Duration // 0 = unset (pgx default)
+		Url                  string
+		UrlFile              string
+		VectorEnabled        bool
+		SkipMigrations       bool
+		MaxConns             int           // 0 = unset (pgx default)
+		MinConns             int           // -1 = unset (pgx default); 0 is a valid value
+		MaxConnIdleTime      time.Duration // 0 = unset (pgx default)
+		MaxConnLifetime      time.Duration // 0 = unset (pgx default)
+		SessionRetentionDays int           // 0 = disabled; sliding idle TTL on session.updated_at
 	}
 	Substrate struct {
 		AteAPIEndpoint             string
@@ -191,6 +192,7 @@ func (cfg *Config) SetFlags(commandLine *flag.FlagSet) {
 	commandLine.IntVar(&cfg.Database.MinConns, "db-min-conns", -1, "Minimum number of connections in the Postgres pool. -1 leaves the pgx default.")
 	commandLine.DurationVar(&cfg.Database.MaxConnIdleTime, "db-max-conn-idle-time", 0, "Maximum idle time before a Postgres pool connection is closed. 0 leaves the pgx default (30m).")
 	commandLine.DurationVar(&cfg.Database.MaxConnLifetime, "db-max-conn-lifetime", 0, "Maximum lifetime of a Postgres pool connection. 0 leaves the pgx default (1h).")
+	commandLine.IntVar(&cfg.Database.SessionRetentionDays, "session-retention-days", 0, "Hard-delete idle sessions and cascaded conversation state (events, tasks, checkpoints, shares) when session.updated_at is older than this many days. 0 disables (default). Retention is a sliding window: activity refreshes updated_at.")
 
 	commandLine.StringVar(&cfg.WatchNamespaces, "watch-namespaces", "", "The namespaces to watch for .")
 
@@ -808,9 +810,9 @@ func Start(getExtensionConfig GetExtensionConfig, extraSources []migrations.Sour
 		os.Exit(1)
 	}
 
-	// Memory TTL cleanup runs only on the leader to avoid duplicate deletes.
-	if err := mgr.Add(httpserver.NewMemoryCleanupRunnable(dbClient, 0)); err != nil {
-		setupLog.Error(err, "unable to set up memory cleanup runnable")
+	// DB TTL cleanup (memory + sessions) runs only on the leader to avoid duplicate deletes.
+	if err := mgr.Add(httpserver.NewDbCleanupRunnable(dbClient, 1*time.Minute, cfg.Database.SessionRetentionDays)); err != nil {
+		setupLog.Error(err, "unable to set up DB cleanup runnable")
 		os.Exit(1)
 	}
 

--- a/go/core/pkg/app/app.go
+++ b/go/core/pkg/app/app.go
@@ -811,7 +811,8 @@ func Start(getExtensionConfig GetExtensionConfig, extraSources []migrations.Sour
 	}
 
 	// DB TTL cleanup (memory + sessions) runs only on the leader to avoid duplicate deletes.
-	if err := mgr.Add(httpserver.NewDbCleanupRunnable(dbClient, 1*time.Minute, cfg.Database.SessionRetentionDays)); err != nil {
+	// Currently configured to run every 24 hours.
+	if err := mgr.Add(httpserver.NewDbCleanupRunnable(dbClient, 24*time.Hour, cfg.Database.SessionRetentionDays)); err != nil {
 		setupLog.Error(err, "unable to set up DB cleanup runnable")
 		os.Exit(1)
 	}

--- a/go/core/pkg/app/app_test.go
+++ b/go/core/pkg/app/app_test.go
@@ -306,6 +306,21 @@ func TestPostgresConfigFromAppUnset(t *testing.T) {
 	assert.Nil(t, pgCfg.MaxConnLifetime)
 }
 
+func TestSessionRetentionDaysFlag(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	cfg := Config{}
+	cfg.SetFlags(fs)
+
+	f := fs.Lookup("session-retention-days")
+	assert.NotNil(t, f, "session-retention-days flag should be registered")
+	assert.Equal(t, "0", f.DefValue, "default should be 0 (disabled)")
+
+	t.Setenv("SESSION_RETENTION_DAYS", "30")
+	err := LoadFromEnv(fs)
+	assert.NoError(t, err)
+	assert.Equal(t, 30, cfg.Database.SessionRetentionDays)
+}
+
 func TestSubstrateAteAPITokenFileFlag(t *testing.T) {
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	cfg := Config{}

--- a/helm/kagent/templates/controller-configmap.yaml
+++ b/helm/kagent/templates/controller-configmap.yaml
@@ -74,6 +74,7 @@ data:
   DB_MAX_CONN_LIFETIME: {{ .maxConnLifetime | quote }}
   {{- end }}
   {{- end }}
+  SESSION_RETENTION_DAYS: {{ .Values.database.postgres.sessionRetentionDays | default 0 | quote }}
   WATCH_NAMESPACES: {{ include "kagent.watchNamespaces" . | quote }}
   MCP_EGRESS_PLAINTEXT: {{ .Values.controller.mcpEgressPlaintext | default false | quote }}
   {{- if .Values.controller.a2aClientTimeout }}

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -95,6 +95,10 @@ database:
       minConns: null
       maxConnIdleTime: ""
       maxConnLifetime: ""
+    # -- Hard-delete idle sessions (and cascaded events/tasks/checkpoints/shares) after N days
+    # of no activity. Uses session.updated_at as a sliding idle clock (writes refresh it).
+    # 0 disables cleanup (default, existing installs unchanged).
+    sessionRetentionDays: 0
     # -- Bundled PostgreSQL instance — for development and evaluation only.
     # Not suitable for production. Deployed when enabled is true and url/urlFile are not set.
     bundled:


### PR DESCRIPTION
This targets the 0.10.x release. To use, e.g. set `database.posetgres.sessionRetentionDays: 30`

The following tables are eligible for cleanup: session, shares, events (ADK), push notifications (A2A), tasks (A2A), checkpoints (LangGraph), memory and flow states (CrewAI)

This shares the same cleanup runner as long term memory.