### PR TITLE
feat: add AgentInstance suspend and resume

### DIFF
--- a/go/api/database/client.go
+++ b/go/api/database/client.go
@@ -17,6 +17,8 @@ var ErrTaskOwnedByAnotherUser = errors.New("task id owned by another user")
 
 var ErrIdempotencyConflict = errors.New("request id was already used with different parameters")
 
+var ErrAgentInstanceConflict = errors.New("AgentInstance lifecycle operation conflicts with its current state")
+
 type QueryOptions struct {
 	Limit    int
 	After    time.Time
@@ -119,6 +121,7 @@ type Client interface {
 	GetAgentInstance(context.Context, string, string, string) (*apiv1alpha1.AgentInstance, error)
 	ListAgentInstances(context.Context, string, string, bool, map[string]string, string, int) ([]*apiv1alpha1.AgentInstance, error)
 	MarkAgentInstanceReady(context.Context, string, string) (*apiv1alpha1.AgentInstance, error)
+	TransitionAgentInstance(context.Context, *apiv1alpha1.AgentInstance, apiv1alpha1.AgentInstanceState, apiv1alpha1.AgentInstanceOperation) (*apiv1alpha1.AgentInstance, error)
 	DeleteAgentInstance(context.Context, string) error
 	CreateAgentInstanceShare(context.Context, AgentInstanceShare) (*AgentInstanceShare, error)
 	ListAgentInstanceShares(context.Context, string, string, string, string, int) ([]AgentInstanceShare, error)

--- a/go/core/internal/database/client_agent_instance_test.go
+++ b/go/core/internal/database/client_agent_instance_test.go
@@ -7,9 +7,10 @@ import (
 
 	dbpkg "github.com/kagent-dev/kagent/go/api/database"
 	apiv1alpha1 "github.com/kagent-dev/kagent/go/api/gen/kagent/api/v1alpha1"
+	"google.golang.org/protobuf/proto"
 )
 
-func TestCreateAgentInstanceIsIdempotent(t *testing.T) {
+func TestAgentInstanceCreateAndTransitions(t *testing.T) {
 	client := NewClient(setupTestDB(t))
 	ctx := context.Background()
 	revision := dbpkg.RuntimeRevision{
@@ -57,6 +58,27 @@ func TestCreateAgentInstanceIsIdempotent(t *testing.T) {
 	instances, err := client.ListAgentInstances(ctx, "team-a", "alice", false, nil, "", 10)
 	if err != nil || len(instances) != 1 {
 		t.Fatalf("ListAgentInstances() = %v, error %v", instances, err)
+	}
+	ready, err := client.MarkAgentInstanceReady(ctx, created.GetId(), "actor.example")
+	if err != nil {
+		t.Fatal(err)
+	}
+	suspending := proto.Clone(ready).(*apiv1alpha1.AgentInstance)
+	suspending.Operation = apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_SUSPEND
+	if _, err := client.TransitionAgentInstance(ctx, suspending, ready.GetState(), ready.GetOperation()); err != nil {
+		t.Fatal(err)
+	}
+	resuming := proto.Clone(ready).(*apiv1alpha1.AgentInstance)
+	resuming.Operation = apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_RESUME
+	current, err := client.TransitionAgentInstance(ctx, resuming, ready.GetState(), ready.GetOperation())
+	if !errors.Is(err, dbpkg.ErrAgentInstanceConflict) || current.GetOperation() != apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_SUSPEND {
+		t.Fatalf("conflicting transition = instance %v, error %v", current, err)
+	}
+	suspended := proto.Clone(suspending).(*apiv1alpha1.AgentInstance)
+	suspended.State = apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_SUSPENDED
+	suspended.Operation = apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_UNSPECIFIED
+	if _, err := client.TransitionAgentInstance(ctx, suspended, ready.GetState(), suspending.GetOperation()); err != nil {
+		t.Fatal(err)
 	}
 
 	request.AgentTemplate.Name = "different"

--- a/go/core/internal/database/client_agent_instance_test.go
+++ b/go/core/internal/database/client_agent_instance_test.go
@@ -7,8 +7,31 @@ import (
 
 	dbpkg "github.com/kagent-dev/kagent/go/api/database"
 	apiv1alpha1 "github.com/kagent-dev/kagent/go/api/gen/kagent/api/v1alpha1"
+	dbgen "github.com/kagent-dev/kagent/go/core/internal/database/gen"
 	"google.golang.org/protobuf/proto"
 )
+
+func TestToAgentInstanceUsesIndexedLifecycleColumns(t *testing.T) {
+	data, err := proto.Marshal(&apiv1alpha1.AgentInstance{
+		Id:        "instance-1",
+		State:     apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_READY,
+		Operation: apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_UNSPECIFIED,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	instance, err := toAgentInstance(dbgen.AgentInstance{
+		ID: "instance-1", Data: data, State: "SUSPENDED", Operation: "RESUME",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if instance.GetState() != apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_SUSPENDED ||
+		instance.GetOperation() != apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_RESUME {
+		t.Fatalf("lifecycle = %s/%s, want SUSPENDED/RESUME", instance.GetState(), instance.GetOperation())
+	}
+}
 
 func TestAgentInstanceCreateAndTransitions(t *testing.T) {
 	client := NewClient(setupTestDB(t))

--- a/go/core/internal/database/client_postgres.go
+++ b/go/core/internal/database/client_postgres.go
@@ -593,6 +593,52 @@ func (c *postgresClient) MarkAgentInstanceReady(ctx context.Context, id, authori
 	return toAgentInstance(row)
 }
 
+func (c *postgresClient) TransitionAgentInstance(
+	ctx context.Context,
+	instance *apiv1alpha1.AgentInstance,
+	expectedState apiv1alpha1.AgentInstanceState,
+	expectedOperation apiv1alpha1.AgentInstanceOperation,
+) (*apiv1alpha1.AgentInstance, error) {
+	data, err := marshalAgentInstance(instance)
+	if err != nil {
+		return nil, err
+	}
+	row, err := c.q.TransitionAgentInstance(ctx, dbgen.TransitionAgentInstanceParams{
+		ID: instance.GetId(), Data: data,
+		ExpectedState: agentInstanceStateName(expectedState), ExpectedOperation: agentInstanceOperationName(expectedOperation),
+		NextState: agentInstanceStateName(instance.GetState()), NextOperation: agentInstanceOperationName(instance.GetOperation()),
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		row, err = c.q.GetAgentInstanceByID(ctx, instance.GetId())
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("transition AgentInstance %s: %w", instance.GetId(), dbpkg.ErrNotFound)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("get conflicting AgentInstance %s: %w", instance.GetId(), err)
+		}
+		current, decodeErr := toAgentInstance(row)
+		if decodeErr != nil {
+			return nil, decodeErr
+		}
+		return current, dbpkg.ErrAgentInstanceConflict
+	}
+	if err != nil {
+		return nil, fmt.Errorf("transition AgentInstance %s: %w", instance.GetId(), err)
+	}
+	return toAgentInstance(row)
+}
+
+func agentInstanceStateName(state apiv1alpha1.AgentInstanceState) string {
+	return strings.TrimPrefix(state.String(), "AGENT_INSTANCE_STATE_")
+}
+
+func agentInstanceOperationName(operation apiv1alpha1.AgentInstanceOperation) string {
+	if operation == apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_UNSPECIFIED {
+		return "NONE"
+	}
+	return strings.TrimPrefix(operation.String(), "AGENT_INSTANCE_OPERATION_")
+}
+
 func (c *postgresClient) DeleteAgentInstance(ctx context.Context, id string) error {
 	if err := c.q.DeleteAgentInstance(ctx, id); err != nil {
 		return fmt.Errorf("delete AgentInstance %s: %w", id, err)

--- a/go/core/internal/database/client_postgres.go
+++ b/go/core/internal/database/client_postgres.go
@@ -455,6 +455,22 @@ func toAgentInstance(row dbgen.AgentInstance) (*apiv1alpha1.AgentInstance, error
 	if err := proto.Unmarshal(row.Data, instance); err != nil {
 		return nil, fmt.Errorf("decode AgentInstance %s: %w", row.ID, err)
 	}
+	state, ok := apiv1alpha1.AgentInstanceState_value["AGENT_INSTANCE_STATE_"+row.State]
+	if !ok {
+		return nil, fmt.Errorf("decode AgentInstance %s state %q", row.ID, row.State)
+	}
+	operation := row.Operation
+	if operation == "NONE" {
+		operation = "UNSPECIFIED"
+	}
+	operationValue, ok := apiv1alpha1.AgentInstanceOperation_value["AGENT_INSTANCE_OPERATION_"+operation]
+	if !ok {
+		return nil, fmt.Errorf("decode AgentInstance %s operation %q", row.ID, row.Operation)
+	}
+	// These indexed columns are the lifecycle source of truth. In particular,
+	// migrations can backfill them without rewriting the protobuf blob.
+	instance.State = apiv1alpha1.AgentInstanceState(state)
+	instance.Operation = apiv1alpha1.AgentInstanceOperation(operationValue)
 	return instance, nil
 }
 

--- a/go/core/internal/database/gen/agent_instances.sql.go
+++ b/go/core/internal/database/gen/agent_instances.sql.go
@@ -79,7 +79,7 @@ func (q *Queries) DeleteAgentInstanceShare(ctx context.Context, arg DeleteAgentI
 }
 
 const getAgentInstanceByID = `-- name: GetAgentInstanceByID :one
-SELECT id, namespace, user_id, request_id, prepared_revision, state, labels, data FROM agent_instance WHERE id = $1
+SELECT id, namespace, user_id, request_id, prepared_revision, state, labels, data, operation FROM agent_instance WHERE id = $1
 `
 
 func (q *Queries) GetAgentInstanceByID(ctx context.Context, id string) (AgentInstance, error) {
@@ -94,12 +94,13 @@ func (q *Queries) GetAgentInstanceByID(ctx context.Context, id string) (AgentIns
 		&i.State,
 		&i.Labels,
 		&i.Data,
+		&i.Operation,
 	)
 	return i, err
 }
 
 const getAgentInstanceByRequest = `-- name: GetAgentInstanceByRequest :one
-SELECT id, namespace, user_id, request_id, prepared_revision, state, labels, data FROM agent_instance
+SELECT id, namespace, user_id, request_id, prepared_revision, state, labels, data, operation FROM agent_instance
 WHERE user_id = $1 AND namespace = $2 AND request_id = $3
 `
 
@@ -121,12 +122,13 @@ func (q *Queries) GetAgentInstanceByRequest(ctx context.Context, arg GetAgentIns
 		&i.State,
 		&i.Labels,
 		&i.Data,
+		&i.Operation,
 	)
 	return i, err
 }
 
 const getAgentInstanceForUser = `-- name: GetAgentInstanceForUser :one
-SELECT id, namespace, user_id, request_id, prepared_revision, state, labels, data FROM agent_instance WHERE namespace = $1 AND id = $2 AND user_id = $3
+SELECT id, namespace, user_id, request_id, prepared_revision, state, labels, data, operation FROM agent_instance WHERE namespace = $1 AND id = $2 AND user_id = $3
 `
 
 type GetAgentInstanceForUserParams struct {
@@ -147,6 +149,7 @@ func (q *Queries) GetAgentInstanceForUser(ctx context.Context, arg GetAgentInsta
 		&i.State,
 		&i.Labels,
 		&i.Data,
+		&i.Operation,
 	)
 	return i, err
 }
@@ -212,10 +215,10 @@ func (q *Queries) GetLatestRuntimeRevisionForInstance(ctx context.Context, arg G
 
 const insertAgentInstance = `-- name: InsertAgentInstance :one
 INSERT INTO agent_instance (
-    id, namespace, user_id, request_id, prepared_revision, state, labels, data
-) VALUES ($1, $2, $3, $4, $5, 'CREATING', $6, $7)
+    id, namespace, user_id, request_id, prepared_revision, state, operation, labels, data
+) VALUES ($1, $2, $3, $4, $5, 'CREATING', 'CREATE', $6, $7)
 ON CONFLICT (user_id, namespace, request_id) DO NOTHING
-RETURNING id, namespace, user_id, request_id, prepared_revision, state, labels, data
+RETURNING id, namespace, user_id, request_id, prepared_revision, state, labels, data, operation
 `
 
 type InsertAgentInstanceParams struct {
@@ -248,6 +251,7 @@ func (q *Queries) InsertAgentInstance(ctx context.Context, arg InsertAgentInstan
 		&i.State,
 		&i.Labels,
 		&i.Data,
+		&i.Operation,
 	)
 	return i, err
 }
@@ -304,7 +308,7 @@ func (q *Queries) ListAgentInstanceShares(ctx context.Context, arg ListAgentInst
 }
 
 const listAgentInstances = `-- name: ListAgentInstances :many
-SELECT id, namespace, user_id, request_id, prepared_revision, state, labels, data FROM agent_instance
+SELECT id, namespace, user_id, request_id, prepared_revision, state, labels, data, operation FROM agent_instance
 WHERE namespace = $1
   AND ($2::boolean OR user_id = $3)
   AND id > $4
@@ -347,6 +351,7 @@ func (q *Queries) ListAgentInstances(ctx context.Context, arg ListAgentInstances
 			&i.State,
 			&i.Labels,
 			&i.Data,
+			&i.Operation,
 		); err != nil {
 			return nil, err
 		}
@@ -360,9 +365,9 @@ func (q *Queries) ListAgentInstances(ctx context.Context, arg ListAgentInstances
 
 const markAgentInstanceReady = `-- name: MarkAgentInstanceReady :one
 UPDATE agent_instance
-SET state = 'READY', data = $2
-WHERE id = $1 AND state = 'CREATING'
-RETURNING id, namespace, user_id, request_id, prepared_revision, state, labels, data
+SET state = 'READY', operation = 'NONE', data = $2
+WHERE id = $1 AND state = 'CREATING' AND operation = 'CREATE'
+RETURNING id, namespace, user_id, request_id, prepared_revision, state, labels, data, operation
 `
 
 type MarkAgentInstanceReadyParams struct {
@@ -382,6 +387,49 @@ func (q *Queries) MarkAgentInstanceReady(ctx context.Context, arg MarkAgentInsta
 		&i.State,
 		&i.Labels,
 		&i.Data,
+		&i.Operation,
+	)
+	return i, err
+}
+
+const transitionAgentInstance = `-- name: TransitionAgentInstance :one
+UPDATE agent_instance
+SET state = $1, operation = $2, data = $3
+WHERE id = $4
+  AND state = $5
+  AND operation = $6
+RETURNING id, namespace, user_id, request_id, prepared_revision, state, labels, data, operation
+`
+
+type TransitionAgentInstanceParams struct {
+	NextState         string
+	NextOperation     string
+	Data              []byte
+	ID                string
+	ExpectedState     string
+	ExpectedOperation string
+}
+
+func (q *Queries) TransitionAgentInstance(ctx context.Context, arg TransitionAgentInstanceParams) (AgentInstance, error) {
+	row := q.db.QueryRow(ctx, transitionAgentInstance,
+		arg.NextState,
+		arg.NextOperation,
+		arg.Data,
+		arg.ID,
+		arg.ExpectedState,
+		arg.ExpectedOperation,
+	)
+	var i AgentInstance
+	err := row.Scan(
+		&i.ID,
+		&i.Namespace,
+		&i.UserID,
+		&i.RequestID,
+		&i.PreparedRevision,
+		&i.State,
+		&i.Labels,
+		&i.Data,
+		&i.Operation,
 	)
 	return i, err
 }

--- a/go/core/internal/database/gen/models.go
+++ b/go/core/internal/database/gen/models.go
@@ -32,6 +32,7 @@ type AgentInstance struct {
 	State            string
 	Labels           []byte
 	Data             []byte
+	Operation        string
 }
 
 type AgentInstanceShare struct {

--- a/go/core/internal/database/gen/querier.go
+++ b/go/core/internal/database/gen/querier.go
@@ -102,6 +102,7 @@ type Querier interface {
 	SoftDeleteToolServer(ctx context.Context, arg SoftDeleteToolServerParams) error
 	SoftDeleteToolsForServer(ctx context.Context, arg SoftDeleteToolsForServerParams) error
 	TaskExists(ctx context.Context, id string) (bool, error)
+	TransitionAgentInstance(ctx context.Context, arg TransitionAgentInstanceParams) (AgentInstance, error)
 	UpsertAgent(ctx context.Context, arg UpsertAgentParams) error
 	UpsertAgentTemplateHarnessPair(ctx context.Context, arg UpsertAgentTemplateHarnessPairParams) error
 	UpsertCheckpoint(ctx context.Context, arg UpsertCheckpointParams) error

--- a/go/core/internal/database/queries/agent_instances.sql
+++ b/go/core/internal/database/queries/agent_instances.sql
@@ -13,8 +13,8 @@ WHERE p.namespace = $1
 
 -- name: InsertAgentInstance :one
 INSERT INTO agent_instance (
-    id, namespace, user_id, request_id, prepared_revision, state, labels, data
-) VALUES ($1, $2, $3, $4, $5, 'CREATING', $6, $7)
+    id, namespace, user_id, request_id, prepared_revision, state, operation, labels, data
+) VALUES ($1, $2, $3, $4, $5, 'CREATING', 'CREATE', $6, $7)
 ON CONFLICT (user_id, namespace, request_id) DO NOTHING
 RETURNING *;
 
@@ -35,8 +35,16 @@ LIMIT sqlc.arg(page_size);
 
 -- name: MarkAgentInstanceReady :one
 UPDATE agent_instance
-SET state = 'READY', data = $2
-WHERE id = $1 AND state = 'CREATING'
+SET state = 'READY', operation = 'NONE', data = $2
+WHERE id = $1 AND state = 'CREATING' AND operation = 'CREATE'
+RETURNING *;
+
+-- name: TransitionAgentInstance :one
+UPDATE agent_instance
+SET state = sqlc.arg(next_state), operation = sqlc.arg(next_operation), data = sqlc.arg(data)
+WHERE id = sqlc.arg(id)
+  AND state = sqlc.arg(expected_state)
+  AND operation = sqlc.arg(expected_operation)
 RETURNING *;
 
 -- name: DeleteAgentInstance :exec

--- a/go/core/internal/grpcserver/interceptors.go
+++ b/go/core/internal/grpcserver/interceptors.go
@@ -208,6 +208,8 @@ func serviceErrorCode(code serviceerrors.Code) codes.Code {
 		return codes.FailedPrecondition
 	case serviceerrors.CodeResourceExhausted:
 		return codes.ResourceExhausted
+	case serviceerrors.CodeAborted:
+		return codes.Aborted
 	case serviceerrors.CodeUnavailable:
 		return codes.Unavailable
 	default:

--- a/go/core/internal/grpcserver/interceptors_test.go
+++ b/go/core/internal/grpcserver/interceptors_test.go
@@ -198,6 +198,7 @@ func TestMapError(t *testing.T) {
 		{"service already exists", serviceerrors.NewAlreadyExists("exists", nil), codes.AlreadyExists},
 		{"service failed precondition", serviceerrors.NewFailedPrecondition("precondition", nil), codes.FailedPrecondition},
 		{"service resource exhausted", serviceerrors.NewResourceExhausted("exhausted", nil), codes.ResourceExhausted},
+		{"service aborted", serviceerrors.NewAborted("aborted", nil), codes.Aborted},
 		{"service unavailable", serviceerrors.NewUnavailable("unavailable", nil), codes.Unavailable},
 		{"service internal", serviceerrors.NewInternal("internal detail", nil), codes.Internal},
 		{"unknown redacted", errors.New("database secret"), codes.Internal},

--- a/go/core/internal/service/serviceerrors/errors.go
+++ b/go/core/internal/service/serviceerrors/errors.go
@@ -12,6 +12,7 @@ const (
 	CodeAlreadyExists      Code = "already_exists"
 	CodeFailedPrecondition Code = "failed_precondition"
 	CodeResourceExhausted  Code = "resource_exhausted"
+	CodeAborted            Code = "aborted"
 	CodeUnavailable        Code = "unavailable"
 	CodeInternal           Code = "internal"
 )
@@ -77,6 +78,10 @@ func NewFailedPrecondition(message string, cause error) *Error {
 
 func NewResourceExhausted(message string, cause error) *Error {
 	return New(CodeResourceExhausted, message, cause)
+}
+
+func NewAborted(message string, cause error) *Error {
+	return New(CodeAborted, message, cause)
 }
 
 func NewUnavailable(message string, cause error) *Error {

--- a/go/core/pkg/migrations/core/000010_agent_instance_operation.down.sql
+++ b/go/core/pkg/migrations/core/000010_agent_instance_operation.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE agent_instance DROP COLUMN IF EXISTS operation;

--- a/go/core/pkg/migrations/core/000010_agent_instance_operation.up.sql
+++ b/go/core/pkg/migrations/core/000010_agent_instance_operation.up.sql
@@ -1,0 +1,10 @@
+-- The protobuf remains the public record; this column exists only so lifecycle
+-- operations can use an atomic compare-and-set across controller replicas.
+ALTER TABLE agent_instance
+    ADD COLUMN IF NOT EXISTS operation TEXT NOT NULL DEFAULT 'NONE',
+    ADD CONSTRAINT agent_instance_operation_check
+        CHECK (operation IN ('NONE', 'CREATE', 'SUSPEND', 'RESUME', 'DELETE'));
+
+UPDATE agent_instance
+SET operation = 'CREATE'
+WHERE state = 'CREATING';

--- a/go/core/v2/agentinstance/grpc.go
+++ b/go/core/v2/agentinstance/grpc.go
@@ -48,6 +48,22 @@ func (s *grpcServer) ListAgentInstances(ctx context.Context, request *apiv1alpha
 	}, nil
 }
 
+func (s *grpcServer) SuspendAgentInstance(ctx context.Context, request *apiv1alpha1.SuspendAgentInstanceRequest) (*apiv1alpha1.SuspendAgentInstanceResponse, error) {
+	instance, err := s.service.Suspend(ctx, request.GetNamespace(), request.GetAgentInstanceId())
+	if err != nil {
+		return nil, err
+	}
+	return &apiv1alpha1.SuspendAgentInstanceResponse{AgentInstance: instance}, nil
+}
+
+func (s *grpcServer) ResumeAgentInstance(ctx context.Context, request *apiv1alpha1.ResumeAgentInstanceRequest) (*apiv1alpha1.ResumeAgentInstanceResponse, error) {
+	instance, err := s.service.Resume(ctx, request.GetNamespace(), request.GetAgentInstanceId())
+	if err != nil {
+		return nil, err
+	}
+	return &apiv1alpha1.ResumeAgentInstanceResponse{AgentInstance: instance}, nil
+}
+
 func (s *grpcServer) DeleteAgentInstance(ctx context.Context, request *apiv1alpha1.DeleteAgentInstanceRequest) (*apiv1alpha1.DeleteAgentInstanceResponse, error) {
 	instance, err := s.service.Delete(ctx, request.GetNamespace(), request.GetAgentInstanceId())
 	if err != nil {

--- a/go/core/v2/agentinstance/service.go
+++ b/go/core/v2/agentinstance/service.go
@@ -33,6 +33,8 @@ type store interface {
 
 type instanceWorkflow interface {
 	Create(context.Context, *apiv1alpha1.AgentInstance) (*apiv1alpha1.AgentInstance, error)
+	Suspend(context.Context, *apiv1alpha1.AgentInstance) (*apiv1alpha1.AgentInstance, error)
+	Resume(context.Context, *apiv1alpha1.AgentInstance) (*apiv1alpha1.AgentInstance, error)
 	Delete(context.Context, *apiv1alpha1.AgentInstance) (*apiv1alpha1.AgentInstance, error)
 }
 
@@ -163,8 +165,61 @@ func (s *Service) Delete(ctx context.Context, namespace, id string) (*apiv1alpha
 		return nil, serviceerrors.NewInternal("Failed to get AgentInstance", err)
 	}
 	instance, err = s.workflow.Delete(ctx, instance)
+	if errors.Is(err, dbpkg.ErrAgentInstanceConflict) {
+		return nil, serviceerrors.NewAborted("AgentInstance has a conflicting lifecycle operation", err)
+	}
 	if err != nil {
 		return nil, serviceerrors.NewUnavailable("Failed to delete AgentInstance", err)
+	}
+	return instance, nil
+}
+
+func (s *Service) Suspend(ctx context.Context, namespace, id string) (*apiv1alpha1.AgentInstance, error) {
+	if err := validateIdentity(namespace, id); err != nil {
+		return nil, err
+	}
+	creator, err := s.authorize(ctx, auth.VerbUpdate, namespace+"/"+id)
+	if err != nil {
+		return nil, err
+	}
+	instance, err := s.store.GetAgentInstance(ctx, namespace, id, creator)
+	if errors.Is(err, dbpkg.ErrNotFound) {
+		return nil, serviceerrors.NewNotFound("AgentInstance not found", err)
+	}
+	if err != nil {
+		return nil, serviceerrors.NewInternal("Failed to get AgentInstance", err)
+	}
+	instance, err = s.workflow.Suspend(ctx, instance)
+	if errors.Is(err, dbpkg.ErrAgentInstanceConflict) {
+		return nil, serviceerrors.NewAborted("AgentInstance has a conflicting lifecycle operation", err)
+	}
+	if err != nil {
+		return nil, serviceerrors.NewUnavailable("Failed to suspend AgentInstance", err)
+	}
+	return instance, nil
+}
+
+func (s *Service) Resume(ctx context.Context, namespace, id string) (*apiv1alpha1.AgentInstance, error) {
+	if err := validateIdentity(namespace, id); err != nil {
+		return nil, err
+	}
+	creator, err := s.authorize(ctx, auth.VerbUpdate, namespace+"/"+id)
+	if err != nil {
+		return nil, err
+	}
+	instance, err := s.store.GetAgentInstance(ctx, namespace, id, creator)
+	if errors.Is(err, dbpkg.ErrNotFound) {
+		return nil, serviceerrors.NewNotFound("AgentInstance not found", err)
+	}
+	if err != nil {
+		return nil, serviceerrors.NewInternal("Failed to get AgentInstance", err)
+	}
+	instance, err = s.workflow.Resume(ctx, instance)
+	if errors.Is(err, dbpkg.ErrAgentInstanceConflict) {
+		return nil, serviceerrors.NewAborted("AgentInstance has a conflicting lifecycle operation", err)
+	}
+	if err != nil {
+		return nil, serviceerrors.NewUnavailable("Failed to resume AgentInstance", err)
 	}
 	return instance, nil
 }

--- a/go/core/v2/agentinstance/service_test.go
+++ b/go/core/v2/agentinstance/service_test.go
@@ -154,11 +154,22 @@ func TestServiceCreateRejectsInvalidOrUnauthorizedRequests(t *testing.T) {
 	}
 }
 
-func TestServiceSuspendMapsLifecycleConflictToAborted(t *testing.T) {
+func TestServiceLifecycleMethodsMapConflictToAborted(t *testing.T) {
 	service := NewService(&serviceTestStore{}, serviceTestAuthorizer{}, serviceTestWorkflow{err: dbpkg.ErrAgentInstanceConflict})
-	_, err := service.Suspend(serviceTestContext("alice"), "team-a", "8bd650a8-9775-488f-8bc1-0d52bf7bdcab")
-	if !serviceerrors.IsCode(err, serviceerrors.CodeAborted) {
-		t.Fatalf("Suspend() error = %v, want code %s", err, serviceerrors.CodeAborted)
+	for _, test := range []struct {
+		name string
+		call func(*Service, context.Context, string, string) (*apiv1alpha1.AgentInstance, error)
+	}{
+		{name: "suspend", call: (*Service).Suspend},
+		{name: "resume", call: (*Service).Resume},
+		{name: "delete", call: (*Service).Delete},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := test.call(service, serviceTestContext("alice"), "team-a", "8bd650a8-9775-488f-8bc1-0d52bf7bdcab")
+			if !serviceerrors.IsCode(err, serviceerrors.CodeAborted) {
+				t.Fatalf("error = %v, want code %s", err, serviceerrors.CodeAborted)
+			}
+		})
 	}
 }
 

--- a/go/core/v2/agentinstance/service_test.go
+++ b/go/core/v2/agentinstance/service_test.go
@@ -74,14 +74,22 @@ func (*serviceTestStore) DeleteAgentInstanceShare(context.Context, string, strin
 	return nil
 }
 
-type serviceTestWorkflow struct{}
+type serviceTestWorkflow struct{ err error }
 
-func (serviceTestWorkflow) Create(_ context.Context, instance *apiv1alpha1.AgentInstance) (*apiv1alpha1.AgentInstance, error) {
-	return instance, nil
+func (w serviceTestWorkflow) Create(_ context.Context, instance *apiv1alpha1.AgentInstance) (*apiv1alpha1.AgentInstance, error) {
+	return instance, w.err
 }
 
-func (serviceTestWorkflow) Delete(_ context.Context, instance *apiv1alpha1.AgentInstance) (*apiv1alpha1.AgentInstance, error) {
-	return instance, nil
+func (w serviceTestWorkflow) Suspend(_ context.Context, instance *apiv1alpha1.AgentInstance) (*apiv1alpha1.AgentInstance, error) {
+	return instance, w.err
+}
+
+func (w serviceTestWorkflow) Resume(_ context.Context, instance *apiv1alpha1.AgentInstance) (*apiv1alpha1.AgentInstance, error) {
+	return instance, w.err
+}
+
+func (w serviceTestWorkflow) Delete(_ context.Context, instance *apiv1alpha1.AgentInstance) (*apiv1alpha1.AgentInstance, error) {
+	return instance, w.err
 }
 
 func serviceTestContext(userID string) context.Context {
@@ -143,6 +151,14 @@ func TestServiceCreateRejectsInvalidOrUnauthorizedRequests(t *testing.T) {
 				t.Fatalf("Create() error = %v, want code %s", err, test.code)
 			}
 		})
+	}
+}
+
+func TestServiceSuspendMapsLifecycleConflictToAborted(t *testing.T) {
+	service := NewService(&serviceTestStore{}, serviceTestAuthorizer{}, serviceTestWorkflow{err: dbpkg.ErrAgentInstanceConflict})
+	_, err := service.Suspend(serviceTestContext("alice"), "team-a", "8bd650a8-9775-488f-8bc1-0d52bf7bdcab")
+	if !serviceerrors.IsCode(err, serviceerrors.CodeAborted) {
+		t.Fatalf("Suspend() error = %v, want code %s", err, serviceerrors.CodeAborted)
 	}
 }
 

--- a/go/core/v2/agentinstance/workflow.go
+++ b/go/core/v2/agentinstance/workflow.go
@@ -44,6 +44,12 @@ func NewActorWorkflow(store workflowStore, actors actorClient) *ActorWorkflow {
 	return &ActorWorkflow{store: store, actors: actors}
 }
 
+// Create converges a persisted CREATING instance to READY. Retries discover
+// the deterministically named Actor before creating it, then resume it if a
+// previous attempt stopped before the Actor was running. An existing Actor is
+// accepted only when it still references the instance's prepared template;
+// this prevents an ID collision from attaching the instance to another
+// workload.
 func (w *ActorWorkflow) Create(ctx context.Context, instance *apiv1alpha1.AgentInstance) (*apiv1alpha1.AgentInstance, error) {
 	if instance.GetState() == apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_READY {
 		return instance, nil
@@ -91,6 +97,10 @@ func (w *ActorWorkflow) Create(ctx context.Context, instance *apiv1alpha1.AgentI
 	return instance, nil
 }
 
+// Suspend completes synchronously: success means both Substrate and the
+// AgentInstance record are suspended. Transitional Actor states are accepted
+// because Substrate's imperative SuspendActor call joins or completes the
+// in-flight operation. The workflow never recreates a missing Actor.
 func (w *ActorWorkflow) Suspend(ctx context.Context, instance *apiv1alpha1.AgentInstance) (*apiv1alpha1.AgentInstance, error) {
 	instance, claimed, err := w.claim(ctx, instance,
 		apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_READY,
@@ -118,6 +128,10 @@ func (w *ActorWorkflow) Suspend(ctx context.Context, instance *apiv1alpha1.Agent
 	)
 }
 
+// Resume completes synchronously: success means Substrate reports the Actor
+// running and the AgentInstance record is ready. As with Suspend, retries may
+// join a transitional Actor, but a missing Actor is an error rather than a
+// request to recreate it.
 func (w *ActorWorkflow) Resume(ctx context.Context, instance *apiv1alpha1.AgentInstance) (*apiv1alpha1.AgentInstance, error) {
 	instance, claimed, err := w.claim(ctx, instance,
 		apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_SUSPENDED,
@@ -148,6 +162,10 @@ func (w *ActorWorkflow) Resume(ctx context.Context, instance *apiv1alpha1.AgentI
 	)
 }
 
+// lifecycleActor is intentionally lookup-only. Lifecycle operations may act
+// only on the Actor created for this prepared revision; a missing Actor or a
+// changed ActorTemplate indicates broken identity and must be surfaced rather
+// than repaired by creating or adopting an Actor.
 func (w *ActorWorkflow) lifecycleActor(ctx context.Context, instance *apiv1alpha1.AgentInstance) (*ateapipb.Actor, error) {
 	revision, err := w.store.GetRuntimeRevision(ctx, instance.GetPreparedRevision())
 	if err != nil {
@@ -172,7 +190,9 @@ func (w *ActorWorkflow) claim(
 ) (*apiv1alpha1.AgentInstance, bool, error) {
 	// The operation is persisted with a compare-and-set before touching
 	// Substrate. This lets every API replica reject a different mutation while
-	// still allowing the same mutation to finish after a lost response.
+	// still allowing the same mutation to finish after a lost response. The
+	// returned bool reports whether this call installed the marker; a retry
+	// which finds the same operation joins it but must not later clear it.
 	if instance.GetState() != expectedState {
 		return nil, false, dbpkg.ErrAgentInstanceConflict
 	}
@@ -197,8 +217,9 @@ func (w *ActorWorkflow) finish(
 	instance *apiv1alpha1.AgentInstance,
 	expectedState, nextState apiv1alpha1.AgentInstanceState,
 ) (*apiv1alpha1.AgentInstance, error) {
-	// Completing the operation uses the same compare-and-set. If another retry
-	// already committed the target state, that state is the successful result.
+	// Completing the operation uses a second compare-and-set so only the owner
+	// of the active operation can publish the new stable state. If another retry
+	// already committed that state, its result makes this retry successful too.
 	next := proto.Clone(instance).(*apiv1alpha1.AgentInstance)
 	next.State = nextState
 	next.Operation = apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_UNSPECIFIED
@@ -212,7 +233,9 @@ func (w *ActorWorkflow) finish(
 
 func (w *ActorWorkflow) release(ctx context.Context, instance *apiv1alpha1.AgentInstance, state apiv1alpha1.AgentInstanceState, claimed bool, operationErr error) error {
 	// Only the request that installed the marker may clear it. A concurrent
-	// retry must not release an operation that it merely joined.
+	// retry must not release an operation that it merely joined. Clearing the
+	// marker restores the last stable database state after the Substrate call
+	// failed, allowing a later request to retry the workflow.
 	if !claimed {
 		return operationErr
 	}
@@ -226,6 +249,11 @@ func (w *ActorWorkflow) release(ctx context.Context, instance *apiv1alpha1.Agent
 	return errors.Join(operationErr, err)
 }
 
+// Delete fences other lifecycle mutations with the same persisted operation
+// marker used by Suspend and Resume. A missing Actor is treated as recovery
+// from a previously completed Substrate deletion. Otherwise the Actor's
+// template identity is checked and it is suspended before deletion, as
+// required by Substrate's lifecycle contract.
 func (w *ActorWorkflow) Delete(ctx context.Context, instance *apiv1alpha1.AgentInstance) (*apiv1alpha1.AgentInstance, error) {
 	originalState := instance.GetState()
 	instance, claimed, err := w.claim(ctx, instance, originalState, apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_DELETE)
@@ -263,6 +291,10 @@ func (w *ActorWorkflow) Delete(ctx context.Context, instance *apiv1alpha1.AgentI
 	return w.finishDelete(ctx, instance)
 }
 
+// finishDelete removes the durable AgentInstance row only after the Actor is
+// gone. The returned message is detached from storage and scrubbed of runtime
+// routing details so the synchronous Delete RPC can describe the completed
+// operation without leaving a tombstone in the database.
 func (w *ActorWorkflow) finishDelete(ctx context.Context, instance *apiv1alpha1.AgentInstance) (*apiv1alpha1.AgentInstance, error) {
 	if err := w.store.DeleteAgentInstance(ctx, instance.GetId()); err != nil {
 		return nil, fmt.Errorf("delete AgentInstance: %w", err)

--- a/go/core/v2/agentinstance/workflow.go
+++ b/go/core/v2/agentinstance/workflow.go
@@ -2,6 +2,7 @@ package agentinstance
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -11,11 +12,14 @@ import (
 	legacysubstrate "github.com/kagent-dev/kagent/go/core/pkg/sandboxbackend/substrate"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type workflowStore interface {
 	GetRuntimeRevision(context.Context, string) (*dbpkg.RuntimeRevision, error)
 	MarkAgentInstanceReady(context.Context, string, string) (*apiv1alpha1.AgentInstance, error)
+	TransitionAgentInstance(context.Context, *apiv1alpha1.AgentInstance, apiv1alpha1.AgentInstanceState, apiv1alpha1.AgentInstanceOperation) (*apiv1alpha1.AgentInstance, error)
 	DeleteAgentInstance(context.Context, string) error
 }
 
@@ -29,7 +33,7 @@ type actorClient interface {
 }
 
 // ActorWorkflow runs the imperative Substrate operations behind AgentInstance
-// create and delete RPCs. It returns only when the requested operation finishes
+// lifecycle RPCs. It returns only when the requested operation finishes
 // or the RPC context is canceled.
 type ActorWorkflow struct {
 	store  workflowStore
@@ -66,7 +70,7 @@ func (w *ActorWorkflow) Create(ctx context.Context, instance *apiv1alpha1.AgentI
 		return nil, fmt.Errorf("ensure Actor %s/%s: %w", atespace, name, err)
 	}
 	if actor.GetActorTemplateNamespace() != revision.ActorTemplateNamespace || actor.GetActorTemplateName() != revision.ActorTemplateName {
-		return nil, fmt.Errorf("Actor %s/%s uses unexpected ActorTemplate %s/%s", atespace, name, actor.GetActorTemplateNamespace(), actor.GetActorTemplateName())
+		return nil, fmt.Errorf("actor %s/%s uses unexpected ActorTemplate %s/%s", atespace, name, actor.GetActorTemplateNamespace(), actor.GetActorTemplateName())
 	}
 	// Substrate's resume RPC is an imperative workflow and returns only after
 	// the Actor is running.
@@ -87,10 +91,150 @@ func (w *ActorWorkflow) Create(ctx context.Context, instance *apiv1alpha1.AgentI
 	return instance, nil
 }
 
-func (w *ActorWorkflow) Delete(ctx context.Context, instance *apiv1alpha1.AgentInstance) (*apiv1alpha1.AgentInstance, error) {
+func (w *ActorWorkflow) Suspend(ctx context.Context, instance *apiv1alpha1.AgentInstance) (*apiv1alpha1.AgentInstance, error) {
+	instance, claimed, err := w.claim(ctx, instance,
+		apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_READY,
+		apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_SUSPEND,
+	)
+	if err != nil {
+		return nil, err
+	}
+	actor, err := w.lifecycleActor(ctx, instance)
+	if err == nil {
+		switch actor.GetStatus() {
+		case ateapipb.Actor_STATUS_SUSPENDED:
+		case ateapipb.Actor_STATUS_RUNNING, ateapipb.Actor_STATUS_RESUMING, ateapipb.Actor_STATUS_SUSPENDING:
+			err = w.actors.SuspendActor(ctx, instance.GetNamespace(), actorName(instance.GetId()))
+		default:
+			err = fmt.Errorf("actor %s/%s cannot be suspended from status %s", instance.GetNamespace(), actorName(instance.GetId()), actor.GetStatus())
+		}
+	}
+	if err != nil {
+		return nil, w.release(ctx, instance, apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_READY, claimed, err)
+	}
+	return w.finish(ctx, instance,
+		apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_READY,
+		apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_SUSPENDED,
+	)
+}
+
+func (w *ActorWorkflow) Resume(ctx context.Context, instance *apiv1alpha1.AgentInstance) (*apiv1alpha1.AgentInstance, error) {
+	instance, claimed, err := w.claim(ctx, instance,
+		apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_SUSPENDED,
+		apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_RESUME,
+	)
+	if err != nil {
+		return nil, err
+	}
+	actor, err := w.lifecycleActor(ctx, instance)
+	if err == nil {
+		switch actor.GetStatus() {
+		case ateapipb.Actor_STATUS_RUNNING:
+		case ateapipb.Actor_STATUS_SUSPENDED, ateapipb.Actor_STATUS_SUSPENDING, ateapipb.Actor_STATUS_RESUMING:
+			actor, err = w.actors.ResumeActor(ctx, instance.GetNamespace(), actorName(instance.GetId()))
+			if err == nil && actor.GetStatus() != ateapipb.Actor_STATUS_RUNNING {
+				err = fmt.Errorf("resume Actor %s/%s returned status %s", instance.GetNamespace(), actorName(instance.GetId()), actor.GetStatus())
+			}
+		default:
+			err = fmt.Errorf("actor %s/%s cannot be resumed from status %s", instance.GetNamespace(), actorName(instance.GetId()), actor.GetStatus())
+		}
+	}
+	if err != nil {
+		return nil, w.release(ctx, instance, apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_SUSPENDED, claimed, err)
+	}
+	return w.finish(ctx, instance,
+		apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_SUSPENDED,
+		apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_READY,
+	)
+}
+
+func (w *ActorWorkflow) lifecycleActor(ctx context.Context, instance *apiv1alpha1.AgentInstance) (*ateapipb.Actor, error) {
 	revision, err := w.store.GetRuntimeRevision(ctx, instance.GetPreparedRevision())
 	if err != nil {
 		return nil, fmt.Errorf("load prepared revision: %w", err)
+	}
+	atespace, name := instance.GetNamespace(), actorName(instance.GetId())
+	actor, err := w.actors.GetActor(ctx, atespace, name)
+	if err != nil {
+		return nil, fmt.Errorf("get Actor %s/%s: %w", atespace, name, err)
+	}
+	if actor.GetActorTemplateNamespace() != revision.ActorTemplateNamespace || actor.GetActorTemplateName() != revision.ActorTemplateName {
+		return nil, fmt.Errorf("actor %s/%s uses unexpected ActorTemplate %s/%s", atespace, name, actor.GetActorTemplateNamespace(), actor.GetActorTemplateName())
+	}
+	return actor, nil
+}
+
+func (w *ActorWorkflow) claim(
+	ctx context.Context,
+	instance *apiv1alpha1.AgentInstance,
+	expectedState apiv1alpha1.AgentInstanceState,
+	operation apiv1alpha1.AgentInstanceOperation,
+) (*apiv1alpha1.AgentInstance, bool, error) {
+	// The operation is persisted with a compare-and-set before touching
+	// Substrate. This lets every API replica reject a different mutation while
+	// still allowing the same mutation to finish after a lost response.
+	if instance.GetState() != expectedState {
+		return nil, false, dbpkg.ErrAgentInstanceConflict
+	}
+	if instance.GetOperation() == operation {
+		return instance, false, nil
+	}
+	if instance.GetOperation() != apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_UNSPECIFIED {
+		return nil, false, dbpkg.ErrAgentInstanceConflict
+	}
+	next := proto.Clone(instance).(*apiv1alpha1.AgentInstance)
+	next.Operation = operation
+	next.UpdatedAt = timestamppb.Now()
+	claimed, err := w.store.TransitionAgentInstance(ctx, next, expectedState, apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_UNSPECIFIED)
+	if errors.Is(err, dbpkg.ErrAgentInstanceConflict) && claimed.GetState() == expectedState && claimed.GetOperation() == operation {
+		return claimed, false, nil
+	}
+	return claimed, err == nil, err
+}
+
+func (w *ActorWorkflow) finish(
+	ctx context.Context,
+	instance *apiv1alpha1.AgentInstance,
+	expectedState, nextState apiv1alpha1.AgentInstanceState,
+) (*apiv1alpha1.AgentInstance, error) {
+	// Completing the operation uses the same compare-and-set. If another retry
+	// already committed the target state, that state is the successful result.
+	next := proto.Clone(instance).(*apiv1alpha1.AgentInstance)
+	next.State = nextState
+	next.Operation = apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_UNSPECIFIED
+	next.UpdatedAt = timestamppb.Now()
+	current, err := w.store.TransitionAgentInstance(ctx, next, expectedState, instance.GetOperation())
+	if errors.Is(err, dbpkg.ErrAgentInstanceConflict) && current.GetState() == nextState && current.GetOperation() == apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_UNSPECIFIED {
+		return current, nil
+	}
+	return current, err
+}
+
+func (w *ActorWorkflow) release(ctx context.Context, instance *apiv1alpha1.AgentInstance, state apiv1alpha1.AgentInstanceState, claimed bool, operationErr error) error {
+	// Only the request that installed the marker may clear it. A concurrent
+	// retry must not release an operation that it merely joined.
+	if !claimed {
+		return operationErr
+	}
+	next := proto.Clone(instance).(*apiv1alpha1.AgentInstance)
+	next.Operation = apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_UNSPECIFIED
+	next.UpdatedAt = timestamppb.Now()
+	_, err := w.store.TransitionAgentInstance(ctx, next, state, instance.GetOperation())
+	if errors.Is(err, dbpkg.ErrAgentInstanceConflict) {
+		return operationErr
+	}
+	return errors.Join(operationErr, err)
+}
+
+func (w *ActorWorkflow) Delete(ctx context.Context, instance *apiv1alpha1.AgentInstance) (*apiv1alpha1.AgentInstance, error) {
+	originalState := instance.GetState()
+	instance, claimed, err := w.claim(ctx, instance, originalState, apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_DELETE)
+	if err != nil {
+		return nil, err
+	}
+	revision, err := w.store.GetRuntimeRevision(ctx, instance.GetPreparedRevision())
+	if err != nil {
+		return nil, w.release(ctx, instance, originalState, claimed, fmt.Errorf("load prepared revision: %w", err))
 	}
 	atespace := instance.GetNamespace()
 	name := actorName(instance.GetId())
@@ -99,10 +243,10 @@ func (w *ActorWorkflow) Delete(ctx context.Context, instance *apiv1alpha1.AgentI
 		return w.finishDelete(ctx, instance)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("get Actor %s/%s for deletion: %w", atespace, name, err)
+		return nil, w.release(ctx, instance, originalState, claimed, fmt.Errorf("get Actor %s/%s for deletion: %w", atespace, name, err))
 	}
 	if actor.GetActorTemplateNamespace() != revision.ActorTemplateNamespace || actor.GetActorTemplateName() != revision.ActorTemplateName {
-		return nil, fmt.Errorf("refuse to delete Actor %s/%s: ActorTemplate changed", atespace, name)
+		return nil, w.release(ctx, instance, originalState, claimed, fmt.Errorf("refuse to delete Actor %s/%s: ActorTemplate changed", atespace, name))
 	}
 	// Substrate's suspend and delete RPCs each run their workflows to
 	// completion, so no local status polling is needed between them.
@@ -110,11 +254,11 @@ func (w *ActorWorkflow) Delete(ctx context.Context, instance *apiv1alpha1.AgentI
 	case ateapipb.Actor_STATUS_SUSPENDED, ateapipb.Actor_STATUS_CRASHED, ateapipb.Actor_STATUS_DELETING:
 	default:
 		if err := w.actors.SuspendActor(ctx, atespace, name); err != nil && status.Code(err) != codes.NotFound {
-			return nil, fmt.Errorf("suspend Actor %s/%s before deletion: %w", atespace, name, err)
+			return nil, w.release(ctx, instance, originalState, claimed, fmt.Errorf("suspend Actor %s/%s before deletion: %w", atespace, name, err))
 		}
 	}
 	if err := w.actors.DeleteActor(ctx, atespace, name); err != nil && status.Code(err) != codes.NotFound {
-		return nil, fmt.Errorf("delete Actor %s/%s: %w", atespace, name, err)
+		return nil, w.release(ctx, instance, originalState, claimed, fmt.Errorf("delete Actor %s/%s: %w", atespace, name, err))
 	}
 	return w.finishDelete(ctx, instance)
 }

--- a/go/core/v2/agentinstance/workflow_test.go
+++ b/go/core/v2/agentinstance/workflow_test.go
@@ -9,9 +9,10 @@ import (
 	apiv1alpha1 "github.com/kagent-dev/kagent/go/api/gen/kagent/api/v1alpha1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
-func TestActorWorkflowCreatesAndDeletesActor(t *testing.T) {
+func TestActorWorkflowLifecycle(t *testing.T) {
 	instance := &apiv1alpha1.AgentInstance{
 		Id: "8bd650a8-9775-488f-8bc1-0d52bf7bdcab", Namespace: "team-a",
 		PreparedRevision: "revision-1", State: apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_CREATING,
@@ -39,7 +40,26 @@ func TestActorWorkflowCreatesAndDeletesActor(t *testing.T) {
 		t.Fatalf("created Actor status = %s", actor.GetStatus())
 	}
 
-	deleted, err := workflow.Delete(context.Background(), instance)
+	suspended, err := workflow.Suspend(context.Background(), created)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if suspended.GetState() != apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_SUSPENDED || suspended.GetOperation() != apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_UNSPECIFIED {
+		t.Fatalf("suspended instance = %+v", suspended)
+	}
+	if actor := actors.actors[actorKey("team-a", actorName(instance.GetId()))]; actor.GetStatus() != ateapipb.Actor_STATUS_SUSPENDED {
+		t.Fatalf("suspended Actor status = %s", actor.GetStatus())
+	}
+
+	resumed, err := workflow.Resume(context.Background(), suspended)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resumed.GetState() != apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_READY || resumed.GetOperation() != apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_UNSPECIFIED {
+		t.Fatalf("resumed instance = %+v", resumed)
+	}
+
+	deleted, err := workflow.Delete(context.Background(), resumed)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -59,7 +79,16 @@ func (s *lifecycleTestStore) GetRuntimeRevision(context.Context, string) (*dbpkg
 
 func (s *lifecycleTestStore) MarkAgentInstanceReady(_ context.Context, _ string, authority string) (*apiv1alpha1.AgentInstance, error) {
 	s.instance.State = apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_READY
+	s.instance.Operation = apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_UNSPECIFIED
 	s.instance.A2AAuthority = authority
+	return s.instance, nil
+}
+
+func (s *lifecycleTestStore) TransitionAgentInstance(_ context.Context, instance *apiv1alpha1.AgentInstance, expectedState apiv1alpha1.AgentInstanceState, expectedOperation apiv1alpha1.AgentInstanceOperation) (*apiv1alpha1.AgentInstance, error) {
+	if s.instance.GetState() != expectedState || s.instance.GetOperation() != expectedOperation {
+		return s.instance, dbpkg.ErrAgentInstanceConflict
+	}
+	s.instance = proto.Clone(instance).(*apiv1alpha1.AgentInstance)
 	return s.instance, nil
 }
 


### PR DESCRIPTION
## Summary

- add synchronous AgentInstance suspend and resume workflows backed by Substrate
- persist lifecycle operations for atomic conflict fencing across controller replicas
- return ABORTED for conflicting transitions and apply the same fence to delete

## Testing

- `go test ./core/v2/agentinstance ./core/internal/database ./core/internal/grpcserver ./core/pkg/migrations`
- `go test ./core/v2/... ./core/cmd/controller-v2`
- `go test ./core/internal/...`
- targeted golangci-lint: 0 issues
- Kind mTLS smoke: Create READY -> Suspend SUSPENDED -> Resume READY -> conflicting Resume ABORTED -> Delete DELETED -> Get NOT_FOUND
