### PR TITLE
feat: add upstream A2A gRPC runtime servers

### DIFF
--- a/go/adk/pkg/a2a/server/server.go
+++ b/go/adk/pkg/a2a/server/server.go
@@ -13,9 +13,14 @@ import (
 	"time"
 
 	a2atype "github.com/a2aproject/a2a-go/v2/a2a"
+	a2agrpc "github.com/a2aproject/a2a-go/v2/a2agrpc/v1"
+	a2apb "github.com/a2aproject/a2a-go/v2/a2apb/v1"
 	"github.com/a2aproject/a2a-go/v2/a2asrv"
 	"github.com/go-logr/logr"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	grpc_health_v1 "google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/kagent-dev/kagent/go/adk/pkg/telemetry"
 )
@@ -34,10 +39,12 @@ type ServerConfig struct {
 
 // A2AServer wraps the A2A server with health endpoints and graceful shutdown.
 type A2AServer struct {
-	httpServer *http.Server
-	logger     logr.Logger
-	config     ServerConfig
-	listenErr  chan error
+	httpServer   *http.Server
+	grpcServer   *grpc.Server
+	healthServer *health.Server
+	logger       logr.Logger
+	config       ServerConfig
+	listenErr    chan error
 }
 
 // NewA2AServer creates a new A2A server using a2asrv.
@@ -52,11 +59,26 @@ func NewA2AServer(agentCard a2atype.AgentCard, executor a2asrv.AgentExecutor, lo
 	RegisterHealthEndpoints(mux)
 	mux.Handle(a2asrv.WellKnownAgentCardPath, a2asrv.NewStaticAgentCardHandler(&agentCard))
 	mux.Handle("/", jsonrpcHandler)
+
+	grpcServer := grpc.NewServer()
+	a2agrpc.NewHandler(requestHandler).RegisterWith(grpcServer)
+	healthServer := health.NewServer()
+	healthServer.SetServingStatus(a2apb.A2AService_ServiceDesc.ServiceName, grpc_health_v1.HealthCheckResponse_SERVING)
+	grpc_health_v1.RegisterHealthServer(grpcServer, healthServer)
+	handlerMux := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.ProtoMajor == 2 && strings.HasPrefix(r.Header.Get("Content-Type"), "application/grpc") {
+			grpcServer.ServeHTTP(w, r)
+			return
+		}
+		mux.ServeHTTP(w, r)
+	})
 	// Health and agent-card requests are neither traced nor flushed; only A2A
 	// requests get an inbound server span and a span flush.
 	isA2ARequest := func(r *http.Request) bool {
-		switch r.URL.Path {
-		case "/health", "/healthz", a2asrv.WellKnownAgentCardPath:
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/grpc.health.v1.Health/"):
+			return false
+		case r.URL.Path == "/health", r.URL.Path == "/healthz", r.URL.Path == a2asrv.WellKnownAgentCardPath:
 			return false
 		default:
 			return true
@@ -65,7 +87,7 @@ func NewA2AServer(agentCard a2atype.AgentCard, executor a2asrv.AgentExecutor, lo
 	// Wrap the whole server mux to enable trace context extraction and an inbound
 	// HTTP server span for each request.
 	instrumentedHandler := otelhttp.NewHandler(
-		mux,
+		handlerMux,
 		"a2a-server",
 		otelhttp.WithSpanNameFormatter(func(_ string, r *http.Request) string {
 			return r.Method + " " + r.URL.Path
@@ -97,13 +119,20 @@ func NewA2AServer(agentCard a2atype.AgentCard, executor a2asrv.AgentExecutor, lo
 		addr = net.JoinHostPort(config.Host, config.Port)
 	}
 
+	protocols := new(http.Protocols)
+	protocols.SetHTTP1(true)
+	protocols.SetUnencryptedHTTP2(true)
+
 	return &A2AServer{
 		httpServer: &http.Server{
-			Addr:    addr,
-			Handler: handler,
+			Addr:      addr,
+			Handler:   handler,
+			Protocols: protocols,
 		},
-		logger: logger,
-		config: config,
+		grpcServer:   grpcServer,
+		healthServer: healthServer,
+		logger:       logger,
+		config:       config,
 	}, nil
 }
 
@@ -174,9 +203,19 @@ func (s *A2AServer) WaitForShutdown() error {
 	ctx, cancel := context.WithTimeout(context.Background(), s.config.ShutdownTimeout)
 	defer cancel()
 
+	s.healthServer.Shutdown()
+	grpcStopped := make(chan struct{})
+	go func() {
+		s.grpcServer.GracefulStop()
+		close(grpcStopped)
+	}()
+
 	if err := s.httpServer.Shutdown(ctx); err != nil {
+		s.grpcServer.Stop()
+		<-grpcStopped
 		return fmt.Errorf("error shutting down server: %w", err)
 	}
+	<-grpcStopped
 
 	return nil
 }

--- a/go/adk/pkg/a2a/server/server_test.go
+++ b/go/adk/pkg/a2a/server/server_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"iter"
 	"net/http"
 	"net/http/httptest"
@@ -11,11 +12,16 @@ import (
 	"testing"
 
 	a2atype "github.com/a2aproject/a2a-go/v2/a2a"
+	a2apb "github.com/a2aproject/a2a-go/v2/a2apb/v1"
+	"github.com/a2aproject/a2a-go/v2/a2apb/v1/pbconv"
 	"github.com/a2aproject/a2a-go/v2/a2asrv"
 	"github.com/go-logr/logr"
 	"go.opentelemetry.io/otel"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	grpc_health_v1 "google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/kagent-dev/kagent/go/adk/pkg/telemetry"
 )
@@ -47,6 +53,116 @@ func (substrateExecutor) Execute(ctx context.Context, reqCtx *a2asrv.ExecutorCon
 
 func (substrateExecutor) Cancel(context.Context, *a2asrv.ExecutorContext) iter.Seq2[a2atype.Event, error] {
 	return func(yield func(a2atype.Event, error) bool) {}
+}
+
+func startTestServer(t *testing.T) (*httptest.Server, *grpc.ClientConn) {
+	t.Helper()
+
+	srv, err := NewA2AServer(a2atype.AgentCard{}, substrateExecutor{}, logr.Discard(), ServerConfig{Port: "0"})
+	if err != nil {
+		t.Fatalf("NewA2AServer: %v", err)
+	}
+
+	testServer := httptest.NewUnstartedServer(srv.httpServer.Handler)
+	testServer.Config.Protocols = srv.httpServer.Protocols
+	testServer.Start()
+	conn, err := grpc.NewClient(testServer.Listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("create gRPC client: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = conn.Close()
+		srv.grpcServer.Stop()
+		testServer.Close()
+	})
+	return testServer, conn
+}
+
+func TestHTTPAndGRPCHealthSharePort(t *testing.T) {
+	testServer, conn := startTestServer(t)
+
+	resp, err := testServer.Client().Get(testServer.URL + "/healthz")
+	if err != nil {
+		t.Fatalf("GET /healthz: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("GET /healthz status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	health, err := grpc_health_v1.NewHealthClient(conn).Check(t.Context(), &grpc_health_v1.HealthCheckRequest{
+		Service: a2apb.A2AService_ServiceDesc.ServiceName,
+	})
+	if err != nil {
+		t.Fatalf("gRPC health check: %v", err)
+	}
+	if health.GetStatus() != grpc_health_v1.HealthCheckResponse_SERVING {
+		t.Errorf("gRPC health status = %s, want SERVING", health.GetStatus())
+	}
+}
+
+func TestGRPCAndJSONRPCShareRequestHandler(t *testing.T) {
+	testServer, conn := startTestServer(t)
+	client := a2apb.NewA2AServiceClient(conn)
+
+	pbReq, err := pbconv.ToProtoSendMessageRequest(&a2atype.SendMessageRequest{
+		Message: a2atype.NewMessage(a2atype.MessageRoleUser, a2atype.NewTextPart("hi")),
+	})
+	if err != nil {
+		t.Fatalf("convert request: %v", err)
+	}
+	result, err := client.SendMessage(t.Context(), pbReq)
+	if err != nil {
+		t.Fatalf("gRPC SendMessage: %v", err)
+	}
+	task := result.GetTask()
+	if task == nil {
+		t.Fatal("gRPC SendMessage did not return a task")
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "1",
+		"method":  "GetTask",
+		"params":  &a2atype.GetTaskRequest{ID: a2atype.TaskID(task.GetId())},
+	})
+	if err != nil {
+		t.Fatalf("marshal GetTask: %v", err)
+	}
+	httpResp, err := testServer.Client().Post(testServer.URL, "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("JSON-RPC GetTask: %v", err)
+	}
+	defer httpResp.Body.Close()
+	var getTaskResp struct {
+		Result a2atype.Task `json:"result"`
+	}
+	if err := json.NewDecoder(httpResp.Body).Decode(&getTaskResp); err != nil {
+		t.Fatalf("decode GetTask response: %v", err)
+	}
+	if getTaskResp.Result.ID != a2atype.TaskID(task.GetId()) {
+		t.Errorf("JSON-RPC task ID = %q, want %q", getTaskResp.Result.ID, task.GetId())
+	}
+
+	stream, err := client.SendStreamingMessage(t.Context(), pbReq)
+	if err != nil {
+		t.Fatalf("gRPC SendStreamingMessage: %v", err)
+	}
+	var sawTask, sawStatus bool
+	for {
+		event, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("receive streaming response: %v", err)
+		}
+		sawTask = sawTask || event.GetTask() != nil
+		sawStatus = sawStatus || event.GetStatusUpdate() != nil
+	}
+	if !sawTask || !sawStatus {
+		t.Errorf("stream responses missing task or status update: sawTask=%t sawStatus=%t", sawTask, sawStatus)
+	}
 }
 
 // runA2ARequest builds a server against an in-memory batch exporter, serves

--- a/go/adk/pkg/app/app.go
+++ b/go/adk/pkg/app/app.go
@@ -123,12 +123,15 @@ func New(cfg AppConfig, executor a2asrv.AgentExecutor) (*KAgentApp, error) {
 		sessionSvc := session.NewKAgentSessionService(controllerClient)
 		app.sessionService = sessionSvc
 		log.Info("Using KAgent gRPC session service", "target", cfg.KAgentGRPCURL)
+	} else {
+		log.Info("No KAgent gRPC target configured, using in-memory session")
+	}
 
-		taskStore := taskstore.NewKAgentTaskStore(controllerClient)
-		handlerOpts = append(handlerOpts, a2asrv.WithTaskStore(taskStore))
+	if controllerClient != nil {
+		handlerOpts = append(handlerOpts, a2asrv.WithTaskStore(taskstore.NewKAgentTaskStore(controllerClient)))
 		log.Info("Using KAgent gRPC task store", "target", cfg.KAgentGRPCURL)
 	} else {
-		log.Info("No KAgent gRPC target configured, using in-memory session and no task persistence")
+		log.Info("No task store configured, using in-memory task storage")
 	}
 
 	// Activate the optional HITL extension and resolve the authenticated user.

--- a/go/adk/pkg/taskstore/store.go
+++ b/go/adk/pkg/taskstore/store.go
@@ -3,6 +3,7 @@ package taskstore
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	a2atype "github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/a2aproject/a2a-go/v2/a2apb/v1/pbconv"
@@ -104,7 +105,61 @@ func isPartial(metadata map[string]any) bool {
 	return false
 }
 
-// List implements a2asrv.TaskStore. Listing is not supported against the KAgent task API.
+// List implements a2asrv.TaskStore.
 func (s *KAgentTaskStore) List(ctx context.Context, req *a2atype.ListTasksRequest) (*a2atype.ListTasksResponse, error) {
-	return nil, fmt.Errorf("task listing is not supported by the KAgent task store")
+	const defaultPageSize = 50
+	pageSize := req.PageSize
+	if pageSize == 0 {
+		pageSize = defaultPageSize
+	} else if pageSize < 1 || pageSize > 100 {
+		return nil, fmt.Errorf("page size must be between 1 and 100 inclusive, got %d: %w", pageSize, a2atype.ErrInvalidRequest)
+	}
+	if req.ContextID == "" {
+		return &a2atype.ListTasksResponse{Tasks: []*a2atype.Task{}, PageSize: pageSize}, nil
+	}
+
+	callContext, cancel := s.client.CallContext(ctx, "")
+	defer cancel()
+	response, err := s.client.TaskService().ListTasks(callContext, &apiv1alpha1.ListTasksRequest{SessionId: req.ContextID})
+	if err != nil {
+		return nil, fmt.Errorf("list tasks: %w", err)
+	}
+
+	tasks := make([]*a2atype.Task, 0, len(response.GetTasks()))
+	for _, encoded := range response.GetTasks() {
+		task, err := pbconv.FromProtoTask(encoded)
+		if err != nil {
+			return nil, fmt.Errorf("decode listed task: %w", err)
+		}
+		if req.Status != a2atype.TaskStateUnspecified && task.Status.State != req.Status {
+			continue
+		}
+		if req.StatusTimestampAfter != nil && (task.Status.Timestamp == nil || task.Status.Timestamp.Before(*req.StatusTimestampAfter)) {
+			continue
+		}
+		tasks = append(tasks, task)
+	}
+
+	start := 0
+	if req.PageToken != "" {
+		start, err = strconv.Atoi(req.PageToken)
+		if err != nil || start < 0 {
+			return nil, fmt.Errorf("invalid page token %q: %w", req.PageToken, a2atype.ErrInvalidRequest)
+		}
+	}
+	totalSize := len(tasks)
+	if start > totalSize {
+		start = totalSize
+	}
+	end := min(start+pageSize, totalSize)
+	nextPageToken := ""
+	if end < totalSize {
+		nextPageToken = strconv.Itoa(end)
+	}
+	return &a2atype.ListTasksResponse{
+		Tasks:         tasks[start:end],
+		TotalSize:     totalSize,
+		PageSize:      pageSize,
+		NextPageToken: nextPageToken,
+	}, nil
 }

--- a/go/adk/pkg/taskstore/store_test.go
+++ b/go/adk/pkg/taskstore/store_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	a2a "github.com/a2aproject/a2a-go/v2/a2a"
+	a2apb "github.com/a2aproject/a2a-go/v2/a2apb/v1"
 	"github.com/a2aproject/a2a-go/v2/a2apb/v1/pbconv"
 	a2ataskstore "github.com/a2aproject/a2a-go/v2/a2asrv/taskstore"
 	"github.com/kagent-dev/kagent/go/adk/pkg/auth"
@@ -24,6 +25,7 @@ type taskTestServer struct {
 	apiv1alpha1.UnimplementedTaskStoreServiceServer
 	upsert func(context.Context, *apiv1alpha1.UpsertTaskRequest) (*apiv1alpha1.UpsertTaskResponse, error)
 	get    func(context.Context, *apiv1alpha1.GetTaskRequest) (*apiv1alpha1.GetTaskResponse, error)
+	list   func(context.Context, *apiv1alpha1.ListTasksRequest) (*apiv1alpha1.ListTasksResponse, error)
 }
 
 func (server *taskTestServer) UpsertTask(ctx context.Context, request *apiv1alpha1.UpsertTaskRequest) (*apiv1alpha1.UpsertTaskResponse, error) {
@@ -32,6 +34,10 @@ func (server *taskTestServer) UpsertTask(ctx context.Context, request *apiv1alph
 
 func (server *taskTestServer) GetTask(ctx context.Context, request *apiv1alpha1.GetTaskRequest) (*apiv1alpha1.GetTaskResponse, error) {
 	return server.get(ctx, request)
+}
+
+func (server *taskTestServer) ListTasks(ctx context.Context, request *apiv1alpha1.ListTasksRequest) (*apiv1alpha1.ListTasksResponse, error) {
+	return server.list(ctx, request)
 }
 
 func newTaskStore(t *testing.T, service *taskTestServer) *KAgentTaskStore {
@@ -126,6 +132,26 @@ func TestGetMapsNotFound(t *testing.T) {
 	stored, err := service.Get(t.Context(), a2a.TaskID("missing"))
 	require.ErrorIs(t, err, a2a.ErrTaskNotFound)
 	assert.Nil(t, stored)
+}
+
+func TestListUsesContextID(t *testing.T) {
+	encoded, err := pbconv.ToProtoTask(&a2a.Task{
+		ID:        a2a.TaskID("task-3"),
+		ContextID: "session-3",
+		Status:    a2a.TaskStatus{State: a2a.TaskStateCompleted},
+	})
+	require.NoError(t, err)
+	service := newTaskStore(t, &taskTestServer{list: func(_ context.Context, request *apiv1alpha1.ListTasksRequest) (*apiv1alpha1.ListTasksResponse, error) {
+		assert.Equal(t, "session-3", request.GetSessionId())
+		return &apiv1alpha1.ListTasksResponse{Tasks: []*a2apb.Task{encoded}}, nil
+	}})
+
+	response, err := service.List(t.Context(), &a2a.ListTasksRequest{ContextID: "session-3"})
+	require.NoError(t, err)
+	require.Len(t, response.Tasks, 1)
+	assert.Equal(t, a2a.TaskID("task-3"), response.Tasks[0].ID)
+	assert.Equal(t, 1, response.TotalSize)
+	assert.Equal(t, 50, response.PageSize)
 }
 
 func TestSaveRejectsNilTask(t *testing.T) {

--- a/python/packages/kagent-adk/pyproject.toml
+++ b/python/packages/kagent-adk/pyproject.toml
@@ -31,6 +31,8 @@ dependencies = [
   "typing-extensions>=4.16.0",
   "jsonref>=1.1.0",
   "a2a-sdk>=1.1.0,<2",
+  "grpcio>=1.83.0",
+  "grpcio-health-checking>=1.74.0,<1.75.0",
   # Security: pin minimum versions for CVE fixes in transitive dependencies
   "urllib3>=2.6.3",  # CVE-2025-66418, CVE-2025-66471, CVE-2026-21441: unbounded decompression DoS
   "filelock>=3.20.3",  # CVE-2025-68146, CVE-2026-22701: TOCTOU symlink race condition

--- a/python/packages/kagent-adk/src/kagent/adk/_a2a.py
+++ b/python/packages/kagent-adk/src/kagent/adk/_a2a.py
@@ -2,12 +2,15 @@
 import faulthandler
 import logging
 import os
+from contextlib import asynccontextmanager
 from typing import Any, Callable, List, Optional
 
+import grpc
 from a2a.server.request_handlers import DefaultRequestHandlerV2
+from a2a.server.request_handlers.grpc_handler import GrpcHandler
 from a2a.server.routes import add_a2a_routes_to_fastapi, create_agent_card_routes, create_jsonrpc_routes
-from a2a.server.tasks import InMemoryTaskStore
-from a2a.types import AgentCard
+from a2a.server.tasks import InMemoryTaskStore, TaskStore
+from a2a.types import AgentCard, a2a_pb2, a2a_pb2_grpc
 from fastapi import FastAPI, Request
 from fastapi.responses import PlainTextResponse
 from google.adk.agents import BaseAgent
@@ -18,9 +21,11 @@ from google.adk.plugins import BasePlugin
 from google.adk.runners import Runner
 from google.adk.sessions import DatabaseSessionService, InMemorySessionService
 from google.genai import types
+from grpc_health.v1 import health, health_pb2, health_pb2_grpc
 from kagent.core import AsyncControllerClient
 from kagent.core.a2a import (
     A2ARequestSizeLimitMiddleware,
+    KAgentGrpcServerCallContextBuilder,
     KAgentRequestContextBuilder,
     KAgentTaskStore,
     attach_hitl_agent_extension,
@@ -62,6 +67,7 @@ class KAgentApp:
         stream: bool = False,
         agent_config: Optional[AgentConfig] = None,
         kagent_grpc_url: Optional[str] = None,
+        a2a_grpc_address: Optional[str] = None,
     ):
         """Initialize the KAgent application.
 
@@ -74,10 +80,12 @@ class KAgentApp:
             plugins: Optional list of plugins
             stream: Whether to stream the response
             agent_config: Optional agent configuration
+            a2a_grpc_address: Address for the A2A gRPC listener
         """
         self.root_agent_factory = root_agent_factory
         self.kagent_url = kagent_url
         self.kagent_grpc_url = kagent_grpc_url or os.getenv("KAGENT_GRPC_URL")
+        self.a2a_grpc_address = a2a_grpc_address or os.getenv("KAGENT_A2A_GRPC_ADDRESS", "[::]:80")
         self.app_name = app_name
         self.agent_card = agent_card
         self._lifespan = lifespan
@@ -154,7 +162,7 @@ class KAgentApp:
                 memory_service=memory_service,
             )
 
-        task_store: InMemoryTaskStore | KAgentTaskStore = InMemoryTaskStore()
+        task_store: TaskStore = InMemoryTaskStore()
         if not local and controller_client is not None:
             task_store = KAgentTaskStore(controller_client)
 
@@ -175,6 +183,7 @@ class KAgentApp:
 
         lifespan_manager = LifespanManager()
         lifespan_manager.add(self._lifespan)
+        lifespan_manager.add(self._grpc_lifespan(request_handler))
         if not local:
             lifespan_manager.add(token_service.lifespan())
             lifespan_manager.add(controller_client.lifespan())
@@ -195,6 +204,33 @@ class KAgentApp:
         )
 
         return app
+
+    def _grpc_lifespan(self, request_handler: DefaultRequestHandlerV2):
+        @asynccontextmanager
+        async def lifespan(app: FastAPI):
+            server = grpc.aio.server()
+            context_builder = KAgentGrpcServerCallContextBuilder()
+            a2a_pb2_grpc.add_A2AServiceServicer_to_server(
+                GrpcHandler(request_handler, context_builder=context_builder), server
+            )
+
+            health_service = health.aio.HealthServicer()
+            service_name = a2a_pb2.DESCRIPTOR.services_by_name["A2AService"].full_name
+            await health_service.set(service_name, health_pb2.HealthCheckResponse.SERVING)
+            health_pb2_grpc.add_HealthServicer_to_server(health_service, server)
+
+            port = server.add_insecure_port(self.a2a_grpc_address)
+            if port == 0:
+                raise RuntimeError(f"failed to bind A2A gRPC server to {self.a2a_grpc_address}")
+            app.state.a2a_grpc_port = port
+            await server.start()
+            try:
+                yield
+            finally:
+                await health_service.enter_graceful_shutdown()
+                await server.stop(grace=5)
+
+        return lifespan
 
     async def test(self, task: str):
         session_service = InMemorySessionService()

--- a/python/packages/kagent-adk/tests/unittests/test_a2a_grpc.py
+++ b/python/packages/kagent-adk/tests/unittests/test_a2a_grpc.py
@@ -1,0 +1,85 @@
+import grpc
+import pytest
+from a2a.types import AgentCard, a2a_pb2, a2a_pb2_grpc
+from google.protobuf.json_format import ParseDict
+from grpc_health.v1 import health_pb2, health_pb2_grpc
+from kagent.core.a2a import KAgentGrpcServerCallContextBuilder
+
+import kagent.adk._a2a as _a2a
+from kagent.adk import KAgentApp
+
+
+def make_app(address: str = "127.0.0.1:0"):
+    card = ParseDict(
+        {
+            "name": "test-app",
+            "description": "test agent",
+            "version": "0.0.1",
+            "supportedInterfaces": [{"url": "http://localhost:8080", "protocolBinding": "JSONRPC"}],
+            "capabilities": {},
+            "defaultInputModes": ["text/plain"],
+            "defaultOutputModes": ["text/plain"],
+            "skills": [],
+        },
+        AgentCard(),
+    )
+    return KAgentApp(
+        root_agent_factory=lambda: None,
+        agent_card=card,
+        kagent_url="http://unused",
+        app_name="test-app",
+        a2a_grpc_address=address,
+    ).build(local=True)
+
+
+@pytest.mark.asyncio
+async def test_grpc_health():
+    app = make_app()
+
+    async with app.router.lifespan_context(app):
+        async with grpc.aio.insecure_channel(f"127.0.0.1:{app.state.a2a_grpc_port}") as channel:
+            response = await health_pb2_grpc.HealthStub(channel).Check(
+                health_pb2.HealthCheckRequest(service="lf.a2a.v1.A2AService")
+            )
+
+    assert response.status == health_pb2.HealthCheckResponse.SERVING
+
+
+@pytest.mark.asyncio
+async def test_grpc_dispatch_uses_jsonrpc_handler(monkeypatch):
+    handlers = []
+    real_create_jsonrpc_routes = _a2a.create_jsonrpc_routes
+    real_grpc_handler = _a2a.GrpcHandler
+
+    def capture_jsonrpc_handler(handler, *args, **kwargs):
+        handlers.append(handler)
+        return real_create_jsonrpc_routes(handler, *args, **kwargs)
+
+    def capture_grpc_handler(handler, *args, **kwargs):
+        handlers.append(handler)
+        return real_grpc_handler(handler, *args, **kwargs)
+
+    monkeypatch.setattr(_a2a, "create_jsonrpc_routes", capture_jsonrpc_handler)
+    monkeypatch.setattr(_a2a, "GrpcHandler", capture_grpc_handler)
+    app = make_app()
+
+    async with app.router.lifespan_context(app):
+        async with grpc.aio.insecure_channel(f"127.0.0.1:{app.state.a2a_grpc_port}") as channel:
+            response = await a2a_pb2_grpc.A2AServiceStub(channel).ListTasks(a2a_pb2.ListTasksRequest())
+
+    assert response.total_size == 0
+    assert len(handlers) == 2
+    assert handlers[0] is handlers[1]
+
+
+def test_grpc_metadata_preserves_user_identity():
+    class FakeContext:
+        @staticmethod
+        def invocation_metadata():
+            return (("x-user-id", "alice"), ("x-kagent-source", "parent"))
+
+    context = KAgentGrpcServerCallContextBuilder().build(FakeContext())
+
+    assert context.user.user_name == "alice"
+    assert context.state["headers"]["x-kagent-source"] == "parent"
+    assert context.state["kagent_source"] == "parent"

--- a/python/packages/kagent-core/src/kagent/core/a2a/__init__.py
+++ b/python/packages/kagent-core/src/kagent/core/a2a/__init__.py
@@ -37,7 +37,7 @@ from ._hitl import (
     require_tool_approval_response,
 )
 from ._request_size import A2ARequestSizeLimitMiddleware
-from ._requests import KAgentRequestContextBuilder
+from ._requests import KAgentGrpcServerCallContextBuilder, KAgentRequestContextBuilder
 from ._task_store import KAgentTaskStore
 from ._time import now_timestamp
 
@@ -47,6 +47,7 @@ __all__ = [
     "get_request_user_id",
     "set_request_user_id",
     "KAgentRequestContextBuilder",
+    "KAgentGrpcServerCallContextBuilder",
     "KAgentTaskStore",
     "now_timestamp",
     "get_kagent_metadata_key",

--- a/python/packages/kagent-core/src/kagent/core/a2a/_requests.py
+++ b/python/packages/kagent-core/src/kagent/core/a2a/_requests.py
@@ -1,8 +1,10 @@
 import logging
 
+import grpc
 from a2a.auth.user import User
 from a2a.server.agent_execution import RequestContext, SimpleRequestContextBuilder
 from a2a.server.context import ServerCallContext
+from a2a.server.request_handlers.grpc_handler import DefaultGrpcServerCallContextBuilder
 from a2a.server.tasks import TaskStore
 from a2a.types import SendMessageRequest, Task
 
@@ -27,6 +29,27 @@ class KAgentUser(User):
         return self.user_id
 
 
+def _apply_kagent_headers(context: ServerCallContext) -> None:
+    headers = context.state.get("headers", {})
+    user_id = headers.get("x-user-id")
+    if user_id:
+        context.user = KAgentUser(user_id=user_id)
+        set_request_user_id(user_id)
+    source = headers.get("x-kagent-source")
+    if source:
+        context.state["kagent_source"] = source
+
+
+class KAgentGrpcServerCallContextBuilder(DefaultGrpcServerCallContextBuilder):
+    """Preserve gateway metadata in upstream A2A gRPC call contexts."""
+
+    def build(self, context: grpc.aio.ServicerContext) -> ServerCallContext:
+        call_context = super().build(context)
+        call_context.state["headers"] = {key.lower(): value for key, value in context.invocation_metadata()}
+        _apply_kagent_headers(call_context)
+        return call_context
+
+
 class KAgentRequestContextBuilder(SimpleRequestContextBuilder):
     """
     A request context builder that will be used to hack in the user_id for now.
@@ -44,17 +67,7 @@ class KAgentRequestContextBuilder(SimpleRequestContextBuilder):
         task: Task | None = None,
     ) -> RequestContext:
         if context:
-            headers = context.state.get("headers", {})
-            # Extract the authenticated user ID forwarded by the parent agent
-            user_id = headers.get("x-user-id", None)
-            if user_id:
-                context.user = KAgentUser(user_id=user_id)
-                set_request_user_id(user_id)
-            # Propagate x-kagent-source so downstream code (e.g. session
-            # creation) can tag this session as agent-originated.
-            source = headers.get("x-kagent-source", None)
-            if source:
-                context.state["kagent_source"] = source
+            _apply_kagent_headers(context)
         request_context = await super().build(
             context=context,
             params=params,

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1391,6 +1391,19 @@ wheels = [
 ]
 
 [[package]]
+name = "grpcio-health-checking"
+version = "1.74.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "grpcio" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/69/87ad1cd826a9f06567bccb66f0c3228a0758ea47a1d35eef15db36b2f492/grpcio_health_checking-1.74.0.tar.gz", hash = "sha256:d6749451d4cef543c3f6260ae9a86c84b9ab02a92421cecae73a632e7fe920bf", size = 16770, upload-time = "2025-07-24T19:02:01.298Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/62/2fd797be7514855a0b28f946f57b9a134bba25a9873c269fa730d8fd49d8/grpcio_health_checking-1.74.0-py3-none-any.whl", hash = "sha256:9a6e7bcdf16395105425753d6e3fe31f57cb6ab3f232282254b50f02cc63d9c7", size = 18921, upload-time = "2025-07-24T19:01:24.856Z" },
+]
+
+[[package]]
 name = "grpcio-status"
 version = "1.74.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1790,6 +1803,8 @@ dependencies = [
     { name = "google-adk", extra = ["a2a", "db"] },
     { name = "google-auth" },
     { name = "google-genai" },
+    { name = "grpcio" },
+    { name = "grpcio-health-checking" },
     { name = "httpx" },
     { name = "httpx-sse" },
     { name = "jsonref" },
@@ -1832,6 +1847,8 @@ requires-dist = [
     { name = "google-adk", extras = ["a2a", "db"], specifier = ">=2.6.2,<3" },
     { name = "google-auth", specifier = ">=2.40.2" },
     { name = "google-genai", specifier = ">=2.17.0,<3" },
+    { name = "grpcio", specifier = ">=1.83.0" },
+    { name = "grpcio-health-checking", specifier = ">=1.74.0,<1.75.0" },
     { name = "httpx", specifier = ">=0.25.0" },
     { name = "httpx-sse", specifier = ">=0.4.3" },
     { name = "jsonref", specifier = ">=1.1.0" },


### PR DESCRIPTION
## Summary

- serve upstream A2A v1 gRPC and health from the Go and Python runtimes
- bind Python gRPC to the Actor endpoint on port 80, avoiding a Substrate routing change
- preserve gateway identity metadata across Python gRPC requests
- persist private A2A tasks in DurableDir-backed SQLite stores while retaining the legacy controller TaskStore fallback

## Verification

- `go test ./adk/...`
- focused Python A2A/task-store tests
- Python package Ruff checks

Legacy HTTP/JSON-RPC reachability is not required for the API-v2 runtime contract.