### PR TITLE
feat: support file upload in agent chat

### DIFF
--- a/go/adk/pkg/models/anthropic_adk.go
+++ b/go/adk/pkg/models/anthropic_adk.go
@@ -145,11 +145,11 @@ func genaiContentsToAnthropicMessages(contents []*genai.Content, config *genai.G
 				name := blobName(part.InlineData)
 				if isImageMIME(mime) {
 					mediaBlocks = append(mediaBlocks, anthropic.NewImageBlockBase64(mime, base64.StdEncoding.EncodeToString(part.InlineData.Data)))
-				} else if isAnthropicPDF(mime) {
+				} else if isAnthropicPDF(mime, name) {
 					mediaBlocks = append(mediaBlocks, anthropic.NewDocumentBlock(anthropic.Base64PDFSourceParam{
 						Data: base64.StdEncoding.EncodeToString(part.InlineData.Data),
 					}))
-				} else if isAnthropicPlainText(mime) {
+				} else if isAnthropicPlainText(mime, name) {
 					mediaBlocks = append(mediaBlocks, anthropic.NewDocumentBlock(anthropic.PlainTextSourceParam{
 						Data: string(part.InlineData.Data),
 					}))
@@ -160,7 +160,7 @@ func genaiContentsToAnthropicMessages(contents []*genai.Content, config *genai.G
 				mime := part.FileData.MIMEType
 				name := fileDataName(part.FileData)
 				uri := part.FileData.FileURI
-				if uri != "" && isAnthropicPDF(mime) {
+				if uri != "" && isAnthropicPDF(mime, name) {
 					mediaBlocks = append(mediaBlocks, anthropic.NewDocumentBlock(anthropic.URLPDFSourceParam{URL: uri}))
 				} else {
 					textParts = append(textParts, unsupportedFileNote(name, mime))

--- a/go/adk/pkg/models/anthropic_adk.go
+++ b/go/adk/pkg/models/anthropic_adk.go
@@ -130,10 +130,7 @@ func genaiContentsToAnthropicMessages(contents []*genai.Content, config *genai.G
 
 		var textParts []string
 		var functionCalls []*genai.FunctionCall
-		var imageParts []struct {
-			mimeType string
-			data     []byte
-		}
+		var mediaBlocks []anthropic.ContentBlockParamUnion
 
 		for _, part := range content.Parts {
 			if part == nil {
@@ -143,11 +140,31 @@ func genaiContentsToAnthropicMessages(contents []*genai.Content, config *genai.G
 				textParts = append(textParts, part.Text)
 			} else if part.FunctionCall != nil {
 				functionCalls = append(functionCalls, part.FunctionCall)
-			} else if part.InlineData != nil && strings.HasPrefix(part.InlineData.MIMEType, "image/") {
-				imageParts = append(imageParts, struct {
-					mimeType string
-					data     []byte
-				}{part.InlineData.MIMEType, part.InlineData.Data})
+			} else if part.InlineData != nil {
+				mime := part.InlineData.MIMEType
+				name := blobName(part.InlineData)
+				if isImageMIME(mime) {
+					mediaBlocks = append(mediaBlocks, anthropic.NewImageBlockBase64(mime, base64.StdEncoding.EncodeToString(part.InlineData.Data)))
+				} else if isAnthropicPDF(mime) {
+					mediaBlocks = append(mediaBlocks, anthropic.NewDocumentBlock(anthropic.Base64PDFSourceParam{
+						Data: base64.StdEncoding.EncodeToString(part.InlineData.Data),
+					}))
+				} else if isAnthropicPlainText(mime) {
+					mediaBlocks = append(mediaBlocks, anthropic.NewDocumentBlock(anthropic.PlainTextSourceParam{
+						Data: string(part.InlineData.Data),
+					}))
+				} else {
+					textParts = append(textParts, unsupportedFileNote(name, mime))
+				}
+			} else if part.FileData != nil {
+				mime := part.FileData.MIMEType
+				name := fileDataName(part.FileData)
+				uri := part.FileData.FileURI
+				if uri != "" && isAnthropicPDF(mime) {
+					mediaBlocks = append(mediaBlocks, anthropic.NewDocumentBlock(anthropic.URLPDFSourceParam{URL: uri}))
+				} else {
+					textParts = append(textParts, unsupportedFileNote(name, mime))
+				}
 			}
 		}
 
@@ -188,13 +205,7 @@ func genaiContentsToAnthropicMessages(contents []*genai.Content, config *genai.G
 		} else {
 			// Regular user message
 			var contentBlocks []anthropic.ContentBlockParamUnion
-
-			// Add images first
-			for _, img := range imageParts {
-				contentBlocks = append(contentBlocks, anthropic.NewImageBlockBase64(img.mimeType, base64.StdEncoding.EncodeToString(img.data)))
-			}
-
-			// Add text
+			contentBlocks = append(contentBlocks, mediaBlocks...)
 			if len(textParts) > 0 {
 				contentBlocks = append(contentBlocks, anthropic.NewTextBlock(strings.Join(textParts, "\n")))
 			}

--- a/go/adk/pkg/models/bedrock.go
+++ b/go/adk/pkg/models/bedrock.go
@@ -753,12 +753,35 @@ func convertGenaiContentsToBedrockMessages(contents []*genai.Content, nameMap ma
 			}
 		}
 
+		// Bedrock Converse: a document ContentBlock requires a text ContentBlock
+		// in the same message (https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Message.html).
+		contentBlocks = ensureBedrockDocumentHasText(contentBlocks)
+
 		if len(contentBlocks) > 0 {
 			messages = append(messages, types.Message{Role: role, Content: contentBlocks})
 		}
 	}
 
 	return messages, mergeSystemInstructionFromConfig(systemInstruction, config)
+}
+
+// ensureBedrockDocumentHasText appends a short prompt when a message has documents but no text
+func ensureBedrockDocumentHasText(blocks []types.ContentBlock) []types.ContentBlock {
+	hasDoc, hasText := false, false
+	for _, b := range blocks {
+		switch b.(type) {
+		case *types.ContentBlockMemberDocument:
+			hasDoc = true
+		case *types.ContentBlockMemberText:
+			hasText = true
+		}
+	}
+	if hasDoc && !hasText {
+		blocks = append(blocks, &types.ContentBlockMemberText{
+			Value: "Please review the attached document.",
+		})
+	}
+	return blocks
 }
 
 // convertGenaiToolsToBedrock converts genai.Tool to Bedrock Tool format.

--- a/go/adk/pkg/models/bedrock.go
+++ b/go/adk/pkg/models/bedrock.go
@@ -667,6 +667,40 @@ func convertGenaiContentsToBedrockMessages(contents []*genai.Content, nameMap ma
 				continue
 			}
 
+			if part.InlineData != nil {
+				mime := part.InlineData.MIMEType
+				name := blobName(part.InlineData)
+				if fmtStr := bedrockImageFormat(mime); fmtStr != "" {
+					contentBlocks = append(contentBlocks, &types.ContentBlockMemberImage{
+						Value: types.ImageBlock{
+							Format: types.ImageFormat(fmtStr),
+							Source: &types.ImageSourceMemberBytes{Value: part.InlineData.Data},
+						},
+					})
+				} else if docFmt := bedrockDocumentFormat(mime, name); docFmt != "" {
+					contentBlocks = append(contentBlocks, &types.ContentBlockMemberDocument{
+						Value: types.DocumentBlock{
+							Format: types.DocumentFormat(docFmt),
+							Name:   aws.String(bedrockSafeDocName(name)),
+							Source: &types.DocumentSourceMemberBytes{Value: part.InlineData.Data},
+						},
+					})
+				} else {
+					contentBlocks = append(contentBlocks, &types.ContentBlockMemberText{
+						Value: unsupportedFileNote(name, mime),
+					})
+				}
+				continue
+			}
+
+			if part.FileData != nil {
+				// Bedrock Converse document/image blocks are bytes-only.
+				contentBlocks = append(contentBlocks, &types.ContentBlockMemberText{
+					Value: unsupportedFileNote(fileDataName(part.FileData), part.FileData.MIMEType),
+				})
+				continue
+			}
+
 			// Handle function call (tool use in Bedrock terminology).
 			// Use the sanitized name from nameMap so Bedrock can correlate the
 			// tool call with the tool spec sent in the same request.

--- a/go/adk/pkg/models/file_parts.go
+++ b/go/adk/pkg/models/file_parts.go
@@ -213,7 +213,8 @@ func bedrockDocumentFormat(mime, name string) string {
 	return ""
 }
 
-// bedrockSafeDocName keeps only chars Bedrock accepts in DocumentBlock.Name.
+// bedrockSafeDocName keeps only chars Bedrock accepts in DocumentBlock.Name
+// (alphanumeric, single spaces, -()[]; max 200). Neutral renaming is left to callers.
 func bedrockSafeDocName(name string) string {
 	if name == "" {
 		return "document"
@@ -236,6 +237,9 @@ func bedrockSafeDocName(name string) string {
 	out := strings.TrimSpace(b.String())
 	if out == "" {
 		return "document"
+	}
+	if rs := []rune(out); len(rs) > 200 {
+		return string(rs[:200])
 	}
 	return out
 }

--- a/go/adk/pkg/models/file_parts.go
+++ b/go/adk/pkg/models/file_parts.go
@@ -1,0 +1,145 @@
+package models
+
+import (
+	"encoding/base64"
+	"fmt"
+	"path"
+	"strings"
+
+	"google.golang.org/genai"
+)
+
+// unsupportedFileNote is appended as text when a file part cannot be mapped
+// to a provider-native input. Prefer this over silently dropping the part.
+func unsupportedFileNote(name, mime string) string {
+	if name == "" {
+		name = "unnamed"
+	}
+	if mime == "" {
+		mime = "unknown"
+	}
+	return fmt.Sprintf("[unsupported file: %s (%s)]", name, mime)
+}
+
+func dataURI(mime string, data []byte) string {
+	return fmt.Sprintf("data:%s;base64,%s", mime, base64.StdEncoding.EncodeToString(data))
+}
+
+func blobName(b *genai.Blob) string {
+	if b == nil {
+		return ""
+	}
+	return b.DisplayName
+}
+
+func fileDataName(f *genai.FileData) string {
+	if f == nil {
+		return ""
+	}
+	return f.DisplayName
+}
+
+func isImageMIME(mime string) bool {
+	return strings.HasPrefix(mime, "image/")
+}
+
+func isOpenAIFileMIME(mime string) bool {
+	return mime == "application/pdf"
+}
+
+func isAnthropicPDF(mime string) bool {
+	return mime == "application/pdf"
+}
+
+func isAnthropicPlainText(mime string) bool {
+	return mime == "text/plain" || mime == "text/markdown"
+}
+
+// bedrockImageFormat maps image MIME → Bedrock ImageFormat. Empty if unsupported.
+func bedrockImageFormat(mime string) string {
+	switch strings.ToLower(mime) {
+	case "image/png":
+		return "png"
+	case "image/jpeg", "image/jpg":
+		return "jpeg"
+	case "image/gif":
+		return "gif"
+	case "image/webp":
+		return "webp"
+	default:
+		return ""
+	}
+}
+
+// bedrockDocumentFormat maps document MIME → Bedrock DocumentFormat. Empty if unsupported.
+func bedrockDocumentFormat(mime, name string) string {
+	switch strings.ToLower(mime) {
+	case "application/pdf":
+		return "pdf"
+	case "text/csv":
+		return "csv"
+	case "application/msword":
+		return "doc"
+	case "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+		return "docx"
+	case "application/vnd.ms-excel":
+		return "xls"
+	case "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
+		return "xlsx"
+	case "text/html":
+		return "html"
+	case "text/plain":
+		return "txt"
+	case "text/markdown":
+		return "md"
+	}
+	// Fallback: extension from display name.
+	switch strings.ToLower(path.Ext(name)) {
+	case ".pdf":
+		return "pdf"
+	case ".csv":
+		return "csv"
+	case ".doc":
+		return "doc"
+	case ".docx":
+		return "docx"
+	case ".xls":
+		return "xls"
+	case ".xlsx":
+		return "xlsx"
+	case ".html", ".htm":
+		return "html"
+	case ".txt":
+		return "txt"
+	case ".md", ".markdown":
+		return "md"
+	}
+	return ""
+}
+
+// bedrockSafeDocName keeps only chars Bedrock accepts in DocumentBlock.Name.
+func bedrockSafeDocName(name string) string {
+	if name == "" {
+		return "document"
+	}
+	var b strings.Builder
+	prevSpace := false
+	for _, r := range name {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') ||
+			r == '-' || r == '(' || r == ')' || r == '[' || r == ']':
+			b.WriteRune(r)
+			prevSpace = false
+		case r == ' ' || r == '_' || r == '.':
+			if !prevSpace && b.Len() > 0 {
+				b.WriteByte(' ')
+				prevSpace = true
+			}
+		}
+	}
+	out := strings.TrimSpace(b.String())
+	if out == "" {
+		return "document"
+	}
+	return out
+}

--- a/go/adk/pkg/models/file_parts.go
+++ b/go/adk/pkg/models/file_parts.go
@@ -43,16 +43,112 @@ func isImageMIME(mime string) bool {
 	return strings.HasPrefix(mime, "image/")
 }
 
-func isOpenAIFileMIME(mime string) bool {
-	return mime == "application/pdf"
+// OpenAI file support differs by API surface:
+//
+//   - Chat Completions (`messages[].content[].type=file`, inline file_data): PDF only.
+//   - Responses (`input_file`): broad list (txt/md/csv/docx/xlsx/pptx/…).
+func isOpenAIPDF(mime, name string) bool {
+	if strings.ToLower(mime) == "application/pdf" {
+		return true
+	}
+	return strings.ToLower(path.Ext(name)) == ".pdf"
 }
 
-func isAnthropicPDF(mime string) bool {
-	return mime == "application/pdf"
+// isOpenAIResponsesFileMIME is the Responses input_file allowlist (common types).
+// Link: https://platform.openai.com/docs/guides/file-inputs
+func isOpenAIResponsesFileMIME(mime, name string) bool {
+	if isOpenAIPDF(mime, name) {
+		return true
+	}
+	switch strings.ToLower(mime) {
+	case "text/plain", "text/markdown", "text/csv", "text/tsv", "text/html", "text/xml", "text/css",
+		"application/json", "application/xml", "application/rtf", "application/csv", "text/rtf",
+		"application/msword",
+		"application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+		"application/vnd.ms-excel",
+		"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+		"application/vnd.ms-powerpoint",
+		"application/vnd.openxmlformats-officedocument.presentationml.presentation",
+		"application/vnd.oasis.opendocument.text":
+		return true
+	}
+	if strings.HasPrefix(strings.ToLower(mime), "text/") {
+		return true
+	}
+	// Browsers often send "" / application/octet-stream — use extension.
+	switch strings.ToLower(path.Ext(name)) {
+	case ".pdf", ".txt", ".text", ".md", ".markdown", ".csv", ".tsv", ".html", ".htm",
+		".xml", ".json", ".rtf", ".odt",
+		".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx",
+		".py", ".js", ".mjs", ".ts", ".go", ".java", ".c", ".cc", ".cpp", ".h", ".rb",
+		".sh", ".yaml", ".yml", ".css", ".sql":
+		return true
+	}
+	return false
 }
 
-func isAnthropicPlainText(mime string) bool {
-	return mime == "text/plain" || mime == "text/markdown"
+func isAnthropicPDF(mime, name string) bool {
+	return isOpenAIPDF(mime, name)
+}
+
+// isTextFileMIME is true for UTF-8 text we can inline (CC fallback) or send as
+// Anthropic PlainTextSource. Binary office formats are excluded.
+func isTextFileMIME(mime, name string) bool {
+	switch strings.ToLower(mime) {
+	case "text/plain", "text/markdown", "text/csv", "text/tsv", "text/html", "text/xml", "text/css",
+		"application/json", "application/xml", "application/x-yaml", "text/yaml", "text/x-yaml":
+		return true
+	}
+	if strings.HasPrefix(strings.ToLower(mime), "text/") {
+		return true
+	}
+	switch strings.ToLower(path.Ext(name)) {
+	case ".txt", ".text", ".md", ".markdown", ".csv", ".tsv", ".html", ".htm",
+		".xml", ".json", ".yaml", ".yml", ".css",
+		".py", ".js", ".mjs", ".ts", ".go", ".java", ".c", ".cc", ".cpp", ".h", ".rb", ".sh", ".sql":
+		return true
+	}
+	return false
+}
+
+func isAnthropicPlainText(mime, name string) bool {
+	return isTextFileMIME(mime, name)
+}
+
+// inlineFileText wraps file bytes as a labeled text chunk for APIs that cannot
+// take the file natively (Chat Completions non-PDF).
+func inlineFileText(name string, data []byte) string {
+	if name == "" {
+		name = "file"
+	}
+	return fmt.Sprintf("[file: %s]\n%s", name, string(data))
+}
+
+// openAIFilename ensures OpenAI gets a filename (it uses the extension for type detection).
+func openAIFilename(name, mime string) string {
+	if name != "" {
+		return name
+	}
+	switch strings.ToLower(mime) {
+	case "application/pdf":
+		return "document.pdf"
+	case "text/plain":
+		return "document.txt"
+	case "text/markdown":
+		return "document.md"
+	case "text/csv", "application/csv":
+		return "document.csv"
+	case "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+		return "document.docx"
+	case "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
+		return "document.xlsx"
+	case "application/vnd.openxmlformats-officedocument.presentationml.presentation":
+		return "document.pptx"
+	case "application/json":
+		return "document.json"
+	default:
+		return "document"
+	}
 }
 
 // bedrockImageFormat maps image MIME → Bedrock ImageFormat. Empty if unsupported.

--- a/go/adk/pkg/models/file_parts_test.go
+++ b/go/adk/pkg/models/file_parts_test.go
@@ -9,298 +9,91 @@ import (
 	"google.golang.org/genai"
 )
 
-func TestUnsupportedFileNote(t *testing.T) {
-	got := unsupportedFileNote("report.pdf", "application/pdf")
-	if got != "[unsupported file: report.pdf (application/pdf)]" {
-		t.Fatalf("got %q", got)
-	}
-	if unsupportedFileNote("", "") != "[unsupported file: unnamed (unknown)]" {
-		t.Fatalf("empty defaults: %q", unsupportedFileNote("", ""))
-	}
-}
-
-func TestBedrockDocumentFormat(t *testing.T) {
-	tests := []struct {
-		mime, name, want string
-	}{
-		{"application/pdf", "a.pdf", "pdf"},
-		{"text/plain", "a.txt", "txt"},
-		{"application/zip", "a.zip", ""},
-		{"", "notes.md", "md"},
-	}
-	for _, tt := range tests {
-		if got := bedrockDocumentFormat(tt.mime, tt.name); got != tt.want {
-			t.Errorf("bedrockDocumentFormat(%q,%q)=%q want %q", tt.mime, tt.name, got, tt.want)
-		}
-	}
-}
-
 func TestGenaiContentsToOpenAIMessages_FileParts(t *testing.T) {
-	t.Run("pdf", func(t *testing.T) {
-		msgs, _ := genaiContentsToOpenAIMessages([]*genai.Content{{
-			Role: "user",
-			Parts: []*genai.Part{
-				{Text: "summarize"},
-				{InlineData: &genai.Blob{MIMEType: "application/pdf", Data: []byte("%PDF"), DisplayName: "doc.pdf"}},
-			},
-		}}, nil)
-		if len(msgs) != 1 || msgs[0].OfUser == nil {
-			t.Fatalf("msgs = %#v", msgs)
-		}
-		b, err := json.Marshal(msgs[0].OfUser)
-		if err != nil {
-			t.Fatal(err)
-		}
-		s := string(b)
-		if !strings.Contains(s, `"type":"file"`) || !strings.Contains(s, "file_data") || !strings.Contains(s, "application/pdf") {
-			t.Fatalf("missing file part: %s", s)
-		}
-	})
-
-	t.Run("image still works", func(t *testing.T) {
-		msgs, _ := genaiContentsToOpenAIMessages([]*genai.Content{{
-			Role: "user",
-			Parts: []*genai.Part{
-				{InlineData: &genai.Blob{MIMEType: "image/png", Data: []byte{0x89, 0x50}}},
-			},
-		}}, nil)
-		b, _ := json.Marshal(msgs[0].OfUser)
-		if !strings.Contains(string(b), "image_url") || !strings.Contains(string(b), "data:image/png;base64,") {
-			t.Fatalf("missing image: %s", b)
-		}
-	})
-
-	t.Run("unsupported mime becomes note", func(t *testing.T) {
-		msgs, _ := genaiContentsToOpenAIMessages([]*genai.Content{{
-			Role: "user",
-			Parts: []*genai.Part{
-				{InlineData: &genai.Blob{MIMEType: "application/zip", Data: []byte("PK"), DisplayName: "a.zip"}},
-			},
-		}}, nil)
-		b, _ := json.Marshal(msgs[0].OfUser)
-		if strings.Contains(string(b), `"type":"file"`) {
-			t.Fatalf("should not send zip as file: %s", b)
-		}
-		if !strings.Contains(string(b), "unsupported file: a.zip") {
-			t.Fatalf("missing note: %s", b)
-		}
-	})
-
-	t.Run("filedata uri unsupported on chat completions", func(t *testing.T) {
-		msgs, _ := genaiContentsToOpenAIMessages([]*genai.Content{{
-			Role: "user",
-			Parts: []*genai.Part{
-				{FileData: &genai.FileData{MIMEType: "application/pdf", FileURI: "https://example.com/a.pdf", DisplayName: "a.pdf"}},
-			},
-		}}, nil)
-		b, _ := json.Marshal(msgs[0].OfUser)
-		if !strings.Contains(string(b), "unsupported file: a.pdf") {
-			t.Fatalf("missing note: %s", b)
-		}
-	})
+	// Chat Completions: PDF → file part; text → inlined (file_data is PDF-only).
+	msgs, _ := genaiContentsToOpenAIMessages([]*genai.Content{{
+		Role: "user",
+		Parts: []*genai.Part{
+			{InlineData: &genai.Blob{MIMEType: "application/pdf", Data: []byte("%PDF"), DisplayName: "doc.pdf"}},
+			{InlineData: &genai.Blob{MIMEType: "text/plain", Data: []byte("hello"), DisplayName: "notes.txt"}},
+		},
+	}}, nil)
+	b, err := json.Marshal(msgs[0].OfUser)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	if !strings.Contains(s, `"type":"file"`) || !strings.Contains(s, "application/pdf") {
+		t.Fatalf("missing pdf file part: %s", s)
+	}
+	if !strings.Contains(s, "[file: notes.txt]") || !strings.Contains(s, "hello") {
+		t.Fatalf("expected inlined txt: %s", s)
+	}
 }
 
 func TestGenaiContentsToResponsesInput_FileParts(t *testing.T) {
-	t.Run("pdf inline", func(t *testing.T) {
-		input, _ := genaiContentsToResponsesInput([]*genai.Content{{
-			Role: "user",
-			Parts: []*genai.Part{
-				{Text: "read this"},
-				{InlineData: &genai.Blob{MIMEType: "application/pdf", Data: []byte("%PDF"), DisplayName: "doc.pdf"}},
-			},
-		}}, nil)
-		b, err := json.Marshal(input[0].OfMessage)
-		if err != nil {
-			t.Fatal(err)
-		}
-		s := string(b)
-		if !strings.Contains(s, "input_file") || !strings.Contains(s, "file_data") {
-			t.Fatalf("missing input_file: %s", s)
-		}
-	})
-
-	t.Run("pdf uri", func(t *testing.T) {
-		input, _ := genaiContentsToResponsesInput([]*genai.Content{{
-			Role: "user",
-			Parts: []*genai.Part{
-				{FileData: &genai.FileData{MIMEType: "application/pdf", FileURI: "https://example.com/a.pdf", DisplayName: "a.pdf"}},
-			},
-		}}, nil)
-		b, _ := json.Marshal(input[0].OfMessage)
-		if !strings.Contains(string(b), "file_url") || !strings.Contains(string(b), "https://example.com/a.pdf") {
-			t.Fatalf("missing file_url: %s", b)
-		}
-	})
-
-	t.Run("unsupported mime", func(t *testing.T) {
-		input, _ := genaiContentsToResponsesInput([]*genai.Content{{
-			Role: "user",
-			Parts: []*genai.Part{
-				{InlineData: &genai.Blob{MIMEType: "application/zip", Data: []byte("PK"), DisplayName: "a.zip"}},
-			},
-		}}, nil)
-		b, _ := json.Marshal(input[0].OfMessage)
-		if strings.Contains(string(b), "input_file") {
-			t.Fatalf("should not send zip: %s", b)
-		}
-		if !strings.Contains(string(b), "unsupported file: a.zip") {
-			t.Fatalf("missing note: %s", b)
-		}
-	})
+	// Responses input_file accepts PDF and text.
+	input, _ := genaiContentsToResponsesInput([]*genai.Content{{
+		Role: "user",
+		Parts: []*genai.Part{
+			{InlineData: &genai.Blob{MIMEType: "text/plain", Data: []byte("hello"), DisplayName: "notes.txt"}},
+		},
+	}}, nil)
+	b, _ := json.Marshal(input[0].OfMessage)
+	if !strings.Contains(string(b), "input_file") || !strings.Contains(string(b), "notes.txt") {
+		t.Fatalf("missing input_file: %s", b)
+	}
 }
 
 func TestGenaiContentsToAnthropicMessages_FileParts(t *testing.T) {
-	t.Run("pdf", func(t *testing.T) {
-		msgs, _ := genaiContentsToAnthropicMessages([]*genai.Content{{
-			Role: "user",
-			Parts: []*genai.Part{
-				{Text: "summarize"},
-				{InlineData: &genai.Blob{MIMEType: "application/pdf", Data: []byte("%PDF")}},
-			},
-		}}, nil)
-		if len(msgs) != 1 {
-			t.Fatalf("len=%d", len(msgs))
-		}
-		b, err := json.Marshal(msgs[0])
-		if err != nil {
-			t.Fatal(err)
-		}
-		s := string(b)
-		if !strings.Contains(s, `"type":"document"`) || !strings.Contains(s, "application/pdf") {
-			t.Fatalf("missing document: %s", s)
-		}
-	})
-
-	t.Run("plain text document", func(t *testing.T) {
-		msgs, _ := genaiContentsToAnthropicMessages([]*genai.Content{{
-			Role: "user",
-			Parts: []*genai.Part{
-				{InlineData: &genai.Blob{MIMEType: "text/plain", Data: []byte("hello")}},
-			},
-		}}, nil)
-		b, _ := json.Marshal(msgs[0])
-		if !strings.Contains(string(b), `"type":"document"`) {
-			t.Fatalf("missing document: %s", b)
-		}
-	})
-
-	t.Run("pdf uri", func(t *testing.T) {
-		msgs, _ := genaiContentsToAnthropicMessages([]*genai.Content{{
-			Role: "user",
-			Parts: []*genai.Part{
-				{FileData: &genai.FileData{MIMEType: "application/pdf", FileURI: "https://example.com/a.pdf"}},
-			},
-		}}, nil)
-		b, _ := json.Marshal(msgs[0])
-		if !strings.Contains(string(b), "https://example.com/a.pdf") {
-			t.Fatalf("missing url: %s", b)
-		}
-	})
-
-	t.Run("image still works", func(t *testing.T) {
-		msgs, _ := genaiContentsToAnthropicMessages([]*genai.Content{{
-			Role: "user",
-			Parts: []*genai.Part{
-				{InlineData: &genai.Blob{MIMEType: "image/png", Data: []byte{0x89, 0x50}}},
-			},
-		}}, nil)
-		b, _ := json.Marshal(msgs[0])
-		if !strings.Contains(string(b), `"type":"image"`) {
-			t.Fatalf("missing image: %s", b)
-		}
-	})
-
-	t.Run("unsupported mime", func(t *testing.T) {
-		msgs, _ := genaiContentsToAnthropicMessages([]*genai.Content{{
-			Role: "user",
-			Parts: []*genai.Part{
-				{InlineData: &genai.Blob{MIMEType: "application/zip", Data: []byte("PK"), DisplayName: "a.zip"}},
-			},
-		}}, nil)
-		b, _ := json.Marshal(msgs[0])
-		if strings.Contains(string(b), `"type":"document"`) {
-			t.Fatalf("should not send zip: %s", b)
-		}
-		if !strings.Contains(string(b), "unsupported file: a.zip") {
-			t.Fatalf("missing note: %s", b)
-		}
-	})
+	msgs, _ := genaiContentsToAnthropicMessages([]*genai.Content{{
+		Role: "user",
+		Parts: []*genai.Part{
+			{InlineData: &genai.Blob{MIMEType: "application/pdf", Data: []byte("%PDF"), DisplayName: "doc.pdf"}},
+		},
+	}}, nil)
+	b, _ := json.Marshal(msgs[0])
+	if !strings.Contains(string(b), `"type":"document"`) {
+		t.Fatalf("missing document: %s", b)
+	}
 }
 
 func TestConvertGenaiContentsToBedrockMessages_FileParts(t *testing.T) {
-	t.Run("pdf", func(t *testing.T) {
-		msgs, _ := convertGenaiContentsToBedrockMessages([]*genai.Content{{
-			Role: "user",
-			Parts: []*genai.Part{
-				{InlineData: &genai.Blob{MIMEType: "application/pdf", Data: []byte("%PDF"), DisplayName: "doc.pdf"}},
-			},
-		}}, nil, nil)
-		if len(msgs) != 1 || len(msgs[0].Content) != 1 {
-			t.Fatalf("msgs=%#v", msgs)
+	// Document-only user turns must also carry a text block (Bedrock Converse API).
+	msgs, _ := convertGenaiContentsToBedrockMessages([]*genai.Content{{
+		Role: "user",
+		Parts: []*genai.Part{
+			{InlineData: &genai.Blob{MIMEType: "application/pdf", Data: []byte("%PDF"), DisplayName: "doc.pdf"}},
+		},
+	}}, nil, nil)
+	if len(msgs) != 1 {
+		t.Fatalf("msgs=%#v", msgs)
+	}
+	var hasDoc, hasText bool
+	for _, block := range msgs[0].Content {
+		switch block.(type) {
+		case *types.ContentBlockMemberDocument:
+			hasDoc = true
+		case *types.ContentBlockMemberText:
+			hasText = true
 		}
-		doc, ok := msgs[0].Content[0].(*types.ContentBlockMemberDocument)
-		if !ok {
-			t.Fatalf("want document, got %T", msgs[0].Content[0])
-		}
-		if doc.Value.Format != types.DocumentFormatPdf {
-			t.Fatalf("format=%q", doc.Value.Format)
-		}
-	})
-
-	t.Run("image", func(t *testing.T) {
-		msgs, _ := convertGenaiContentsToBedrockMessages([]*genai.Content{{
-			Role: "user",
-			Parts: []*genai.Part{
-				{InlineData: &genai.Blob{MIMEType: "image/png", Data: []byte{0x89, 0x50}}},
-			},
-		}}, nil, nil)
-		if _, ok := msgs[0].Content[0].(*types.ContentBlockMemberImage); !ok {
-			t.Fatalf("want image, got %T", msgs[0].Content[0])
-		}
-	})
-
-	t.Run("unsupported", func(t *testing.T) {
-		msgs, _ := convertGenaiContentsToBedrockMessages([]*genai.Content{{
-			Role: "user",
-			Parts: []*genai.Part{
-				{InlineData: &genai.Blob{MIMEType: "application/zip", Data: []byte("PK"), DisplayName: "a.zip"}},
-			},
-		}}, nil, nil)
-		text, ok := msgs[0].Content[0].(*types.ContentBlockMemberText)
-		if !ok || !strings.Contains(text.Value, "unsupported file: a.zip") {
-			t.Fatalf("want text note, got %#v", msgs[0].Content[0])
-		}
-	})
+	}
+	if !hasDoc || !hasText {
+		t.Fatalf("want document+text, got %#v", msgs[0].Content)
+	}
 }
 
 func TestConvertGenaiContentsToOllamaMessages_FileParts(t *testing.T) {
-	t.Run("image", func(t *testing.T) {
-		msgs, _ := convertGenaiContentsToOllamaMessages([]*genai.Content{{
-			Role: "user",
-			Parts: []*genai.Part{
-				{Text: "what"},
-				{InlineData: &genai.Blob{MIMEType: "image/png", Data: []byte{0x89, 0x50}}},
-			},
-		}}, nil)
-		if len(msgs) != 1 || len(msgs[0].Images) != 1 {
-			t.Fatalf("msgs=%#v", msgs)
-		}
-	})
-
-	t.Run("pdf note", func(t *testing.T) {
-		msgs, _ := convertGenaiContentsToOllamaMessages([]*genai.Content{{
-			Role: "user",
-			Parts: []*genai.Part{
-				{InlineData: &genai.Blob{MIMEType: "application/pdf", Data: []byte("%PDF"), DisplayName: "a.pdf"}},
-			},
-		}}, nil)
-		if len(msgs) != 1 || !strings.Contains(msgs[0].Content, "unsupported file: a.pdf") {
-			t.Fatalf("msgs=%#v", msgs)
-		}
-		if len(msgs[0].Images) != 0 {
-			t.Fatalf("should not attach pdf as image")
-		}
-	})
+	msgs, _ := convertGenaiContentsToOllamaMessages([]*genai.Content{{
+		Role: "user",
+		Parts: []*genai.Part{
+			{Text: "what"},
+			{InlineData: &genai.Blob{MIMEType: "image/png", Data: []byte{0x89, 0x50}}},
+		},
+	}}, nil)
+	if len(msgs) != 1 || len(msgs[0].Images) != 1 {
+		t.Fatalf("msgs=%#v", msgs)
+	}
 }
 
 func TestGenaiContentsToOrchTemplate_FileParts(t *testing.T) {
@@ -310,9 +103,6 @@ func TestGenaiContentsToOrchTemplate_FileParts(t *testing.T) {
 			{InlineData: &genai.Blob{MIMEType: "application/pdf", Data: []byte("%PDF"), DisplayName: "a.pdf"}},
 		},
 	}}, nil)
-	if len(msgs) != 1 {
-		t.Fatalf("msgs=%#v", msgs)
-	}
 	content, _ := msgs[0]["content"].(string)
 	if !strings.Contains(content, "unsupported file: a.pdf") {
 		t.Fatalf("content=%q", content)

--- a/go/adk/pkg/models/file_parts_test.go
+++ b/go/adk/pkg/models/file_parts_test.go
@@ -1,0 +1,320 @@
+package models
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+	"google.golang.org/genai"
+)
+
+func TestUnsupportedFileNote(t *testing.T) {
+	got := unsupportedFileNote("report.pdf", "application/pdf")
+	if got != "[unsupported file: report.pdf (application/pdf)]" {
+		t.Fatalf("got %q", got)
+	}
+	if unsupportedFileNote("", "") != "[unsupported file: unnamed (unknown)]" {
+		t.Fatalf("empty defaults: %q", unsupportedFileNote("", ""))
+	}
+}
+
+func TestBedrockDocumentFormat(t *testing.T) {
+	tests := []struct {
+		mime, name, want string
+	}{
+		{"application/pdf", "a.pdf", "pdf"},
+		{"text/plain", "a.txt", "txt"},
+		{"application/zip", "a.zip", ""},
+		{"", "notes.md", "md"},
+	}
+	for _, tt := range tests {
+		if got := bedrockDocumentFormat(tt.mime, tt.name); got != tt.want {
+			t.Errorf("bedrockDocumentFormat(%q,%q)=%q want %q", tt.mime, tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestGenaiContentsToOpenAIMessages_FileParts(t *testing.T) {
+	t.Run("pdf", func(t *testing.T) {
+		msgs, _ := genaiContentsToOpenAIMessages([]*genai.Content{{
+			Role: "user",
+			Parts: []*genai.Part{
+				{Text: "summarize"},
+				{InlineData: &genai.Blob{MIMEType: "application/pdf", Data: []byte("%PDF"), DisplayName: "doc.pdf"}},
+			},
+		}}, nil)
+		if len(msgs) != 1 || msgs[0].OfUser == nil {
+			t.Fatalf("msgs = %#v", msgs)
+		}
+		b, err := json.Marshal(msgs[0].OfUser)
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := string(b)
+		if !strings.Contains(s, `"type":"file"`) || !strings.Contains(s, "file_data") || !strings.Contains(s, "application/pdf") {
+			t.Fatalf("missing file part: %s", s)
+		}
+	})
+
+	t.Run("image still works", func(t *testing.T) {
+		msgs, _ := genaiContentsToOpenAIMessages([]*genai.Content{{
+			Role: "user",
+			Parts: []*genai.Part{
+				{InlineData: &genai.Blob{MIMEType: "image/png", Data: []byte{0x89, 0x50}}},
+			},
+		}}, nil)
+		b, _ := json.Marshal(msgs[0].OfUser)
+		if !strings.Contains(string(b), "image_url") || !strings.Contains(string(b), "data:image/png;base64,") {
+			t.Fatalf("missing image: %s", b)
+		}
+	})
+
+	t.Run("unsupported mime becomes note", func(t *testing.T) {
+		msgs, _ := genaiContentsToOpenAIMessages([]*genai.Content{{
+			Role: "user",
+			Parts: []*genai.Part{
+				{InlineData: &genai.Blob{MIMEType: "application/zip", Data: []byte("PK"), DisplayName: "a.zip"}},
+			},
+		}}, nil)
+		b, _ := json.Marshal(msgs[0].OfUser)
+		if strings.Contains(string(b), `"type":"file"`) {
+			t.Fatalf("should not send zip as file: %s", b)
+		}
+		if !strings.Contains(string(b), "unsupported file: a.zip") {
+			t.Fatalf("missing note: %s", b)
+		}
+	})
+
+	t.Run("filedata uri unsupported on chat completions", func(t *testing.T) {
+		msgs, _ := genaiContentsToOpenAIMessages([]*genai.Content{{
+			Role: "user",
+			Parts: []*genai.Part{
+				{FileData: &genai.FileData{MIMEType: "application/pdf", FileURI: "https://example.com/a.pdf", DisplayName: "a.pdf"}},
+			},
+		}}, nil)
+		b, _ := json.Marshal(msgs[0].OfUser)
+		if !strings.Contains(string(b), "unsupported file: a.pdf") {
+			t.Fatalf("missing note: %s", b)
+		}
+	})
+}
+
+func TestGenaiContentsToResponsesInput_FileParts(t *testing.T) {
+	t.Run("pdf inline", func(t *testing.T) {
+		input, _ := genaiContentsToResponsesInput([]*genai.Content{{
+			Role: "user",
+			Parts: []*genai.Part{
+				{Text: "read this"},
+				{InlineData: &genai.Blob{MIMEType: "application/pdf", Data: []byte("%PDF"), DisplayName: "doc.pdf"}},
+			},
+		}}, nil)
+		b, err := json.Marshal(input[0].OfMessage)
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := string(b)
+		if !strings.Contains(s, "input_file") || !strings.Contains(s, "file_data") {
+			t.Fatalf("missing input_file: %s", s)
+		}
+	})
+
+	t.Run("pdf uri", func(t *testing.T) {
+		input, _ := genaiContentsToResponsesInput([]*genai.Content{{
+			Role: "user",
+			Parts: []*genai.Part{
+				{FileData: &genai.FileData{MIMEType: "application/pdf", FileURI: "https://example.com/a.pdf", DisplayName: "a.pdf"}},
+			},
+		}}, nil)
+		b, _ := json.Marshal(input[0].OfMessage)
+		if !strings.Contains(string(b), "file_url") || !strings.Contains(string(b), "https://example.com/a.pdf") {
+			t.Fatalf("missing file_url: %s", b)
+		}
+	})
+
+	t.Run("unsupported mime", func(t *testing.T) {
+		input, _ := genaiContentsToResponsesInput([]*genai.Content{{
+			Role: "user",
+			Parts: []*genai.Part{
+				{InlineData: &genai.Blob{MIMEType: "application/zip", Data: []byte("PK"), DisplayName: "a.zip"}},
+			},
+		}}, nil)
+		b, _ := json.Marshal(input[0].OfMessage)
+		if strings.Contains(string(b), "input_file") {
+			t.Fatalf("should not send zip: %s", b)
+		}
+		if !strings.Contains(string(b), "unsupported file: a.zip") {
+			t.Fatalf("missing note: %s", b)
+		}
+	})
+}
+
+func TestGenaiContentsToAnthropicMessages_FileParts(t *testing.T) {
+	t.Run("pdf", func(t *testing.T) {
+		msgs, _ := genaiContentsToAnthropicMessages([]*genai.Content{{
+			Role: "user",
+			Parts: []*genai.Part{
+				{Text: "summarize"},
+				{InlineData: &genai.Blob{MIMEType: "application/pdf", Data: []byte("%PDF")}},
+			},
+		}}, nil)
+		if len(msgs) != 1 {
+			t.Fatalf("len=%d", len(msgs))
+		}
+		b, err := json.Marshal(msgs[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := string(b)
+		if !strings.Contains(s, `"type":"document"`) || !strings.Contains(s, "application/pdf") {
+			t.Fatalf("missing document: %s", s)
+		}
+	})
+
+	t.Run("plain text document", func(t *testing.T) {
+		msgs, _ := genaiContentsToAnthropicMessages([]*genai.Content{{
+			Role: "user",
+			Parts: []*genai.Part{
+				{InlineData: &genai.Blob{MIMEType: "text/plain", Data: []byte("hello")}},
+			},
+		}}, nil)
+		b, _ := json.Marshal(msgs[0])
+		if !strings.Contains(string(b), `"type":"document"`) {
+			t.Fatalf("missing document: %s", b)
+		}
+	})
+
+	t.Run("pdf uri", func(t *testing.T) {
+		msgs, _ := genaiContentsToAnthropicMessages([]*genai.Content{{
+			Role: "user",
+			Parts: []*genai.Part{
+				{FileData: &genai.FileData{MIMEType: "application/pdf", FileURI: "https://example.com/a.pdf"}},
+			},
+		}}, nil)
+		b, _ := json.Marshal(msgs[0])
+		if !strings.Contains(string(b), "https://example.com/a.pdf") {
+			t.Fatalf("missing url: %s", b)
+		}
+	})
+
+	t.Run("image still works", func(t *testing.T) {
+		msgs, _ := genaiContentsToAnthropicMessages([]*genai.Content{{
+			Role: "user",
+			Parts: []*genai.Part{
+				{InlineData: &genai.Blob{MIMEType: "image/png", Data: []byte{0x89, 0x50}}},
+			},
+		}}, nil)
+		b, _ := json.Marshal(msgs[0])
+		if !strings.Contains(string(b), `"type":"image"`) {
+			t.Fatalf("missing image: %s", b)
+		}
+	})
+
+	t.Run("unsupported mime", func(t *testing.T) {
+		msgs, _ := genaiContentsToAnthropicMessages([]*genai.Content{{
+			Role: "user",
+			Parts: []*genai.Part{
+				{InlineData: &genai.Blob{MIMEType: "application/zip", Data: []byte("PK"), DisplayName: "a.zip"}},
+			},
+		}}, nil)
+		b, _ := json.Marshal(msgs[0])
+		if strings.Contains(string(b), `"type":"document"`) {
+			t.Fatalf("should not send zip: %s", b)
+		}
+		if !strings.Contains(string(b), "unsupported file: a.zip") {
+			t.Fatalf("missing note: %s", b)
+		}
+	})
+}
+
+func TestConvertGenaiContentsToBedrockMessages_FileParts(t *testing.T) {
+	t.Run("pdf", func(t *testing.T) {
+		msgs, _ := convertGenaiContentsToBedrockMessages([]*genai.Content{{
+			Role: "user",
+			Parts: []*genai.Part{
+				{InlineData: &genai.Blob{MIMEType: "application/pdf", Data: []byte("%PDF"), DisplayName: "doc.pdf"}},
+			},
+		}}, nil, nil)
+		if len(msgs) != 1 || len(msgs[0].Content) != 1 {
+			t.Fatalf("msgs=%#v", msgs)
+		}
+		doc, ok := msgs[0].Content[0].(*types.ContentBlockMemberDocument)
+		if !ok {
+			t.Fatalf("want document, got %T", msgs[0].Content[0])
+		}
+		if doc.Value.Format != types.DocumentFormatPdf {
+			t.Fatalf("format=%q", doc.Value.Format)
+		}
+	})
+
+	t.Run("image", func(t *testing.T) {
+		msgs, _ := convertGenaiContentsToBedrockMessages([]*genai.Content{{
+			Role: "user",
+			Parts: []*genai.Part{
+				{InlineData: &genai.Blob{MIMEType: "image/png", Data: []byte{0x89, 0x50}}},
+			},
+		}}, nil, nil)
+		if _, ok := msgs[0].Content[0].(*types.ContentBlockMemberImage); !ok {
+			t.Fatalf("want image, got %T", msgs[0].Content[0])
+		}
+	})
+
+	t.Run("unsupported", func(t *testing.T) {
+		msgs, _ := convertGenaiContentsToBedrockMessages([]*genai.Content{{
+			Role: "user",
+			Parts: []*genai.Part{
+				{InlineData: &genai.Blob{MIMEType: "application/zip", Data: []byte("PK"), DisplayName: "a.zip"}},
+			},
+		}}, nil, nil)
+		text, ok := msgs[0].Content[0].(*types.ContentBlockMemberText)
+		if !ok || !strings.Contains(text.Value, "unsupported file: a.zip") {
+			t.Fatalf("want text note, got %#v", msgs[0].Content[0])
+		}
+	})
+}
+
+func TestConvertGenaiContentsToOllamaMessages_FileParts(t *testing.T) {
+	t.Run("image", func(t *testing.T) {
+		msgs, _ := convertGenaiContentsToOllamaMessages([]*genai.Content{{
+			Role: "user",
+			Parts: []*genai.Part{
+				{Text: "what"},
+				{InlineData: &genai.Blob{MIMEType: "image/png", Data: []byte{0x89, 0x50}}},
+			},
+		}}, nil)
+		if len(msgs) != 1 || len(msgs[0].Images) != 1 {
+			t.Fatalf("msgs=%#v", msgs)
+		}
+	})
+
+	t.Run("pdf note", func(t *testing.T) {
+		msgs, _ := convertGenaiContentsToOllamaMessages([]*genai.Content{{
+			Role: "user",
+			Parts: []*genai.Part{
+				{InlineData: &genai.Blob{MIMEType: "application/pdf", Data: []byte("%PDF"), DisplayName: "a.pdf"}},
+			},
+		}}, nil)
+		if len(msgs) != 1 || !strings.Contains(msgs[0].Content, "unsupported file: a.pdf") {
+			t.Fatalf("msgs=%#v", msgs)
+		}
+		if len(msgs[0].Images) != 0 {
+			t.Fatalf("should not attach pdf as image")
+		}
+	})
+}
+
+func TestGenaiContentsToOrchTemplate_FileParts(t *testing.T) {
+	msgs, _ := genaiContentsToOrchTemplate([]*genai.Content{{
+		Role: "user",
+		Parts: []*genai.Part{
+			{InlineData: &genai.Blob{MIMEType: "application/pdf", Data: []byte("%PDF"), DisplayName: "a.pdf"}},
+		},
+	}}, nil)
+	if len(msgs) != 1 {
+		t.Fatalf("msgs=%#v", msgs)
+	}
+	content, _ := msgs[0]["content"].(string)
+	if !strings.Contains(content, "unsupported file: a.pdf") {
+		t.Fatalf("content=%q", content)
+	}
+}

--- a/go/adk/pkg/models/ollama_adk.go
+++ b/go/adk/pkg/models/ollama_adk.go
@@ -255,6 +255,7 @@ func convertGenaiContentsToOllamaMessages(contents []*genai.Content, config *gen
 		}
 
 		var textParts []string
+		var images []api.ImageData
 		var toolCalls []api.ToolCall
 		var toolResults []struct {
 			content string
@@ -296,6 +297,22 @@ func convertGenaiContentsToOllamaMessages(contents []*genai.Content, config *gen
 				}{content: content})
 				continue
 			}
+
+			if part.InlineData != nil {
+				mime := part.InlineData.MIMEType
+				name := blobName(part.InlineData)
+				if isImageMIME(mime) {
+					images = append(images, api.ImageData(part.InlineData.Data))
+				} else {
+					textParts = append(textParts, unsupportedFileNote(name, mime))
+				}
+				continue
+			}
+
+			if part.FileData != nil {
+				textParts = append(textParts, unsupportedFileNote(fileDataName(part.FileData), part.FileData.MIMEType))
+				continue
+			}
 		}
 
 		// Build message based on what we found
@@ -319,8 +336,7 @@ func convertGenaiContentsToOllamaMessages(contents []*genai.Content, config *gen
 			}
 		}
 
-		if len(textParts) > 0 {
-			// Regular text message
+		if len(textParts) > 0 || len(images) > 0 {
 			// Check if this is a system message
 			if content.Role == "system" {
 				systemInstruction = strings.Join(textParts, "\n")
@@ -328,6 +344,7 @@ func convertGenaiContentsToOllamaMessages(contents []*genai.Content, config *gen
 				msg := api.Message{
 					Role:    role,
 					Content: strings.Join(textParts, "\n"),
+					Images:  images,
 				}
 				messages = append(messages, msg)
 			}

--- a/go/adk/pkg/models/openai_adk.go
+++ b/go/adk/pkg/models/openai_adk.go
@@ -248,7 +248,7 @@ func genaiContentsToOpenAIMessages(contents []*genai.Content, config *genai.Gene
 		role := strings.TrimSpace(content.Role)
 		var textParts []string
 		var functionCalls []*genai.FunctionCall
-		var imageParts []openai.ChatCompletionContentPartImageImageURLParam
+		var contentParts []openai.ChatCompletionContentPartUnionParam
 
 		for _, part := range content.Parts {
 			if part == nil {
@@ -258,10 +258,27 @@ func genaiContentsToOpenAIMessages(contents []*genai.Content, config *genai.Gene
 				textParts = append(textParts, part.Text)
 			} else if part.FunctionCall != nil {
 				functionCalls = append(functionCalls, part.FunctionCall)
-			} else if part.InlineData != nil && strings.HasPrefix(part.InlineData.MIMEType, "image/") {
-				imageParts = append(imageParts, openai.ChatCompletionContentPartImageImageURLParam{
-					URL: fmt.Sprintf("data:%s;base64,%s", part.InlineData.MIMEType, base64.StdEncoding.EncodeToString(part.InlineData.Data)),
-				})
+			} else if part.InlineData != nil {
+				mime := part.InlineData.MIMEType
+				name := blobName(part.InlineData)
+				if isImageMIME(mime) {
+					contentParts = append(contentParts, openai.ImageContentPart(openai.ChatCompletionContentPartImageImageURLParam{
+						URL: dataURI(mime, part.InlineData.Data),
+					}))
+				} else if isOpenAIFileMIME(mime) {
+					file := openai.ChatCompletionContentPartFileFileParam{
+						FileData: param.NewOpt(dataURI(mime, part.InlineData.Data)),
+					}
+					if name != "" {
+						file.Filename = param.NewOpt(name)
+					}
+					contentParts = append(contentParts, openai.FileContentPart(file))
+				} else {
+					textParts = append(textParts, unsupportedFileNote(name, mime))
+				}
+			} else if part.FileData != nil {
+				// Chat Completions file parts have no URL field.
+				textParts = append(textParts, unsupportedFileNote(fileDataName(part.FileData), part.FileData.MIMEType))
 			}
 		}
 
@@ -311,14 +328,12 @@ func genaiContentsToOpenAIMessages(contents []*genai.Content, config *genai.Gene
 			messages = append(messages, openai.ChatCompletionMessageParamUnion{OfAssistant: &asst})
 			messages = append(messages, toolResponseMessages...)
 		} else {
-			if len(imageParts) > 0 {
-				parts := make([]openai.ChatCompletionContentPartUnionParam, 0, len(textParts)+len(imageParts))
+			if len(contentParts) > 0 {
+				parts := make([]openai.ChatCompletionContentPartUnionParam, 0, len(textParts)+len(contentParts))
 				for _, t := range textParts {
 					parts = append(parts, openai.TextContentPart(t))
 				}
-				for _, img := range imageParts {
-					parts = append(parts, openai.ImageContentPart(img))
-				}
+				parts = append(parts, contentParts...)
 				messages = append(messages, openai.UserMessage(parts))
 			} else if len(textParts) > 0 {
 				messages = append(messages, openai.UserMessage(strings.Join(textParts, "\n")))

--- a/go/adk/pkg/models/openai_adk.go
+++ b/go/adk/pkg/models/openai_adk.go
@@ -265,19 +265,21 @@ func genaiContentsToOpenAIMessages(contents []*genai.Content, config *genai.Gene
 					contentParts = append(contentParts, openai.ImageContentPart(openai.ChatCompletionContentPartImageImageURLParam{
 						URL: dataURI(mime, part.InlineData.Data),
 					}))
-				} else if isOpenAIFileMIME(mime) {
+				} else if isOpenAIPDF(mime, name) {
+					// Chat Completions file_data accepts PDF only (not txt/docx/…).
 					file := openai.ChatCompletionContentPartFileFileParam{
-						FileData: param.NewOpt(dataURI(mime, part.InlineData.Data)),
-					}
-					if name != "" {
-						file.Filename = param.NewOpt(name)
+						FileData: param.NewOpt(dataURI("application/pdf", part.InlineData.Data)),
+						Filename: param.NewOpt(openAIFilename(name, "application/pdf")),
 					}
 					contentParts = append(contentParts, openai.FileContentPart(file))
+				} else if isTextFileMIME(mime, name) {
+					// Fallback: inline text so .txt still reaches the model on CC.
+					textParts = append(textParts, inlineFileText(name, part.InlineData.Data))
 				} else {
 					textParts = append(textParts, unsupportedFileNote(name, mime))
 				}
 			} else if part.FileData != nil {
-				// Chat Completions file parts have no URL field.
+				// Chat Completions has no file_url; only Responses does.
 				textParts = append(textParts, unsupportedFileNote(fileDataName(part.FileData), part.FileData.MIMEType))
 			}
 		}

--- a/go/adk/pkg/models/openai_responses.go
+++ b/go/adk/pkg/models/openai_responses.go
@@ -3,7 +3,6 @@ package models
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"maps"
@@ -97,7 +96,7 @@ func genaiContentsToResponsesInput(contents []*genai.Content, config *genai.Gene
 		role := strings.TrimSpace(content.Role)
 		var textParts []string
 		var functionCalls []*genai.FunctionCall
-		var imageURLs []string
+		var contentParts responses.ResponseInputMessageContentListParam
 
 		for _, part := range content.Parts {
 			if part == nil {
@@ -107,12 +106,39 @@ func genaiContentsToResponsesInput(contents []*genai.Content, config *genai.Gene
 				textParts = append(textParts, part.Text)
 			} else if part.FunctionCall != nil {
 				functionCalls = append(functionCalls, part.FunctionCall)
-			} else if part.InlineData != nil && strings.HasPrefix(part.InlineData.MIMEType, "image/") {
-				imageURLs = append(imageURLs, fmt.Sprintf(
-					"data:%s;base64,%s",
-					part.InlineData.MIMEType,
-					base64.StdEncoding.EncodeToString(part.InlineData.Data),
-				))
+			} else if part.InlineData != nil {
+				mime := part.InlineData.MIMEType
+				name := blobName(part.InlineData)
+				if isImageMIME(mime) {
+					img := responses.ResponseInputContentParamOfInputImage(responses.ResponseInputImageDetailAuto)
+					img.OfInputImage.ImageURL = param.NewOpt(dataURI(mime, part.InlineData.Data))
+					contentParts = append(contentParts, img)
+				} else if isOpenAIFileMIME(mime) {
+					file := responses.ResponseInputFileParam{
+						FileData: param.NewOpt(dataURI(mime, part.InlineData.Data)),
+					}
+					if name != "" {
+						file.Filename = param.NewOpt(name)
+					}
+					contentParts = append(contentParts, responses.ResponseInputContentUnionParam{OfInputFile: &file})
+				} else {
+					textParts = append(textParts, unsupportedFileNote(name, mime))
+				}
+			} else if part.FileData != nil {
+				mime := part.FileData.MIMEType
+				name := fileDataName(part.FileData)
+				uri := part.FileData.FileURI
+				if uri != "" && isOpenAIFileMIME(mime) {
+					file := responses.ResponseInputFileParam{
+						FileURL: param.NewOpt(uri),
+					}
+					if name != "" {
+						file.Filename = param.NewOpt(name)
+					}
+					contentParts = append(contentParts, responses.ResponseInputContentUnionParam{OfInputFile: &file})
+				} else {
+					textParts = append(textParts, unsupportedFileNote(name, mime))
+				}
 			}
 		}
 
@@ -139,7 +165,7 @@ func genaiContentsToResponsesInput(contents []*genai.Content, config *genai.Gene
 			continue
 		}
 
-		if len(textParts) == 0 && len(imageURLs) == 0 {
+		if len(textParts) == 0 && len(contentParts) == 0 {
 			continue
 		}
 
@@ -148,16 +174,12 @@ func genaiContentsToResponsesInput(contents []*genai.Content, config *genai.Gene
 			msgRole = responses.EasyInputMessageRoleAssistant
 		}
 
-		if len(imageURLs) > 0 {
-			parts := make(responses.ResponseInputMessageContentListParam, 0, len(textParts)+len(imageURLs))
+		if len(contentParts) > 0 {
+			parts := make(responses.ResponseInputMessageContentListParam, 0, len(textParts)+len(contentParts))
 			for _, t := range textParts {
 				parts = append(parts, responses.ResponseInputContentParamOfInputText(t))
 			}
-			for _, url := range imageURLs {
-				img := responses.ResponseInputContentParamOfInputImage(responses.ResponseInputImageDetailAuto)
-				img.OfInputImage.ImageURL = param.NewOpt(url)
-				parts = append(parts, img)
-			}
+			parts = append(parts, contentParts...)
 			input = append(input, responses.ResponseInputItemParamOfMessage(parts, msgRole))
 		} else {
 			input = append(input, responses.ResponseInputItemParamOfMessage(strings.Join(textParts, "\n"), msgRole))

--- a/go/adk/pkg/models/openai_responses.go
+++ b/go/adk/pkg/models/openai_responses.go
@@ -113,12 +113,16 @@ func genaiContentsToResponsesInput(contents []*genai.Content, config *genai.Gene
 					img := responses.ResponseInputContentParamOfInputImage(responses.ResponseInputImageDetailAuto)
 					img.OfInputImage.ImageURL = param.NewOpt(dataURI(mime, part.InlineData.Data))
 					contentParts = append(contentParts, img)
-				} else if isOpenAIFileMIME(mime) {
-					file := responses.ResponseInputFileParam{
-						FileData: param.NewOpt(dataURI(mime, part.InlineData.Data)),
+				} else if isOpenAIResponsesFileMIME(mime, name) {
+					// Responses input_file: PDF + txt/md/csv/docx/xlsx/pptx/…
+					fileMIME := mime
+					if isOpenAIPDF(mime, name) {
+						fileMIME = "application/pdf"
 					}
-					if name != "" {
-						file.Filename = param.NewOpt(name)
+					fname := openAIFilename(name, fileMIME)
+					file := responses.ResponseInputFileParam{
+						FileData: param.NewOpt(dataURI(fileMIME, part.InlineData.Data)),
+						Filename: param.NewOpt(fname),
 					}
 					contentParts = append(contentParts, responses.ResponseInputContentUnionParam{OfInputFile: &file})
 				} else {
@@ -128,12 +132,11 @@ func genaiContentsToResponsesInput(contents []*genai.Content, config *genai.Gene
 				mime := part.FileData.MIMEType
 				name := fileDataName(part.FileData)
 				uri := part.FileData.FileURI
-				if uri != "" && isOpenAIFileMIME(mime) {
+				// file_url is Responses-only (Chat Completions docs: not supported).
+				if uri != "" && isOpenAIResponsesFileMIME(mime, name) {
 					file := responses.ResponseInputFileParam{
-						FileURL: param.NewOpt(uri),
-					}
-					if name != "" {
-						file.Filename = param.NewOpt(name)
+						FileURL:  param.NewOpt(uri),
+						Filename: param.NewOpt(openAIFilename(name, mime)),
 					}
 					contentParts = append(contentParts, responses.ResponseInputContentUnionParam{OfInputFile: &file})
 				} else {

--- a/go/adk/pkg/models/sapaicore_adk.go
+++ b/go/adk/pkg/models/sapaicore_adk.go
@@ -204,6 +204,10 @@ func genaiContentsToOrchTemplate(contents []*genai.Content, config *genai.Genera
 				textParts = append(textParts, part.Text)
 			} else if part.FunctionCall != nil {
 				functionCalls = append(functionCalls, part.FunctionCall)
+			} else if part.InlineData != nil {
+				textParts = append(textParts, unsupportedFileNote(blobName(part.InlineData), part.InlineData.MIMEType))
+			} else if part.FileData != nil {
+				textParts = append(textParts, unsupportedFileNote(fileDataName(part.FileData), part.FileData.MIMEType))
 			}
 		}
 

--- a/ui/src/components/chat/ChatInterface.tsx
+++ b/ui/src/components/chat/ChatInterface.tsx
@@ -45,8 +45,11 @@ import {
   type SessionGuardOptions,
 } from "@/lib/chatSessionGuard";
 
-/** Soft client cap so base64 A2A FileParts stay reasonable. */
-const MAX_CHAT_FILE_BYTES = 10 * 1024 * 1024;
+// Soft client caps aligned with the strictest common provider (Bedrock Converse):
+// images ≤ 3.75 MB, documents ≤ 4.5 MB, ≤ 5 documents / ≤ 20 images per message.
+const MAX_CHAT_IMAGE_BYTES = Math.floor(3.75 * 1024 * 1024);
+const MAX_CHAT_DOC_BYTES = Math.floor(4.5 * 1024 * 1024);
+const MAX_CHAT_FILES = 5;
 
 type PendingChatFile = {
   id: string;
@@ -348,12 +351,15 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
     userMessageText: string,
     options: {
       clearInput?: boolean;
+      /** When false, do not attach/clear staged files (MCP ui/message path). */
+      attachPendingFiles?: boolean;
       restoreInputOnError?: boolean;
       errorLabel?: string;
       rethrowOnError?: boolean;
     } = {},
   ) => {
-    const filesToSend = pendingFiles;
+    const attachPendingFiles = options.attachPendingFiles ?? true;
+    const filesToSend = attachPendingFiles ? pendingFiles : [];
     if ((!userMessageText.trim() && filesToSend.length === 0) || !selectedAgentName || !selectedNamespace) {
       return;
     }
@@ -364,11 +370,6 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
         throw error;
       }
       return;
-    }
-
-    if (options.clearInput ?? true) {
-      setCurrentInputMessage("");
-      setPendingFiles([]);
     }
 
     // Cross-tab guard: fetch the latest session state before mutating anything.
@@ -384,11 +385,16 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
           staleOrChanged: "New messages loaded — please review before sending",
         },
       });
+      // Don't clear staged files/input if the send was blocked.
       if (guardResult === "blocked") return;
     }
 
-    setCurrentInputMessage("");
-    setPendingFiles([]);
+    if (options.clearInput ?? true) {
+      setCurrentInputMessage("");
+    }
+    if (attachPendingFiles) {
+      setPendingFiles([]);
+    }
     setChatStatus("thinking");
     setStoredMessages(prev => [...prev, ...streamingMessages]);
     setStreamingMessages([]);
@@ -448,7 +454,7 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
             toast.error("Failed to create session");
             setChatStatus("error");
             setCurrentInputMessage(userMessageText);
-            setPendingFiles(filesToSend);
+            if (attachPendingFiles) setPendingFiles(filesToSend);
             isCreatingSessionRef.current = false;
             return;
           }
@@ -475,7 +481,7 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
           toast.error("Error creating session");
           setChatStatus("error");
           setCurrentInputMessage(userMessageText);
-          setPendingFiles(filesToSend);
+          if (attachPendingFiles) setPendingFiles(filesToSend);
           isCreatingSessionRef.current = false;
           return;
         }
@@ -523,7 +529,7 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
         errorLabel: "Streaming failed",
         onError: () => {
           setCurrentInputMessage(userMessageText);
-          setPendingFiles(filesToSend);
+          if (attachPendingFiles) setPendingFiles(filesToSend);
         },
         sessionIdForWait: currentSessionId,
       });
@@ -533,7 +539,7 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
       setChatStatus("error");
       if (options.restoreInputOnError ?? true) {
         setCurrentInputMessage(userMessageText);
-        setPendingFiles(filesToSend);
+        if (attachPendingFiles) setPendingFiles(filesToSend);
       }
       if (options.rethrowOnError) {
         throw error;
@@ -544,9 +550,22 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
   const handleAttachFiles = async (fileList: FileList | null) => {
     if (!fileList || fileList.length === 0) return;
     const next: PendingChatFile[] = [];
+    let slots = MAX_CHAT_FILES - pendingFiles.length;
+    if (slots <= 0) {
+      toast.error(`You can attach at most ${MAX_CHAT_FILES} files per message`);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      return;
+    }
     for (const file of Array.from(fileList)) {
-      if (file.size > MAX_CHAT_FILE_BYTES) {
-        toast.error(`${file.name} exceeds the ${MAX_CHAT_FILE_BYTES / (1024 * 1024)}MB limit`);
+      if (slots <= 0) {
+        toast.error(`You can attach at most ${MAX_CHAT_FILES} files per message`);
+        break;
+      }
+      const isImage = file.type.startsWith("image/");
+      const maxBytes = isImage ? MAX_CHAT_IMAGE_BYTES : MAX_CHAT_DOC_BYTES;
+      if (file.size > maxBytes) {
+        const mb = (maxBytes / (1024 * 1024)).toFixed(2);
+        toast.error(`${file.name} exceeds the ${mb}MB ${isImage ? "image" : "file"} limit`);
         continue;
       }
       try {
@@ -559,6 +578,7 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
           mimeType: file.type || "application/octet-stream",
           bytes,
         });
+        slots -= 1;
       } catch {
         toast.error(`Failed to read ${file.name}`);
       }
@@ -629,6 +649,7 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
   const handleMcpAppSendMessage = async (text: string) => {
     await sendChatMessageText(text, {
       clearInput: false,
+      attachPendingFiles: false, // don't send/clear user-staged attachments
       restoreInputOnError: false,
       errorLabel: "MCP app message failed",
       rethrowOnError: true,

--- a/ui/src/components/chat/ChatInterface.tsx
+++ b/ui/src/components/chat/ChatInterface.tsx
@@ -46,9 +46,10 @@ import {
 } from "@/lib/chatSessionGuard";
 
 // Soft client caps aligned with the strictest common provider (Bedrock Converse):
-// images ≤ 3.75 MB, documents ≤ 4.5 MB, ≤ 5 documents / ≤ 20 images per message.
+// images ≤ 3.75 MB and ≤ 8000×8000 px; documents ≤ 4.5 MB; ≤ 5 files per message.
 const MAX_CHAT_IMAGE_BYTES = Math.floor(3.75 * 1024 * 1024);
 const MAX_CHAT_DOC_BYTES = Math.floor(4.5 * 1024 * 1024);
+const MAX_CHAT_IMAGE_PX = 8000;
 const MAX_CHAT_FILES = 5;
 
 type PendingChatFile = {
@@ -65,6 +66,18 @@ function readFileAsDataURL(file: File): Promise<string> {
     reader.onerror = () => reject(reader.error ?? new Error("read failed"));
     reader.readAsDataURL(file);
   });
+}
+
+/** Returns false when dimensions exceed maxPx. Unreadable images pass (provider rejects). */
+async function imageWithinPixelLimit(file: File, maxPx: number): Promise<boolean> {
+  try {
+    const bmp = await createImageBitmap(file);
+    const ok = bmp.width <= maxPx && bmp.height <= maxPx;
+    bmp.close();
+    return ok;
+  } catch {
+    return true;
+  }
 }
 
 /** Build A2A message parts: optional text + FileParts (wire shape a2a-go accepts). */
@@ -549,18 +562,10 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
 
   const handleAttachFiles = async (fileList: FileList | null) => {
     if (!fileList || fileList.length === 0) return;
-    const next: PendingChatFile[] = [];
-    let slots = MAX_CHAT_FILES - pendingFiles.length;
-    if (slots <= 0) {
-      toast.error(`You can attach at most ${MAX_CHAT_FILES} files per message`);
-      if (fileInputRef.current) fileInputRef.current.value = "";
-      return;
-    }
+    // Read first; enforce MAX_CHAT_FILES in the state updater so overlapping
+    // picker/drop ops cannot both append past the cap.
+    const candidates: PendingChatFile[] = [];
     for (const file of Array.from(fileList)) {
-      if (slots <= 0) {
-        toast.error(`You can attach at most ${MAX_CHAT_FILES} files per message`);
-        break;
-      }
       const isImage = file.type.startsWith("image/");
       const maxBytes = isImage ? MAX_CHAT_IMAGE_BYTES : MAX_CHAT_DOC_BYTES;
       if (file.size > maxBytes) {
@@ -568,23 +573,41 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
         toast.error(`${file.name} exceeds the ${mb}MB ${isImage ? "image" : "file"} limit`);
         continue;
       }
+      if (isImage && !(await imageWithinPixelLimit(file, MAX_CHAT_IMAGE_PX))) {
+        toast.error(`${file.name} exceeds the ${MAX_CHAT_IMAGE_PX}×${MAX_CHAT_IMAGE_PX}px image limit`);
+        continue;
+      }
       try {
         const dataUrl = await readFileAsDataURL(file);
         const comma = dataUrl.indexOf(",");
         const bytes = comma >= 0 ? dataUrl.slice(comma + 1) : dataUrl;
-        next.push({
+        candidates.push({
           id: uuidv4(),
           name: file.name,
           mimeType: file.type || "application/octet-stream",
           bytes,
         });
-        slots -= 1;
       } catch {
         toast.error(`Failed to read ${file.name}`);
       }
     }
-    if (next.length > 0) {
-      setPendingFiles(prev => [...prev, ...next]);
+    if (candidates.length > 0) {
+      let overflow = false;
+      setPendingFiles(prev => {
+        const room = MAX_CHAT_FILES - prev.length;
+        if (room <= 0) {
+          overflow = true;
+          return prev;
+        }
+        if (candidates.length > room) {
+          overflow = true;
+          return [...prev, ...candidates.slice(0, room)];
+        }
+        return [...prev, ...candidates];
+      });
+      if (overflow) {
+        toast.error(`You can attach at most ${MAX_CHAT_FILES} files per message`);
+      }
     }
     if (fileInputRef.current) {
       fileInputRef.current.value = "";

--- a/ui/src/components/chat/ChatInterface.tsx
+++ b/ui/src/components/chat/ChatInterface.tsx
@@ -2,7 +2,7 @@
 
 import type React from "react";
 import { useState, useRef, useEffect, useMemo, useCallback } from "react";
-import { ArrowBigUp, X, Loader2, Mic, Square } from "lucide-react";
+import { ArrowBigUp, X, Loader2, Mic, Square, Paperclip, FileIcon, ImageIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Tooltip,
@@ -45,6 +45,47 @@ import {
   type SessionGuardOptions,
 } from "@/lib/chatSessionGuard";
 
+/** Soft client cap so base64 A2A FileParts stay reasonable. */
+const MAX_CHAT_FILE_BYTES = 10 * 1024 * 1024;
+
+type PendingChatFile = {
+  id: string;
+  name: string;
+  mimeType: string;
+  bytes: string; // raw base64 (no data: prefix)
+};
+
+function readFileAsDataURL(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result ?? ""));
+    reader.onerror = () => reject(reader.error ?? new Error("read failed"));
+    reader.readAsDataURL(file);
+  });
+}
+
+/** Build A2A message parts: optional text + FileParts (wire shape a2a-go accepts). */
+function buildUserMessageParts(text: string, files: PendingChatFile[]): Message["parts"] {
+  // SDK Part typings are protobuf-shaped; chat already sends JSON {kind,text} parts.
+  const parts: Message["parts"] = [];
+  const push = (part: unknown) => parts.push(part as Message["parts"][number]);
+  const trimmed = text.trim();
+  if (trimmed) {
+    push({ kind: "text", text: trimmed });
+  }
+  for (const file of files) {
+    push({
+      kind: "file",
+      file: {
+        bytes: file.bytes,
+        mimeType: file.mimeType,
+        name: file.name,
+      },
+    });
+  }
+  return parts;
+}
+
 interface ChatInterfaceProps {
   selectedAgentName: string;
   selectedNamespace: string;
@@ -61,7 +102,15 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
   const substrateSandbox = useChatSubstrateSandbox();
   const router = useRouter();
   const containerRef = useRef<HTMLDivElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const fileDragDepthRef = useRef(0);
   const [currentInputMessage, setCurrentInputMessage] = useState("");
+  const [pendingFiles, setPendingFiles] = useState<PendingChatFile[]>([]);
+  const [isDraggingFiles, setIsDraggingFiles] = useState(false);
+  // File attach is Go declarative agents only (Python adapters still drop non-images).
+  const supportsFileAttach =
+    currentAgent.agent?.spec?.type === "Declarative" &&
+    currentAgent.agent?.spec?.declarative?.runtime === "go";
 
   const [chatStatus, setChatStatus] = useState<ChatStatus>("ready");
 
@@ -304,7 +353,8 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
       rethrowOnError?: boolean;
     } = {},
   ) => {
-    if (!userMessageText.trim() || !selectedAgentName || !selectedNamespace) {
+    const filesToSend = pendingFiles;
+    if ((!userMessageText.trim() && filesToSend.length === 0) || !selectedAgentName || !selectedNamespace) {
       return;
     }
     if (chatStatus !== "ready") {
@@ -318,6 +368,7 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
 
     if (options.clearInput ?? true) {
       setCurrentInputMessage("");
+      setPendingFiles([]);
     }
 
     // Cross-tab guard: fetch the latest session state before mutating anything.
@@ -337,6 +388,7 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
     }
 
     setCurrentInputMessage("");
+    setPendingFiles([]);
     setChatStatus("thinking");
     setStoredMessages(prev => [...prev, ...streamingMessages]);
     setStreamingMessages([]);
@@ -347,16 +399,14 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
     pendingTurnStatsRef.current = undefined;
 
     const messageId = uuidv4();
+    const messageParts = buildUserMessageParts(userMessageText, filesToSend);
 
     // For new sessions or when no stored messages exist, show the user message immediately
     const userMessage: Message = {
       kind: "message",
       messageId,
       role: "user",
-      parts: [{
-        kind: "text",
-        text: userMessageText
-      }],
+      parts: messageParts,
       contextId: guardSessionId,
       metadata: {
         timestamp: Date.now()
@@ -385,7 +435,10 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
           isCreatingSessionRef.current = true;
           setIsFirstMessage(true);
 
-          const sessionName = deriveSessionTitle(userMessageText);
+          const sessionName =
+            deriveSessionTitle(userMessageText) ||
+            deriveSessionTitle(filesToSend[0]?.name ?? "") ||
+            "New Chat";
           const newSessionResponse = await createSession({
             agent_ref: `${selectedNamespace}/${selectedAgentName}`,
             name: sessionName,
@@ -395,6 +448,7 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
             toast.error("Failed to create session");
             setChatStatus("error");
             setCurrentInputMessage(userMessageText);
+            setPendingFiles(filesToSend);
             isCreatingSessionRef.current = false;
             return;
           }
@@ -421,6 +475,7 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
           toast.error("Error creating session");
           setChatStatus("error");
           setCurrentInputMessage(userMessageText);
+          setPendingFiles(filesToSend);
           isCreatingSessionRef.current = false;
           return;
         }
@@ -462,10 +517,14 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
         messageId,
         contextId: currentSessionId,
       });
+      a2aMessage.parts = messageParts;
 
       await streamA2AMessage(a2aMessage, {
         errorLabel: "Streaming failed",
-        onError: () => setCurrentInputMessage(userMessageText),
+        onError: () => {
+          setCurrentInputMessage(userMessageText);
+          setPendingFiles(filesToSend);
+        },
         sessionIdForWait: currentSessionId,
       });
     } catch (error) {
@@ -474,6 +533,7 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
       setChatStatus("error");
       if (options.restoreInputOnError ?? true) {
         setCurrentInputMessage(userMessageText);
+        setPendingFiles(filesToSend);
       }
       if (options.rethrowOnError) {
         throw error;
@@ -481,12 +541,82 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
     }
   };
 
+  const handleAttachFiles = async (fileList: FileList | null) => {
+    if (!fileList || fileList.length === 0) return;
+    const next: PendingChatFile[] = [];
+    for (const file of Array.from(fileList)) {
+      if (file.size > MAX_CHAT_FILE_BYTES) {
+        toast.error(`${file.name} exceeds the ${MAX_CHAT_FILE_BYTES / (1024 * 1024)}MB limit`);
+        continue;
+      }
+      try {
+        const dataUrl = await readFileAsDataURL(file);
+        const comma = dataUrl.indexOf(",");
+        const bytes = comma >= 0 ? dataUrl.slice(comma + 1) : dataUrl;
+        next.push({
+          id: uuidv4(),
+          name: file.name,
+          mimeType: file.type || "application/octet-stream",
+          bytes,
+        });
+      } catch {
+        toast.error(`Failed to read ${file.name}`);
+      }
+    }
+    if (next.length > 0) {
+      setPendingFiles(prev => [...prev, ...next]);
+    }
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
+
+  const resetFileDrag = () => {
+    fileDragDepthRef.current = 0;
+    setIsDraggingFiles(false);
+  };
+
+  const handleComposerDragEnter = (e: React.DragEvent) => {
+    if (!supportsFileAttach || chatStatus !== "ready") return;
+    if (![...e.dataTransfer.types].includes("Files")) return;
+    e.preventDefault();
+    e.stopPropagation();
+    fileDragDepthRef.current += 1;
+    setIsDraggingFiles(true);
+  };
+
+  const handleComposerDragLeave = (e: React.DragEvent) => {
+    if (!supportsFileAttach) return;
+    e.preventDefault();
+    e.stopPropagation();
+    fileDragDepthRef.current = Math.max(0, fileDragDepthRef.current - 1);
+    if (fileDragDepthRef.current === 0) {
+      setIsDraggingFiles(false);
+    }
+  };
+
+  const handleComposerDragOver = (e: React.DragEvent) => {
+    if (!supportsFileAttach || chatStatus !== "ready") return;
+    if (![...e.dataTransfer.types].includes("Files")) return;
+    e.preventDefault();
+    e.stopPropagation();
+    e.dataTransfer.dropEffect = "copy";
+  };
+
+  const handleComposerDrop = (e: React.DragEvent) => {
+    if (!supportsFileAttach || chatStatus !== "ready") return;
+    e.preventDefault();
+    e.stopPropagation();
+    resetFileDrag();
+    void handleAttachFiles(e.dataTransfer.files);
+  };
+
   const handleSendMessage = async (e: React.FormEvent) => {
     e.preventDefault();
     if (isListening) {
       stopListening();
     }
-    if (!currentInputMessage.trim()) {
+    if (!currentInputMessage.trim() && pendingFiles.length === 0) {
       return;
     }
 
@@ -986,7 +1116,12 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
       e.preventDefault();
-      if (currentInputMessage.trim() && selectedAgentName && selectedNamespace && chatStatus === "ready") {
+      if (
+        (currentInputMessage.trim() || pendingFiles.length > 0) &&
+        selectedAgentName &&
+        selectedNamespace &&
+        chatStatus === "ready"
+      ) {
         handleSendMessage(e);
       }
     }
@@ -1100,18 +1235,92 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
               </div>
             </div>
 
-            <form onSubmit={handleSendMessage}>
+            <form
+              onSubmit={handleSendMessage}
+              onDragEnter={handleComposerDragEnter}
+              onDragLeave={handleComposerDragLeave}
+              onDragOver={handleComposerDragOver}
+              onDrop={handleComposerDrop}
+              className={`relative rounded-md transition-colors ${isDraggingFiles ? "ring-2 ring-primary/50 bg-primary/5" : ""}`}
+              data-testid="chat-composer"
+            >
+              {isDraggingFiles && (
+                <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center rounded-md border border-dashed border-primary/40 bg-background/70 text-sm text-muted-foreground">
+                  Drop files to attach
+                </div>
+              )}
               <Textarea
                 data-testid="chat-input"
                 value={currentInputMessage}
                 onChange={(e) => setCurrentInputMessage(e.target.value)}
-                placeholder={getStatusPlaceholder(chatStatus)}
+                placeholder={
+                  supportsFileAttach && chatStatus === "ready"
+                    ? `${getStatusPlaceholder(chatStatus)} (or drop files here)`
+                    : getStatusPlaceholder(chatStatus)
+                }
                 onKeyDown={handleKeyDown}
                 className={`min-h-[100px] border-0 shadow-none p-0 focus-visible:ring-0 resize-none ${chatStatus !== "ready" ? "opacity-50 cursor-not-allowed" : ""}`}
                 disabled={chatStatus !== "ready"}
               />
 
+              {supportsFileAttach && pendingFiles.length > 0 && (
+                <div className="flex flex-wrap gap-2 mt-3" data-testid="chat-file-chips">
+                  {pendingFiles.map(file => {
+                    const isImage = file.mimeType.startsWith("image/");
+                    const Icon = isImage ? ImageIcon : FileIcon;
+                    return (
+                      <span
+                        key={file.id}
+                        className="inline-flex items-center gap-1 rounded-md bg-muted px-2 py-1 text-xs"
+                      >
+                        <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden />
+                        {file.name}
+                        <button
+                          type="button"
+                          aria-label={`Remove ${file.name}`}
+                          className="opacity-70 hover:opacity-100"
+                          onClick={() => setPendingFiles(prev => prev.filter(f => f.id !== file.id))}
+                          disabled={chatStatus !== "ready"}
+                        >
+                          <X className="h-3 w-3" />
+                        </button>
+                      </span>
+                    );
+                  })}
+                </div>
+              )}
+
               <div className="flex items-center justify-end gap-2 mt-4">
+                {supportsFileAttach && (
+                  <>
+                    <input
+                      ref={fileInputRef}
+                      type="file"
+                      multiple
+                      className="hidden"
+                      data-testid="chat-file-input"
+                      onChange={(e) => void handleAttachFiles(e.target.files)}
+                    />
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="icon"
+                            data-testid="chat-attach"
+                            onClick={() => fileInputRef.current?.click()}
+                            disabled={chatStatus !== "ready"}
+                            aria-label="Attach files"
+                          >
+                            <Paperclip className="h-4 w-4" aria-hidden />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent side="top">Attach files</TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  </>
+                )}
                 {isVoiceSupported && (
                   <TooltipProvider>
                     <Tooltip>
@@ -1142,7 +1351,12 @@ export default function ChatInterface({ selectedAgentName, selectedNamespace, se
                     </Tooltip>
                   </TooltipProvider>
                 )}
-                <Button type="submit" data-testid="chat-send" className={""} disabled={!currentInputMessage.trim() || chatStatus !== "ready"}>
+                <Button
+                  type="submit"
+                  data-testid="chat-send"
+                  className={""}
+                  disabled={(!currentInputMessage.trim() && pendingFiles.length === 0) || chatStatus !== "ready"}
+                >
                   Send
                   <ArrowBigUp className="h-4 w-4 ml-2" />
                 </Button>

--- a/ui/src/components/chat/ChatMessage.tsx
+++ b/ui/src/components/chat/ChatMessage.tsx
@@ -3,7 +3,7 @@ import { TruncatableText } from "@/components/chat/TruncatableText";
 import ToolCallDisplay from "@/components/chat/ToolCallDisplay";
 import AskUserDisplay, { AskUserQuestion } from "@/components/chat/AskUserDisplay";
 import KagentLogo from "../kagent-logo";
-import { ThumbsUp, ThumbsDown } from "lucide-react";
+import { ThumbsUp, ThumbsDown, FileIcon, ImageIcon } from "lucide-react";
 import TokenStatsTooltip from "@/components/chat/TokenStatsTooltip";
 import type { TokenStats } from "@/types";
 import { useState } from "react";
@@ -13,6 +13,22 @@ import { convertToUserFriendlyName } from "@/lib/utils";
 import { ADKMetadata, getMetadataValue } from "@/lib/messageHandlers";
 import { ToolDecision } from "@/types";
 import type { ChatMcpAppTool } from "@/components/chat/ChatMcpAppsContext";
+
+type MessageFileChip = { name: string; mimeType: string };
+
+/** Extract A2A FileParts for chip display (icons only — no previews). */
+function fileChipsFromMessage(message: Message): MessageFileChip[] {
+  const chips: MessageFileChip[] = [];
+  for (const part of message.parts ?? []) {
+    const p = part as { kind?: string; file?: { name?: string; mimeType?: string } };
+    if (p.kind !== "file" || !p.file) continue;
+    chips.push({
+      name: p.file.name || "file",
+      mimeType: p.file.mimeType || "",
+    });
+  }
+  return chips;
+}
 
 interface ChatMessageProps {
   message: Message;
@@ -37,6 +53,7 @@ export default function ChatMessage({ message, allMessages, agentContext, onAppr
 
   const textParts = message.parts?.filter(part => part.kind === "text") || [];
   const content = textParts.map(part => (part as TextPart).text).join("");
+  const fileChips = fileChipsFromMessage(message);
 
   const source = message.role === "user" ? "user" : "assistant";
   const tokenStats = (message.metadata as Record<string, unknown> | undefined)?.tokenStats as TokenStats | undefined;
@@ -151,8 +168,8 @@ export default function ChatMessage({ message, allMessages, agentContext, onAppr
     return null;
   }
 
-  // Skip empty messages
-  if (!content) {
+  // Skip empty messages (allow file-only user turns)
+  if (!content && fileChips.length === 0) {
     return null;
   }
 
@@ -175,7 +192,27 @@ export default function ChatMessage({ message, allMessages, agentContext, onAppr
         <KagentLogo className="w-4 h-4" />
         <div className="text-xs font-bold">{displayName}</div>
       </div> : <div className="text-xs font-bold">{displayName}</div>}
-      <TruncatableText content={String(content)} className="break-all text-primary-foreground" />
+      {content ? (
+        <TruncatableText content={String(content)} className="break-all text-primary-foreground" />
+      ) : null}
+      {fileChips.length > 0 && (
+        <div className="flex flex-wrap gap-2 mt-1" data-testid="chat-message-file-chips">
+          {fileChips.map((file, i) => {
+            const isImage = file.mimeType.startsWith("image/");
+            const Icon = isImage ? ImageIcon : FileIcon;
+            return (
+              <span
+                key={`${file.name}-${i}`}
+                className="inline-flex items-center gap-1 rounded-md bg-muted px-2 py-1 text-xs"
+                title={file.mimeType || undefined}
+              >
+                <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden />
+                {file.name}
+              </span>
+            );
+          })}
+        </div>
+      )}
       {source !== "user" && (
         <div className="flex mt-2 justify-end items-center gap-2">
           {tokenStats && <TokenStatsTooltip stats={tokenStats} />}


### PR DESCRIPTION
- Forward non-image file parts through Go model adapters instead of silently dropping them
- Add chat UI file attach (paperclip, drag/drop, history chips) for Go declarative agents only
- Demo video is attached in a comment below

---
Current support matrix:

Provider | Native images | Native documents
-- | -- | --
OpenAI (CC / Azure / Foundry) | image/* | PDF only, text extracted from text files
OpenAI (Responses) | image/* | PDF, text, markdown, csv, html, json, word, pptx, etc.
Anthropic | image/* | PDF, text/plain, text/markdown
Bedrock | png/jpeg/gif/webp | pdf, txt, md, csv, html, doc/docx, xls/xlsx
Ollama | image/* only | —