### PR TITLE
feat(hermes): pass ModelConfig baseUrl into Hermes config

### DIFF
--- a/go/core/pkg/sandboxbackend/modelconfig/baseurl.go
+++ b/go/core/pkg/sandboxbackend/modelconfig/baseurl.go
@@ -1,0 +1,40 @@
+// Package modelconfig holds backend-agnostic helpers for reading ModelConfig
+// fields shared by Substrate harness adapters (OpenClaw, Hermes, …).
+package modelconfig
+
+import (
+	"strings"
+
+	"github.com/kagent-dev/kagent/go/api/v1alpha3"
+)
+
+// ExplicitBaseURL returns a non-empty provider endpoint from ModelConfig when
+// the user set one (OpenAI/Anthropic baseUrl, Azure endpoint, Ollama host, etc.).
+func ExplicitBaseURL(mc *v1alpha3.ModelConfig) string {
+	if mc == nil {
+		return ""
+	}
+	switch mc.Spec.Provider {
+	case v1alpha3.ModelProviderOpenAI:
+		if mc.Spec.OpenAI != nil && strings.TrimSpace(mc.Spec.OpenAI.BaseURL) != "" {
+			return strings.TrimSpace(mc.Spec.OpenAI.BaseURL)
+		}
+	case v1alpha3.ModelProviderAnthropic:
+		if mc.Spec.Anthropic != nil && strings.TrimSpace(mc.Spec.Anthropic.BaseURL) != "" {
+			return strings.TrimSpace(mc.Spec.Anthropic.BaseURL)
+		}
+	case v1alpha3.ModelProviderAzureOpenAI:
+		if mc.Spec.AzureOpenAI != nil && strings.TrimSpace(mc.Spec.AzureOpenAI.Endpoint) != "" {
+			return strings.TrimSpace(mc.Spec.AzureOpenAI.Endpoint)
+		}
+	case v1alpha3.ModelProviderOllama:
+		if mc.Spec.Ollama != nil && strings.TrimSpace(mc.Spec.Ollama.Host) != "" {
+			return strings.TrimSpace(mc.Spec.Ollama.Host)
+		}
+	case v1alpha3.ModelProviderSAPAICore:
+		if mc.Spec.SAPAICore != nil && strings.TrimSpace(mc.Spec.SAPAICore.BaseURL) != "" {
+			return strings.TrimSpace(mc.Spec.SAPAICore.BaseURL)
+		}
+	}
+	return ""
+}

