### PR TITLE
fix: key STS token cache by acting subject, not session alone

### DIFF
--- a/go/adk/pkg/a2a/executor.go
+++ b/go/adk/pkg/a2a/executor.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"iter"
-	"strings"
 	"time"
 
 	"log/slog"
@@ -269,23 +268,11 @@ func extractSessionName(message *a2atype.Message) string {
 // withBearerToken extracts the Bearer token from the incoming A2A request's
 // Authorization header and stores it in ctx for API key passthrough.
 func withBearerToken(ctx context.Context) context.Context {
-	callCtx, ok := a2asrv.CallContextFrom(ctx)
-	if !ok {
+	token := models.BearerFromCallContext(ctx)
+	if token == "" {
 		return ctx
 	}
-	meta := callCtx.ServiceParams()
-	if meta == nil {
-		return ctx
-	}
-	vals, ok := meta.Get("authorization")
-	if !ok || len(vals) == 0 || vals[0] == "" {
-		return ctx
-	}
-	parts := strings.Fields(strings.TrimSpace(vals[0]))
-	if len(parts) >= 2 && strings.EqualFold(parts[0], "Bearer") {
-		return context.WithValue(ctx, models.BearerTokenKey, parts[1])
-	}
-	return ctx
+	return context.WithValue(ctx, models.BearerTokenKey, token)
 }
 
 // dropPreAppendedDecisionFromHistory removes a pre-appended HITL decision

--- a/go/adk/pkg/models/base.go
+++ b/go/adk/pkg/models/base.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/a2aproject/a2a-go/v2/a2asrv"
+	"github.com/kagent-dev/kagent/go/adk/pkg/constants"
 	"google.golang.org/genai"
 )
 
@@ -95,6 +97,39 @@ func PassthroughToken(ctx context.Context, apiKeyPassthrough bool) (token string
 }
 
 type contextKey struct{}
+
+// BearerFromCallContext returns the bearer token carried by the A2A call
+// context's Authorization header, or "" when there is none.
+func BearerFromCallContext(ctx context.Context) string {
+	callCtx, ok := a2asrv.CallContextFrom(ctx)
+	if !ok {
+		return ""
+	}
+	meta := callCtx.ServiceParams()
+	if meta == nil {
+		return ""
+	}
+	vals, ok := meta.Get(constants.AuthorizationHeader)
+	if !ok || len(vals) == 0 {
+		return ""
+	}
+	parts := strings.Fields(strings.TrimSpace(vals[0]))
+	if len(parts) >= 2 && strings.EqualFold(parts[0], "Bearer") {
+		return parts[1]
+	}
+	return ""
+}
+
+// BearerTokenFromContext returns the credential the request authenticates with.
+// It prefers the value stored under BearerTokenKey and falls back to the A2A
+// call context, which reaches callers whose context was not threaded through
+// the executor.
+func BearerTokenFromContext(ctx context.Context) string {
+	if token, ok := ctx.Value(BearerTokenKey).(string); ok && token != "" {
+		return token
+	}
+	return BearerFromCallContext(ctx)
+}
 
 // headerTransport wraps an http.RoundTripper and adds custom headers to all requests
 type headerTransport struct {

--- a/go/adk/pkg/models/base.go
+++ b/go/adk/pkg/models/base.go
@@ -85,6 +85,10 @@ var BearerTokenKey = &contextKey{}
 // is enabled, so every model/embedding provider resolves passthrough the same way.
 // Each caller wraps the returned token in its own SDK's request-option type, since
 // that varies by provider (e.g. Authorization vs Api-Key header).
+//
+// It reads BearerTokenKey alone and takes no call-context fallback, unlike
+// BearerTokenFromContext: passthrough sends the credential to a third-party model
+// provider, so it is limited to the contexts the executor threaded it through.
 func PassthroughToken(ctx context.Context, apiKeyPassthrough bool) (token string, ok bool) {
 	if !apiKeyPassthrough {
 		return "", false

--- a/go/adk/pkg/sts/integration.go
+++ b/go/adk/pkg/sts/integration.go
@@ -9,6 +9,11 @@ import (
 // GetSubjectTokenFunc is a function type for extracting subject tokens.
 // It receives the bearer token (from Authorization header) and should return
 // the subject token for STS exchange, or empty string if not available.
+//
+// It must be a pure function of bearerToken. TokenPropagationPlugin caches the
+// exchange under a hash of the bearer, so an implementation that mints or
+// fetches a token returns one value per call while the cache keeps serving the
+// first for the entry's lifetime.
 type GetSubjectTokenFunc func(bearerToken string) string
 
 // DefaultGetSubjectToken extracts the JWT token from the Authorization header.

--- a/go/adk/pkg/sts/plugin.go
+++ b/go/adk/pkg/sts/plugin.go
@@ -49,7 +49,7 @@ type TokenPropagationPlugin struct {
 	mu              sync.RWMutex
 	logger          *slog.Logger
 	bufferSeconds   int64
-	earliestExpiry  int64    // earliest Expiry in tokenCache; 0 when nothing is evictable
+	earliestExpiry  int64    // lower bound on the earliest Expiry in tokenCache; 0 when nothing is evictable
 	resource        []string // RFC 8707 resource indicators sent on the STS exchange; empty omits them
 	audience        []string // RFC 8693 audiences sent on the STS exchange; empty omits them
 }
@@ -70,8 +70,8 @@ func NewTokenPropagationPlugin(integration *STSIntegration, logger *slog.Logger,
 }
 
 // parseUnverifiedClaims parses a JWT's claims WITHOUT signature or time
-// validation. It is used only for cache partitioning and TTL, never for a
-// security decision; tokens are validated server-side during STS exchange.
+// validation. It is used only for cache TTL; tokens are validated server-side
+// during STS exchange.
 func parseUnverifiedClaims(token string) (jwt.MapClaims, bool) {
 	if token == "" {
 		return nil, false
@@ -83,27 +83,25 @@ func parseUnverifiedClaims(token string) (jwt.MapClaims, bool) {
 	return claims, true
 }
 
-// subjectKey derives a stable per-principal cache discriminator from a bearer
-// token: the issuer-scoped "sub" claim when present, otherwise a hash of the
-// raw token so opaque or sub-less tokens still partition per principal. "sub"
-// is only unique within an issuer, so it is combined with "iss" to avoid two
-// principals from different issuers colliding onto one cache entry.
+// subjectKey derives a per-principal cache discriminator from a bearer token: a
+// hash of the raw token.
+//
+// A cache hit hands the caller a delegated token without performing an exchange,
+// so the key decides who receives someone else's authority. Deriving it from
+// unverified "iss"/"sub" claims would let a forged, unsigned token select a
+// victim's entry and never reach the STS that would have rejected it. Hashing
+// the raw token instead makes a forged token a cache miss, so it goes to the
+// STS and fails there.
+//
+// The cost is a re-exchange when a principal's bearer rotates mid-session, which
+// is wanted anyway: the delegated token's lifetime tracks the subject token it
+// was exchanged from.
 func subjectKey(token string) string {
 	if token == "" {
 		return ""
 	}
-	if claims, ok := parseUnverifiedClaims(token); ok {
-		if sub, _ := claims["sub"].(string); sub != "" {
-			// An absent "iss" leaves "sub" unqualified, which would collide
-			// across two issuers that both omit it, so those fall back to the
-			// token hash rather than a half-formed key.
-			if iss, _ := claims["iss"].(string); iss != "" {
-				return iss + "\x00" + sub
-			}
-		}
-	}
 	sum := sha256.Sum256([]byte(token))
-	return "h:" + hex.EncodeToString(sum[:])
+	return hex.EncodeToString(sum[:])
 }
 
 // actingCredential returns the credential this request authenticates with, which
@@ -346,6 +344,7 @@ func (p *TokenPropagationPlugin) AfterRunCallback(_ agent.InvocationContext) {
 	}
 
 	if p.actorTokenCache != nil && p.actorTokenCache.HasExpired(p.bufferSeconds) {
+		p.logger.Debug("removing expired actor token from cache")
 		p.actorTokenCache = nil
 	}
 }

--- a/go/adk/pkg/sts/plugin.go
+++ b/go/adk/pkg/sts/plugin.go
@@ -70,20 +70,6 @@ func NewTokenPropagationPlugin(integration *STSIntegration, logger *slog.Logger,
 	}
 }
 
-// parseUnverifiedClaims parses a JWT's claims WITHOUT signature or time
-// validation. It is used only for cache TTL; tokens are validated server-side
-// during STS exchange.
-func parseUnverifiedClaims(token string) (jwt.MapClaims, bool) {
-	if token == "" {
-		return nil, false
-	}
-	claims := jwt.MapClaims{}
-	if _, _, err := jwt.NewParser(jwt.WithoutClaimsValidation()).ParseUnverified(token, claims); err != nil {
-		return nil, false
-	}
-	return claims, true
-}
-
 // earlierExpiry returns the earlier of two Unix expiry timestamps, treating 0
 // as "no expiry known" rather than as the epoch.
 func earlierExpiry(current, candidate int64) int64 {
@@ -411,8 +397,11 @@ func (p *TokenPropagationPlugin) ADKPlugin() (*adkplugin.Plugin, error) {
 // its signature. This is ONLY used for cache TTL management, not for security
 // decisions. Token validation happens server-side during STS exchange.
 func extractJWTExpiry(token string) int64 {
-	claims, ok := parseUnverifiedClaims(token)
-	if !ok {
+	if token == "" {
+		return 0
+	}
+	claims := jwt.MapClaims{}
+	if _, _, err := jwt.NewParser(jwt.WithoutClaimsValidation()).ParseUnverified(token, claims); err != nil {
 		return 0
 	}
 	exp, err := claims.GetExpirationTime()

--- a/go/adk/pkg/sts/plugin.go
+++ b/go/adk/pkg/sts/plugin.go
@@ -106,13 +106,14 @@ func subjectKey(token string) string {
 	return "h:" + hex.EncodeToString(sum[:])
 }
 
-// actingBearer recovers the caller's raw bearer token for this request. It
-// prefers the value executor.withBearerToken stored (models.BearerTokenKey) and
-// falls back to the A2A CallContext Authorization header. The fallback keeps the
-// per-subject cache key reliable at the MCP transport layer: the CallContext is
-// the same source the round-tripper's propagateToken path reads, so it reaches
-// the caller even when BearerTokenKey is not threaded to the MCP request context.
-func actingBearer(ctx context.Context) string {
+// actingCredential returns the credential this request authenticates with, which
+// is also what the cache key is derived from. It prefers the value
+// executor.withBearerToken stored (models.BearerTokenKey) and falls back to the
+// A2A CallContext Authorization header. The fallback keeps the per-subject cache
+// key reliable at the MCP transport layer: the CallContext is the same source the
+// round-tripper's propagateToken path reads, so it reaches the caller even when
+// BearerTokenKey is not threaded to the MCP request context.
+func actingCredential(ctx context.Context) string {
 	if token, ok := ctx.Value(models.BearerTokenKey).(string); ok && token != "" {
 		return token
 	}
@@ -145,6 +146,11 @@ type cacheKey struct {
 
 // getCachedToken retrieves a valid cached token for the session and subject.
 func (p *TokenPropagationPlugin) getCachedToken(sessionID, subject string) (*TokenCacheEntry, bool) {
+	// An empty subject identifies no principal, so it must never match an entry.
+	if subject == "" {
+		return nil, false
+	}
+
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 
@@ -162,6 +168,12 @@ func (p *TokenPropagationPlugin) getCachedToken(sessionID, subject string) (*Tok
 
 // setCachedToken caches a token for the session and subject.
 func (p *TokenPropagationPlugin) setCachedToken(sessionID, subject, token string, expiry int64) {
+	// An empty subject identifies no principal, so an entry stored under it would
+	// be shared by every credential-less caller in the session.
+	if subject == "" {
+		return
+	}
+
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
@@ -232,10 +244,10 @@ func (p *TokenPropagationPlugin) BeforeRunCallback(ctx agent.InvocationContext) 
 		return nil, nil
 	}
 
-	// Recover the acting bearer before the cache lookup: the cache is keyed by the
-	// acting subject, and a session shared by multiple subjects would otherwise
+	// Resolve the acting credential before the cache lookup: the cache is keyed by
+	// the acting subject, and a session shared by multiple subjects would otherwise
 	// reuse the first caller's token for every later caller.
-	bearerToken := actingBearer(ctx)
+	bearerToken := actingCredential(ctx)
 
 	if bearerToken == "" {
 		p.logger.Debug("no bearer token in context, skipping token propagation", "session_id", sessionID)
@@ -351,10 +363,10 @@ func (p *TokenPropagationPlugin) HeaderProvider(ctx context.Context) map[string]
 		return nil
 	}
 
-	// Recover the acting subject from this request's own bearer, so the injected
+	// Derive the acting subject from this request's own credential, so the injected
 	// token matches the caller of this request rather than whichever subject
 	// first seeded the session.
-	subject := subjectKey(actingBearer(ctx))
+	subject := subjectKey(actingCredential(ctx))
 
 	entry, ok := p.getCachedToken(sessionID, subject)
 	if !ok {

--- a/go/adk/pkg/sts/plugin.go
+++ b/go/adk/pkg/sts/plugin.go
@@ -70,16 +70,15 @@ func hasPassed(deadline, bufferSeconds int64) bool {
 // It registers as a Go ADK plugin for run-level token preparation and exposes
 // a header provider used by MCP tool transports.
 type TokenPropagationPlugin struct {
-	integration      *STSIntegration
-	tokenCache       map[cacheKey]*TokenCacheEntry
-	actorTokenCache  *TokenCacheEntry // used only for dynamic fetchActorToken providers
-	mu               sync.RWMutex
-	logger           *slog.Logger
-	bufferSeconds    int64
-	earliestEviction int64    // lower bound on the earliest EvictAfter in tokenCache; 0 when nothing is evictable
-	uses             uint64   // monotonic use counter, read by touch
-	resource         []string // RFC 8707 resource indicators sent on the STS exchange; empty omits them
-	audience         []string // RFC 8693 audiences sent on the STS exchange; empty omits them
+	integration     *STSIntegration
+	tokenCache      map[cacheKey]*TokenCacheEntry
+	actorTokenCache *TokenCacheEntry // used only for dynamic fetchActorToken providers
+	mu              sync.RWMutex
+	logger          *slog.Logger
+	bufferSeconds   int64
+	uses            uint64   // monotonic use counter, read by touch
+	resource        []string // RFC 8707 resource indicators sent on the STS exchange; empty omits them
+	audience        []string // RFC 8693 audiences sent on the STS exchange; empty omits them
 }
 
 // NewTokenPropagationPlugin creates a new token propagation plugin.
@@ -126,17 +125,6 @@ func subjectKey(token string) string {
 	}
 	sum := sha256.Sum256([]byte(token))
 	return hex.EncodeToString(sum[:])
-}
-
-// actingCredential returns the credential this request authenticates with, which
-// is also what the cache key is derived from. models.BearerTokenFromContext
-// prefers the value executor.withBearerToken stored and falls back to the A2A
-// call context, which is what reaches the MCP transport layer: the call context
-// is the same source the round-tripper's propagateToken path reads, so the
-// per-subject key stays derivable even when BearerTokenKey is not threaded to
-// the MCP request context.
-func actingCredential(ctx context.Context) string {
-	return models.BearerTokenFromContext(ctx)
 }
 
 // cacheKey scopes a cache entry to both the session and the acting subject so a
@@ -211,7 +199,7 @@ func (p *TokenPropagationPlugin) evictOverSessionCapacity(sessionID string) {
 			keys = append(keys, key)
 		}
 	}
-	p.evictLeastRecentlyUsed(keys, len(keys)-maxEntriesPerSession, "session_id", sessionID)
+	p.evictLeastRecentlyUsed(keys, len(keys)-maxEntriesPerSession, "session")
 }
 
 // evictOverCapacity drops the least recently used entries once the whole cache
@@ -229,7 +217,7 @@ func (p *TokenPropagationPlugin) evictOverCapacity() {
 	for key := range p.tokenCache {
 		keys = append(keys, key)
 	}
-	p.evictLeastRecentlyUsed(keys, overflow)
+	p.evictLeastRecentlyUsed(keys, overflow, "cache")
 }
 
 // evictLeastRecentlyUsed drops the overflow least recently used entries among
@@ -239,7 +227,7 @@ func (p *TokenPropagationPlugin) evictOverCapacity() {
 // run that is between tool calls can lose the token it would have injected next.
 // It is reported above debug for that reason. The entry the caller just cached
 // is the most recently used, so it is never dropped here.
-func (p *TokenPropagationPlugin) evictLeastRecentlyUsed(keys []cacheKey, overflow int, logAttrs ...any) {
+func (p *TokenPropagationPlugin) evictLeastRecentlyUsed(keys []cacheKey, overflow int, bound string) {
 	if overflow <= 0 {
 		return
 	}
@@ -250,8 +238,8 @@ func (p *TokenPropagationPlugin) evictLeastRecentlyUsed(keys []cacheKey, overflo
 	for _, key := range keys[:overflow] {
 		delete(p.tokenCache, key)
 	}
-	p.logger.Warn("dropped valid cached tokens to stay within the cache capacity; callers may re-exchange",
-		append([]any{"dropped", overflow}, logAttrs...)...)
+	p.logger.Warn("dropped valid cached tokens to stay within capacity; callers may re-exchange",
+		"bound", bound, "dropped", overflow)
 }
 
 // setCachedToken caches a token for the session and subject.
@@ -271,9 +259,6 @@ func (p *TokenPropagationPlugin) setCachedToken(sessionID, subject, token string
 	p.tokenCache[cacheKey{sessionID: sessionID, subject: subject}] = entry
 	p.touch(entry)
 
-	if p.earliestEviction == 0 || entry.evictAfter < p.earliestEviction {
-		p.earliestEviction = entry.evictAfter
-	}
 	p.evictOverSessionCapacity(sessionID)
 	p.evictOverCapacity()
 }
@@ -335,7 +320,7 @@ func (p *TokenPropagationPlugin) BeforeRunCallback(ctx agent.InvocationContext) 
 	// Resolve the acting credential before the cache lookup: the cache is keyed by
 	// the acting subject, and a session shared by multiple subjects would otherwise
 	// reuse the first caller's token for every later caller.
-	bearerToken := actingCredential(ctx)
+	bearerToken := models.BearerTokenFromContext(ctx)
 
 	if bearerToken == "" {
 		p.logger.Debug("no bearer token in context, skipping token propagation", "session_id", sessionID)
@@ -426,20 +411,12 @@ func (p *TokenPropagationPlugin) AfterRunCallback(_ agent.InvocationContext) {
 	// The sweep covers every entry rather than the caller's alone; scoping it to
 	// the current session would strand the entries of sessions that never run
 	// again. A use renews the eviction time, so this cannot drop the credential
-	// of a run that is still in flight. The earliest eviction time gates the
-	// walk, so a large cache is only traversed once something can be evicted.
-	if p.earliestEviction != 0 && p.earliestEviction <= time.Now().Unix()+p.bufferSeconds {
-		earliest := int64(0)
-		for key, entry := range p.tokenCache {
-			if entry.evictable(p.bufferSeconds) {
-				delete(p.tokenCache, key)
-				continue
-			}
-			if earliest == 0 || entry.evictAfter < earliest {
-				earliest = entry.evictAfter
-			}
+	// of a run that is still in flight. The capacity bounds hold the walk to
+	// maxCacheEntries, and a run spans model calls, so it is not worth gating.
+	for key, entry := range p.tokenCache {
+		if entry.evictable(p.bufferSeconds) {
+			delete(p.tokenCache, key)
 		}
-		p.earliestEviction = earliest
 	}
 
 	if p.actorTokenCache != nil && p.actorTokenCache.HasExpired(p.bufferSeconds) {
@@ -463,8 +440,11 @@ func (p *TokenPropagationPlugin) HeaderProvider(ctx context.Context) map[string]
 
 	// Derive the acting subject from this request's own credential, so the injected
 	// token matches the caller of this request rather than whichever subject
-	// first seeded the session.
-	subject := subjectKey(actingCredential(ctx))
+	// first seeded the session. BearerTokenFromContext falls back to the A2A call
+	// context, the same source the round-tripper's propagateToken path reads, so
+	// the key stays derivable here even when BearerTokenKey was not threaded into
+	// the MCP request context.
+	subject := subjectKey(models.BearerTokenFromContext(ctx))
 	if subject == "" {
 		p.logger.DebugContext(ctx, "no caller credential on the request, MCP request will use existing headers", "session_id", sessionID)
 		return nil
@@ -502,7 +482,6 @@ func (p *TokenPropagationPlugin) ClearCache() {
 	defer p.mu.Unlock()
 
 	p.tokenCache = make(map[cacheKey]*TokenCacheEntry)
-	p.earliestEviction = 0
 	p.actorTokenCache = nil
 	p.logger.Info("cleared STS token cache")
 }

--- a/go/adk/pkg/sts/plugin.go
+++ b/go/adk/pkg/sts/plugin.go
@@ -2,13 +2,18 @@ package sts
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
 	"log/slog"
 
+	"github.com/a2aproject/a2a-go/v2/a2asrv"
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/kagent-dev/kagent/go/adk/pkg/constants"
 	"github.com/kagent-dev/kagent/go/adk/pkg/models"
 	"google.golang.org/adk/v2/agent"
 	adkplugin "google.golang.org/adk/v2/plugin"
@@ -34,8 +39,8 @@ func (e *TokenCacheEntry) HasExpired(bufferSeconds int64) bool {
 // a header provider used by MCP tool transports.
 type TokenPropagationPlugin struct {
 	integration     *STSIntegration
-	tokenCache      map[string]*TokenCacheEntry // keyed by session ID
-	actorTokenCache *TokenCacheEntry            // used only for dynamic fetchActorToken providers
+	tokenCache      map[cacheKey]*TokenCacheEntry
+	actorTokenCache *TokenCacheEntry // used only for dynamic fetchActorToken providers
 	mu              sync.RWMutex
 	logger          *slog.Logger
 	bufferSeconds   int64
@@ -50,7 +55,7 @@ type TokenPropagationPlugin struct {
 func NewTokenPropagationPlugin(integration *STSIntegration, logger *slog.Logger, resource, audience []string) *TokenPropagationPlugin {
 	return &TokenPropagationPlugin{
 		integration:   integration,
-		tokenCache:    make(map[string]*TokenCacheEntry),
+		tokenCache:    make(map[cacheKey]*TokenCacheEntry),
 		logger:        logger.With("component", "sts-plugin"),
 		bufferSeconds: 5,
 		resource:      resource,
@@ -58,12 +63,82 @@ func NewTokenPropagationPlugin(integration *STSIntegration, logger *slog.Logger,
 	}
 }
 
-// getCachedToken retrieves a valid cached token for the session.
-func (p *TokenPropagationPlugin) getCachedToken(sessionID string) (*TokenCacheEntry, bool) {
+// parseUnverifiedClaims parses a JWT's claims WITHOUT signature or time
+// validation. It is used only for cache partitioning and TTL, never for a
+// security decision; tokens are validated server-side during STS exchange.
+func parseUnverifiedClaims(token string) (jwt.MapClaims, bool) {
+	if token == "" {
+		return nil, false
+	}
+	claims := jwt.MapClaims{}
+	if _, _, err := jwt.NewParser(jwt.WithoutClaimsValidation()).ParseUnverified(token, claims); err != nil {
+		return nil, false
+	}
+	return claims, true
+}
+
+// subjectKey derives a stable per-principal cache discriminator from a bearer
+// token: the issuer-scoped "sub" claim when present, otherwise a hash of the
+// raw token so opaque or sub-less tokens still partition per principal. "sub"
+// is only unique within an issuer, so it is combined with "iss" to avoid two
+// principals from different issuers colliding onto one cache entry.
+func subjectKey(token string) string {
+	if token == "" {
+		return ""
+	}
+	if claims, ok := parseUnverifiedClaims(token); ok {
+		if sub, _ := claims["sub"].(string); sub != "" {
+			iss, _ := claims["iss"].(string)
+			return iss + "\x00" + sub
+		}
+	}
+	sum := sha256.Sum256([]byte(token))
+	return "h:" + hex.EncodeToString(sum[:])
+}
+
+// actingBearer recovers the caller's raw bearer token for this request. It
+// prefers the value executor.withBearerToken stored (models.BearerTokenKey) and
+// falls back to the A2A CallContext Authorization header. The fallback keeps the
+// per-subject cache key reliable at the MCP transport layer: the CallContext is
+// the same source the round-tripper's propagateToken path reads, so it reaches
+// the caller even when BearerTokenKey is not threaded to the MCP request context.
+func actingBearer(ctx context.Context) string {
+	if token, ok := ctx.Value(models.BearerTokenKey).(string); ok && token != "" {
+		return token
+	}
+	callCtx, ok := a2asrv.CallContextFrom(ctx)
+	if !ok {
+		return ""
+	}
+	meta := callCtx.ServiceParams()
+	if meta == nil {
+		return ""
+	}
+	vals, ok := meta.Get(constants.AuthorizationHeader)
+	if !ok || len(vals) == 0 {
+		return ""
+	}
+	parts := strings.Fields(strings.TrimSpace(vals[0]))
+	if len(parts) >= 2 && strings.EqualFold(parts[0], "Bearer") {
+		return parts[1]
+	}
+	return ""
+}
+
+// cacheKey scopes a cache entry to both the session and the acting subject so a
+// session that carries messages from multiple subjects keeps one exchanged
+// token per subject rather than collapsing to whichever arrived first.
+type cacheKey struct {
+	sessionID string
+	subject   string
+}
+
+// getCachedToken retrieves a valid cached token for the session and subject.
+func (p *TokenPropagationPlugin) getCachedToken(sessionID, subject string) (*TokenCacheEntry, bool) {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 
-	entry, ok := p.tokenCache[sessionID]
+	entry, ok := p.tokenCache[cacheKey{sessionID: sessionID, subject: subject}]
 	if !ok {
 		return nil, false
 	}
@@ -75,12 +150,12 @@ func (p *TokenPropagationPlugin) getCachedToken(sessionID string) (*TokenCacheEn
 	return entry, true
 }
 
-// setCachedToken caches a token for the session.
-func (p *TokenPropagationPlugin) setCachedToken(sessionID string, token string, expiry int64) {
+// setCachedToken caches a token for the session and subject.
+func (p *TokenPropagationPlugin) setCachedToken(sessionID, subject, token string, expiry int64) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	p.tokenCache[sessionID] = &TokenCacheEntry{
+	p.tokenCache[cacheKey{sessionID: sessionID, subject: subject}] = &TokenCacheEntry{
 		Token:  token,
 		Expiry: expiry,
 	}
@@ -140,26 +215,25 @@ func (p *TokenPropagationPlugin) BeforeRunCallback(ctx agent.InvocationContext) 
 		return nil, nil
 	}
 
-	// Check if we already have a valid cached token for this session.
-	if entry, ok := p.getCachedToken(sessionID); ok {
+	// Recover the acting bearer before the cache lookup: the cache is keyed by the
+	// acting subject, and a session shared by multiple subjects would otherwise
+	// reuse the first caller's token for every later caller.
+	bearerToken := actingBearer(ctx)
+
+	if bearerToken == "" {
+		p.logger.Debug("no bearer token in context, skipping token propagation", "session_id", sessionID)
+		return nil, nil
+	}
+
+	subject := subjectKey(bearerToken)
+
+	// Check if we already have a valid cached token for this session and subject.
+	if entry, ok := p.getCachedToken(sessionID, subject); ok {
 		p.logger.Debug("using cached STS token", "session_id", sessionID)
 		if entry.Expiry > 0 {
 			p.logger.Debug("token expiry remaining",
 				"expires_in", time.Until(time.Unix(entry.Expiry, 0)).String())
 		}
-		return nil, nil
-	}
-
-	// Extract bearer token from context. executor.go stores it with models.BearerTokenKey.
-	bearerToken := ""
-	if v := ctx.Value(models.BearerTokenKey); v != nil {
-		if token, ok := v.(string); ok {
-			bearerToken = token
-		}
-	}
-
-	if bearerToken == "" {
-		p.logger.Debug("no bearer token in context, skipping token propagation", "session_id", sessionID)
 		return nil, nil
 	}
 
@@ -192,7 +266,7 @@ func (p *TokenPropagationPlugin) BeforeRunCallback(ctx agent.InvocationContext) 
 			"", // requestedTokenType
 		)
 		if err != nil {
-			p.logger.Error("token exchange with STS failed; tools may not authenticate", "error", err, "session_id", sessionID)
+			p.logger.Error("sTS token exchange failed, tools may not authenticate", "error", err, "session_id", sessionID)
 			return nil, nil
 		}
 
@@ -205,12 +279,12 @@ func (p *TokenPropagationPlugin) BeforeRunCallback(ctx agent.InvocationContext) 
 			// Fall back to JWT exp claim for cache TTL.
 			expiry = extractJWTExpiry(exchangedToken)
 		}
-		p.setCachedToken(sessionID, exchangedToken, expiry)
+		p.setCachedToken(sessionID, subject, exchangedToken, expiry)
 		p.logger.Info("successfully exchanged and cached STS token", "session_id", sessionID)
 	} else {
 		// No STS integration — cache the raw subject token for header injection.
 		expiry := extractJWTExpiry(subjectToken)
-		p.setCachedToken(sessionID, subjectToken, expiry)
+		p.setCachedToken(sessionID, subject, subjectToken, expiry)
 		p.logger.Debug("cached subject token (no STS exchange)", "session_id", sessionID)
 	}
 
@@ -219,27 +293,16 @@ func (p *TokenPropagationPlugin) BeforeRunCallback(ctx agent.InvocationContext) 
 
 // AfterRunCallback is called after the ADK run finishes.
 // It cleans up expired tokens from the cache.
-func (p *TokenPropagationPlugin) AfterRunCallback(ctx agent.InvocationContext) {
-	sessionID := ""
-	if session := ctx.Session(); session != nil {
-		sessionID = session.ID()
-	}
-	if sessionID == "" {
-		return
-	}
-
+func (p *TokenPropagationPlugin) AfterRunCallback(_ agent.InvocationContext) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	// Remove expired subject token.
-	if entry, ok := p.tokenCache[sessionID]; ok {
+	for key, entry := range p.tokenCache {
 		if entry.HasExpired(p.bufferSeconds) {
-			p.logger.Debug("removing expired subject token from cache", "session_id", sessionID)
-			delete(p.tokenCache, sessionID)
+			delete(p.tokenCache, key)
 		}
 	}
 	if p.actorTokenCache != nil && p.actorTokenCache.HasExpired(p.bufferSeconds) {
-		p.logger.Debug("removing expired actor token from cache")
 		p.actorTokenCache = nil
 	}
 }
@@ -257,9 +320,14 @@ func (p *TokenPropagationPlugin) HeaderProvider(ctx context.Context) map[string]
 		return nil
 	}
 
-	entry, ok := p.getCachedToken(sessionID)
+	// Recover the acting subject from this request's own bearer, so the injected
+	// token matches the caller of this request rather than whichever subject
+	// first seeded the session.
+	subject := subjectKey(actingBearer(ctx))
+
+	entry, ok := p.getCachedToken(sessionID, subject)
 	if !ok {
-		p.logger.DebugContext(ctx, "no cached STS token for session, MCP request will use existing headers", "session_id", sessionID)
+		p.logger.DebugContext(ctx, "no cached STS token for session/subject, MCP request will use existing headers", "session_id", sessionID)
 		return nil
 	}
 
@@ -281,22 +349,12 @@ func sessionIDFromContext(ctx context.Context) string {
 	return sessionCtx.SessionID()
 }
 
-// GetTokenForSession retrieves the cached token for a specific session.
-// Returns empty string if no valid token is cached.
-func (p *TokenPropagationPlugin) GetTokenForSession(sessionID string) string {
-	entry, ok := p.getCachedToken(sessionID)
-	if !ok {
-		return ""
-	}
-	return entry.Token
-}
-
 // ClearCache clears all cached tokens.
 func (p *TokenPropagationPlugin) ClearCache() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	p.tokenCache = make(map[string]*TokenCacheEntry)
+	p.tokenCache = make(map[cacheKey]*TokenCacheEntry)
 	p.actorTokenCache = nil
 	p.logger.Info("cleared STS token cache")
 }
@@ -310,29 +368,17 @@ func (p *TokenPropagationPlugin) ADKPlugin() (*adkplugin.Plugin, error) {
 	})
 }
 
-// extractJWTExpiry extracts the 'exp' claim from a JWT token without verifying its signature.
-// This is ONLY used for cache TTL management, not for security decisions.
-// Token validation happens server-side during STS exchange.
+// extractJWTExpiry extracts the 'exp' claim from a JWT token without verifying
+// its signature. This is ONLY used for cache TTL management, not for security
+// decisions. Token validation happens server-side during STS exchange.
 func extractJWTExpiry(token string) int64 {
-	if token == "" {
+	claims, ok := parseUnverifiedClaims(token)
+	if !ok {
 		return 0
 	}
-
-	claims := jwt.MapClaims{}
-	if _, _, err := jwt.NewParser(jwt.WithoutClaimsValidation()).ParseUnverified(token, claims); err != nil {
+	exp, err := claims.GetExpirationTime()
+	if err != nil || exp == nil {
 		return 0
 	}
-
-	if exp, ok := claims["exp"]; ok {
-		switch v := exp.(type) {
-		case float64:
-			return int64(v)
-		case int64:
-			return v
-		case int:
-			return int64(v)
-		}
-	}
-
-	return 0
+	return exp.Unix()
 }

--- a/go/adk/pkg/sts/plugin.go
+++ b/go/adk/pkg/sts/plugin.go
@@ -1,10 +1,12 @@
 package sts
 
 import (
+	"cmp"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -17,42 +19,62 @@ import (
 	"google.golang.org/genai"
 )
 
-// maxCacheTTL bounds an entry whose token carries no usable expiry. The cache
-// holds one entry per (session, subject), so a token without an expiry would
-// otherwise pin an entry per caller for the lifetime of the process.
+// maxCacheTTL bounds an entry whose tokens state no expiry, so that such an
+// entry does not pin a slot for the lifetime of the process. It bounds memory
+// only, never the caller's authority, and a cache hit renews it.
 const maxCacheTTL = 5 * time.Minute
 
+// maxCacheEntries bounds the subject cache. The sweep runs between runs, so
+// concurrent runs holding many distinct credentials need a bound that does not
+// wait for one.
+const maxCacheEntries = 1024
+
 // TokenCacheEntry holds a cached token with its expiry time.
-//
-// Expiry 0 means the entry never expires. Only the actor token cache stores
-// such entries; setCachedToken bounds every subject entry, because the subject
-// cache holds one entry per caller rather than one per session.
 type TokenCacheEntry struct {
-	Token  string
-	Expiry int64 // Unix timestamp, 0 if no expiry
+	Token string
+	// Expiry is when the authority behind the token ends, 0 when nothing on
+	// this path states one. It decides whether the token may still be injected.
+	Expiry int64
+	// EvictAfter is when the entry may be dropped. It bounds memory only, never
+	// the caller's authority, so it can come due before Expiry. touch sets it
+	// when nothing states an expiry.
+	EvictAfter int64
+	// LastUsed is a use sequence, set by touch. It orders the capacity bound.
+	LastUsed uint64
 }
 
 // HasExpired checks if the token has expired or will expire soon.
 func (e *TokenCacheEntry) HasExpired(bufferSeconds int64) bool {
-	if e.Expiry == 0 {
+	return hasPassed(e.Expiry, bufferSeconds)
+}
+
+// evictable reports whether the entry may be dropped to bound memory.
+func (e *TokenCacheEntry) evictable(bufferSeconds int64) bool {
+	return hasPassed(e.EvictAfter, bufferSeconds)
+}
+
+// hasPassed reports whether a deadline has come due; 0 means there is none.
+func hasPassed(deadline, bufferSeconds int64) bool {
+	if deadline == 0 {
 		return false
 	}
-	return e.Expiry <= time.Now().Unix()+bufferSeconds
+	return deadline <= time.Now().Unix()+bufferSeconds
 }
 
 // TokenPropagationPlugin propagates STS tokens to ADK tools.
 // It registers as a Go ADK plugin for run-level token preparation and exposes
 // a header provider used by MCP tool transports.
 type TokenPropagationPlugin struct {
-	integration     *STSIntegration
-	tokenCache      map[cacheKey]*TokenCacheEntry
-	actorTokenCache *TokenCacheEntry // used only for dynamic fetchActorToken providers
-	mu              sync.RWMutex
-	logger          *slog.Logger
-	bufferSeconds   int64
-	earliestExpiry  int64    // lower bound on the earliest Expiry in tokenCache; 0 when nothing is evictable
-	resource        []string // RFC 8707 resource indicators sent on the STS exchange; empty omits them
-	audience        []string // RFC 8693 audiences sent on the STS exchange; empty omits them
+	integration      *STSIntegration
+	tokenCache       map[cacheKey]*TokenCacheEntry
+	actorTokenCache  *TokenCacheEntry // used only for dynamic fetchActorToken providers
+	mu               sync.RWMutex
+	logger           *slog.Logger
+	bufferSeconds    int64
+	earliestEviction int64    // lower bound on the earliest EvictAfter in tokenCache; 0 when nothing is evictable
+	uses             uint64   // monotonic use counter, read by touch
+	resource         []string // RFC 8707 resource indicators sent on the STS exchange; empty omits them
+	audience         []string // RFC 8693 audiences sent on the STS exchange; empty omits them
 }
 
 // NewTokenPropagationPlugin creates a new token propagation plugin.
@@ -127,19 +149,65 @@ func (p *TokenPropagationPlugin) getCachedToken(sessionID, subject string) (*Tok
 		return nil, false
 	}
 
-	p.mu.RLock()
-	defer p.mu.RUnlock()
+	// A write lock, not a read lock: a hit records the use, which is what keeps
+	// the sweep and the capacity bound off an entry a run is still using.
+	p.mu.Lock()
+	defer p.mu.Unlock()
 
 	entry, ok := p.tokenCache[cacheKey{sessionID: sessionID, subject: subject}]
 	if !ok {
 		return nil, false
 	}
 
+	// Tested on Expiry, never on EvictAfter: the entry is capped at the caller
+	// credential's own expiry, so an expired one means the caller's authority is
+	// gone. The sweep runs between runs, so the check belongs here too.
 	if entry.HasExpired(p.bufferSeconds) {
 		return nil, false
 	}
 
+	p.touch(entry)
 	return entry, true
+}
+
+// touch records that a run is using an entry. It must be called with p.mu held.
+//
+// Both bounds on the cache drop the entries no run is using: the capacity bound
+// by use order, the sweep by eviction time. An entry whose tokens state no
+// expiry carries a synthetic eviction time, so a use renews it. Without this, a
+// concurrent run's sweep drops the credential of a run that is still in flight,
+// which BeforeRunCallback runs too late to re-mint.
+func (p *TokenPropagationPlugin) touch(entry *TokenCacheEntry) {
+	p.uses++
+	entry.LastUsed = p.uses
+	if entry.Expiry == 0 {
+		entry.EvictAfter = time.Now().Add(maxCacheTTL).Unix()
+	}
+}
+
+// evictOverCapacity drops the least recently used entries once the cache is over
+// capacity. It must be called with p.mu held.
+//
+// The sweep runs between runs only, so it cannot bound a run that sees many
+// distinct credentials while it holds them. The entry the caller just cached is
+// the most recently used, so it is never dropped here.
+func (p *TokenPropagationPlugin) evictOverCapacity() {
+	overflow := len(p.tokenCache) - maxCacheEntries
+	if overflow <= 0 {
+		return
+	}
+
+	keys := make([]cacheKey, 0, len(p.tokenCache))
+	for key := range p.tokenCache {
+		keys = append(keys, key)
+	}
+	slices.SortFunc(keys, func(a, b cacheKey) int {
+		return cmp.Compare(p.tokenCache[a].LastUsed, p.tokenCache[b].LastUsed)
+	})
+	for _, key := range keys[:overflow] {
+		delete(p.tokenCache, key)
+	}
+	p.logger.Debug("dropped cached tokens over the cache capacity")
 }
 
 // setCachedToken caches a token for the session and subject.
@@ -153,20 +221,16 @@ func (p *TokenPropagationPlugin) setCachedToken(sessionID, subject, token string
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	// Every subject entry carries an expiry so the sweep can always evict it.
-	// Only entries whose token has no usable exp fall back to maxCacheTTL;
-	// a token that states its own expiry keeps it.
-	if expiry == 0 {
-		expiry = time.Now().Add(maxCacheTTL).Unix()
-	}
+	// EvictAfter defaults to Expiry; touch supplies the synthetic bound when
+	// nothing states an expiry, so every entry stays evictable.
+	entry := &TokenCacheEntry{Token: token, Expiry: expiry, EvictAfter: expiry}
+	p.tokenCache[cacheKey{sessionID: sessionID, subject: subject}] = entry
+	p.touch(entry)
 
-	p.tokenCache[cacheKey{sessionID: sessionID, subject: subject}] = &TokenCacheEntry{
-		Token:  token,
-		Expiry: expiry,
+	if p.earliestEviction == 0 || entry.EvictAfter < p.earliestEviction {
+		p.earliestEviction = entry.EvictAfter
 	}
-	if p.earliestExpiry == 0 || expiry < p.earliestExpiry {
-		p.earliestExpiry = expiry
-	}
+	p.evictOverCapacity()
 }
 
 func (p *TokenPropagationPlugin) getCachedActorToken() (*TokenCacheEntry, bool) {
@@ -306,23 +370,23 @@ func (p *TokenPropagationPlugin) AfterRunCallback(_ agent.InvocationContext) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	// A session holds one entry per subject and only the acting subject's key is
-	// derivable here, so the sweep covers every entry rather than the caller's
-	// alone; scoping it to the current session would strand the entries of
-	// sessions that never run again. The earliest expiry gates the walk, so a
-	// large cache is only traversed once something can actually be evicted.
-	if p.earliestExpiry != 0 && p.earliestExpiry <= time.Now().Unix()+p.bufferSeconds {
+	// The sweep covers every entry rather than the caller's alone; scoping it to
+	// the current session would strand the entries of sessions that never run
+	// again. A use renews the eviction time, so this cannot drop the credential
+	// of a run that is still in flight. The earliest eviction time gates the
+	// walk, so a large cache is only traversed once something can be evicted.
+	if p.earliestEviction != 0 && p.earliestEviction <= time.Now().Unix()+p.bufferSeconds {
 		earliest := int64(0)
 		for key, entry := range p.tokenCache {
-			if entry.HasExpired(p.bufferSeconds) {
+			if entry.evictable(p.bufferSeconds) {
 				delete(p.tokenCache, key)
 				continue
 			}
-			if earliest == 0 || entry.Expiry < earliest {
-				earliest = entry.Expiry
+			if earliest == 0 || entry.EvictAfter < earliest {
+				earliest = entry.EvictAfter
 			}
 		}
-		p.earliestExpiry = earliest
+		p.earliestEviction = earliest
 	}
 
 	if p.actorTokenCache != nil && p.actorTokenCache.HasExpired(p.bufferSeconds) {
@@ -348,10 +412,16 @@ func (p *TokenPropagationPlugin) HeaderProvider(ctx context.Context) map[string]
 	// token matches the caller of this request rather than whichever subject
 	// first seeded the session.
 	subject := subjectKey(actingCredential(ctx))
+	if subject == "" {
+		p.logger.DebugContext(ctx, "no caller credential on the request, MCP request will use existing headers", "session_id", sessionID)
+		return nil
+	}
 
 	entry, ok := p.getCachedToken(sessionID, subject)
 	if !ok {
-		p.logger.DebugContext(ctx, "no cached STS token for session/subject, MCP request will use existing headers", "session_id", sessionID)
+		// The caller is identified but has no usable entry, so this request loses
+		// its delegated identity. Reported above debug: nothing else says so.
+		p.logger.WarnContext(ctx, "no valid cached STS token for this caller, MCP request will use existing headers", "session_id", sessionID)
 		return nil
 	}
 
@@ -379,7 +449,7 @@ func (p *TokenPropagationPlugin) ClearCache() {
 	defer p.mu.Unlock()
 
 	p.tokenCache = make(map[cacheKey]*TokenCacheEntry)
-	p.earliestExpiry = 0
+	p.earliestEviction = 0
 	p.actorTokenCache = nil
 	p.logger.Info("cleared STS token cache")
 }

--- a/go/adk/pkg/sts/plugin.go
+++ b/go/adk/pkg/sts/plugin.go
@@ -5,15 +5,12 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
 	"log/slog"
 
-	"github.com/a2aproject/a2a-go/v2/a2asrv"
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/kagent-dev/kagent/go/adk/pkg/constants"
 	"github.com/kagent-dev/kagent/go/adk/pkg/models"
 	"google.golang.org/adk/v2/agent"
 	adkplugin "google.golang.org/adk/v2/plugin"
@@ -26,6 +23,10 @@ import (
 const maxCacheTTL = 5 * time.Minute
 
 // TokenCacheEntry holds a cached token with its expiry time.
+//
+// Expiry 0 means the entry never expires. Only the actor token cache stores
+// such entries; setCachedToken bounds every subject entry, because the subject
+// cache holds one entry per caller rather than one per session.
 type TokenCacheEntry struct {
 	Token  string
 	Expiry int64 // Unix timestamp, 0 if no expiry
@@ -83,6 +84,18 @@ func parseUnverifiedClaims(token string) (jwt.MapClaims, bool) {
 	return claims, true
 }
 
+// earlierExpiry returns the earlier of two Unix expiry timestamps, treating 0
+// as "no expiry known" rather than as the epoch.
+func earlierExpiry(current, candidate int64) int64 {
+	if candidate == 0 {
+		return current
+	}
+	if current == 0 || candidate < current {
+		return candidate
+	}
+	return current
+}
+
 // subjectKey derives a per-principal cache discriminator from a bearer token: a
 // hash of the raw token.
 //
@@ -93,9 +106,7 @@ func parseUnverifiedClaims(token string) (jwt.MapClaims, bool) {
 // the raw token instead makes a forged token a cache miss, so it goes to the
 // STS and fails there.
 //
-// The cost is a re-exchange when a principal's bearer rotates mid-session, which
-// is wanted anyway: the delegated token's lifetime tracks the subject token it
-// was exchanged from.
+// The cost is a re-exchange when a principal's bearer rotates mid-session.
 func subjectKey(token string) string {
 	if token == "" {
 		return ""
@@ -105,33 +116,14 @@ func subjectKey(token string) string {
 }
 
 // actingCredential returns the credential this request authenticates with, which
-// is also what the cache key is derived from. It prefers the value
-// executor.withBearerToken stored (models.BearerTokenKey) and falls back to the
-// A2A CallContext Authorization header. The fallback keeps the per-subject cache
-// key reliable at the MCP transport layer: the CallContext is the same source the
-// round-tripper's propagateToken path reads, so it reaches the caller even when
-// BearerTokenKey is not threaded to the MCP request context.
+// is also what the cache key is derived from. models.BearerTokenFromContext
+// prefers the value executor.withBearerToken stored and falls back to the A2A
+// call context, which is what reaches the MCP transport layer: the call context
+// is the same source the round-tripper's propagateToken path reads, so the
+// per-subject key stays derivable even when BearerTokenKey is not threaded to
+// the MCP request context.
 func actingCredential(ctx context.Context) string {
-	if token, ok := ctx.Value(models.BearerTokenKey).(string); ok && token != "" {
-		return token
-	}
-	callCtx, ok := a2asrv.CallContextFrom(ctx)
-	if !ok {
-		return ""
-	}
-	meta := callCtx.ServiceParams()
-	if meta == nil {
-		return ""
-	}
-	vals, ok := meta.Get(constants.AuthorizationHeader)
-	if !ok || len(vals) == 0 {
-		return ""
-	}
-	parts := strings.Fields(strings.TrimSpace(vals[0]))
-	if len(parts) >= 2 && strings.EqualFold(parts[0], "Bearer") {
-		return parts[1]
-	}
-	return ""
+	return models.BearerTokenFromContext(ctx)
 }
 
 // cacheKey scopes a cache entry to both the session and the acting subject so a
@@ -175,6 +167,9 @@ func (p *TokenPropagationPlugin) setCachedToken(sessionID, subject, token string
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
+	// Every subject entry carries an expiry so the sweep can always evict it.
+	// Only entries whose token has no usable exp fall back to maxCacheTTL;
+	// a token that states its own expiry keeps it.
 	if expiry == 0 {
 		expiry = time.Now().Add(maxCacheTTL).Unix()
 	}
@@ -256,11 +251,8 @@ func (p *TokenPropagationPlugin) BeforeRunCallback(ctx agent.InvocationContext) 
 
 	// Check if we already have a valid cached token for this session and subject.
 	if entry, ok := p.getCachedToken(sessionID, subject); ok {
-		p.logger.Debug("using cached STS token", "session_id", sessionID)
-		if entry.Expiry > 0 {
-			p.logger.Debug("token expiry remaining",
-				"expires_in", time.Until(time.Unix(entry.Expiry, 0)).String())
-		}
+		p.logger.Debug("using cached STS token", "session_id", sessionID,
+			"expires_in", time.Until(time.Unix(entry.Expiry, 0)).String())
 		return nil, nil
 	}
 
@@ -306,11 +298,15 @@ func (p *TokenPropagationPlugin) BeforeRunCallback(ctx agent.InvocationContext) 
 			// Fall back to JWT exp claim for cache TTL.
 			expiry = extractJWTExpiry(exchangedToken)
 		}
+		// The entry is keyed by the caller's credential, so it must not outlive
+		// it: replaying an expired bearer would otherwise keep hitting a cached
+		// delegated token instead of reaching the STS.
+		expiry = earlierExpiry(expiry, extractJWTExpiry(bearerToken))
 		p.setCachedToken(sessionID, subject, exchangedToken, expiry)
 		p.logger.Info("successfully exchanged and cached STS token", "session_id", sessionID)
 	} else {
 		// No STS integration — cache the raw subject token for header injection.
-		expiry := extractJWTExpiry(subjectToken)
+		expiry := earlierExpiry(extractJWTExpiry(subjectToken), extractJWTExpiry(bearerToken))
 		p.setCachedToken(sessionID, subject, subjectToken, expiry)
 		p.logger.Debug("cached subject token (no STS exchange)", "session_id", sessionID)
 	}

--- a/go/adk/pkg/sts/plugin.go
+++ b/go/adk/pkg/sts/plugin.go
@@ -20,6 +20,11 @@ import (
 	"google.golang.org/genai"
 )
 
+// maxCacheTTL bounds an entry whose token carries no usable expiry. The cache
+// holds one entry per (session, subject), so a token without an expiry would
+// otherwise pin an entry per caller for the lifetime of the process.
+const maxCacheTTL = 5 * time.Minute
+
 // TokenCacheEntry holds a cached token with its expiry time.
 type TokenCacheEntry struct {
 	Token  string
@@ -44,6 +49,7 @@ type TokenPropagationPlugin struct {
 	mu              sync.RWMutex
 	logger          *slog.Logger
 	bufferSeconds   int64
+	earliestExpiry  int64    // earliest Expiry in tokenCache; 0 when nothing is evictable
 	resource        []string // RFC 8707 resource indicators sent on the STS exchange; empty omits them
 	audience        []string // RFC 8693 audiences sent on the STS exchange; empty omits them
 }
@@ -88,8 +94,12 @@ func subjectKey(token string) string {
 	}
 	if claims, ok := parseUnverifiedClaims(token); ok {
 		if sub, _ := claims["sub"].(string); sub != "" {
-			iss, _ := claims["iss"].(string)
-			return iss + "\x00" + sub
+			// An absent "iss" leaves "sub" unqualified, which would collide
+			// across two issuers that both omit it, so those fall back to the
+			// token hash rather than a half-formed key.
+			if iss, _ := claims["iss"].(string); iss != "" {
+				return iss + "\x00" + sub
+			}
 		}
 	}
 	sum := sha256.Sum256([]byte(token))
@@ -155,9 +165,16 @@ func (p *TokenPropagationPlugin) setCachedToken(sessionID, subject, token string
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
+	if expiry == 0 {
+		expiry = time.Now().Add(maxCacheTTL).Unix()
+	}
+
 	p.tokenCache[cacheKey{sessionID: sessionID, subject: subject}] = &TokenCacheEntry{
 		Token:  token,
 		Expiry: expiry,
+	}
+	if p.earliestExpiry == 0 || expiry < p.earliestExpiry {
+		p.earliestExpiry = expiry
 	}
 }
 
@@ -297,11 +314,25 @@ func (p *TokenPropagationPlugin) AfterRunCallback(_ agent.InvocationContext) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	for key, entry := range p.tokenCache {
-		if entry.HasExpired(p.bufferSeconds) {
-			delete(p.tokenCache, key)
+	// A session holds one entry per subject and only the acting subject's key is
+	// derivable here, so the sweep covers every entry rather than the caller's
+	// alone; scoping it to the current session would strand the entries of
+	// sessions that never run again. The earliest expiry gates the walk, so a
+	// large cache is only traversed once something can actually be evicted.
+	if p.earliestExpiry != 0 && p.earliestExpiry <= time.Now().Unix()+p.bufferSeconds {
+		earliest := int64(0)
+		for key, entry := range p.tokenCache {
+			if entry.HasExpired(p.bufferSeconds) {
+				delete(p.tokenCache, key)
+				continue
+			}
+			if earliest == 0 || entry.Expiry < earliest {
+				earliest = entry.Expiry
+			}
 		}
+		p.earliestExpiry = earliest
 	}
+
 	if p.actorTokenCache != nil && p.actorTokenCache.HasExpired(p.bufferSeconds) {
 		p.actorTokenCache = nil
 	}
@@ -355,6 +386,7 @@ func (p *TokenPropagationPlugin) ClearCache() {
 	defer p.mu.Unlock()
 
 	p.tokenCache = make(map[cacheKey]*TokenCacheEntry)
+	p.earliestExpiry = 0
 	p.actorTokenCache = nil
 	p.logger.Info("cleared STS token cache")
 }

--- a/go/adk/pkg/sts/plugin.go
+++ b/go/adk/pkg/sts/plugin.go
@@ -19,14 +19,19 @@ import (
 	"google.golang.org/genai"
 )
 
-// maxCacheTTL bounds an entry whose tokens state no expiry, so that such an
+// evictAfterIdle bounds an entry whose tokens state no expiry, so that such an
 // entry does not pin a slot for the lifetime of the process. It bounds memory
 // only, never the caller's authority, and a cache hit renews it.
-const maxCacheTTL = 5 * time.Minute
+const evictAfterIdle = 5 * time.Minute
 
-// maxCacheEntries bounds the subject cache. The sweep runs between runs, so
-// concurrent runs holding many distinct credentials need a bound that does not
-// wait for one.
+// maxEntriesPerSession bounds the entries one session may hold. A session
+// carries as many entries as it has distinct callers, so the bound is what
+// keeps one session's burst of credentials from evicting another session's.
+const maxEntriesPerSession = 32
+
+// maxCacheEntries bounds the whole cache, across sessions. The sweep runs
+// between runs, so concurrent runs holding many distinct credentials need a
+// bound that does not wait for one.
 const maxCacheEntries = 1024
 
 // TokenCacheEntry holds a cached token with its expiry time.
@@ -35,12 +40,12 @@ type TokenCacheEntry struct {
 	// Expiry is when the authority behind the token ends, 0 when nothing on
 	// this path states one. It decides whether the token may still be injected.
 	Expiry int64
-	// EvictAfter is when the entry may be dropped. It bounds memory only, never
+	// evictAfter is when the entry may be dropped. It bounds memory only, never
 	// the caller's authority, so it can come due before Expiry. touch sets it
 	// when nothing states an expiry.
-	EvictAfter int64
-	// LastUsed is a use sequence, set by touch. It orders the capacity bound.
-	LastUsed uint64
+	evictAfter int64
+	// useSeq orders the capacity bounds. It is a sequence number, not a time.
+	useSeq uint64
 }
 
 // HasExpired checks if the token has expired or will expire soon.
@@ -50,7 +55,7 @@ func (e *TokenCacheEntry) HasExpired(bufferSeconds int64) bool {
 
 // evictable reports whether the entry may be dropped to bound memory.
 func (e *TokenCacheEntry) evictable(bufferSeconds int64) bool {
-	return hasPassed(e.EvictAfter, bufferSeconds)
+	return hasPassed(e.evictAfter, bufferSeconds)
 }
 
 // hasPassed reports whether a deadline has come due; 0 means there is none.
@@ -142,55 +147,78 @@ type cacheKey struct {
 	subject   string
 }
 
-// getCachedToken retrieves a valid cached token for the session and subject.
-func (p *TokenPropagationPlugin) getCachedToken(sessionID, subject string) (*TokenCacheEntry, bool) {
+// getCachedToken retrieves a valid cached token for the session and subject. It
+// returns a copy, so no caller holds the cached entry once the lock is released
+// and a concurrent touch cannot write fields a caller is reading.
+func (p *TokenPropagationPlugin) getCachedToken(sessionID, subject string) (TokenCacheEntry, bool) {
 	// An empty subject identifies no principal, so it must never match an entry.
 	if subject == "" {
-		return nil, false
+		return TokenCacheEntry{}, false
 	}
 
 	// A write lock, not a read lock: a hit records the use, which is what keeps
-	// the sweep and the capacity bound off an entry a run is still using.
+	// the sweep and the capacity bounds off an entry a run is still using.
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
 	entry, ok := p.tokenCache[cacheKey{sessionID: sessionID, subject: subject}]
 	if !ok {
-		return nil, false
+		return TokenCacheEntry{}, false
 	}
 
-	// Tested on Expiry, never on EvictAfter: the entry is capped at the caller
+	// Tested on Expiry, never on evictAfter: the entry is capped at the caller
 	// credential's own expiry, so an expired one means the caller's authority is
 	// gone. The sweep runs between runs, so the check belongs here too.
 	if entry.HasExpired(p.bufferSeconds) {
-		return nil, false
+		return TokenCacheEntry{}, false
 	}
 
 	p.touch(entry)
-	return entry, true
+	return *entry, true
 }
 
 // touch records that a run is using an entry. It must be called with p.mu held.
 //
-// Both bounds on the cache drop the entries no run is using: the capacity bound
-// by use order, the sweep by eviction time. An entry whose tokens state no
-// expiry carries a synthetic eviction time, so a use renews it. Without this, a
-// concurrent run's sweep drops the credential of a run that is still in flight,
-// which BeforeRunCallback runs too late to re-mint.
+// Every bound on the cache drops the entries no run is using: the capacity
+// bounds by use order, the sweep by eviction time. An entry whose tokens state
+// no expiry carries a synthetic eviction time, so a use renews it. Without
+// this, a concurrent run's sweep drops the credential of a run that is still in
+// flight, which BeforeRunCallback runs too late to re-mint.
 func (p *TokenPropagationPlugin) touch(entry *TokenCacheEntry) {
 	p.uses++
-	entry.LastUsed = p.uses
+	entry.useSeq = p.uses
 	if entry.Expiry == 0 {
-		entry.EvictAfter = time.Now().Add(maxCacheTTL).Unix()
+		entry.evictAfter = time.Now().Add(evictAfterIdle).Unix()
 	}
 }
 
-// evictOverCapacity drops the least recently used entries once the cache is over
-// capacity. It must be called with p.mu held.
+// evictOverSessionCapacity drops the least recently used entries of one session
+// once that session is over capacity. It must be called with p.mu held.
 //
-// The sweep runs between runs only, so it cannot bound a run that sees many
-// distinct credentials while it holds them. The entry the caller just cached is
-// the most recently used, so it is never dropped here.
+// The bound is per session so that a session presenting many distinct
+// credentials evicts its own entries and not those of unrelated sessions.
+func (p *TokenPropagationPlugin) evictOverSessionCapacity(sessionID string) {
+	// The whole cache is walked because entries are not indexed by session, but
+	// only the keys of this session are collected, and only once the session can
+	// be over capacity at all.
+	if len(p.tokenCache) <= maxEntriesPerSession {
+		return
+	}
+
+	keys := make([]cacheKey, 0, maxEntriesPerSession+1)
+	for key := range p.tokenCache {
+		if key.sessionID == sessionID {
+			keys = append(keys, key)
+		}
+	}
+	p.evictLeastRecentlyUsed(keys, len(keys)-maxEntriesPerSession, "session_id", sessionID)
+}
+
+// evictOverCapacity drops the least recently used entries once the whole cache
+// is over capacity. It must be called with p.mu held.
+//
+// The sweep runs between runs only, so it cannot bound runs that see many
+// distinct credentials while they hold them.
 func (p *TokenPropagationPlugin) evictOverCapacity() {
 	overflow := len(p.tokenCache) - maxCacheEntries
 	if overflow <= 0 {
@@ -201,13 +229,29 @@ func (p *TokenPropagationPlugin) evictOverCapacity() {
 	for key := range p.tokenCache {
 		keys = append(keys, key)
 	}
+	p.evictLeastRecentlyUsed(keys, overflow)
+}
+
+// evictLeastRecentlyUsed drops the overflow least recently used entries among
+// keys. It must be called with p.mu held.
+//
+// Unlike the sweep, this drops entries whose credentials are still valid, so a
+// run that is between tool calls can lose the token it would have injected next.
+// It is reported above debug for that reason. The entry the caller just cached
+// is the most recently used, so it is never dropped here.
+func (p *TokenPropagationPlugin) evictLeastRecentlyUsed(keys []cacheKey, overflow int, logAttrs ...any) {
+	if overflow <= 0 {
+		return
+	}
+
 	slices.SortFunc(keys, func(a, b cacheKey) int {
-		return cmp.Compare(p.tokenCache[a].LastUsed, p.tokenCache[b].LastUsed)
+		return cmp.Compare(p.tokenCache[a].useSeq, p.tokenCache[b].useSeq)
 	})
 	for _, key := range keys[:overflow] {
 		delete(p.tokenCache, key)
 	}
-	p.logger.Debug("dropped cached tokens over the cache capacity")
+	p.logger.Warn("dropped valid cached tokens to stay within the cache capacity; callers may re-exchange",
+		append([]any{"dropped", overflow}, logAttrs...)...)
 }
 
 // setCachedToken caches a token for the session and subject.
@@ -221,15 +265,16 @@ func (p *TokenPropagationPlugin) setCachedToken(sessionID, subject, token string
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	// EvictAfter defaults to Expiry; touch supplies the synthetic bound when
+	// evictAfter defaults to Expiry; touch supplies the synthetic bound when
 	// nothing states an expiry, so every entry stays evictable.
-	entry := &TokenCacheEntry{Token: token, Expiry: expiry, EvictAfter: expiry}
+	entry := &TokenCacheEntry{Token: token, Expiry: expiry, evictAfter: expiry}
 	p.tokenCache[cacheKey{sessionID: sessionID, subject: subject}] = entry
 	p.touch(entry)
 
-	if p.earliestEviction == 0 || entry.EvictAfter < p.earliestEviction {
-		p.earliestEviction = entry.EvictAfter
+	if p.earliestEviction == 0 || entry.evictAfter < p.earliestEviction {
+		p.earliestEviction = entry.evictAfter
 	}
+	p.evictOverSessionCapacity(sessionID)
 	p.evictOverCapacity()
 }
 
@@ -301,8 +346,14 @@ func (p *TokenPropagationPlugin) BeforeRunCallback(ctx agent.InvocationContext) 
 
 	// Check if we already have a valid cached token for this session and subject.
 	if entry, ok := p.getCachedToken(sessionID, subject); ok {
-		p.logger.Debug("using cached STS token", "session_id", sessionID,
-			"expires_in", time.Until(time.Unix(entry.Expiry, 0)).String())
+		// Nothing on this path states an expiry for an opaque credential, and
+		// time.Unix(0, 0) would report the epoch as a deadline decades past.
+		if entry.Expiry == 0 {
+			p.logger.Debug("using cached STS token", "session_id", sessionID)
+		} else {
+			p.logger.Debug("using cached STS token", "session_id", sessionID,
+				"expires_in", time.Until(time.Unix(entry.Expiry, 0)).String())
+		}
 		return nil, nil
 	}
 
@@ -335,7 +386,7 @@ func (p *TokenPropagationPlugin) BeforeRunCallback(ctx agent.InvocationContext) 
 			"", // requestedTokenType
 		)
 		if err != nil {
-			p.logger.Error("sTS token exchange failed, tools may not authenticate", "error", err, "session_id", sessionID)
+			p.logger.Error("STS token exchange failed, tools may not authenticate", "error", err, "session_id", sessionID)
 			return nil, nil
 		}
 
@@ -349,8 +400,10 @@ func (p *TokenPropagationPlugin) BeforeRunCallback(ctx agent.InvocationContext) 
 			expiry = extractJWTExpiry(exchangedToken)
 		}
 		// The entry is keyed by the caller's credential, so it must not outlive
-		// it: replaying an expired bearer would otherwise keep hitting a cached
-		// delegated token instead of reaching the STS.
+		// it, nor the subject token the exchange rests on: replaying an expired
+		// credential would otherwise keep hitting a cached delegated token
+		// instead of reaching the STS.
+		expiry = earlierExpiry(expiry, extractJWTExpiry(subjectToken))
 		expiry = earlierExpiry(expiry, extractJWTExpiry(bearerToken))
 		p.setCachedToken(sessionID, subject, exchangedToken, expiry)
 		p.logger.Info("successfully exchanged and cached STS token", "session_id", sessionID)
@@ -382,8 +435,8 @@ func (p *TokenPropagationPlugin) AfterRunCallback(_ agent.InvocationContext) {
 				delete(p.tokenCache, key)
 				continue
 			}
-			if earliest == 0 || entry.EvictAfter < earliest {
-				earliest = entry.EvictAfter
+			if earliest == 0 || entry.evictAfter < earliest {
+				earliest = entry.evictAfter
 			}
 		}
 		p.earliestEviction = earliest

--- a/go/adk/pkg/sts/plugin_test.go
+++ b/go/adk/pkg/sts/plugin_test.go
@@ -430,6 +430,22 @@ func TestHeaderProviderNoBearerDoesNotLeakSubjectToken(t *testing.T) {
 	}
 }
 
+// An empty subject identifies no principal, so it must not be storable: an entry
+// under it would be shared by every credential-less caller in the session.
+func TestEmptySubjectIsNotCacheable(t *testing.T) {
+	t.Parallel()
+
+	plugin := NewTokenPropagationPlugin(nil, slog.New(slog.DiscardHandler), nil, nil)
+	plugin.setCachedToken("sess-x", "", "anonymous-token", 0)
+
+	if len(plugin.tokenCache) != 0 {
+		t.Fatalf("expected empty subject not to be cached, got %d entries", len(plugin.tokenCache))
+	}
+	if _, ok := plugin.getCachedToken("sess-x", ""); ok {
+		t.Fatal("expected no cache hit for an empty subject")
+	}
+}
+
 // An absent "iss" leaves "sub" unqualified, so those tokens partition by hash
 // rather than by a key two issuers could both produce.
 func TestSubjectKeyWithoutIssuerUsesTokenHash(t *testing.T) {

--- a/go/adk/pkg/sts/plugin_test.go
+++ b/go/adk/pkg/sts/plugin_test.go
@@ -270,6 +270,12 @@ func signedTokenWithSub(t *testing.T, sub string) string {
 	return signedTokenWithKey(t, "https://issuer.example", sub, "secret")
 }
 
+// subjectOf is the cache subject of a named caller's opaque bearer, so a test
+// that seeds the cache directly keys the entry the way the plugin does.
+func subjectOf(caller string) string {
+	return subjectKey(caller + "-bearer")
+}
+
 // A cache hit hands out a delegated token without an STS exchange, so the key
 // must not be derivable from claims anyone can write: a token carrying the
 // victim's "iss" and "sub" must miss the victim's entry and be sent to the STS,
@@ -386,7 +392,7 @@ func TestHeaderProviderNoBearerDoesNotLeakSubjectToken(t *testing.T) {
 	t.Parallel()
 
 	plugin := NewTokenPropagationPlugin(nil, slog.New(slog.DiscardHandler), nil, nil)
-	plugin.setCachedToken("sess-x", "alice", "alice-token", 0)
+	plugin.setCachedToken("sess-x", subjectOf("alice"), "alice-token", 0)
 
 	headers := plugin.HeaderProvider(fakeSessionContext{
 		Context:   context.Background(),
@@ -445,20 +451,20 @@ func TestCachedTokenWithoutExpiryStaysEvictable(t *testing.T) {
 	t.Parallel()
 
 	plugin := NewTokenPropagationPlugin(nil, slog.New(slog.DiscardHandler), nil, nil)
-	plugin.setCachedToken("sess-ttl", "alice", "opaque-token", 0)
+	plugin.setCachedToken("sess-ttl", subjectOf("alice"), "opaque-token", 0)
 
-	entry, ok := plugin.getCachedToken("sess-ttl", "alice")
+	entry, ok := plugin.getCachedToken("sess-ttl", subjectOf("alice"))
 	if !ok {
 		t.Fatal("expected a cached entry")
 	}
 	if entry.Expiry != 0 {
 		t.Fatalf("entry expiry = %d, want 0: nothing on this path states one", entry.Expiry)
 	}
-	if entry.EvictAfter == 0 {
+	if entry.evictAfter == 0 {
 		t.Fatal("entry with no exp claim must be given a bounded eviction time")
 	}
-	if ceiling := time.Now().Add(maxCacheTTL).Unix(); entry.EvictAfter > ceiling {
-		t.Fatalf("entry eviction time %d exceeds the %s ceiling %d", entry.EvictAfter, maxCacheTTL, ceiling)
+	if ceiling := time.Now().Add(evictAfterIdle).Unix(); entry.evictAfter > ceiling {
+		t.Fatalf("entry eviction time %d exceeds the %s ceiling %d", entry.evictAfter, evictAfterIdle, ceiling)
 	}
 }
 
@@ -479,7 +485,7 @@ func TestSweepKeepsAnInFlightCallerStillUsingItsEntry(t *testing.T) {
 
 	// The bound comes due while the run is still in flight.
 	due := time.Now().Add(-time.Minute).Unix()
-	plugin.tokenCache[cacheKey{sessionID: sessionID, subject: subjectKey(bearer)}].EvictAfter = due
+	plugin.tokenCache[cacheKey{sessionID: sessionID, subject: subjectKey(bearer)}].evictAfter = due
 	plugin.earliestEviction = due
 
 	// The run makes another tool call, which renews the bound.
@@ -503,22 +509,23 @@ func TestSweepEvictsAnIdleEntryWithoutExpiry(t *testing.T) {
 	t.Parallel()
 
 	plugin := NewTokenPropagationPlugin(nil, slog.New(slog.DiscardHandler), nil, nil)
-	plugin.setCachedToken("sess-idle", "alice", "opaque-token", 0)
+	plugin.setCachedToken("sess-idle", subjectOf("alice"), "opaque-token", 0)
 
 	due := time.Now().Add(-time.Minute).Unix()
-	plugin.tokenCache[cacheKey{sessionID: "sess-idle", subject: "alice"}].EvictAfter = due
+	plugin.tokenCache[cacheKey{sessionID: "sess-idle", subject: subjectOf("alice")}].evictAfter = due
 	plugin.earliestEviction = due
 
 	plugin.AfterRunCallback(&fakeInvocationContext{Context: context.Background(), sessionID: "sess-idle"})
 
-	if _, ok := plugin.tokenCache[cacheKey{sessionID: "sess-idle", subject: "alice"}]; ok {
+	if _, ok := plugin.tokenCache[cacheKey{sessionID: "sess-idle", subject: subjectOf("alice")}]; ok {
 		t.Fatal("an entry no run is using must age out")
 	}
 }
 
-// A burst of distinct credentials is capped, and the cap drops the least recently
-// used entries rather than the one a run is still making tool calls with.
-func TestCapacityBoundKeepsTheEntryOfAnInFlightCaller(t *testing.T) {
+// A burst of distinct credentials on one session is capped, and the cap drops
+// the least recently used of that session's entries rather than the one a run is
+// still making tool calls with.
+func TestSessionCapacityBoundKeepsTheEntryOfAnInFlightCaller(t *testing.T) {
 	t.Parallel()
 
 	plugin := NewTokenPropagationPlugin(nil, slog.New(slog.DiscardHandler), nil, nil)
@@ -529,8 +536,8 @@ func TestCapacityBoundKeepsTheEntryOfAnInFlightCaller(t *testing.T) {
 	ctx := context.WithValue(context.Background(), kagentmodels.BearerTokenKey, bearer)
 	toolCall := fakeSessionContext{Context: ctx, sessionID: sessionID}
 
-	const overflow = 25
-	for i := range maxCacheEntries + overflow {
+	const overflow = 5
+	for i := range maxEntriesPerSession + overflow {
 		// Each new caller is more recent than the last tool call of the
 		// in-flight run, so only a renewed entry survives the burst.
 		if got := plugin.HeaderProvider(toolCall)["Authorization"]; got != "Bearer delegated-alice" {
@@ -539,8 +546,8 @@ func TestCapacityBoundKeepsTheEntryOfAnInFlightCaller(t *testing.T) {
 		plugin.setCachedToken(sessionID, subjectKey(fmt.Sprintf("token-%d", i)), "delegated", 0)
 	}
 
-	if len(plugin.tokenCache) != maxCacheEntries {
-		t.Fatalf("cache holds %d entries, want the %d cap", len(plugin.tokenCache), maxCacheEntries)
+	if len(plugin.tokenCache) != maxEntriesPerSession {
+		t.Fatalf("cache holds %d entries, want the %d per-session cap", len(plugin.tokenCache), maxEntriesPerSession)
 	}
 	if got := plugin.HeaderProvider(toolCall)["Authorization"]; got != "Bearer delegated-alice" {
 		t.Fatalf("the in-flight run lost its credential to the capacity bound, Authorization = %q", got)
@@ -555,6 +562,50 @@ func TestCapacityBoundKeepsTheEntryOfAnInFlightCaller(t *testing.T) {
 	}
 }
 
+// One session's burst of credentials must not evict another session's entry. The
+// bound is per session for that reason: the victim's run is between tool calls,
+// so it has nothing more recent to show, and BeforeRunCallback has already run.
+func TestSessionCapacityBoundSparesOtherSessions(t *testing.T) {
+	t.Parallel()
+
+	plugin := NewTokenPropagationPlugin(nil, slog.New(slog.DiscardHandler), nil, nil)
+	const victimSession = "sess-victim"
+	const victimBearer = "opaque-victim"
+	plugin.setCachedToken(victimSession, subjectKey(victimBearer), "delegated-victim", 0)
+
+	for i := range maxEntriesPerSession * 4 {
+		plugin.setCachedToken("sess-flood", subjectKey(fmt.Sprintf("token-%d", i)), "delegated", 0)
+	}
+
+	ctx := context.WithValue(context.Background(), kagentmodels.BearerTokenKey, victimBearer)
+	toolCall := fakeSessionContext{Context: ctx, sessionID: victimSession}
+	if got := plugin.HeaderProvider(toolCall)["Authorization"]; got != "Bearer delegated-victim" {
+		t.Fatalf("another session's burst took the victim's credential, Authorization = %q", got)
+	}
+}
+
+// The whole-cache bound still backstops the per-session one, so many sessions
+// cannot grow the cache without limit.
+func TestCacheCapacityBoundCapsEverySession(t *testing.T) {
+	t.Parallel()
+
+	plugin := NewTokenPropagationPlugin(nil, slog.New(slog.DiscardHandler), nil, nil)
+	sessions := maxCacheEntries/maxEntriesPerSession + 4
+	for session := range sessions {
+		for i := range maxEntriesPerSession {
+			plugin.setCachedToken(
+				fmt.Sprintf("sess-%d", session),
+				subjectKey(fmt.Sprintf("token-%d-%d", session, i)),
+				"delegated", 0,
+			)
+		}
+	}
+
+	if len(plugin.tokenCache) != maxCacheEntries {
+		t.Fatalf("cache holds %d entries, want the %d whole-cache cap", len(plugin.tokenCache), maxCacheEntries)
+	}
+}
+
 // The sweep must evict entries belonging to subjects and sessions other than the
 // acting one, since only the acting subject's key is derivable in the callback.
 func TestAfterRunCallbackEvictsExpiredEntriesOfOtherSubjects(t *testing.T) {
@@ -563,15 +614,15 @@ func TestAfterRunCallbackEvictsExpiredEntriesOfOtherSubjects(t *testing.T) {
 	plugin := NewTokenPropagationPlugin(nil, slog.New(slog.DiscardHandler), nil, nil)
 	past := time.Now().Add(-time.Hour).Unix()
 	future := time.Now().Add(time.Hour).Unix()
-	plugin.setCachedToken("sess-a", "alice", "alice-token", past)
-	plugin.setCachedToken("sess-b", "bob", "bob-token", future)
+	plugin.setCachedToken("sess-a", subjectOf("alice"), "alice-token", past)
+	plugin.setCachedToken("sess-b", subjectOf("bob"), "bob-token", future)
 
 	plugin.AfterRunCallback(&fakeInvocationContext{Context: context.Background(), sessionID: "sess-b"})
 
-	if _, ok := plugin.getCachedToken("sess-a", "alice"); ok {
+	if _, ok := plugin.getCachedToken("sess-a", subjectOf("alice")); ok {
 		t.Fatal("expired entry of another session/subject must be evicted")
 	}
-	if _, ok := plugin.getCachedToken("sess-b", "bob"); !ok {
+	if _, ok := plugin.getCachedToken("sess-b", subjectOf("bob")); !ok {
 		t.Fatal("unexpired entry must survive the sweep")
 	}
 	if plugin.earliestEviction != future {
@@ -586,11 +637,11 @@ func TestAfterRunCallbackSkipsWalkUntilSomethingExpires(t *testing.T) {
 
 	plugin := NewTokenPropagationPlugin(nil, slog.New(slog.DiscardHandler), nil, nil)
 	future := time.Now().Add(time.Hour).Unix()
-	plugin.setCachedToken("sess-a", "alice", "alice-token", future)
+	plugin.setCachedToken("sess-a", subjectOf("alice"), "alice-token", future)
 
 	plugin.AfterRunCallback(&fakeInvocationContext{Context: context.Background(), sessionID: "sess-a"})
 
-	if _, ok := plugin.getCachedToken("sess-a", "alice"); !ok {
+	if _, ok := plugin.getCachedToken("sess-a", subjectOf("alice")); !ok {
 		t.Fatal("unexpired entry must survive")
 	}
 	if plugin.earliestEviction != future {
@@ -602,7 +653,7 @@ func TestClearCacheResetsEarliestEviction(t *testing.T) {
 	t.Parallel()
 
 	plugin := NewTokenPropagationPlugin(nil, slog.New(slog.DiscardHandler), nil, nil)
-	plugin.setCachedToken("sess-a", "alice", "alice-token", time.Now().Add(time.Hour).Unix())
+	plugin.setCachedToken("sess-a", subjectOf("alice"), "alice-token", time.Now().Add(time.Hour).Unix())
 	plugin.ClearCache()
 
 	if plugin.earliestEviction != 0 {

--- a/go/adk/pkg/sts/plugin_test.go
+++ b/go/adk/pkg/sts/plugin_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -426,6 +427,104 @@ func TestHeaderProviderNoBearerDoesNotLeakSubjectToken(t *testing.T) {
 
 	if got, ok := headers["Authorization"]; ok {
 		t.Fatalf("expected no Authorization header for empty-bearer request, got %q", got)
+	}
+}
+
+// An absent "iss" leaves "sub" unqualified, so those tokens partition by hash
+// rather than by a key two issuers could both produce.
+func TestSubjectKeyWithoutIssuerUsesTokenHash(t *testing.T) {
+	t.Parallel()
+
+	key := subjectKey(signedTokenWith(t, "", "alice"))
+	if !strings.HasPrefix(key, "h:") {
+		t.Fatalf("subjectKey() = %q, want a hash-derived key for a token without iss", key)
+	}
+
+	other, err := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"sub": "alice",
+		"jti": "second-issuer",
+	}).SignedString([]byte("secret"))
+	if err != nil {
+		t.Fatalf("failed to sign token: %v", err)
+	}
+	if subjectKey(other) == key {
+		t.Fatal("two issuer-less tokens sharing a sub must not share a cache key")
+	}
+}
+
+// A token with no exp claim must still get a bounded cache lifetime: the cache
+// holds one entry per (session, subject), so an immortal entry per caller would
+// grow without limit.
+func TestCachedTokenWithoutExpiryStaysEvictable(t *testing.T) {
+	t.Parallel()
+
+	plugin := NewTokenPropagationPlugin(nil, slog.New(slog.DiscardHandler), nil, nil)
+	plugin.setCachedToken("sess-ttl", "alice", "opaque-token", 0)
+
+	entry, ok := plugin.getCachedToken("sess-ttl", "alice")
+	if !ok {
+		t.Fatal("expected a cached entry")
+	}
+	if entry.Expiry == 0 {
+		t.Fatal("entry with no exp claim must be given a bounded expiry")
+	}
+	if ceiling := time.Now().Add(maxCacheTTL).Unix(); entry.Expiry > ceiling {
+		t.Fatalf("entry expiry %d exceeds the %s ceiling %d", entry.Expiry, maxCacheTTL, ceiling)
+	}
+}
+
+// The sweep must evict entries belonging to subjects and sessions other than the
+// acting one, since only the acting subject's key is derivable in the callback.
+func TestAfterRunCallbackEvictsExpiredEntriesOfOtherSubjects(t *testing.T) {
+	t.Parallel()
+
+	plugin := NewTokenPropagationPlugin(nil, slog.New(slog.DiscardHandler), nil, nil)
+	past := time.Now().Add(-time.Hour).Unix()
+	future := time.Now().Add(time.Hour).Unix()
+	plugin.setCachedToken("sess-a", "alice", "alice-token", past)
+	plugin.setCachedToken("sess-b", "bob", "bob-token", future)
+
+	plugin.AfterRunCallback(&fakeInvocationContext{Context: context.Background(), sessionID: "sess-b"})
+
+	if _, ok := plugin.getCachedToken("sess-a", "alice"); ok {
+		t.Fatal("expired entry of another session/subject must be evicted")
+	}
+	if _, ok := plugin.getCachedToken("sess-b", "bob"); !ok {
+		t.Fatal("unexpired entry must survive the sweep")
+	}
+	if plugin.earliestExpiry != future {
+		t.Fatalf("earliestExpiry = %d, want %d after the sweep", plugin.earliestExpiry, future)
+	}
+}
+
+// The earliest expiry gates the walk, so a cache with nothing evictable is left
+// untouched instead of being traversed on every run.
+func TestAfterRunCallbackSkipsWalkUntilSomethingExpires(t *testing.T) {
+	t.Parallel()
+
+	plugin := NewTokenPropagationPlugin(nil, slog.New(slog.DiscardHandler), nil, nil)
+	future := time.Now().Add(time.Hour).Unix()
+	plugin.setCachedToken("sess-a", "alice", "alice-token", future)
+
+	plugin.AfterRunCallback(&fakeInvocationContext{Context: context.Background(), sessionID: "sess-a"})
+
+	if _, ok := plugin.getCachedToken("sess-a", "alice"); !ok {
+		t.Fatal("unexpired entry must survive")
+	}
+	if plugin.earliestExpiry != future {
+		t.Fatalf("earliestExpiry = %d, want it left at %d", plugin.earliestExpiry, future)
+	}
+}
+
+func TestClearCacheResetsEarliestExpiry(t *testing.T) {
+	t.Parallel()
+
+	plugin := NewTokenPropagationPlugin(nil, slog.New(slog.DiscardHandler), nil, nil)
+	plugin.setCachedToken("sess-a", "alice", "alice-token", time.Now().Add(time.Hour).Unix())
+	plugin.ClearCache()
+
+	if plugin.earliestExpiry != 0 {
+		t.Fatalf("earliestExpiry = %d, want 0 after ClearCache", plugin.earliestExpiry)
 	}
 }
 

--- a/go/adk/pkg/sts/plugin_test.go
+++ b/go/adk/pkg/sts/plugin_test.go
@@ -573,3 +573,84 @@ func TestExtractJWTExpiryUsesUnverifiedClaims(t *testing.T) {
 		t.Fatalf("extractJWTExpiry() = %d, want %d", got, want)
 	}
 }
+
+// signedTokenExpiringIn mints a token whose exp claim is offset from now.
+func signedTokenExpiringIn(t *testing.T, sub string, d time.Duration) string {
+	t.Helper()
+	claims := jwt.MapClaims{
+		"iss": "https://issuer.example",
+		"sub": sub,
+		"exp": time.Now().Add(d).Unix(),
+	}
+	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte("secret"))
+	if err != nil {
+		t.Fatalf("failed to sign token: %v", err)
+	}
+	return token
+}
+
+// The entry is keyed by the caller's credential, so it must not outlive it.
+// Otherwise a caller replaying an expired bearer keeps hitting a cached
+// delegated token instead of reaching the STS that would reject it.
+func TestCachedEntryDoesNotOutliveTheCallerCredential(t *testing.T) {
+	t.Parallel()
+
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/oauth-authorization-server" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"issuer":         srv.URL,
+				"token_endpoint": srv.URL + "/token",
+			})
+			return
+		}
+		// A delegated token that long outlives the caller's own credential.
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":      "long-lived",
+			"issued_token_type": string(TokenTypeJWT),
+			"expires_in":        3600,
+		})
+	}))
+	defer srv.Close()
+
+	integration, err := NewSTSIntegration(
+		srv.URL+"/.well-known/oauth-authorization-server",
+		"",
+		func(context.Context) (string, error) { return "actor", nil },
+		nil,
+		5,
+		true,
+		false,
+	)
+	if err != nil {
+		t.Fatalf("NewSTSIntegration() error = %v", err)
+	}
+
+	plugin := NewTokenPropagationPlugin(integration, slog.New(slog.DiscardHandler), nil, nil)
+
+	const sessionID = "sess-ttl"
+	bearer := signedTokenExpiringIn(t, "alice", 30*time.Second)
+	ctx := context.WithValue(context.Background(), kagentmodels.BearerTokenKey, bearer)
+	if _, err := plugin.BeforeRunCallback(&fakeInvocationContext{Context: ctx, sessionID: sessionID}); err != nil {
+		t.Fatalf("BeforeRunCallback() error = %v", err)
+	}
+
+	entry, ok := plugin.getCachedToken(sessionID, subjectKey(bearer))
+	if !ok {
+		t.Fatal("expected a cached entry after the exchange")
+	}
+	if want := extractJWTExpiry(bearer); entry.Expiry != want {
+		t.Fatalf("entry expiry = %d, want the caller credential's exp %d", entry.Expiry, want)
+	}
+}
+
+// A credential with no exp claim leaves the exchange's own lifetime in place
+// rather than truncating it.
+func TestCachedEntryKeepsExchangeExpiryWhenCredentialHasNone(t *testing.T) {
+	t.Parallel()
+
+	exchanged := signedTokenExpiringIn(t, "alice", time.Hour)
+	if got := earlierExpiry(extractJWTExpiry(exchanged), extractJWTExpiry(signedTokenWithSub(t, "alice"))); got != extractJWTExpiry(exchanged) {
+		t.Fatalf("earlierExpiry() = %d, want the exchange expiry %d", got, extractJWTExpiry(exchanged))
+	}
+}

--- a/go/adk/pkg/sts/plugin_test.go
+++ b/go/adk/pkg/sts/plugin_test.go
@@ -87,6 +87,16 @@ func TestHeaderProvider_UsesSessionIDMethod(t *testing.T) {
 func newSTSIntegration(t *testing.T, fetchActor func(context.Context) (string, error), issue func(*http.Request) map[string]any) *STSIntegration {
 	t.Helper()
 
+	return newSTSIntegrationWithTokenHandler(t, fetchActor, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(issue(r))
+	})
+}
+
+// newSTSIntegrationWithTokenHandler serves the token endpoint with handler, so a
+// test can answer an exchange with a failure status instead of a token.
+func newSTSIntegrationWithTokenHandler(t *testing.T, fetchActor func(context.Context) (string, error), handler http.HandlerFunc) *STSIntegration {
+	t.Helper()
+
 	var srv *httptest.Server
 	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/.well-known/oauth-authorization-server" {
@@ -100,7 +110,7 @@ func newSTSIntegration(t *testing.T, fetchActor func(context.Context) (string, e
 			http.NotFound(w, r)
 			return
 		}
-		_ = json.NewEncoder(w).Encode(issue(r))
+		handler(w, r)
 	}))
 	t.Cleanup(srv.Close)
 
@@ -560,6 +570,80 @@ func TestCachedEntryDoesNotOutliveTheCallerCredential(t *testing.T) {
 	}
 	if want := extractJWTExpiry(bearer); entry.Expiry != want {
 		t.Fatalf("entry expiry = %d, want the caller credential's exp %d", entry.Expiry, want)
+	}
+}
+
+// The entry's expiry is capped at the caller credential's own exp, so an expired
+// entry means the caller's authority is gone. AfterRunCallback only sweeps
+// between runs, so HeaderProvider has to reject such an entry itself.
+func TestHeaderProviderRejectsEntryPastTheCallerExpiry(t *testing.T) {
+	t.Parallel()
+
+	integration := newSTSIntegration(t, staticActor("actor"), func(*http.Request) map[string]any {
+		resp := issued("long-lived")
+		resp["expires_in"] = 3600
+		return resp
+	})
+
+	plugin := NewTokenPropagationPlugin(integration, slog.New(slog.DiscardHandler), nil, nil)
+
+	const sessionID = "sess-expired-caller"
+	bearer := signedTokenExpiringIn(t, "alice", 30*time.Second)
+	ctx := context.WithValue(context.Background(), kagentmodels.BearerTokenKey, bearer)
+	if _, err := plugin.BeforeRunCallback(&fakeInvocationContext{Context: ctx, sessionID: sessionID}); err != nil {
+		t.Fatalf("BeforeRunCallback() error = %v", err)
+	}
+
+	headerCtx := fakeSessionContext{Context: ctx, sessionID: sessionID}
+	if got := plugin.HeaderProvider(headerCtx)["Authorization"]; got != "Bearer long-lived" {
+		t.Fatalf("Authorization header = %q, want the delegated token", got)
+	}
+
+	plugin.tokenCache[cacheKey{sessionID: sessionID, subject: subjectKey(bearer)}].Expiry = time.Now().Unix() - 1
+	if headers := plugin.HeaderProvider(headerCtx); headers != nil {
+		t.Fatalf("HeaderProvider() = %v, want no headers once the caller credential expired", headers)
+	}
+}
+
+// An exchange the STS rejects must not leave the previous delegated token
+// injectable. The cache lookup precedes the exchange, so an exchange only runs
+// once the entry is already unusable, and HeaderProvider applies the same check.
+func TestFailedExchangeLeavesNoUsableEntry(t *testing.T) {
+	t.Parallel()
+
+	reject := false
+	integration := newSTSIntegrationWithTokenHandler(t, staticActor("actor"), func(w http.ResponseWriter, _ *http.Request) {
+		if reject {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]any{"error": "invalid_grant"})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(issued("exchanged-alice"))
+	})
+
+	plugin := NewTokenPropagationPlugin(integration, slog.New(slog.DiscardHandler), nil, nil)
+
+	const sessionID = "sess-rejected"
+	bearer := signedTokenWithSub(t, "alice")
+	ctx := context.WithValue(context.Background(), kagentmodels.BearerTokenKey, bearer)
+	if _, err := plugin.BeforeRunCallback(&fakeInvocationContext{Context: ctx, sessionID: sessionID}); err != nil {
+		t.Fatalf("BeforeRunCallback() error = %v", err)
+	}
+
+	headerCtx := fakeSessionContext{Context: ctx, sessionID: sessionID}
+	if got := plugin.HeaderProvider(headerCtx)["Authorization"]; got != "Bearer exchanged-alice" {
+		t.Fatalf("Authorization header = %q, want the delegated token", got)
+	}
+
+	// Age the entry out, then have the STS reject the refresh.
+	plugin.tokenCache[cacheKey{sessionID: sessionID, subject: subjectKey(bearer)}].Expiry = time.Now().Unix() - 1
+	reject = true
+	if _, err := plugin.BeforeRunCallback(&fakeInvocationContext{Context: ctx, sessionID: sessionID}); err != nil {
+		t.Fatalf("BeforeRunCallback() error = %v", err)
+	}
+
+	if headers := plugin.HeaderProvider(headerCtx); headers != nil {
+		t.Fatalf("HeaderProvider() = %v, want no headers after the exchange was rejected", headers)
 	}
 }
 

--- a/go/adk/pkg/sts/plugin_test.go
+++ b/go/adk/pkg/sts/plugin_test.go
@@ -3,6 +3,7 @@ package sts
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -438,7 +439,8 @@ func TestHeaderProviderRejectsForgedSubjectClaims(t *testing.T) {
 
 // A token with no exp claim must still get a bounded cache lifetime: the cache
 // holds one entry per (session, subject), so an immortal entry per caller would
-// grow without limit.
+// grow without limit. The bound is the eviction time, never the expiry, which
+// would end the caller's authority on a deadline nothing stated.
 func TestCachedTokenWithoutExpiryStaysEvictable(t *testing.T) {
 	t.Parallel()
 
@@ -449,11 +451,107 @@ func TestCachedTokenWithoutExpiryStaysEvictable(t *testing.T) {
 	if !ok {
 		t.Fatal("expected a cached entry")
 	}
-	if entry.Expiry == 0 {
-		t.Fatal("entry with no exp claim must be given a bounded expiry")
+	if entry.Expiry != 0 {
+		t.Fatalf("entry expiry = %d, want 0: nothing on this path states one", entry.Expiry)
 	}
-	if ceiling := time.Now().Add(maxCacheTTL).Unix(); entry.Expiry > ceiling {
-		t.Fatalf("entry expiry %d exceeds the %s ceiling %d", entry.Expiry, maxCacheTTL, ceiling)
+	if entry.EvictAfter == 0 {
+		t.Fatal("entry with no exp claim must be given a bounded eviction time")
+	}
+	if ceiling := time.Now().Add(maxCacheTTL).Unix(); entry.EvictAfter > ceiling {
+		t.Fatalf("entry eviction time %d exceeds the %s ceiling %d", entry.EvictAfter, maxCacheTTL, ceiling)
+	}
+}
+
+// A run that is still making tool calls keeps its entry when a concurrent run
+// finishes and sweeps. BeforeRunCallback runs once per run, so a swept entry has
+// nothing to re-mint it and the rest of that run would reach the backend with no
+// credential at all.
+func TestSweepKeepsAnInFlightCallerStillUsingItsEntry(t *testing.T) {
+	t.Parallel()
+
+	plugin := NewTokenPropagationPlugin(nil, slog.New(slog.DiscardHandler), nil, nil)
+	const sessionID = "sess-in-flight"
+	const bearer = "opaque-caller-bearer"
+
+	// An opaque credential states no expiry, so the entry carries only the
+	// synthetic eviction bound.
+	plugin.setCachedToken(sessionID, subjectKey(bearer), "delegated-opaque", 0)
+
+	// The bound comes due while the run is still in flight.
+	due := time.Now().Add(-time.Minute).Unix()
+	plugin.tokenCache[cacheKey{sessionID: sessionID, subject: subjectKey(bearer)}].EvictAfter = due
+	plugin.earliestEviction = due
+
+	// The run makes another tool call, which renews the bound.
+	ctx := context.WithValue(context.Background(), kagentmodels.BearerTokenKey, bearer)
+	toolCall := fakeSessionContext{Context: ctx, sessionID: sessionID}
+	if got := plugin.HeaderProvider(toolCall)["Authorization"]; got != "Bearer delegated-opaque" {
+		t.Fatalf("in-flight tool call got Authorization %q", got)
+	}
+
+	// A concurrent run finishes and sweeps the whole cache.
+	plugin.AfterRunCallback(&fakeInvocationContext{Context: context.Background(), sessionID: "sess-other"})
+
+	if got := plugin.HeaderProvider(toolCall)["Authorization"]; got != "Bearer delegated-opaque" {
+		t.Fatalf("the in-flight run lost its credential to another run's sweep, Authorization = %q", got)
+	}
+}
+
+// An entry no run is using still ages out, so the eviction bound keeps bounding
+// memory.
+func TestSweepEvictsAnIdleEntryWithoutExpiry(t *testing.T) {
+	t.Parallel()
+
+	plugin := NewTokenPropagationPlugin(nil, slog.New(slog.DiscardHandler), nil, nil)
+	plugin.setCachedToken("sess-idle", "alice", "opaque-token", 0)
+
+	due := time.Now().Add(-time.Minute).Unix()
+	plugin.tokenCache[cacheKey{sessionID: "sess-idle", subject: "alice"}].EvictAfter = due
+	plugin.earliestEviction = due
+
+	plugin.AfterRunCallback(&fakeInvocationContext{Context: context.Background(), sessionID: "sess-idle"})
+
+	if _, ok := plugin.tokenCache[cacheKey{sessionID: "sess-idle", subject: "alice"}]; ok {
+		t.Fatal("an entry no run is using must age out")
+	}
+}
+
+// A burst of distinct credentials is capped, and the cap drops the least recently
+// used entries rather than the one a run is still making tool calls with.
+func TestCapacityBoundKeepsTheEntryOfAnInFlightCaller(t *testing.T) {
+	t.Parallel()
+
+	plugin := NewTokenPropagationPlugin(nil, slog.New(slog.DiscardHandler), nil, nil)
+	const sessionID = "sess-burst"
+	const bearer = "opaque-alice"
+	plugin.setCachedToken(sessionID, subjectKey(bearer), "delegated-alice", 0)
+
+	ctx := context.WithValue(context.Background(), kagentmodels.BearerTokenKey, bearer)
+	toolCall := fakeSessionContext{Context: ctx, sessionID: sessionID}
+
+	const overflow = 25
+	for i := range maxCacheEntries + overflow {
+		// Each new caller is more recent than the last tool call of the
+		// in-flight run, so only a renewed entry survives the burst.
+		if got := plugin.HeaderProvider(toolCall)["Authorization"]; got != "Bearer delegated-alice" {
+			t.Fatalf("in-flight tool call %d got Authorization %q", i, got)
+		}
+		plugin.setCachedToken(sessionID, subjectKey(fmt.Sprintf("token-%d", i)), "delegated", 0)
+	}
+
+	if len(plugin.tokenCache) != maxCacheEntries {
+		t.Fatalf("cache holds %d entries, want the %d cap", len(plugin.tokenCache), maxCacheEntries)
+	}
+	if got := plugin.HeaderProvider(toolCall)["Authorization"]; got != "Bearer delegated-alice" {
+		t.Fatalf("the in-flight run lost its credential to the capacity bound, Authorization = %q", got)
+	}
+	// The cap drops by use order, so the callers the burst left untouched
+	// longest are exactly the ones gone.
+	for i := range overflow + 1 {
+		key := cacheKey{sessionID: sessionID, subject: subjectKey(fmt.Sprintf("token-%d", i))}
+		if _, ok := plugin.tokenCache[key]; ok {
+			t.Fatalf("token-%d is still cached, want the least recently used entries dropped", i)
+		}
 	}
 }
 
@@ -476,8 +574,8 @@ func TestAfterRunCallbackEvictsExpiredEntriesOfOtherSubjects(t *testing.T) {
 	if _, ok := plugin.getCachedToken("sess-b", "bob"); !ok {
 		t.Fatal("unexpired entry must survive the sweep")
 	}
-	if plugin.earliestExpiry != future {
-		t.Fatalf("earliestExpiry = %d, want %d after the sweep", plugin.earliestExpiry, future)
+	if plugin.earliestEviction != future {
+		t.Fatalf("earliestEviction = %d, want %d after the sweep", plugin.earliestEviction, future)
 	}
 }
 
@@ -495,20 +593,20 @@ func TestAfterRunCallbackSkipsWalkUntilSomethingExpires(t *testing.T) {
 	if _, ok := plugin.getCachedToken("sess-a", "alice"); !ok {
 		t.Fatal("unexpired entry must survive")
 	}
-	if plugin.earliestExpiry != future {
-		t.Fatalf("earliestExpiry = %d, want it left at %d", plugin.earliestExpiry, future)
+	if plugin.earliestEviction != future {
+		t.Fatalf("earliestEviction = %d, want it left at %d", plugin.earliestEviction, future)
 	}
 }
 
-func TestClearCacheResetsEarliestExpiry(t *testing.T) {
+func TestClearCacheResetsEarliestEviction(t *testing.T) {
 	t.Parallel()
 
 	plugin := NewTokenPropagationPlugin(nil, slog.New(slog.DiscardHandler), nil, nil)
 	plugin.setCachedToken("sess-a", "alice", "alice-token", time.Now().Add(time.Hour).Unix())
 	plugin.ClearCache()
 
-	if plugin.earliestExpiry != 0 {
-		t.Fatalf("earliestExpiry = %d, want 0 after ClearCache", plugin.earliestExpiry)
+	if plugin.earliestEviction != 0 {
+		t.Fatalf("earliestEviction = %d, want 0 after ClearCache", plugin.earliestEviction)
 	}
 }
 

--- a/go/adk/pkg/sts/plugin_test.go
+++ b/go/adk/pkg/sts/plugin_test.go
@@ -486,7 +486,6 @@ func TestSweepKeepsAnInFlightCallerStillUsingItsEntry(t *testing.T) {
 	// The bound comes due while the run is still in flight.
 	due := time.Now().Add(-time.Minute).Unix()
 	plugin.tokenCache[cacheKey{sessionID: sessionID, subject: subjectKey(bearer)}].evictAfter = due
-	plugin.earliestEviction = due
 
 	// The run makes another tool call, which renews the bound.
 	ctx := context.WithValue(context.Background(), kagentmodels.BearerTokenKey, bearer)
@@ -513,7 +512,6 @@ func TestSweepEvictsAnIdleEntryWithoutExpiry(t *testing.T) {
 
 	due := time.Now().Add(-time.Minute).Unix()
 	plugin.tokenCache[cacheKey{sessionID: "sess-idle", subject: subjectOf("alice")}].evictAfter = due
-	plugin.earliestEviction = due
 
 	plugin.AfterRunCallback(&fakeInvocationContext{Context: context.Background(), sessionID: "sess-idle"})
 
@@ -625,39 +623,21 @@ func TestAfterRunCallbackEvictsExpiredEntriesOfOtherSubjects(t *testing.T) {
 	if _, ok := plugin.getCachedToken("sess-b", subjectOf("bob")); !ok {
 		t.Fatal("unexpired entry must survive the sweep")
 	}
-	if plugin.earliestEviction != future {
-		t.Fatalf("earliestEviction = %d, want %d after the sweep", plugin.earliestEviction, future)
-	}
 }
 
-// The earliest expiry gates the walk, so a cache with nothing evictable is left
-// untouched instead of being traversed on every run.
-func TestAfterRunCallbackSkipsWalkUntilSomethingExpires(t *testing.T) {
-	t.Parallel()
-
-	plugin := NewTokenPropagationPlugin(nil, slog.New(slog.DiscardHandler), nil, nil)
-	future := time.Now().Add(time.Hour).Unix()
-	plugin.setCachedToken("sess-a", subjectOf("alice"), "alice-token", future)
-
-	plugin.AfterRunCallback(&fakeInvocationContext{Context: context.Background(), sessionID: "sess-a"})
-
-	if _, ok := plugin.getCachedToken("sess-a", subjectOf("alice")); !ok {
-		t.Fatal("unexpired entry must survive")
-	}
-	if plugin.earliestEviction != future {
-		t.Fatalf("earliestEviction = %d, want it left at %d", plugin.earliestEviction, future)
-	}
-}
-
-func TestClearCacheResetsEarliestEviction(t *testing.T) {
+func TestClearCacheDropsEveryEntry(t *testing.T) {
 	t.Parallel()
 
 	plugin := NewTokenPropagationPlugin(nil, slog.New(slog.DiscardHandler), nil, nil)
 	plugin.setCachedToken("sess-a", subjectOf("alice"), "alice-token", time.Now().Add(time.Hour).Unix())
+	plugin.setCachedToken("sess-b", subjectOf("bob"), "bob-token", 0)
 	plugin.ClearCache()
 
-	if plugin.earliestEviction != 0 {
-		t.Fatalf("earliestEviction = %d, want 0 after ClearCache", plugin.earliestEviction)
+	if len(plugin.tokenCache) != 0 {
+		t.Fatalf("cache holds %d entries, want none after ClearCache", len(plugin.tokenCache))
+	}
+	if _, ok := plugin.getCachedToken("sess-a", subjectOf("alice")); ok {
+		t.Fatal("expected no cache hit after ClearCache")
 	}
 }
 

--- a/go/adk/pkg/sts/plugin_test.go
+++ b/go/adk/pkg/sts/plugin_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 	"time"
 
@@ -246,13 +245,13 @@ func TestBeforeRunCallback_SendsResourceAndAudience(t *testing.T) {
 	}
 }
 
-func signedTokenWith(t *testing.T, iss, sub string) string {
+func signedTokenWithKey(t *testing.T, iss, sub, signingKey string) string {
 	t.Helper()
 	claims := jwt.MapClaims{"sub": sub}
 	if iss != "" {
 		claims["iss"] = iss
 	}
-	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte("secret"))
+	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(signingKey))
 	if err != nil {
 		t.Fatalf("failed to sign token: %v", err)
 	}
@@ -261,15 +260,30 @@ func signedTokenWith(t *testing.T, iss, sub string) string {
 
 func signedTokenWithSub(t *testing.T, sub string) string {
 	t.Helper()
-	return signedTokenWith(t, "https://issuer.example", sub)
+	return signedTokenWithKey(t, "https://issuer.example", sub, "secret")
 }
 
-// "sub" is only unique within an issuer, so two principals that share a "sub"
-// value across different issuers must not collapse onto one cache key.
-func TestSubjectKeyDistinguishesIssuers(t *testing.T) {
+// A cache hit hands out a delegated token without an STS exchange, so the key
+// must not be derivable from claims anyone can write: a token carrying the
+// victim's "iss" and "sub" must miss the victim's entry and be sent to the STS,
+// which is what rejects it.
+func TestSubjectKeyIgnoresUnverifiedClaims(t *testing.T) {
 	t.Parallel()
-	if subjectKey(signedTokenWith(t, "iss-a", "same")) == subjectKey(signedTokenWith(t, "iss-b", "same")) {
-		t.Fatal("same sub from different issuers must not share a cache key")
+	genuine := signedTokenWithKey(t, "https://issuer.example", "alice", "genuine-signing-key")
+	forged := signedTokenWithKey(t, "https://issuer.example", "alice", "attacker-signing-key")
+	if subjectKey(genuine) == subjectKey(forged) {
+		t.Fatal("a token claiming the victim's iss/sub must not share the victim's cache key")
+	}
+}
+
+// Distinct credentials must partition, and no credential must yield no key.
+func TestSubjectKeyPartitionsOpaqueTokens(t *testing.T) {
+	t.Parallel()
+	if subjectKey("opaque-a") == subjectKey("opaque-b") {
+		t.Fatal("distinct opaque tokens must not share a cache key")
+	}
+	if got := subjectKey(""); got != "" {
+		t.Fatalf("subjectKey(\"\") = %q, want an empty key", got)
 	}
 }
 
@@ -446,25 +460,26 @@ func TestEmptySubjectIsNotCacheable(t *testing.T) {
 	}
 }
 
-// An absent "iss" leaves "sub" unqualified, so those tokens partition by hash
-// rather than by a key two issuers could both produce.
-func TestSubjectKeyWithoutIssuerUsesTokenHash(t *testing.T) {
+// The forged-token case end to end: a caller presenting a token that merely
+// claims to be alice must not be handed alice's cached entry.
+func TestHeaderProviderRejectsForgedSubjectClaims(t *testing.T) {
 	t.Parallel()
 
-	key := subjectKey(signedTokenWith(t, "", "alice"))
-	if !strings.HasPrefix(key, "h:") {
-		t.Fatalf("subjectKey() = %q, want a hash-derived key for a token without iss", key)
+	plugin := NewTokenPropagationPlugin(nil, slog.New(slog.DiscardHandler), nil, nil)
+	const sessionID = "sess-forge"
+	alice := signedTokenWithKey(t, "https://issuer.example", "alice", "genuine-signing-key")
+
+	seedCtx := context.WithValue(context.Background(), kagentmodels.BearerTokenKey, alice)
+	if _, err := plugin.BeforeRunCallback(&fakeInvocationContext{Context: seedCtx, sessionID: sessionID}); err != nil {
+		t.Fatalf("BeforeRunCallback() error = %v", err)
 	}
 
-	other, err := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-		"sub": "alice",
-		"jti": "second-issuer",
-	}).SignedString([]byte("secret"))
-	if err != nil {
-		t.Fatalf("failed to sign token: %v", err)
-	}
-	if subjectKey(other) == key {
-		t.Fatal("two issuer-less tokens sharing a sub must not share a cache key")
+	forged := signedTokenWithKey(t, "https://issuer.example", "alice", "attacker-signing-key")
+	forgedCtx := context.WithValue(context.Background(), kagentmodels.BearerTokenKey, forged)
+	headers := plugin.HeaderProvider(fakeSessionContext{Context: forgedCtx, sessionID: sessionID})
+
+	if got, ok := headers["Authorization"]; ok {
+		t.Fatalf("forged token must not receive a cached entry, got %q", got)
 	}
 }
 

--- a/go/adk/pkg/sts/plugin_test.go
+++ b/go/adk/pkg/sts/plugin_test.go
@@ -10,6 +10,7 @@ import (
 
 	"log/slog"
 
+	"github.com/a2aproject/a2a-go/v2/a2asrv"
 	"github.com/golang-jwt/jwt/v5"
 	kagentmodels "github.com/kagent-dev/kagent/go/adk/pkg/models"
 	"google.golang.org/adk/v2/agent"
@@ -66,10 +67,12 @@ func (f fakeSession) LastUpdateTime() time.Time { return time.Time{} }
 func TestHeaderProvider_UsesSessionIDMethod(t *testing.T) {
 	t.Parallel()
 	plugin := NewTokenPropagationPlugin(nil, slog.New(slog.DiscardHandler), nil, nil)
-	plugin.setCachedToken("sess-123", "token-abc", 0)
+	bearer := signedTokenWithSub(t, "alice")
+	plugin.setCachedToken("sess-123", subjectKey(bearer), "token-abc", 0)
 
+	ctx := context.WithValue(context.Background(), kagentmodels.BearerTokenKey, bearer)
 	headers := plugin.HeaderProvider(fakeSessionContext{
-		Context:   context.Background(),
+		Context:   ctx,
 		sessionID: "sess-123",
 	})
 
@@ -239,6 +242,190 @@ func TestBeforeRunCallback_SendsResourceAndAudience(t *testing.T) {
 				t.Fatal("timed out waiting for token exchange request")
 			}
 		})
+	}
+}
+
+func signedTokenWith(t *testing.T, iss, sub string) string {
+	t.Helper()
+	claims := jwt.MapClaims{"sub": sub}
+	if iss != "" {
+		claims["iss"] = iss
+	}
+	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte("secret"))
+	if err != nil {
+		t.Fatalf("failed to sign token: %v", err)
+	}
+	return token
+}
+
+func signedTokenWithSub(t *testing.T, sub string) string {
+	t.Helper()
+	return signedTokenWith(t, "https://issuer.example", sub)
+}
+
+// "sub" is only unique within an issuer, so two principals that share a "sub"
+// value across different issuers must not collapse onto one cache key.
+func TestSubjectKeyDistinguishesIssuers(t *testing.T) {
+	t.Parallel()
+	if subjectKey(signedTokenWith(t, "iss-a", "same")) == subjectKey(signedTokenWith(t, "iss-b", "same")) {
+		t.Fatal("same sub from different issuers must not share a cache key")
+	}
+}
+
+// A session shared by multiple subjects must run each caller's tool calls under
+// that caller's exchanged token, not whichever subject seeded the session first.
+func TestSharedSessionKeepsPerSubjectTokens(t *testing.T) {
+	t.Parallel()
+
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/oauth-authorization-server" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"issuer":         srv.URL,
+				"token_endpoint": srv.URL + "/token",
+			})
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm() error = %v", err)
+		}
+		// Echo the incoming subject into the issued token so each caller receives
+		// a distinct exchanged token.
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":      "exchanged-for-" + subjectKey(r.FormValue("subject_token")),
+			"issued_token_type": string(TokenTypeJWT),
+		})
+	}))
+	defer srv.Close()
+
+	integration, err := NewSTSIntegration(
+		srv.URL+"/.well-known/oauth-authorization-server",
+		"",
+		func(context.Context) (string, error) { return "actor", nil },
+		nil,
+		5,
+		true,
+		false,
+	)
+	if err != nil {
+		t.Fatalf("NewSTSIntegration() error = %v", err)
+	}
+
+	plugin := NewTokenPropagationPlugin(integration, slog.New(slog.DiscardHandler), nil, nil)
+
+	const sessionID = "shared-session"
+	alice := signedTokenWithSub(t, "alice")
+	bob := signedTokenWithSub(t, "bob")
+
+	for _, bearer := range []string{alice, bob} {
+		ctx := context.WithValue(context.Background(), kagentmodels.BearerTokenKey, bearer)
+		if _, err := plugin.BeforeRunCallback(&fakeInvocationContext{Context: ctx, sessionID: sessionID}); err != nil {
+			t.Fatalf("BeforeRunCallback() error = %v", err)
+		}
+	}
+
+	for _, bearer := range []string{alice, bob} {
+		ctx := context.WithValue(context.Background(), kagentmodels.BearerTokenKey, bearer)
+		headers := plugin.HeaderProvider(fakeSessionContext{Context: ctx, sessionID: sessionID})
+		want := "Bearer exchanged-for-" + subjectKey(bearer)
+		if headers["Authorization"] != want {
+			t.Fatalf("Authorization header = %q, want %q", headers["Authorization"], want)
+		}
+	}
+}
+
+// HeaderProvider must recover the acting subject even when the bearer reaches it
+// only through the A2A CallContext, the channel the MCP round-tripper reads, and
+// not via models.BearerTokenKey. This pins the plumbing the per-subject lookup
+// depends on at the transport layer.
+func TestHeaderProviderRecoversSubjectFromCallContext(t *testing.T) {
+	t.Parallel()
+
+	plugin := NewTokenPropagationPlugin(nil, slog.New(slog.DiscardHandler), nil, nil)
+	const sessionID = "sess-cc"
+	alice := signedTokenWithSub(t, "alice")
+
+	// Seed the cache through the executor path (bearer via BearerTokenKey).
+	seedCtx := context.WithValue(context.Background(), kagentmodels.BearerTokenKey, alice)
+	if _, err := plugin.BeforeRunCallback(&fakeInvocationContext{Context: seedCtx, sessionID: sessionID}); err != nil {
+		t.Fatalf("BeforeRunCallback() error = %v", err)
+	}
+
+	// Look up through the transport path: no BearerTokenKey, bearer only in the
+	// A2A CallContext Authorization header.
+	ccCtx, _ := a2asrv.NewCallContext(context.Background(),
+		a2asrv.NewServiceParams(map[string][]string{"authorization": {"Bearer " + alice}}))
+	headers := plugin.HeaderProvider(fakeSessionContext{Context: ccCtx, sessionID: sessionID})
+
+	if got := headers["Authorization"]; got != "Bearer "+alice {
+		t.Fatalf("Authorization header = %q, want %q", got, "Bearer "+alice)
+	}
+}
+
+// A repeat request from the same subject on the same session reuses the cached
+// exchange rather than exchanging again.
+func TestBeforeRunCallbackSameSubjectCachesExchange(t *testing.T) {
+	t.Parallel()
+
+	exchangeCount := 0
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/oauth-authorization-server" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"issuer":         srv.URL,
+				"token_endpoint": srv.URL + "/token",
+			})
+			return
+		}
+		exchangeCount++
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":      "access",
+			"issued_token_type": string(TokenTypeJWT),
+		})
+	}))
+	defer srv.Close()
+
+	integration, err := NewSTSIntegration(
+		srv.URL+"/.well-known/oauth-authorization-server",
+		"",
+		func(context.Context) (string, error) { return "actor", nil },
+		nil,
+		5,
+		true,
+		false,
+	)
+	if err != nil {
+		t.Fatalf("NewSTSIntegration() error = %v", err)
+	}
+
+	plugin := NewTokenPropagationPlugin(integration, slog.New(slog.DiscardHandler), nil, nil)
+	bearer := signedTokenWithSub(t, "alice")
+	for range 2 {
+		ctx := context.WithValue(context.Background(), kagentmodels.BearerTokenKey, bearer)
+		if _, err := plugin.BeforeRunCallback(&fakeInvocationContext{Context: ctx, sessionID: "sess"}); err != nil {
+			t.Fatalf("BeforeRunCallback() error = %v", err)
+		}
+	}
+
+	if exchangeCount != 1 {
+		t.Fatalf("token exchange calls = %d, want 1", exchangeCount)
+	}
+}
+
+// A request with no bearer must not receive another subject's cached token.
+func TestHeaderProviderNoBearerDoesNotLeakSubjectToken(t *testing.T) {
+	t.Parallel()
+
+	plugin := NewTokenPropagationPlugin(nil, slog.New(slog.DiscardHandler), nil, nil)
+	plugin.setCachedToken("sess-x", "alice", "alice-token", 0)
+
+	headers := plugin.HeaderProvider(fakeSessionContext{
+		Context:   context.Background(),
+		sessionID: "sess-x",
+	})
+
+	if got, ok := headers["Authorization"]; ok {
+		t.Fatalf("expected no Authorization header for empty-bearer request, got %q", got)
 	}
 }
 

--- a/go/adk/pkg/sts/plugin_test.go
+++ b/go/adk/pkg/sts/plugin_test.go
@@ -81,11 +81,12 @@ func TestHeaderProvider_UsesSessionIDMethod(t *testing.T) {
 	}
 }
 
-func TestBeforeRunCallback_ReusesCachedDynamicActorTokenForExchange(t *testing.T) {
-	t.Parallel()
+// newSTSIntegration wires an STSIntegration to a fake authorization server whose
+// token endpoint answers with issue(r); every other path is discovery. issue
+// runs on the server goroutine, so it must not call t.Fatal.
+func newSTSIntegration(t *testing.T, fetchActor func(context.Context) (string, error), issue func(*http.Request) map[string]any) *STSIntegration {
+	t.Helper()
 
-	fetchCount := 0
-	exchangeCount := 0
 	var srv *httptest.Server
 	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/.well-known/oauth-authorization-server" {
@@ -99,27 +100,14 @@ func TestBeforeRunCallback_ReusesCachedDynamicActorTokenForExchange(t *testing.T
 			http.NotFound(w, r)
 			return
 		}
-		exchangeCount++
-		if err := r.ParseForm(); err != nil {
-			t.Fatalf("ParseForm() error = %v", err)
-		}
-		if got := r.FormValue("actor_token"); got != "dynamic-actor" {
-			t.Fatalf("actor_token = %q, want %q", got, "dynamic-actor")
-		}
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"access_token":      "access-token",
-			"issued_token_type": string(TokenTypeJWT),
-		})
+		_ = json.NewEncoder(w).Encode(issue(r))
 	}))
-	defer srv.Close()
+	t.Cleanup(srv.Close)
 
 	integration, err := NewSTSIntegration(
 		srv.URL+"/.well-known/oauth-authorization-server",
 		"",
-		func(context.Context) (string, error) {
-			fetchCount++
-			return "dynamic-actor", nil
-		},
+		fetchActor,
 		nil,
 		5,
 		true,
@@ -128,6 +116,39 @@ func TestBeforeRunCallback_ReusesCachedDynamicActorTokenForExchange(t *testing.T
 	if err != nil {
 		t.Fatalf("NewSTSIntegration() error = %v", err)
 	}
+	return integration
+}
+
+// staticActor is an actor-token provider that always returns the same token.
+func staticActor(token string) func(context.Context) (string, error) {
+	return func(context.Context) (string, error) { return token, nil }
+}
+
+// issued is a token endpoint response carrying accessToken.
+func issued(accessToken string) map[string]any {
+	return map[string]any{
+		"access_token":      accessToken,
+		"issued_token_type": string(TokenTypeJWT),
+	}
+}
+
+func TestBeforeRunCallback_ReusesCachedDynamicActorTokenForExchange(t *testing.T) {
+	t.Parallel()
+
+	fetchCount := 0
+	exchangeCount := 0
+	gotActorToken := ""
+	integration := newSTSIntegration(t,
+		func(context.Context) (string, error) {
+			fetchCount++
+			return "dynamic-actor", nil
+		},
+		func(r *http.Request) map[string]any {
+			exchangeCount++
+			gotActorToken = r.FormValue("actor_token")
+			return issued("access-token")
+		},
+	)
 
 	plugin := NewTokenPropagationPlugin(integration, slog.New(slog.DiscardHandler), nil, nil)
 	for _, sessionID := range []string{"sess-one", "sess-two"} {
@@ -145,6 +166,9 @@ func TestBeforeRunCallback_ReusesCachedDynamicActorTokenForExchange(t *testing.T
 	}
 	if exchangeCount != 2 {
 		t.Fatalf("token exchange calls = %d, want 2", exchangeCount)
+	}
+	if gotActorToken != "dynamic-actor" {
+		t.Fatalf("actor_token = %q, want %q", gotActorToken, "dynamic-actor")
 	}
 }
 
@@ -185,38 +209,10 @@ func TestBeforeRunCallback_SendsResourceAndAudience(t *testing.T) {
 			// back on the test goroutine to avoid a data race on the captured form.
 			gotForm := make(chan exchangeForm, 1)
 
-			var srv *httptest.Server
-			srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path == "/.well-known/oauth-authorization-server" {
-					_ = json.NewEncoder(w).Encode(map[string]any{
-						"issuer":         srv.URL,
-						"token_endpoint": srv.URL + "/token",
-					})
-					return
-				}
-				if r.URL.Path != "/token" {
-					http.NotFound(w, r)
-					return
-				}
-				if err := r.ParseForm(); err != nil {
-					gotForm <- exchangeForm{err: err}
-				} else {
-					gotForm <- exchangeForm{resource: r.FormValue("resource"), audience: r.FormValue("audience")}
-				}
-				_ = json.NewEncoder(w).Encode(map[string]any{
-					"access_token":      "access-token",
-					"issued_token_type": string(TokenTypeJWT),
-				})
-			}))
-			defer srv.Close()
-
-			integration, err := NewSTSIntegration(
-				srv.URL+"/.well-known/oauth-authorization-server",
-				"", nil, nil, 5, true, false,
-			)
-			if err != nil {
-				t.Fatalf("NewSTSIntegration() error = %v", err)
-			}
+			integration := newSTSIntegration(t, nil, func(r *http.Request) map[string]any {
+				gotForm <- exchangeForm{resource: r.FormValue("resource"), audience: r.FormValue("audience")}
+				return issued("access-token")
+			})
 
 			plugin := NewTokenPropagationPlugin(integration, slog.New(slog.DiscardHandler), tt.resource, tt.audience)
 			ctx := context.WithValue(context.Background(), kagentmodels.BearerTokenKey, "subject-token")
@@ -292,39 +288,11 @@ func TestSubjectKeyPartitionsOpaqueTokens(t *testing.T) {
 func TestSharedSessionKeepsPerSubjectTokens(t *testing.T) {
 	t.Parallel()
 
-	var srv *httptest.Server
-	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/.well-known/oauth-authorization-server" {
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"issuer":         srv.URL,
-				"token_endpoint": srv.URL + "/token",
-			})
-			return
-		}
-		if err := r.ParseForm(); err != nil {
-			t.Fatalf("ParseForm() error = %v", err)
-		}
-		// Echo the incoming subject into the issued token so each caller receives
-		// a distinct exchanged token.
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"access_token":      "exchanged-for-" + subjectKey(r.FormValue("subject_token")),
-			"issued_token_type": string(TokenTypeJWT),
-		})
-	}))
-	defer srv.Close()
-
-	integration, err := NewSTSIntegration(
-		srv.URL+"/.well-known/oauth-authorization-server",
-		"",
-		func(context.Context) (string, error) { return "actor", nil },
-		nil,
-		5,
-		true,
-		false,
-	)
-	if err != nil {
-		t.Fatalf("NewSTSIntegration() error = %v", err)
-	}
+	// Echo the incoming subject into the issued token so each caller receives a
+	// distinct exchanged token.
+	integration := newSTSIntegration(t, staticActor("actor"), func(r *http.Request) map[string]any {
+		return issued("exchanged-for-" + subjectKey(r.FormValue("subject_token")))
+	})
 
 	plugin := NewTokenPropagationPlugin(integration, slog.New(slog.DiscardHandler), nil, nil)
 
@@ -383,35 +351,10 @@ func TestBeforeRunCallbackSameSubjectCachesExchange(t *testing.T) {
 	t.Parallel()
 
 	exchangeCount := 0
-	var srv *httptest.Server
-	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/.well-known/oauth-authorization-server" {
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"issuer":         srv.URL,
-				"token_endpoint": srv.URL + "/token",
-			})
-			return
-		}
+	integration := newSTSIntegration(t, staticActor("actor"), func(*http.Request) map[string]any {
 		exchangeCount++
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"access_token":      "access",
-			"issued_token_type": string(TokenTypeJWT),
-		})
-	}))
-	defer srv.Close()
-
-	integration, err := NewSTSIntegration(
-		srv.URL+"/.well-known/oauth-authorization-server",
-		"",
-		func(context.Context) (string, error) { return "actor", nil },
-		nil,
-		5,
-		true,
-		false,
-	)
-	if err != nil {
-		t.Fatalf("NewSTSIntegration() error = %v", err)
-	}
+		return issued("access")
+	})
 
 	plugin := NewTokenPropagationPlugin(integration, slog.New(slog.DiscardHandler), nil, nil)
 	bearer := signedTokenWithSub(t, "alice")
@@ -595,36 +538,12 @@ func signedTokenExpiringIn(t *testing.T, sub string, d time.Duration) string {
 func TestCachedEntryDoesNotOutliveTheCallerCredential(t *testing.T) {
 	t.Parallel()
 
-	var srv *httptest.Server
-	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/.well-known/oauth-authorization-server" {
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"issuer":         srv.URL,
-				"token_endpoint": srv.URL + "/token",
-			})
-			return
-		}
-		// A delegated token that long outlives the caller's own credential.
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"access_token":      "long-lived",
-			"issued_token_type": string(TokenTypeJWT),
-			"expires_in":        3600,
-		})
-	}))
-	defer srv.Close()
-
-	integration, err := NewSTSIntegration(
-		srv.URL+"/.well-known/oauth-authorization-server",
-		"",
-		func(context.Context) (string, error) { return "actor", nil },
-		nil,
-		5,
-		true,
-		false,
-	)
-	if err != nil {
-		t.Fatalf("NewSTSIntegration() error = %v", err)
-	}
+	// A delegated token that long outlives the caller's own credential.
+	integration := newSTSIntegration(t, staticActor("actor"), func(*http.Request) map[string]any {
+		resp := issued("long-lived")
+		resp["expires_in"] = 3600
+		return resp
+	})
 
 	plugin := NewTokenPropagationPlugin(integration, slog.New(slog.DiscardHandler), nil, nil)
 
@@ -644,13 +563,30 @@ func TestCachedEntryDoesNotOutliveTheCallerCredential(t *testing.T) {
 	}
 }
 
-// A credential with no exp claim leaves the exchange's own lifetime in place
-// rather than truncating it.
-func TestCachedEntryKeepsExchangeExpiryWhenCredentialHasNone(t *testing.T) {
+// earlierExpiry decides the cached entry's lifetime, so it must treat a missing
+// expiry as "unknown" rather than as the epoch.
+func TestEarlierExpiry(t *testing.T) {
 	t.Parallel()
 
-	exchanged := signedTokenExpiringIn(t, "alice", time.Hour)
-	if got := earlierExpiry(extractJWTExpiry(exchanged), extractJWTExpiry(signedTokenWithSub(t, "alice"))); got != extractJWTExpiry(exchanged) {
-		t.Fatalf("earlierExpiry() = %d, want the exchange expiry %d", got, extractJWTExpiry(exchanged))
+	tests := []struct {
+		name      string
+		current   int64
+		candidate int64
+		want      int64
+	}{
+		{name: "the candidate expires first", current: 200, candidate: 100, want: 100},
+		{name: "the current entry expires first", current: 100, candidate: 200, want: 100},
+		{name: "no candidate expiry keeps the current one", current: 100, candidate: 0, want: 100},
+		{name: "no current expiry takes the candidate", current: 0, candidate: 100, want: 100},
+		{name: "neither expires", current: 0, candidate: 0, want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := earlierExpiry(tt.current, tt.candidate); got != tt.want {
+				t.Fatalf("earlierExpiry(%d, %d) = %d, want %d", tt.current, tt.candidate, got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Supersedes #2317 (auto-closed by stale-bot; a rebase onto main conflicted with #2106, so GitHub would not let it be reopened).

Closes #2181. The Python counterpart is #2460.

## Problem

The STS token cache was keyed by session ID alone. When several subjects share one session (for example several users on the same A2A session), every caller runs its tool calls with whichever exchanged token was cached first.

## Change

Key the cache by `(sessionID, subject)`, where `subject` is a SHA-256 hash of the caller's bearer token. `BeforeRunCallback` and `HeaderProvider` both resolve the caller's bearer before the cache lookup, so each caller gets its own exchanged token.

The bearer resolution moves to `models.BearerTokenFromContext`. It prefers the value the executor stored under `BearerTokenKey` and falls back to the A2A call context, which is what reaches the MCP transport layer when `BearerTokenKey` was not threaded into the request context. `a2a/executor.go` now calls the same helper, so there is one copy of the parser instead of two.

`GetSubjectTokenFunc` documents that it must be a pure function of the bearer. The hash of the bearer stands in for the subject token only because the hook derives one from the other; an implementation that mints or fetches a token would have its first result served for the entry's lifetime.

## Why the key is a token hash and not iss+sub

A cache hit returns a delegated token without performing an exchange, so the key decides who receives whose authority. `iss` and `sub` are not verified anywhere on this path: a forged, unsigned token carrying a victim's claims would select the victim's entry and never reach the STS that would have rejected it. Hashing the raw token makes a forged token a cache miss, so it goes to the STS and fails there.

The cost is one extra exchange when a caller's bearer rotates mid-session.

An empty subject identifies no principal, so it yields no key at all. An entry stored under it would be shared by every credential-less caller in the session.

## Cache lifetime

An entry never outlives the credential that keyed it. The expiry is the earliest of the exchange's own lifetime (`expires_in`, or the exchanged token's `exp`), the subject token's `exp`, and the caller bearer's `exp`. Without that cap, a caller replaying an expired credential keeps hitting the cached delegated token instead of reaching the STS that would reject it.

When no token states an `exp` there is no expiry, and nothing may invent one: `BeforeRunCallback` runs once per run, so a run outliving a made-up deadline would lose its credential part way through. The entry carries a second field, `evictAfter`, which bounds memory alone. `Expiry` decides whether the token may still be injected; `evictAfter` decides only when the entry may be dropped, and it comes due 5 minutes after the last use when nothing states an expiry.

A cache hit renews `evictAfter` and records a use sequence, so neither the sweep nor either capacity bound can drop an entry a run is still using, and a bound drops the least recently used entries first. `getCachedToken` therefore takes the write lock, and returns a copy so that no caller reads a cached entry's fields once the lock is released. `AfterRunCallback` sweeps every entry whose `evictAfter` has come due.

## Cache capacity

The cache is bounded per session (`maxEntriesPerSession`) and across sessions (`maxCacheEntries`). The per-session bound is what matters: without it, one session presenting many distinct credentials evicts the entries of unrelated sessions, and a victim run that is between tool calls has nothing more recent to show. `BeforeRunCallback` has already run by then, so that run would reach its backends with no delegated identity. The whole-cache bound backstops it so that many sessions cannot grow the cache without limit.

Unlike the sweep, a capacity eviction drops entries whose credentials are still valid, so it is reported above debug.

## API change

`GetTokenForSession` is removed. A session no longer has a single token, so the signature cannot answer the question it asks. It had no callers outside the plugin.

## Out of scope

#2181 also describes session state being keyed by `userID`. A shared session still works: `userID` defaults to `A2A_USER_<contextID>`, so callers on one context share a session and this fix gives each of them its own exchanged token. What remains is that `userID` is part of the session address, so sending a per-sender `x-user-id` resolves those senders onto separate sessions instead of one conversation. That affects attribution, not authorization, and is untouched here.

## Header path

`getCachedToken` checks the entry's expiry, and both `BeforeRunCallback` and `HeaderProvider` go through it, so an entry past the caller credential's expiry is never injected and a rejected exchange leaves nothing usable behind. Two regression tests pin both, matching the cases the Python plugin needed a fix for.

A request whose caller is identified but has no usable entry is reported above debug. It loses its delegated identity, and nothing else says so.