--- a/go/core/pkg/sandboxbackend/modelconfig/baseurl_test.go
+++ b/go/core/pkg/sandboxbackend/modelconfig/baseurl_test.go
@@ -1,0 +1,47 @@
+package modelconfig
+
+import (
+	"testing"
+
+	"github.com/kagent-dev/kagent/go/api/v1alpha3"
+)
+
+func TestExplicitBaseURL(t *testing.T) {
+	tests := []struct {
+		name string
+		mc   *v1alpha3.ModelConfig
+		want string
+	}{
+		{name: "nil", mc: nil, want: ""},
+		{
+			name: "openai explicit",
+			mc: &v1alpha3.ModelConfig{Spec: v1alpha3.ModelConfigSpec{
+				Provider: v1alpha3.ModelProviderOpenAI,
+				OpenAI:   &v1alpha3.OpenAIConfig{BaseURL: " https://api.example/v1 "},
+			}},
+			want: "https://api.example/v1",
+		},
+		{
+			name: "openai unset",
+			mc: &v1alpha3.ModelConfig{Spec: v1alpha3.ModelConfigSpec{
+				Provider: v1alpha3.ModelProviderOpenAI,
+			}},
+			want: "",
+		},
+		{
+			name: "anthropic explicit",
+			mc: &v1alpha3.ModelConfig{Spec: v1alpha3.ModelConfigSpec{
+				Provider:  v1alpha3.ModelProviderAnthropic,
+				Anthropic: &v1alpha3.AnthropicConfig{BaseURL: "https://anthropic.example"},
+			}},
+			want: "https://anthropic.example",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExplicitBaseURL(tt.mc); got != tt.want {
+				t.Fatalf("ExplicitBaseURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/go/core/pkg/sandboxbackend/openclaw/bootstrap_shared.go
+++ b/go/core/pkg/sandboxbackend/openclaw/bootstrap_shared.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/kagent-dev/kagent/go/api/v1alpha3"
+	"github.com/kagent-dev/kagent/go/core/pkg/sandboxbackend/modelconfig"
 )
 
 // GatewayBootstrapConfig describes the gateway section of openclaw.json for a harness runtime.
@@ -60,7 +61,7 @@ func buildCoreBootstrapDocument(mc *v1alpha3.ModelConfig, gw GatewayBootstrapCon
 	// Substrate: do not emit models.providers without baseUrl (OpenClaw rejects undefined baseUrl).
 	// Rely on agents.defaults + API key env unless the user set an explicit URL on ModelConfig.
 	if defaultBaseURLWhenUnset == SubstrateBootstrapDefaultBaseURL {
-		if explicit := modelConfigExplicitBaseURL(mc); explicit != "" {
+		if explicit := modelconfig.ExplicitBaseURL(mc); explicit != "" {
 			doc.Models = &modelsSection{
 				Mode: "merge",
 				Providers: map[string]providerSettings{

--- a/go/core/pkg/sandboxbackend/openclaw/provider.go
+++ b/go/core/pkg/sandboxbackend/openclaw/provider.go
@@ -2,39 +2,13 @@ package openclaw
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/kagent-dev/kagent/go/api/v1alpha3"
+	"github.com/kagent-dev/kagent/go/core/pkg/sandboxbackend/modelconfig"
 )
 
-func modelConfigExplicitBaseURL(mc *v1alpha3.ModelConfig) string {
-	switch mc.Spec.Provider {
-	case v1alpha3.ModelProviderOpenAI:
-		if mc.Spec.OpenAI != nil && strings.TrimSpace(mc.Spec.OpenAI.BaseURL) != "" {
-			return strings.TrimSpace(mc.Spec.OpenAI.BaseURL)
-		}
-	case v1alpha3.ModelProviderAnthropic:
-		if mc.Spec.Anthropic != nil && strings.TrimSpace(mc.Spec.Anthropic.BaseURL) != "" {
-			return strings.TrimSpace(mc.Spec.Anthropic.BaseURL)
-		}
-	case v1alpha3.ModelProviderAzureOpenAI:
-		if mc.Spec.AzureOpenAI != nil && strings.TrimSpace(mc.Spec.AzureOpenAI.Endpoint) != "" {
-			return strings.TrimSpace(mc.Spec.AzureOpenAI.Endpoint)
-		}
-	case v1alpha3.ModelProviderOllama:
-		if mc.Spec.Ollama != nil && strings.TrimSpace(mc.Spec.Ollama.Host) != "" {
-			return strings.TrimSpace(mc.Spec.Ollama.Host)
-		}
-	case v1alpha3.ModelProviderSAPAICore:
-		if mc.Spec.SAPAICore != nil && strings.TrimSpace(mc.Spec.SAPAICore.BaseURL) != "" {
-			return strings.TrimSpace(mc.Spec.SAPAICore.BaseURL)
-		}
-	}
-	return ""
-}
-
 func bootstrapProviderBaseURL(mc *v1alpha3.ModelConfig, defaultWhenUnset string) string {
-	if u := modelConfigExplicitBaseURL(mc); u != "" {
+	if u := modelconfig.ExplicitBaseURL(mc); u != "" {
 		return u
 	}
 	return defaultWhenUnset

--- a/go/core/pkg/sandboxbackend/substrate/channels_hermes_test.go
+++ b/go/core/pkg/sandboxbackend/substrate/channels_hermes_test.go
@@ -2,6 +2,7 @@ package substrate
 
 import (
 	"context"
+	"encoding/base64"
 	"strings"
 	"testing"
 
@@ -136,5 +137,72 @@ func TestBuildAcpStartupScript(t *testing.T) {
 	}
 	if !strings.Contains(gateway, "exec hermes acp") {
 		t.Fatalf("expected child exec inside shell: %q", gateway)
+	}
+}
+
+func decodeHermesConfigYAML(t *testing.T, prelude string) string {
+	t.Helper()
+	const marker = "echo "
+	i := strings.Index(prelude, marker)
+	if i < 0 {
+		t.Fatalf("prelude missing echo payload: %q", prelude)
+	}
+	rest := prelude[i+len(marker):]
+	b64 := strings.Fields(rest)[0]
+	raw, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		t.Fatalf("decode config yaml: %v", err)
+	}
+	return string(raw)
+}
+
+func TestHermesConfigPrelude_IncludesExplicitBaseURL(t *testing.T) {
+	mc := &v1alpha3.ModelConfig{
+		Spec: v1alpha3.ModelConfigSpec{
+			Provider: v1alpha3.ModelProviderOpenAI,
+			Model:    "gpt-4.1-mini",
+			OpenAI:   &v1alpha3.OpenAIConfig{BaseURL: "https://api.example/v1"},
+		},
+	}
+	yaml := decodeHermesConfigYAML(t, hermesConfigPrelude(mc))
+	if !strings.Contains(yaml, `default: "gpt-4.1-mini"`) {
+		t.Fatalf("missing model default: %s", yaml)
+	}
+	if !strings.Contains(yaml, `provider: "openai-api"`) {
+		t.Fatalf("missing provider: %s", yaml)
+	}
+	if !strings.Contains(yaml, `base_url: "https://api.example/v1"`) {
+		t.Fatalf("expected ModelConfig baseUrl in hermes config: %s", yaml)
+	}
+	if !strings.Contains(yaml, "api_mode: chat_completions") {
+		t.Fatalf("expected openai api_mode pin: %s", yaml)
+	}
+}
+
+func TestHermesConfigPrelude_OmitsBaseURLWhenUnset(t *testing.T) {
+	mc := &v1alpha3.ModelConfig{
+		Spec: v1alpha3.ModelConfigSpec{
+			Provider: v1alpha3.ModelProviderAnthropic,
+			Model:    "claude-sonnet-4-5",
+		},
+	}
+	yaml := decodeHermesConfigYAML(t, hermesConfigPrelude(mc))
+	if strings.Contains(yaml, "base_url:") {
+		t.Fatalf("base_url must be omitted when ModelConfig has no explicit endpoint: %s", yaml)
+	}
+	if !strings.Contains(yaml, `provider: "anthropic"`) {
+		t.Fatalf("missing provider: %s", yaml)
+	}
+}
+
+func TestHermesConfigPrelude_UnsupportedProvider(t *testing.T) {
+	mc := &v1alpha3.ModelConfig{
+		Spec: v1alpha3.ModelConfigSpec{
+			Provider: v1alpha3.ModelProviderOllama,
+			Model:    "llama3",
+		},
+	}
+	if got := hermesConfigPrelude(mc); got != "" {
+		t.Fatalf("expected empty prelude for unsupported provider, got %q", got)
 	}
 }

--- a/go/core/pkg/sandboxbackend/substrate/lifecycle_acp.go
+++ b/go/core/pkg/sandboxbackend/substrate/lifecycle_acp.go
@@ -9,6 +9,7 @@ import (
 	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 	"github.com/kagent-dev/kagent/go/api/v1alpha3"
 	"github.com/kagent-dev/kagent/go/core/internal/utils"
+	"github.com/kagent-dev/kagent/go/core/pkg/sandboxbackend/modelconfig"
 	"github.com/kagent-dev/kagent/go/core/pkg/sandboxbackend/openclaw"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -150,6 +151,9 @@ var hermesProviderSlugs = map[v1alpha3.ModelProvider]string{
 // hermesConfigPrelude returns shell lines that write ~/.hermes/config.yaml
 // selecting the ModelConfig's model and provider. Without it hermes defaults
 // to an unauthenticated provider and prompts silently produce no output.
+// When ModelConfig sets an explicit provider base URL (e.g. OpenAI/Anthropic
+// baseUrl), it is written as model.base_url so Hermes targets that endpoint
+// instead of the provider default (LiteLLM, vLLM, corporate proxies, etc.).
 // Returns "" when the ModelConfig provider has no hermes equivalent.
 func hermesConfigPrelude(mc *v1alpha3.ModelConfig) string {
 	slug, ok := hermesProviderSlugs[mc.Spec.Provider]
@@ -157,6 +161,9 @@ func hermesConfigPrelude(mc *v1alpha3.ModelConfig) string {
 		return ""
 	}
 	cfg := fmt.Sprintf("model:\n  default: %q\n  provider: %q\n", mc.Spec.Model, slug)
+	if baseURL := modelconfig.ExplicitBaseURL(mc); baseURL != "" {
+		cfg += fmt.Sprintf("  base_url: %q\n", baseURL)
+	}
 	if mc.Spec.Provider == v1alpha3.ModelProviderOpenAI {
 		// Hermes auto-upgrades direct api.openai.com to its codex_responses
 		// transport, which requests reasoning.encrypted_content — rejected


### PR DESCRIPTION
## Summary
- Propagate ModelConfig OpenAI/Anthropic `baseUrl` (and other explicit endpoints) into Hermes `model.base_url` during Substrate actor startup
- Extract shared `modelconfig.ExplicitBaseURL` helper used by OpenClaw and Hermes
- Add unit coverage for Hermes prelude with/without baseUrl

## Test plan
- [x] `go test ./pkg/sandboxbackend/modelconfig/ ./pkg/sandboxbackend/substrate/ ./pkg/sandboxbackend/openclaw/`
- [ ] Deploy Hermes AgentHarness with ModelConfig `openAI.baseUrl` pointing at a proxy and confirm traffic hits that endpoint