### PR TITLE
feat(a2a): emit aggregated turn token usage on the terminal status update

### DIFF
--- a/go/adk/pkg/a2a/executor.go
+++ b/go/adk/pkg/a2a/executor.go
@@ -55,7 +55,7 @@ func NewKAgentExecutor(cfg KAgentExecutorConfig) *KAgentExecutor {
 		runnerConfig.SessionService = cfg.SessionService
 	}
 	builtin := adka2a.NewExecutor(adka2a.ExecutorConfig{
-		RunnerConfig:       runnerConfig,
+		RunnerProvider:     usageObservingRunnerProvider(runnerConfig),
 		RunConfig:          runConfig,
 		A2APartConverter:   a2aPartConverter,
 		GenAIPartConverter: genAIPartConverter,
@@ -63,6 +63,13 @@ func NewKAgentExecutor(cfg KAgentExecutorConfig) *KAgentExecutor {
 			if event.InvocationID != "" {
 				trace.SpanFromContext(ctx).SetAttributes(attribute.String("gcp.vertex.agent.invocation_id", event.InvocationID))
 			}
+			return nil
+		},
+		// The aggregate rides on the terminal status update (completed,
+		// input-required or failed), whose metadata a2a-go merges into the
+		// stored task.
+		AfterExecuteCallback: func(ctx adka2a.ExecutorContext, finalEvent *a2atype.TaskStatusUpdateEvent, _ error) error {
+			turnUsageFrom(ctx).stampEvent(finalEvent)
 			return nil
 		},
 		OutputMode: adka2a.OutputArtifactPerEvent,
@@ -121,6 +128,12 @@ func (e *KAgentExecutor) Execute(ctx context.Context, reqCtx *a2asrv.ExecutorCon
 
 		ctx = withBearerToken(ctx)
 		ctx = auth.WithUserID(ctx, userID)
+
+		// Resumed tasks (HITL cycles, follow-up messages) carry the previously
+		// persisted total, so kagent_usage_total stays a task-lifetime sum.
+		usage := &turnUsage{}
+		usage.seedFromTask(reqCtx.StoredTask)
+		ctx = withTurnUsage(ctx, usage)
 		spanAttributes := map[string]string{
 			"kagent.user_id":         userID,
 			"gen_ai.task.id":         string(reqCtx.TaskID),

--- a/go/adk/pkg/a2a/executor.go
+++ b/go/adk/pkg/a2a/executor.go
@@ -15,6 +15,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	adkagent "google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/plugin"
 	"google.golang.org/adk/v2/runner"
 	"google.golang.org/adk/v2/server/adka2a/v2"
 	adksession "google.golang.org/adk/v2/session"
@@ -54,8 +55,14 @@ func NewKAgentExecutor(cfg KAgentExecutorConfig) *KAgentExecutor {
 	if cfg.SessionService != nil {
 		runnerConfig.SessionService = cfg.SessionService
 	}
+	logger := cfg.Logger.WithName("kagent-executor")
+	if usagePlugin, err := newTurnUsagePlugin(); err != nil {
+		logger.Error(err, "token usage aggregation is disabled")
+	} else {
+		runnerConfig.PluginConfig.Plugins = append([]*plugin.Plugin{usagePlugin}, runnerConfig.PluginConfig.Plugins...)
+	}
 	builtin := adka2a.NewExecutor(adka2a.ExecutorConfig{
-		RunnerProvider:     usageObservingRunnerProvider(runnerConfig),
+		RunnerConfig:       runnerConfig,
 		RunConfig:          runConfig,
 		A2APartConverter:   a2aPartConverter,
 		GenAIPartConverter: genAIPartConverter,
@@ -79,7 +86,7 @@ func NewKAgentExecutor(cfg KAgentExecutorConfig) *KAgentExecutor {
 		builtin:        builtin,
 		sessionService: runnerConfig.SessionService,
 		appName:        cfg.AppName,
-		logger:         cfg.Logger.WithName("kagent-executor"),
+		logger:         logger,
 	}
 }
 

--- a/go/adk/pkg/a2a/usage.go
+++ b/go/adk/pkg/a2a/usage.go
@@ -19,7 +19,9 @@ import (
 
 // usageTotalMetadataKey is the A2A metadata key carrying the aggregated
 // token usage of a task. The value has the same shape as the per-event
-// adk_usage_metadata entry, plus modelVersion.
+// adk_usage_metadata entry, plus modelVersion. Every terminal status update of
+// a task carries the running task-lifetime total, so consumers take the latest
+// value rather than summing across executions.
 var usageTotalMetadataKey = GetKAgentMetadataKey("usage_total")
 
 // turnUsage accumulates token usage across the ADK events of one execution so
@@ -162,6 +164,16 @@ func (u *turnUsage) empty() bool {
 	return u.promptTokens == 0 && u.completionTokens == 0 && u.totalTokens == 0
 }
 
+// totalTokenCount derives a total when no provider reported one. The Anthropic
+// models report per-call input and output counts without a total, and emitting
+// a zero total next to non-zero counts reads as "no tokens were used".
+func (u *turnUsage) totalTokenCount() int64 {
+	if u.totalTokens != 0 {
+		return u.totalTokens
+	}
+	return u.promptTokens + u.completionTokens + u.thoughtsTokens
+}
+
 // stampEvent attaches the aggregate to a terminal status update under
 // kagent_usage_total. The value is serialized exactly like the per-event
 // adk_usage_metadata (same genai type, same JSON mapping) plus modelVersion, so
@@ -175,7 +187,7 @@ func (u *turnUsage) stampEvent(event *a2atype.TaskStatusUpdateEvent) {
 		CandidatesTokenCount:    clampInt32(u.completionTokens),
 		ThoughtsTokenCount:      clampInt32(u.thoughtsTokens),
 		CachedContentTokenCount: clampInt32(u.cachedContentTokens),
-		TotalTokenCount:         clampInt32(u.totalTokens),
+		TotalTokenCount:         clampInt32(u.totalTokenCount()),
 	})
 	if err != nil || total == nil {
 		return

--- a/go/adk/pkg/a2a/usage.go
+++ b/go/adk/pkg/a2a/usage.go
@@ -1,0 +1,197 @@
+package a2a
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"math"
+	"slices"
+
+	a2atype "github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2asrv"
+	adkagent "google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/plugin"
+	"google.golang.org/adk/v2/runner"
+	"google.golang.org/adk/v2/server/adka2a/v2"
+	adksession "google.golang.org/adk/v2/session"
+	"google.golang.org/genai"
+)
+
+// usageTotalMetadataKey is the A2A metadata key carrying the aggregated
+// token usage of a task. The value has the same shape as the per-event
+// adk_usage_metadata entry, plus modelVersion.
+var usageTotalMetadataKey = GetKAgentMetadataKey("usage_total")
+
+// turnUsage accumulates token usage across the ADK events of one execution so
+// the aggregated total can be emitted on the terminal status update. Partial
+// (streaming chunk) events are skipped: each LLM call reports its usage on the
+// final non-partial event, so summing partials would double-count.
+type turnUsage struct {
+	promptTokens        int64
+	completionTokens    int64
+	thoughtsTokens      int64
+	cachedContentTokens int64
+	totalTokens         int64
+	modelVersion        string
+}
+
+type turnUsageContextKey struct{}
+
+// withTurnUsage binds an accumulator to ctx. The upstream ADK executor derives
+// its ExecutorContext from this context, so the per-event and post-execution
+// callbacks reach the accumulator of the execution they belong to.
+func withTurnUsage(ctx context.Context, usage *turnUsage) context.Context {
+	return context.WithValue(ctx, turnUsageContextKey{}, usage)
+}
+
+func turnUsageFrom(ctx context.Context) *turnUsage {
+	usage, _ := ctx.Value(turnUsageContextKey{}).(*turnUsage)
+	return usage
+}
+
+// usageObservingRunnerProvider mirrors the ADK executor's default runner
+// provider and wraps the runner so every ADK event is seen. Events are counted
+// before A2A conversion, which drops the ones it cannot turn into an artifact
+// (a paused tool call, for instance) even though they report token usage.
+func usageObservingRunnerProvider(baseConfig runner.Config) adka2a.RunnerProvider {
+	return func(_ context.Context, _ *a2asrv.ExecutorContext, executorPlugin *plugin.Plugin) (adka2a.RunnerConfig, adka2a.Runner, error) {
+		if baseConfig.Agent == nil {
+			return adka2a.RunnerConfig{}, nil, fmt.Errorf("runner.Config.Agent is not provided")
+		}
+		if baseConfig.SessionService == nil {
+			return adka2a.RunnerConfig{}, nil, fmt.Errorf("runner.Config.SessionService is not provided")
+		}
+
+		cfg := baseConfig
+		cfg.PluginConfig.Plugins = append(slices.Clone(cfg.PluginConfig.Plugins), executorPlugin)
+		adkRunner, err := runner.New(cfg)
+		if err != nil {
+			return adka2a.RunnerConfig{}, nil, err
+		}
+		return adka2a.RunnerConfig{
+				AppName:        cfg.AppName,
+				Agent:          cfg.Agent,
+				SessionService: cfg.SessionService,
+			},
+			&usageObservingRunner{runner: adkRunner}, nil
+	}
+}
+
+type usageObservingRunner struct {
+	runner *runner.Runner
+}
+
+func (r *usageObservingRunner) Run(
+	ctx context.Context,
+	userID, sessionID string,
+	message *genai.Content,
+	config adkagent.RunConfig,
+) iter.Seq2[*adksession.Event, error] {
+	events := r.runner.Run(ctx, userID, sessionID, message, config)
+	usage := turnUsageFrom(ctx)
+	if usage == nil {
+		return events
+	}
+	return func(yield func(*adksession.Event, error) bool) {
+		for event, err := range events {
+			if err == nil {
+				usage.add(event)
+			}
+			if !yield(event, err) {
+				return
+			}
+		}
+	}
+}
+
+func (u *turnUsage) add(event *adksession.Event) {
+	if u == nil || event == nil || event.Partial || event.UsageMetadata == nil {
+		return
+	}
+	u.promptTokens += int64(event.UsageMetadata.PromptTokenCount)
+	u.completionTokens += int64(event.UsageMetadata.CandidatesTokenCount)
+	u.thoughtsTokens += int64(event.UsageMetadata.ThoughtsTokenCount)
+	u.cachedContentTokens += int64(event.UsageMetadata.CachedContentTokenCount)
+	u.totalTokens += int64(event.UsageMetadata.TotalTokenCount)
+	if event.ModelVersion != "" {
+		u.modelVersion = event.ModelVersion
+	}
+}
+
+// seedFromTask primes the accumulator with the total already persisted on a
+// resumed task, so tasks spanning multiple executions (HITL input-required
+// cycles, follow-up messages) report a task-lifetime total instead of the last
+// segment only.
+func (u *turnUsage) seedFromTask(task *a2atype.Task) {
+	if u == nil || task == nil || task.Metadata == nil {
+		return
+	}
+	prior, ok := task.Metadata[usageTotalMetadataKey].(map[string]any)
+	if !ok {
+		return
+	}
+	u.promptTokens += metadataTokenCount(prior["promptTokenCount"])
+	u.completionTokens += metadataTokenCount(prior["candidatesTokenCount"])
+	u.thoughtsTokens += metadataTokenCount(prior["thoughtsTokenCount"])
+	u.cachedContentTokens += metadataTokenCount(prior["cachedContentTokenCount"])
+	u.totalTokens += metadataTokenCount(prior["totalTokenCount"])
+	if modelVersion, ok := prior["modelVersion"].(string); ok && modelVersion != "" {
+		u.modelVersion = modelVersion
+	}
+}
+
+// metadataTokenCount reads a numeric token count from stored task metadata.
+// Counts are float64 after a JSON round-trip but keep an integer type with
+// in-memory task stores.
+func metadataTokenCount(value any) int64 {
+	switch n := value.(type) {
+	case float64:
+		return int64(n)
+	case int64:
+		return n
+	case int32:
+		return int64(n)
+	case int:
+		return int64(n)
+	default:
+		return 0
+	}
+}
+
+func (u *turnUsage) empty() bool {
+	return u.promptTokens == 0 && u.completionTokens == 0 && u.totalTokens == 0
+}
+
+// stampEvent attaches the aggregate to a terminal status update under
+// kagent_usage_total. The value is serialized exactly like the per-event
+// adk_usage_metadata (same genai type, same JSON mapping) plus modelVersion, so
+// consumers can share one parser.
+func (u *turnUsage) stampEvent(event *a2atype.TaskStatusUpdateEvent) {
+	if u == nil || event == nil || u.empty() {
+		return
+	}
+	total, err := toJSONMap(&genai.GenerateContentResponseUsageMetadata{
+		PromptTokenCount:        clampInt32(u.promptTokens),
+		CandidatesTokenCount:    clampInt32(u.completionTokens),
+		ThoughtsTokenCount:      clampInt32(u.thoughtsTokens),
+		CachedContentTokenCount: clampInt32(u.cachedContentTokens),
+		TotalTokenCount:         clampInt32(u.totalTokens),
+	})
+	if err != nil || total == nil {
+		return
+	}
+	if u.modelVersion != "" {
+		total["modelVersion"] = u.modelVersion
+	}
+	if event.Metadata == nil {
+		event.Metadata = map[string]any{}
+	}
+	event.Metadata[usageTotalMetadataKey] = total
+}
+
+func clampInt32(v int64) int32 {
+	if v > math.MaxInt32 {
+		return math.MaxInt32
+	}
+	return int32(v)
+}

--- a/go/adk/pkg/a2a/usage.go
+++ b/go/adk/pkg/a2a/usage.go
@@ -2,17 +2,11 @@ package a2a
 
 import (
 	"context"
-	"fmt"
-	"iter"
 	"math"
-	"slices"
 
 	a2atype "github.com/a2aproject/a2a-go/v2/a2a"
-	"github.com/a2aproject/a2a-go/v2/a2asrv"
 	adkagent "google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/plugin"
-	"google.golang.org/adk/v2/runner"
-	"google.golang.org/adk/v2/server/adka2a/v2"
 	adksession "google.golang.org/adk/v2/session"
 	"google.golang.org/genai"
 )
@@ -23,6 +17,8 @@ import (
 // a task carries the running task-lifetime total, so consumers take the latest
 // value rather than summing across executions.
 var usageTotalMetadataKey = GetKAgentMetadataKey("usage_total")
+
+const turnUsagePluginName = "kagent_turn_usage"
 
 // turnUsage accumulates token usage across the ADK events of one execution so
 // the aggregated total can be emitted on the terminal status update. Partial
@@ -40,8 +36,9 @@ type turnUsage struct {
 type turnUsageContextKey struct{}
 
 // withTurnUsage binds an accumulator to ctx. The upstream ADK executor derives
-// its ExecutorContext from this context, so the per-event and post-execution
-// callbacks reach the accumulator of the execution they belong to.
+// its ExecutorContext from this context, so the runner plugin and the
+// post-execution callback reach the accumulator of the execution they belong
+// to.
 func withTurnUsage(ctx context.Context, usage *turnUsage) context.Context {
 	return context.WithValue(ctx, turnUsageContextKey{}, usage)
 }
@@ -51,70 +48,39 @@ func turnUsageFrom(ctx context.Context) *turnUsage {
 	return usage
 }
 
-// usageObservingRunnerProvider mirrors the ADK executor's default runner
-// provider and wraps the runner so every ADK event is seen. Events are counted
-// before A2A conversion, which drops the ones it cannot turn into an artifact
-// (a paused tool call, for instance) even though they report token usage.
-func usageObservingRunnerProvider(baseConfig runner.Config) adka2a.RunnerProvider {
-	return func(_ context.Context, _ *a2asrv.ExecutorContext, executorPlugin *plugin.Plugin) (adka2a.RunnerConfig, adka2a.Runner, error) {
-		if baseConfig.Agent == nil {
-			return adka2a.RunnerConfig{}, nil, fmt.Errorf("runner.Config.Agent is not provided")
-		}
-		if baseConfig.SessionService == nil {
-			return adka2a.RunnerConfig{}, nil, fmt.Errorf("runner.Config.SessionService is not provided")
-		}
-
-		cfg := baseConfig
-		cfg.PluginConfig.Plugins = append(slices.Clone(cfg.PluginConfig.Plugins), executorPlugin)
-		adkRunner, err := runner.New(cfg)
-		if err != nil {
-			return adka2a.RunnerConfig{}, nil, err
-		}
-		return adka2a.RunnerConfig{
-				AppName:        cfg.AppName,
-				Agent:          cfg.Agent,
-				SessionService: cfg.SessionService,
-			},
-			&usageObservingRunner{runner: adkRunner}, nil
-	}
+// newTurnUsagePlugin counts every ADK event the runner produces. Events are
+// counted before A2A conversion, which drops the ones it cannot turn into an
+// artifact (a paused tool call, for instance) even though they report token
+// usage.
+func newTurnUsagePlugin() (*plugin.Plugin, error) {
+	return plugin.New(plugin.Config{
+		Name: turnUsagePluginName,
+		OnEventCallback: func(ictx adkagent.InvocationContext, event *adksession.Event) (*adksession.Event, error) {
+			turnUsageFrom(ictx).add(event)
+			return nil, nil
+		},
+	})
 }
 
-type usageObservingRunner struct {
-	runner *runner.Runner
-}
-
-func (r *usageObservingRunner) Run(
-	ctx context.Context,
-	userID, sessionID string,
-	message *genai.Content,
-	config adkagent.RunConfig,
-) iter.Seq2[*adksession.Event, error] {
-	events := r.runner.Run(ctx, userID, sessionID, message, config)
-	usage := turnUsageFrom(ctx)
-	if usage == nil {
-		return events
-	}
-	return func(yield func(*adksession.Event, error) bool) {
-		for event, err := range events {
-			if err == nil {
-				usage.add(event)
-			}
-			if !yield(event, err) {
-				return
-			}
-		}
-	}
-}
-
+// add sums one LLM call into the accumulator. A call that reports no total
+// contributes a derived one, so a task mixing providers that report a total
+// with providers that do not keeps a total consistent with its parts.
 func (u *turnUsage) add(event *adksession.Event) {
 	if u == nil || event == nil || event.Partial || event.UsageMetadata == nil {
 		return
 	}
-	u.promptTokens += int64(event.UsageMetadata.PromptTokenCount)
-	u.completionTokens += int64(event.UsageMetadata.CandidatesTokenCount)
-	u.thoughtsTokens += int64(event.UsageMetadata.ThoughtsTokenCount)
+	prompt := int64(event.UsageMetadata.PromptTokenCount)
+	completion := int64(event.UsageMetadata.CandidatesTokenCount)
+	thoughts := int64(event.UsageMetadata.ThoughtsTokenCount)
+	total := int64(event.UsageMetadata.TotalTokenCount)
+	if total == 0 {
+		total = prompt + completion + thoughts
+	}
+	u.promptTokens += prompt
+	u.completionTokens += completion
+	u.thoughtsTokens += thoughts
 	u.cachedContentTokens += int64(event.UsageMetadata.CachedContentTokenCount)
-	u.totalTokens += int64(event.UsageMetadata.TotalTokenCount)
+	u.totalTokens += total
 	if event.ModelVersion != "" {
 		u.modelVersion = event.ModelVersion
 	}
@@ -164,16 +130,6 @@ func (u *turnUsage) empty() bool {
 	return u.promptTokens == 0 && u.completionTokens == 0 && u.totalTokens == 0
 }
 
-// totalTokenCount derives a total when no provider reported one. The Anthropic
-// models report per-call input and output counts without a total, and emitting
-// a zero total next to non-zero counts reads as "no tokens were used".
-func (u *turnUsage) totalTokenCount() int64 {
-	if u.totalTokens != 0 {
-		return u.totalTokens
-	}
-	return u.promptTokens + u.completionTokens + u.thoughtsTokens
-}
-
 // stampEvent attaches the aggregate to a terminal status update under
 // kagent_usage_total. The value is serialized exactly like the per-event
 // adk_usage_metadata (same genai type, same JSON mapping) plus modelVersion, so
@@ -187,7 +143,7 @@ func (u *turnUsage) stampEvent(event *a2atype.TaskStatusUpdateEvent) {
 		CandidatesTokenCount:    clampInt32(u.completionTokens),
 		ThoughtsTokenCount:      clampInt32(u.thoughtsTokens),
 		CachedContentTokenCount: clampInt32(u.cachedContentTokens),
-		TotalTokenCount:         clampInt32(u.totalTokenCount()),
+		TotalTokenCount:         clampInt32(u.totalTokens),
 	})
 	if err != nil || total == nil {
 		return

--- a/go/adk/pkg/a2a/usage_test.go
+++ b/go/adk/pkg/a2a/usage_test.go
@@ -362,7 +362,7 @@ func TestTurnUsageIsPerExecution(t *testing.T) {
 func TestUsageObservingRunnerProviderMirrorsRunnerConfig(t *testing.T) {
 	mirrored := []string{"AppName", "Agent", "SessionService"}
 
-	fields := reflect.VisibleFields(reflect.TypeOf(adka2a.RunnerConfig{}))
+	fields := reflect.VisibleFields(reflect.TypeFor[adka2a.RunnerConfig]())
 	got := make([]string, 0, len(fields))
 	for _, field := range fields {
 		got = append(got, field.Name)

--- a/go/adk/pkg/a2a/usage_test.go
+++ b/go/adk/pkg/a2a/usage_test.go
@@ -1,0 +1,343 @@
+package a2a
+
+import (
+	"context"
+	"iter"
+	"testing"
+
+	a2atype "github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2asrv"
+	"github.com/go-logr/logr"
+	adkagent "google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/adk/v2/runner"
+	"google.golang.org/adk/v2/server/adka2a/v2"
+	adksession "google.golang.org/adk/v2/session"
+	"google.golang.org/genai"
+)
+
+// runUsageAgent runs an agent emitting the given responses through the
+// executor and returns the artifact updates and the terminal status update.
+func runUsageAgent(
+	t *testing.T,
+	storedTask *a2atype.Task,
+	responses ...model.LLMResponse,
+) ([]*a2atype.TaskArtifactUpdateEvent, *a2atype.TaskStatusUpdateEvent) {
+	t.Helper()
+
+	const appName = "usage-app"
+
+	agent, err := adkagent.New(adkagent.Config{
+		Name: "usage-agent",
+		Run: func(ic adkagent.InvocationContext) iter.Seq2[*adksession.Event, error] {
+			return func(yield func(*adksession.Event, error) bool) {
+				for _, response := range responses {
+					event := &adksession.Event{
+						Author:       ic.Agent().Name(),
+						InvocationID: ic.InvocationID(),
+						Branch:       ic.Branch(),
+						LLMResponse:  response,
+					}
+					if !yield(event, nil) {
+						return
+					}
+				}
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("agent.New() error = %v", err)
+	}
+
+	executor := NewKAgentExecutor(KAgentExecutorConfig{
+		AppName:        appName,
+		SessionService: adksession.InMemoryService(),
+		Logger:         logr.Discard(),
+		RunnerConfig: runner.Config{
+			AppName: appName,
+			Agent:   agent,
+		},
+	})
+
+	reqCtx := &a2asrv.ExecutorContext{
+		TaskID:     "task-1",
+		ContextID:  "context-1",
+		Message:    a2atype.NewMessage(a2atype.MessageRoleUser, a2atype.NewTextPart("hi")),
+		StoredTask: storedTask,
+	}
+
+	var (
+		updates  []*a2atype.TaskArtifactUpdateEvent
+		terminal *a2atype.TaskStatusUpdateEvent
+	)
+	for event, err := range executor.Execute(t.Context(), reqCtx) {
+		if err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		switch event := event.(type) {
+		case *a2atype.TaskArtifactUpdateEvent:
+			updates = append(updates, event)
+		case *a2atype.TaskStatusUpdateEvent:
+			if event.Status.State.Terminal() || event.Status.State == a2atype.TaskStateInputRequired {
+				terminal = event
+			}
+		}
+	}
+	if terminal == nil {
+		t.Fatal("no terminal status update emitted")
+	}
+	return updates, terminal
+}
+
+func usageTotalFrom(t *testing.T, event *a2atype.TaskStatusUpdateEvent) map[string]any {
+	t.Helper()
+	total, ok := event.Metadata[usageTotalMetadataKey].(map[string]any)
+	if !ok {
+		t.Fatalf("metadata[%s] = %#v, want map", usageTotalMetadataKey, event.Metadata[usageTotalMetadataKey])
+	}
+	return total
+}
+
+func assertTokenCount(t *testing.T, total map[string]any, key string, want float64) {
+	t.Helper()
+	got, ok := total[key].(float64)
+	if !ok {
+		t.Fatalf("%s = %#v, want number", key, total[key])
+	}
+	if got != want {
+		t.Fatalf("%s = %v, want %v", key, got, want)
+	}
+}
+
+func usageResponse(text string, prompt, candidates, total int32) model.LLMResponse {
+	return model.LLMResponse{
+		Content:      genai.NewContentFromText(text, genai.RoleModel),
+		ModelVersion: "gpt-4o-2024-11-20",
+		UsageMetadata: &genai.GenerateContentResponseUsageMetadata{
+			PromptTokenCount:     prompt,
+			CandidatesTokenCount: candidates,
+			TotalTokenCount:      total,
+		},
+	}
+}
+
+func TestTurnUsageAggregatesNonPartialEvents(t *testing.T) {
+	_, terminal := runUsageAgent(t, nil,
+		usageResponse("first", 10, 5, 15),
+		usageResponse("second", 20, 7, 27),
+	)
+
+	total := usageTotalFrom(t, terminal)
+	assertTokenCount(t, total, "promptTokenCount", 30)
+	assertTokenCount(t, total, "candidatesTokenCount", 12)
+	assertTokenCount(t, total, "totalTokenCount", 42)
+	if got := total["modelVersion"]; got != "gpt-4o-2024-11-20" {
+		t.Fatalf("modelVersion = %#v, want the emitting model", got)
+	}
+}
+
+func TestTurnUsageSkipsPartialAndEmptyEvents(t *testing.T) {
+	partial := usageResponse("par", 100, 100, 200)
+	partial.Partial = true
+	noUsage := model.LLMResponse{Content: genai.NewContentFromText("no usage", genai.RoleModel)}
+
+	_, terminal := runUsageAgent(t, nil, partial, noUsage, usageResponse("final", 10, 5, 15))
+
+	total := usageTotalFrom(t, terminal)
+	assertTokenCount(t, total, "promptTokenCount", 10)
+	assertTokenCount(t, total, "candidatesTokenCount", 5)
+	assertTokenCount(t, total, "totalTokenCount", 15)
+}
+
+func TestTurnUsageOmittedWhenNoUsageReported(t *testing.T) {
+	_, terminal := runUsageAgent(t, nil, model.LLMResponse{
+		Content: genai.NewContentFromText("no usage", genai.RoleModel),
+	})
+
+	if _, ok := terminal.Metadata[usageTotalMetadataKey]; ok {
+		t.Fatalf("metadata[%s] present, want omitted when nothing was reported", usageTotalMetadataKey)
+	}
+}
+
+// TestTurnUsageShapeMatchesPerEventUsageMetadata pins the aggregate to the same
+// serialization as the per-event adk_usage_metadata entry, so consumers can
+// share a single parser.
+func TestTurnUsageShapeMatchesPerEventUsageMetadata(t *testing.T) {
+	updates, terminal := runUsageAgent(t, nil, usageResponse("only", 10, 5, 15))
+
+	var perEvent map[string]any
+	for _, update := range updates {
+		if usage, ok := update.Artifact.Metadata[adka2a.ToA2AMetaKey("usage_metadata")].(map[string]any); ok {
+			perEvent = usage
+		}
+	}
+	if perEvent == nil {
+		t.Fatalf("per-event usage metadata missing from %d artifact updates", len(updates))
+	}
+
+	total := usageTotalFrom(t, terminal)
+	for key, want := range perEvent {
+		if got := total[key]; got != want {
+			t.Fatalf("%s = %#v, want %#v (same shape as per-event usage)", key, got, want)
+		}
+	}
+}
+
+func TestTurnUsageSeedFromTaskAccumulatesAcrossExecutions(t *testing.T) {
+	storedTask := &a2atype.Task{
+		ID:        "task-1",
+		ContextID: "context-1",
+		Metadata: map[string]any{
+			usageTotalMetadataKey: map[string]any{
+				// float64 as it would be after a JSON round-trip through a task store.
+				"promptTokenCount":     float64(100),
+				"candidatesTokenCount": float64(50),
+				"totalTokenCount":      float64(150),
+				"modelVersion":         "gpt-4o-2024-08-06",
+			},
+		},
+	}
+
+	_, terminal := runUsageAgent(t, storedTask, usageResponse("resumed", 10, 5, 15))
+
+	total := usageTotalFrom(t, terminal)
+	assertTokenCount(t, total, "promptTokenCount", 110)
+	assertTokenCount(t, total, "candidatesTokenCount", 55)
+	assertTokenCount(t, total, "totalTokenCount", 165)
+	if got := total["modelVersion"]; got != "gpt-4o-2024-11-20" {
+		t.Fatalf("modelVersion = %#v, want the model of the latest execution", got)
+	}
+}
+
+func TestTurnUsageSeedFromTaskIgnoresMissingOrMalformed(t *testing.T) {
+	tests := map[string]*a2atype.Task{
+		"nil task":          nil,
+		"no metadata":       {ID: "task-1"},
+		"unrelated keys":    {ID: "task-1", Metadata: map[string]any{"other": 1}},
+		"total not a map":   {ID: "task-1", Metadata: map[string]any{usageTotalMetadataKey: "nope"}},
+		"counts not number": {ID: "task-1", Metadata: map[string]any{usageTotalMetadataKey: map[string]any{"promptTokenCount": "many"}}},
+	}
+
+	for name, task := range tests {
+		t.Run(name, func(t *testing.T) {
+			usage := &turnUsage{}
+			usage.seedFromTask(task)
+			if !usage.empty() {
+				t.Fatalf("usage = %#v, want empty", usage)
+			}
+		})
+	}
+}
+
+// TestTurnUsageAcrossHITLCycle covers the input-required terminal state: the
+// pause carries the total so far, and the execution resuming from the stored
+// task continues from it instead of restarting at zero.
+func TestTurnUsageAcrossHITLCycle(t *testing.T) {
+	const (
+		appName   = "hitl-usage-app"
+		contextID = "hitl-usage-context"
+		taskID    = "hitl-usage-task"
+	)
+
+	invocations := 0
+	agent, err := adkagent.New(adkagent.Config{
+		Name: "hitl-usage-agent",
+		Run: func(ic adkagent.InvocationContext) iter.Seq2[*adksession.Event, error] {
+			return func(yield func(*adksession.Event, error) bool) {
+				invocations++
+				if invocations == 1 {
+					call := genai.NewPartFromFunctionCall("adk_request_confirmation", map[string]any{
+						"originalFunctionCall": map[string]any{"name": "delete_file", "id": "tool-call", "args": map[string]any{"path": "/tmp/x"}},
+						"toolConfirmation":     map[string]any{"hint": "Delete /tmp/x?", "confirmed": false, "payload": nil},
+					})
+					call.FunctionCall.ID = "confirmation-call"
+					yield(&adksession.Event{
+						Author: ic.Agent().Name(), InvocationID: ic.InvocationID(), Branch: ic.Branch(),
+						LLMResponse: model.LLMResponse{
+							Content:      &genai.Content{Role: genai.RoleModel, Parts: []*genai.Part{call}},
+							ModelVersion: "gpt-4o-2024-11-20",
+							UsageMetadata: &genai.GenerateContentResponseUsageMetadata{
+								PromptTokenCount: 10, CandidatesTokenCount: 5, TotalTokenCount: 15,
+							},
+						},
+						LongRunningToolIDs: []string{"confirmation-call"},
+					}, nil)
+					return
+				}
+				yield(&adksession.Event{
+					Author: ic.Agent().Name(), InvocationID: ic.InvocationID(), Branch: ic.Branch(),
+					LLMResponse: usageResponse("resumed", 20, 7, 27),
+				}, nil)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("agent.New() error = %v", err)
+	}
+
+	executor := NewKAgentExecutor(KAgentExecutorConfig{
+		AppName: appName, SessionService: adksession.InMemoryService(), Logger: logr.Discard(),
+		RunnerConfig: runner.Config{AppName: appName, Agent: agent},
+	})
+
+	var pause *a2atype.TaskStatusUpdateEvent
+	first := &a2asrv.ExecutorContext{
+		TaskID: taskID, ContextID: contextID,
+		Message: a2atype.NewMessage(a2atype.MessageRoleUser, a2atype.NewTextPart("delete it")),
+	}
+	for event, err := range executor.Execute(t.Context(), first) {
+		if err != nil {
+			t.Fatalf("pause Execute() error = %v", err)
+		}
+		if update, ok := event.(*a2atype.TaskStatusUpdateEvent); ok && update.Status.State == a2atype.TaskStateInputRequired {
+			pause = update
+		}
+	}
+	if pause == nil {
+		t.Fatal("no input-required status update emitted")
+	}
+	paused := usageTotalFrom(t, pause)
+	assertTokenCount(t, paused, "promptTokenCount", 10)
+	assertTokenCount(t, paused, "totalTokenCount", 15)
+
+	// a2a-go merges terminal status update metadata into the stored task.
+	stored := &a2atype.Task{ID: taskID, ContextID: contextID, Status: pause.Status, Metadata: pause.Metadata}
+	decision := hitlDecisionMessage(&ToolApprovalResponse{
+		Type:      HITLTypeToolApprovalResponse,
+		Approvals: []ToolApproval{{ID: "confirmation-call", Approved: true}},
+	})
+	decision.TaskID, decision.ContextID = taskID, contextID
+
+	resume := &a2asrv.ExecutorContext{
+		TaskID: taskID, ContextID: contextID, Message: decision, StoredTask: stored,
+	}
+	var terminal *a2atype.TaskStatusUpdateEvent
+	for event, err := range executor.Execute(t.Context(), resume) {
+		if err != nil {
+			t.Fatalf("resume Execute() error = %v", err)
+		}
+		if update, ok := event.(*a2atype.TaskStatusUpdateEvent); ok && update.Status.State.Terminal() {
+			terminal = update
+		}
+	}
+	if terminal == nil {
+		t.Fatal("no terminal status update emitted on resume")
+	}
+
+	total := usageTotalFrom(t, terminal)
+	assertTokenCount(t, total, "promptTokenCount", 30)
+	assertTokenCount(t, total, "candidatesTokenCount", 12)
+	assertTokenCount(t, total, "totalTokenCount", 42)
+}
+
+func TestTurnUsageIsPerExecution(t *testing.T) {
+	if got := turnUsageFrom(context.Background()); got != nil {
+		t.Fatalf("turnUsageFrom(background) = %#v, want nil", got)
+	}
+
+	usage := &turnUsage{}
+	ctx := withTurnUsage(context.Background(), usage)
+	if got := turnUsageFrom(ctx); got != usage {
+		t.Fatalf("turnUsageFrom(ctx) = %#v, want the bound accumulator", got)
+	}
+}

--- a/go/adk/pkg/a2a/usage_test.go
+++ b/go/adk/pkg/a2a/usage_test.go
@@ -3,6 +3,8 @@ package a2a
 import (
 	"context"
 	"iter"
+	"reflect"
+	"slices"
 	"testing"
 
 	a2atype "github.com/a2aproject/a2a-go/v2/a2a"
@@ -10,6 +12,7 @@ import (
 	"github.com/go-logr/logr"
 	adkagent "google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/model"
+	"google.golang.org/adk/v2/plugin"
 	"google.golang.org/adk/v2/runner"
 	"google.golang.org/adk/v2/server/adka2a/v2"
 	adksession "google.golang.org/adk/v2/session"
@@ -142,6 +145,17 @@ func TestTurnUsageSkipsPartialAndEmptyEvents(t *testing.T) {
 	noUsage := model.LLMResponse{Content: genai.NewContentFromText("no usage", genai.RoleModel)}
 
 	_, terminal := runUsageAgent(t, nil, partial, noUsage, usageResponse("final", 10, 5, 15))
+
+	total := usageTotalFrom(t, terminal)
+	assertTokenCount(t, total, "promptTokenCount", 10)
+	assertTokenCount(t, total, "candidatesTokenCount", 5)
+	assertTokenCount(t, total, "totalTokenCount", 15)
+}
+
+// TestTurnUsageDerivesTotalWhenProviderReportsNone covers the Anthropic models,
+// which report input and output counts without a total.
+func TestTurnUsageDerivesTotalWhenProviderReportsNone(t *testing.T) {
+	_, terminal := runUsageAgent(t, nil, usageResponse("no total", 10, 5, 0))
 
 	total := usageTotalFrom(t, terminal)
 	assertTokenCount(t, total, "promptTokenCount", 10)
@@ -339,5 +353,69 @@ func TestTurnUsageIsPerExecution(t *testing.T) {
 	ctx := withTurnUsage(context.Background(), usage)
 	if got := turnUsageFrom(ctx); got != usage {
 		t.Fatalf("turnUsageFrom(ctx) = %#v, want the bound accumulator", got)
+	}
+}
+
+// TestUsageObservingRunnerProviderMirrorsRunnerConfig fails when the upstream
+// RunnerConfig grows a field, since RunnerProvider replaces RunnerConfig
+// outright and a field the mirror does not carry is silently dropped.
+func TestUsageObservingRunnerProviderMirrorsRunnerConfig(t *testing.T) {
+	mirrored := []string{"AppName", "Agent", "SessionService"}
+
+	fields := reflect.VisibleFields(reflect.TypeOf(adka2a.RunnerConfig{}))
+	got := make([]string, 0, len(fields))
+	for _, field := range fields {
+		got = append(got, field.Name)
+	}
+	if !slices.Equal(got, mirrored) {
+		t.Fatalf("adka2a.RunnerConfig fields = %v, want %v; carry the new field in usageObservingRunnerProvider", got, mirrored)
+	}
+
+	agent, err := adkagent.New(adkagent.Config{
+		Name: "mirror-agent",
+		Run: func(adkagent.InvocationContext) iter.Seq2[*adksession.Event, error] {
+			return func(func(*adksession.Event, error) bool) {}
+		},
+	})
+	if err != nil {
+		t.Fatalf("agent.New() error = %v", err)
+	}
+	sessionService := adksession.InMemoryService()
+	base := runner.Config{AppName: "mirror-app", Agent: agent, SessionService: sessionService}
+
+	cfg, observing, err := usageObservingRunnerProvider(base)(t.Context(), nil, &plugin.Plugin{})
+	if err != nil {
+		t.Fatalf("provider error = %v", err)
+	}
+	if observing == nil {
+		t.Fatal("provider returned a nil runner")
+	}
+	want := adka2a.RunnerConfig{AppName: base.AppName, Agent: base.Agent, SessionService: sessionService}
+	if cfg != want {
+		t.Fatalf("RunnerConfig = %#v, want %#v", cfg, want)
+	}
+}
+
+func TestUsageObservingRunnerProviderRejectsIncompleteConfig(t *testing.T) {
+	agent, err := adkagent.New(adkagent.Config{
+		Name: "mirror-agent",
+		Run: func(adkagent.InvocationContext) iter.Seq2[*adksession.Event, error] {
+			return func(func(*adksession.Event, error) bool) {}
+		},
+	})
+	if err != nil {
+		t.Fatalf("agent.New() error = %v", err)
+	}
+
+	tests := map[string]runner.Config{
+		"no agent":           {AppName: "app", SessionService: adksession.InMemoryService()},
+		"no session service": {AppName: "app", Agent: agent},
+	}
+	for name, base := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, _, err := usageObservingRunnerProvider(base)(t.Context(), nil, &plugin.Plugin{}); err == nil {
+				t.Fatal("provider error = nil, want the default provider's validation error")
+			}
+		})
 	}
 }

--- a/go/adk/pkg/a2a/usage_test.go
+++ b/go/adk/pkg/a2a/usage_test.go
@@ -3,8 +3,6 @@ package a2a
 import (
 	"context"
 	"iter"
-	"reflect"
-	"slices"
 	"testing"
 
 	a2atype "github.com/a2aproject/a2a-go/v2/a2a"
@@ -12,7 +10,6 @@ import (
 	"github.com/go-logr/logr"
 	adkagent "google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/model"
-	"google.golang.org/adk/v2/plugin"
 	"google.golang.org/adk/v2/runner"
 	"google.golang.org/adk/v2/server/adka2a/v2"
 	adksession "google.golang.org/adk/v2/session"
@@ -356,66 +353,41 @@ func TestTurnUsageIsPerExecution(t *testing.T) {
 	}
 }
 
-// TestUsageObservingRunnerProviderMirrorsRunnerConfig fails when the upstream
-// RunnerConfig grows a field, since RunnerProvider replaces RunnerConfig
-// outright and a field the mirror does not carry is silently dropped.
-func TestUsageObservingRunnerProviderMirrorsRunnerConfig(t *testing.T) {
-	mirrored := []string{"AppName", "Agent", "SessionService"}
+// TestTurnUsageDerivesTotalPerCall covers a task mixing calls that report a
+// total with calls that do not: the derived counts of the second call must
+// extend the total reported by the first.
+func TestTurnUsageDerivesTotalPerCall(t *testing.T) {
+	_, terminal := runUsageAgent(t, nil,
+		usageResponse("with total", 10, 5, 15),
+		usageResponse("without total", 20, 7, 0),
+	)
 
-	fields := reflect.VisibleFields(reflect.TypeFor[adka2a.RunnerConfig]())
-	got := make([]string, 0, len(fields))
-	for _, field := range fields {
-		got = append(got, field.Name)
-	}
-	if !slices.Equal(got, mirrored) {
-		t.Fatalf("adka2a.RunnerConfig fields = %v, want %v; carry the new field in usageObservingRunnerProvider", got, mirrored)
-	}
-
-	agent, err := adkagent.New(adkagent.Config{
-		Name: "mirror-agent",
-		Run: func(adkagent.InvocationContext) iter.Seq2[*adksession.Event, error] {
-			return func(func(*adksession.Event, error) bool) {}
-		},
-	})
-	if err != nil {
-		t.Fatalf("agent.New() error = %v", err)
-	}
-	sessionService := adksession.InMemoryService()
-	base := runner.Config{AppName: "mirror-app", Agent: agent, SessionService: sessionService}
-
-	cfg, observing, err := usageObservingRunnerProvider(base)(t.Context(), nil, &plugin.Plugin{})
-	if err != nil {
-		t.Fatalf("provider error = %v", err)
-	}
-	if observing == nil {
-		t.Fatal("provider returned a nil runner")
-	}
-	want := adka2a.RunnerConfig{AppName: base.AppName, Agent: base.Agent, SessionService: sessionService}
-	if cfg != want {
-		t.Fatalf("RunnerConfig = %#v, want %#v", cfg, want)
-	}
+	total := usageTotalFrom(t, terminal)
+	assertTokenCount(t, total, "promptTokenCount", 30)
+	assertTokenCount(t, total, "candidatesTokenCount", 12)
+	assertTokenCount(t, total, "totalTokenCount", 42)
 }
 
-func TestUsageObservingRunnerProviderRejectsIncompleteConfig(t *testing.T) {
-	agent, err := adkagent.New(adkagent.Config{
-		Name: "mirror-agent",
-		Run: func(adkagent.InvocationContext) iter.Seq2[*adksession.Event, error] {
-			return func(func(*adksession.Event, error) bool) {}
+// TestTurnUsageDerivedTotalGrowsAcrossExecutions covers a resumed task whose
+// persisted total was itself derived: the next execution must add its own
+// derived total instead of keeping the stored one.
+func TestTurnUsageDerivedTotalGrowsAcrossExecutions(t *testing.T) {
+	storedTask := &a2atype.Task{
+		ID:        "task-1",
+		ContextID: "context-1",
+		Metadata: map[string]any{
+			usageTotalMetadataKey: map[string]any{
+				"promptTokenCount":     float64(100),
+				"candidatesTokenCount": float64(20),
+				"totalTokenCount":      float64(120),
+			},
 		},
-	})
-	if err != nil {
-		t.Fatalf("agent.New() error = %v", err)
 	}
 
-	tests := map[string]runner.Config{
-		"no agent":           {AppName: "app", SessionService: adksession.InMemoryService()},
-		"no session service": {AppName: "app", Agent: agent},
-	}
-	for name, base := range tests {
-		t.Run(name, func(t *testing.T) {
-			if _, _, err := usageObservingRunnerProvider(base)(t.Context(), nil, &plugin.Plugin{}); err == nil {
-				t.Fatal("provider error = nil, want the default provider's validation error")
-			}
-		})
-	}
+	_, terminal := runUsageAgent(t, storedTask, usageResponse("no total", 200, 30, 0))
+
+	total := usageTotalFrom(t, terminal)
+	assertTokenCount(t, total, "promptTokenCount", 300)
+	assertTokenCount(t, total, "candidatesTokenCount", 50)
+	assertTokenCount(t, total, "totalTokenCount", 350)
 }

--- a/python/packages/kagent-adk/src/kagent/adk/_agent_executor.py
+++ b/python/packages/kagent-adk/src/kagent/adk/_agent_executor.py
@@ -5,7 +5,7 @@ import inspect
 import logging
 import uuid
 from contextlib import suppress
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable, Optional
 
 from a2a.server.agent_execution import AgentExecutor
@@ -40,6 +40,7 @@ from pydantic import BaseModel
 from ._bearer_token import bearer_token, extract_bearer_token
 from ._hitl import build_hitl_status_message, build_resume_hitl_message
 from ._mcp_toolset import is_anyio_cross_task_cancel_scope_error
+from ._turn_usage import TurnUsage
 from .converters.event_converter import serialize_metadata_value
 
 logger = logging.getLogger("kagent_adk." + __name__)
@@ -56,6 +57,7 @@ class _ExecutionState:
     request_context: RequestContext
     invocation_id: str | None = None
     last_usage_metadata: Any = None
+    usage: TurnUsage = field(default_factory=TurnUsage)
 
 
 def _call_state(context: RequestContext) -> dict[str, Any]:
@@ -136,6 +138,10 @@ class A2aAgentExecutor(AgentExecutor):
             )
 
             execution_state = _ExecutionState(request_context=context)
+            # Resumed tasks (HITL cycles, follow-up messages) carry the
+            # previously persisted total, so kagent_usage_total stays a
+            # task-lifetime sum.
+            execution_state.usage.seed_from_task(context.current_task)
             upstream_config = UpstreamA2aAgentExecutorConfig(
                 request_converter=self._convert_request,
                 execute_interceptors=[
@@ -263,6 +269,7 @@ class A2aAgentExecutor(AgentExecutor):
             state.invocation_id = adk_event.invocation_id
         if adk_event.usage_metadata is not None:
             state.last_usage_metadata = adk_event.usage_metadata
+        state.usage.add(adk_event)
         return event
 
     async def _after_agent(
@@ -280,6 +287,7 @@ class A2aAgentExecutor(AgentExecutor):
             metadata[get_kagent_metadata_key("invocation_id")] = state.invocation_id
         if state.last_usage_metadata is not None:
             metadata[get_kagent_metadata_key("usage_metadata")] = serialize_metadata_value(state.last_usage_metadata)
+        state.usage.stamp(metadata)
         event.metadata.update(metadata)
 
         if event.status.state == TaskState.TASK_STATE_INPUT_REQUIRED and event.status.message:

--- a/python/packages/kagent-adk/src/kagent/adk/_agent_executor.py
+++ b/python/packages/kagent-adk/src/kagent/adk/_agent_executor.py
@@ -40,7 +40,7 @@ from pydantic import BaseModel
 from ._bearer_token import bearer_token, extract_bearer_token
 from ._hitl import build_hitl_status_message, build_resume_hitl_message
 from ._mcp_toolset import is_anyio_cross_task_cancel_scope_error
-from ._turn_usage import TurnUsage
+from ._turn_usage import TurnUsage, attach_turn_usage
 from .converters.event_converter import serialize_metadata_value
 
 logger = logging.getLogger("kagent_adk." + __name__)
@@ -121,9 +121,14 @@ class A2aAgentExecutor(AgentExecutor):
 
         runner: Runner | None = None
         context_token = None
+        execution_state = _ExecutionState(request_context=context)
+        # Resumed tasks (HITL cycles, follow-up messages) carry the previously
+        # persisted total, so kagent_usage_total stays a task-lifetime sum.
+        execution_state.usage.seed_from_task(context.current_task)
         try:
             self._translate_hitl_response(context)
             runner = await self._resolve_runner()
+            attach_turn_usage(runner, execution_state.usage)
 
             run_request = self._convert_request(context, None)
             await self._prepare_session(context, run_request, runner)
@@ -137,11 +142,6 @@ class A2aAgentExecutor(AgentExecutor):
                 {key: value for key, value in span_attributes.items() if value is not None}
             )
 
-            execution_state = _ExecutionState(request_context=context)
-            # Resumed tasks (HITL cycles, follow-up messages) carry the
-            # previously persisted total, so kagent_usage_total stays a
-            # task-lifetime sum.
-            execution_state.usage.seed_from_task(context.current_task)
             upstream_config = UpstreamA2aAgentExecutorConfig(
                 request_converter=self._convert_request,
                 execute_interceptors=[
@@ -176,10 +176,13 @@ class A2aAgentExecutor(AgentExecutor):
                 context,
                 event_queue,
                 str(error) or "A2A request execution was cancelled.",
+                execution_state.usage,
             )
         except Exception as error:
             logger.error("Error preparing A2A request: %s", error, exc_info=True)
-            await self._publish_failed_status_event(context, event_queue, _friendly_error_message(str(error)))
+            await self._publish_failed_status_event(
+                context, event_queue, _friendly_error_message(str(error)), execution_state.usage
+            )
         finally:
             if context_token is not None:
                 clear_kagent_span_attributes(context_token)
@@ -269,7 +272,6 @@ class A2aAgentExecutor(AgentExecutor):
             state.invocation_id = adk_event.invocation_id
         if adk_event.usage_metadata is not None:
             state.last_usage_metadata = adk_event.usage_metadata
-        state.usage.add(adk_event)
         return event
 
     async def _after_agent(
@@ -334,23 +336,26 @@ class A2aAgentExecutor(AgentExecutor):
         context: RequestContext,
         event_queue: EventQueue,
         error_message: str,
+        usage: TurnUsage,
     ) -> None:
         try:
-            await event_queue.enqueue_event(
-                TaskStatusUpdateEvent(
-                    task_id=context.task_id,
-                    context_id=context.context_id,
-                    status=TaskStatus(
-                        state=TaskState.TASK_STATE_FAILED,
-                        timestamp=now_timestamp(),
-                        message=Message(
-                            message_id=str(uuid.uuid4()),
-                            role=Role.ROLE_AGENT,
-                            parts=[Part(text=error_message)],
-                        ),
+            event = TaskStatusUpdateEvent(
+                task_id=context.task_id,
+                context_id=context.context_id,
+                status=TaskStatus(
+                    state=TaskState.TASK_STATE_FAILED,
+                    timestamp=now_timestamp(),
+                    message=Message(
+                        message_id=str(uuid.uuid4()),
+                        role=Role.ROLE_AGENT,
+                        parts=[Part(text=error_message)],
                     ),
-                )
+                ),
             )
+            metadata: dict[str, Any] = {}
+            usage.stamp(metadata)
+            event.metadata.update(metadata)
+            await event_queue.enqueue_event(event)
         except BaseException as enqueue_error:
             if isinstance(enqueue_error, (KeyboardInterrupt, SystemExit)):
                 raise

--- a/python/packages/kagent-adk/src/kagent/adk/_turn_usage.py
+++ b/python/packages/kagent-adk/src/kagent/adk/_turn_usage.py
@@ -3,13 +3,21 @@ from __future__ import annotations
 from typing import Any, Optional
 
 from a2a.types import Task
+from google.adk.agents.invocation_context import InvocationContext
 from google.adk.events import Event
+from google.adk.plugins.base_plugin import BasePlugin
+from google.adk.runners import Runner
 from google.genai import types as genai_types
 from kagent.core.a2a import get_kagent_metadata_key
 
 from .converters.event_converter import serialize_metadata_value
 
+# Every terminal status update of a task carries the running task-lifetime
+# total, so consumers take the latest value rather than summing across
+# executions.
 USAGE_TOTAL_KEY = get_kagent_metadata_key("usage_total")
+
+TURN_USAGE_PLUGIN_NAME = "kagent_turn_usage"
 
 
 class TurnUsage:
@@ -18,8 +26,8 @@ class TurnUsage:
 
     Partial (streaming chunk) events are skipped: each LLM call reports its
     usage on the final non-partial event, so summing partials would
-    double-count. One ADK event can be converted into several A2A events, so
-    events already counted are tracked by id.
+    double-count. Events already counted are tracked by id, so an event
+    reaching the accumulator more than once is counted once.
     """
 
     def __init__(self) -> None:
@@ -72,6 +80,14 @@ class TurnUsage:
     def empty(self) -> bool:
         return self.prompt_tokens == 0 and self.completion_tokens == 0 and self.total_tokens == 0
 
+    def total_token_count(self) -> int:
+        """Anthropic and other providers report per-call input and output counts
+        without a total, so derive one rather than emitting a zero total next to
+        non-zero counts."""
+        if self.total_tokens:
+            return self.total_tokens
+        return self.prompt_tokens + self.completion_tokens + self.thoughts_tokens
+
     def stamp(self, metadata: dict[str, Any]) -> None:
         """Attach the aggregate to metadata under kagent_usage_total. The value
         is serialized exactly like the per-event kagent_usage_metadata (same
@@ -85,7 +101,7 @@ class TurnUsage:
                 candidates_token_count=self.completion_tokens or None,
                 thoughts_token_count=self.thoughts_tokens or None,
                 cached_content_token_count=self.cached_content_tokens or None,
-                total_token_count=self.total_tokens or None,
+                total_token_count=self.total_token_count() or None,
             )
         )
         if not isinstance(total, dict):
@@ -103,3 +119,32 @@ def _token_count(value: Any) -> int:
     if isinstance(value, (int, float)):
         return int(value)
     return 0
+
+
+class TurnUsagePlugin(BasePlugin):
+    """Feeds every ADK event the runner produces into the accumulator.
+
+    The A2A after-event interceptor only runs for ADK events the converter
+    turns into at least one A2A event. The event carrying the usage of the call
+    that pauses a task for input has its long-running function call stripped
+    before conversion, produces no A2A event, and would never be counted.
+    """
+
+    def __init__(self, usage: TurnUsage) -> None:
+        super().__init__(name=TURN_USAGE_PLUGIN_NAME)
+        self.usage = usage
+
+    async def on_event_callback(self, *, invocation_context: InvocationContext, event: Event) -> None:
+        del invocation_context
+        self.usage.add(event)
+        return None
+
+
+def attach_turn_usage(runner: Runner, usage: TurnUsage) -> None:
+    """Points the runner's usage plugin at the accumulator of this execution."""
+    manager = runner.plugin_manager
+    existing = manager.get_plugin(TURN_USAGE_PLUGIN_NAME)
+    if isinstance(existing, TurnUsagePlugin):
+        existing.usage = usage
+        return
+    manager.register_plugin(TurnUsagePlugin(usage))

--- a/python/packages/kagent-adk/src/kagent/adk/_turn_usage.py
+++ b/python/packages/kagent-adk/src/kagent/adk/_turn_usage.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from a2a.types import Task
+from google.adk.events import Event
+from google.genai import types as genai_types
+from kagent.core.a2a import get_kagent_metadata_key
+
+from .converters.event_converter import serialize_metadata_value
+
+USAGE_TOTAL_KEY = get_kagent_metadata_key("usage_total")
+
+
+class TurnUsage:
+    """Accumulates token usage across the ADK events of one execution so the
+    aggregated total can be emitted on terminal status updates.
+
+    Partial (streaming chunk) events are skipped: each LLM call reports its
+    usage on the final non-partial event, so summing partials would
+    double-count. One ADK event can be converted into several A2A events, so
+    events already counted are tracked by id.
+    """
+
+    def __init__(self) -> None:
+        self.prompt_tokens = 0
+        self.completion_tokens = 0
+        self.thoughts_tokens = 0
+        self.cached_content_tokens = 0
+        self.total_tokens = 0
+        self.model_version: Optional[str] = None
+        self._counted_event_ids: set[str] = set()
+
+    def add(self, event: Optional[Event]) -> None:
+        if event is None or event.partial:
+            return
+        usage = event.usage_metadata
+        if usage is None:
+            return
+        if event.id:
+            if event.id in self._counted_event_ids:
+                return
+            self._counted_event_ids.add(event.id)
+        self.prompt_tokens += usage.prompt_token_count or 0
+        self.completion_tokens += usage.candidates_token_count or 0
+        self.thoughts_tokens += usage.thoughts_token_count or 0
+        self.cached_content_tokens += usage.cached_content_token_count or 0
+        self.total_tokens += usage.total_token_count or 0
+        if event.model_version:
+            self.model_version = event.model_version
+
+    def seed_from_task(self, task: Optional[Task]) -> None:
+        """Prime the accumulator with the total already persisted on a resumed
+        task, so tasks spanning multiple executions (HITL input-required
+        cycles, follow-up messages) report a task-lifetime total instead of the
+        last segment only."""
+        if task is None or not task.metadata or USAGE_TOTAL_KEY not in task.metadata:
+            return
+        prior = task.metadata[USAGE_TOTAL_KEY]
+        if not hasattr(prior, "items"):
+            return
+        prior = dict(prior.items())
+        self.prompt_tokens += _token_count(prior.get("promptTokenCount"))
+        self.completion_tokens += _token_count(prior.get("candidatesTokenCount"))
+        self.thoughts_tokens += _token_count(prior.get("thoughtsTokenCount"))
+        self.cached_content_tokens += _token_count(prior.get("cachedContentTokenCount"))
+        self.total_tokens += _token_count(prior.get("totalTokenCount"))
+        model_version = prior.get("modelVersion")
+        if isinstance(model_version, str) and model_version:
+            self.model_version = model_version
+
+    def empty(self) -> bool:
+        return self.prompt_tokens == 0 and self.completion_tokens == 0 and self.total_tokens == 0
+
+    def stamp(self, metadata: dict[str, Any]) -> None:
+        """Attach the aggregate to metadata under kagent_usage_total. The value
+        is serialized exactly like the per-event kagent_usage_metadata (same
+        genai type, same serializer) plus modelVersion, so consumers can share
+        one parser."""
+        if self.empty():
+            return
+        total = serialize_metadata_value(
+            genai_types.GenerateContentResponseUsageMetadata(
+                prompt_token_count=self.prompt_tokens or None,
+                candidates_token_count=self.completion_tokens or None,
+                thoughts_token_count=self.thoughts_tokens or None,
+                cached_content_token_count=self.cached_content_tokens or None,
+                total_token_count=self.total_tokens or None,
+            )
+        )
+        if not isinstance(total, dict):
+            return
+        if self.model_version:
+            total["modelVersion"] = self.model_version
+        metadata[USAGE_TOTAL_KEY] = total
+
+
+def _token_count(value: Any) -> int:
+    """Read a numeric token count from stored task metadata; counts may be int
+    or float depending on the task store's JSON round-trip."""
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, (int, float)):
+        return int(value)
+    return 0

--- a/python/packages/kagent-adk/src/kagent/adk/_turn_usage.py
+++ b/python/packages/kagent-adk/src/kagent/adk/_turn_usage.py
@@ -40,6 +40,10 @@ class TurnUsage:
         self._counted_event_ids: set[str] = set()
 
     def add(self, event: Optional[Event]) -> None:
+        """Sum one LLM call into the accumulator. A call that reports no total
+        contributes a derived one, so a task mixing providers that report a
+        total with providers that do not keeps a total consistent with its
+        parts."""
         if event is None or event.partial:
             return
         usage = event.usage_metadata
@@ -49,11 +53,14 @@ class TurnUsage:
             if event.id in self._counted_event_ids:
                 return
             self._counted_event_ids.add(event.id)
-        self.prompt_tokens += usage.prompt_token_count or 0
-        self.completion_tokens += usage.candidates_token_count or 0
-        self.thoughts_tokens += usage.thoughts_token_count or 0
+        prompt = usage.prompt_token_count or 0
+        completion = usage.candidates_token_count or 0
+        thoughts = usage.thoughts_token_count or 0
+        self.prompt_tokens += prompt
+        self.completion_tokens += completion
+        self.thoughts_tokens += thoughts
         self.cached_content_tokens += usage.cached_content_token_count or 0
-        self.total_tokens += usage.total_token_count or 0
+        self.total_tokens += usage.total_token_count or (prompt + completion + thoughts)
         if event.model_version:
             self.model_version = event.model_version
 
@@ -80,14 +87,6 @@ class TurnUsage:
     def empty(self) -> bool:
         return self.prompt_tokens == 0 and self.completion_tokens == 0 and self.total_tokens == 0
 
-    def total_token_count(self) -> int:
-        """Anthropic and other providers report per-call input and output counts
-        without a total, so derive one rather than emitting a zero total next to
-        non-zero counts."""
-        if self.total_tokens:
-            return self.total_tokens
-        return self.prompt_tokens + self.completion_tokens + self.thoughts_tokens
-
     def stamp(self, metadata: dict[str, Any]) -> None:
         """Attach the aggregate to metadata under kagent_usage_total. The value
         is serialized exactly like the per-event kagent_usage_metadata (same
@@ -101,7 +100,7 @@ class TurnUsage:
                 candidates_token_count=self.completion_tokens or None,
                 thoughts_token_count=self.thoughts_tokens or None,
                 cached_content_token_count=self.cached_content_tokens or None,
-                total_token_count=self.total_token_count() or None,
+                total_token_count=self.total_tokens or None,
             )
         )
         if not isinstance(total, dict):

--- a/python/packages/kagent-adk/tests/unittests/test_agent_executor.py
+++ b/python/packages/kagent-adk/tests/unittests/test_agent_executor.py
@@ -7,7 +7,9 @@ from a2a.server.agent_execution.context import RequestContext
 from a2a.server.context import ServerCallContext
 from a2a.types import Message, Part, Role, SendMessageRequest
 from google.adk.a2a.converters.request_converter import AgentRunRequest
+from google.adk.agents.base_agent import BaseAgent
 from google.adk.agents.run_config import RunConfig, StreamingMode
+from google.adk.runners import InMemoryRunner
 
 import kagent.adk._agent_executor as executor_module
 from kagent.adk._agent_executor import A2aAgentExecutor, A2aAgentExecutorConfig
@@ -72,7 +74,7 @@ def test_convert_request_clears_bearer_token_when_no_auth_header():
 async def test_execute_delegates_to_adk_2_executor_and_closes_request_runner(monkeypatch):
     context = _request_context()
     event_queue = object()
-    runner = object()
+    runner = InMemoryRunner(agent=BaseAgent(name="agent"), app_name="app")
     run_request = AgentRunRequest(
         user_id="user-1",
         session_id="context-1",

--- a/python/packages/kagent-adk/tests/unittests/test_turn_usage.py
+++ b/python/packages/kagent-adk/tests/unittests/test_turn_usage.py
@@ -13,12 +13,22 @@ from a2a.types import (
     TaskStatus,
     TaskStatusUpdateEvent,
 )
+from google.adk.a2a.converters.event_converter import convert_event_to_a2a_message
+from google.adk.a2a.converters.long_running_functions import LongRunningFunctions
 from google.adk.a2a.executor.executor_context import ExecutorContext
+from google.adk.agents.base_agent import BaseAgent
 from google.adk.events import Event
+from google.adk.runners import InMemoryRunner
 from google.genai import types as genai_types
 
 from kagent.adk._agent_executor import A2aAgentExecutor, _ExecutionState
-from kagent.adk._turn_usage import USAGE_TOTAL_KEY, TurnUsage
+from kagent.adk._turn_usage import (
+    TURN_USAGE_PLUGIN_NAME,
+    USAGE_TOTAL_KEY,
+    TurnUsage,
+    TurnUsagePlugin,
+    attach_turn_usage,
+)
 from kagent.adk.converters.event_converter import serialize_metadata_value
 
 
@@ -99,8 +109,7 @@ def test_skips_partial_and_empty_events():
 
 
 def test_counts_each_adk_event_once():
-    """One ADK event can be converted into several A2A events, and the
-    after-event interceptor runs for each of them."""
+    """An event reaching the accumulator more than once is counted once."""
     usage = TurnUsage()
     event = usage_event(10, 5, 15, None, partial=False, event_id="event-1")
 
@@ -163,6 +172,76 @@ def test_seed_from_task_ignores_missing_or_malformed():
     assert usage.empty()
 
 
+def test_derives_total_when_provider_reports_none():
+    """Anthropic reports input and output counts without a total."""
+    usage = TurnUsage()
+    usage.add(
+        Event(
+            author="agent",
+            partial=False,
+            usage_metadata=genai_types.GenerateContentResponseUsageMetadata(
+                prompt_token_count=100,
+                candidates_token_count=20,
+            ),
+        )
+    )
+
+    assert stamped_total(usage) == {
+        "promptTokenCount": 100,
+        "candidatesTokenCount": 20,
+        "totalTokenCount": 120,
+    }
+
+
+@pytest.mark.asyncio
+async def test_plugin_counts_events_that_produce_no_a2a_event():
+    """The event carrying the usage of the call that pauses a task has its
+    long-running function call stripped before conversion, so it produces no
+    A2A event and never reaches the after-event interceptor."""
+    usage = TurnUsage()
+    plugin = TurnUsagePlugin(usage)
+    paused = Event(
+        author="agent",
+        partial=False,
+        model_version="model-a",
+        content=genai_types.Content(
+            role="model",
+            parts=[genai_types.Part(function_call=genai_types.FunctionCall(id="call-1", name="delete_file"))],
+        ),
+        long_running_tool_ids={"call-1"},
+        usage_metadata=genai_types.GenerateContentResponseUsageMetadata(
+            prompt_token_count=10,
+            candidates_token_count=5,
+            total_token_count=15,
+        ),
+    )
+
+    stripped = LongRunningFunctions(None).process_event(paused)
+    assert convert_event_to_a2a_message(stripped) is None, "the stripped event must not convert to an A2A event"
+
+    assert await plugin.on_event_callback(invocation_context=None, event=paused) is None
+    assert stamped_total(usage) == {
+        "promptTokenCount": 10,
+        "candidatesTokenCount": 5,
+        "totalTokenCount": 15,
+        "modelVersion": "model-a",
+    }
+
+
+def test_attach_turn_usage_repoints_an_already_registered_plugin():
+    runner = InMemoryRunner(agent=BaseAgent(name="agent"), app_name="app")
+
+    first = TurnUsage()
+    attach_turn_usage(runner, first)
+    second = TurnUsage()
+    attach_turn_usage(runner, second)
+
+    plugin = runner.plugin_manager.get_plugin(TURN_USAGE_PLUGIN_NAME)
+    assert isinstance(plugin, TurnUsagePlugin)
+    assert plugin.usage is second
+    assert len([p for p in runner.plugin_manager.plugins if p.name == TURN_USAGE_PLUGIN_NAME]) == 1
+
+
 @pytest.mark.asyncio
 async def test_executor_stamps_total_on_terminal_status_update():
     message = Message(message_id="message-1", role=Role.ROLE_USER, parts=[Part(text="hi")])
@@ -181,8 +260,8 @@ async def test_executor_stamps_total_on_terminal_status_update():
 
     adk_event = usage_event(10, 5, 15, "model-a", partial=False, event_id="event-1")
     a2a_event = object()
-    for _ in range(2):
-        assert await executor._after_event(state, executor_context, a2a_event, adk_event) is a2a_event
+    await TurnUsagePlugin(state.usage).on_event_callback(invocation_context=None, event=adk_event)
+    assert await executor._after_event(state, executor_context, a2a_event, adk_event) is a2a_event
 
     terminal = TaskStatusUpdateEvent(
         task_id="task-1",
@@ -197,4 +276,36 @@ async def test_executor_stamps_total_on_terminal_status_update():
         "candidatesTokenCount": 25,
         "totalTokenCount": 135,
         "modelVersion": "model-a",
+    }
+
+
+@pytest.mark.asyncio
+async def test_failed_status_event_carries_the_total():
+    """Failures raised outside the upstream executor publish their own terminal
+    event, which must carry the total like every other terminal state."""
+    message = Message(message_id="message-1", role=Role.ROLE_USER, parts=[Part(text="hi")])
+    request_context = RequestContext(
+        ServerCallContext(state={}),
+        SendMessageRequest(message=message),
+        task_id="task-1",
+        context_id="context-1",
+    )
+    executor = A2aAgentExecutor(runner=lambda: None)
+    usage = TurnUsage()
+    usage.seed_from_task(task_with_total({"promptTokenCount": 100, "candidatesTokenCount": 20, "totalTokenCount": 120}))
+
+    published: list[TaskStatusUpdateEvent] = []
+
+    class _Queue:
+        async def enqueue_event(self, event):
+            published.append(event)
+
+    await executor._publish_failed_status_event(request_context, _Queue(), "boom", usage)
+
+    assert len(published) == 1
+    assert published[0].status.state == TaskState.TASK_STATE_FAILED
+    assert dict(published[0].metadata[USAGE_TOTAL_KEY].items()) == {
+        "promptTokenCount": 100,
+        "candidatesTokenCount": 20,
+        "totalTokenCount": 120,
     }

--- a/python/packages/kagent-adk/tests/unittests/test_turn_usage.py
+++ b/python/packages/kagent-adk/tests/unittests/test_turn_usage.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import pytest
+from a2a.server.agent_execution.context import RequestContext
+from a2a.server.context import ServerCallContext
+from a2a.types import (
+    Message,
+    Part,
+    Role,
+    SendMessageRequest,
+    Task,
+    TaskState,
+    TaskStatus,
+    TaskStatusUpdateEvent,
+)
+from google.adk.a2a.executor.executor_context import ExecutorContext
+from google.adk.events import Event
+from google.genai import types as genai_types
+
+from kagent.adk._agent_executor import A2aAgentExecutor, _ExecutionState
+from kagent.adk._turn_usage import USAGE_TOTAL_KEY, TurnUsage
+from kagent.adk.converters.event_converter import serialize_metadata_value
+
+
+def usage_event(
+    prompt: int,
+    completion: int,
+    total: int,
+    model_version: str | None,
+    partial: bool,
+    event_id: str | None = None,
+) -> Event:
+    event = Event(
+        author="agent",
+        partial=partial,
+        model_version=model_version,
+        usage_metadata=genai_types.GenerateContentResponseUsageMetadata(
+            prompt_token_count=prompt,
+            candidates_token_count=completion,
+            total_token_count=total,
+        ),
+    )
+    if event_id is not None:
+        event.id = event_id
+    return event
+
+
+def stamped_total(usage: TurnUsage) -> dict:
+    metadata: dict = {}
+    usage.stamp(metadata)
+    assert USAGE_TOTAL_KEY in metadata, "kagent_usage_total must be stamped"
+    return metadata[USAGE_TOTAL_KEY]
+
+
+def task_with_total(total) -> Task:
+    task = Task(
+        id="task-1",
+        context_id="ctx-1",
+        status=TaskStatus(state=TaskState.TASK_STATE_INPUT_REQUIRED),
+    )
+    task.metadata.update({USAGE_TOTAL_KEY: total})
+    return task
+
+
+def test_aggregates_non_partial_events():
+    usage = TurnUsage()
+    assert usage.empty()
+
+    usage.add(usage_event(100, 20, 120, "model-a", partial=False))
+    usage.add(usage_event(200, 30, 230, "model-b", partial=False))
+
+    assert not usage.empty()
+    assert stamped_total(usage) == {
+        "promptTokenCount": 300,
+        "candidatesTokenCount": 50,
+        "totalTokenCount": 350,
+        "modelVersion": "model-b",
+    }
+
+
+def test_skips_partial_and_empty_events():
+    usage = TurnUsage()
+
+    usage.add(None)
+    usage.add(Event(author="agent"))
+    usage.add(usage_event(999, 999, 999, "chunk-model", partial=True))
+
+    assert usage.empty()
+    metadata: dict = {}
+    usage.stamp(metadata)
+    assert USAGE_TOTAL_KEY not in metadata, "empty usage must not stamp the key"
+
+    usage.add(usage_event(10, 5, 15, None, partial=False))
+    assert stamped_total(usage) == {
+        "promptTokenCount": 10,
+        "candidatesTokenCount": 5,
+        "totalTokenCount": 15,
+    }, "modelVersion must be omitted when no event carried one"
+
+
+def test_counts_each_adk_event_once():
+    """One ADK event can be converted into several A2A events, and the
+    after-event interceptor runs for each of them."""
+    usage = TurnUsage()
+    event = usage_event(10, 5, 15, None, partial=False, event_id="event-1")
+
+    usage.add(event)
+    usage.add(event)
+
+    assert stamped_total(usage) == {
+        "promptTokenCount": 10,
+        "candidatesTokenCount": 5,
+        "totalTokenCount": 15,
+    }
+
+
+def test_shape_matches_per_event_usage_metadata():
+    event = usage_event(10, 5, 15, None, partial=False)
+
+    usage = TurnUsage()
+    usage.add(event)
+
+    assert stamped_total(usage) == serialize_metadata_value(event.usage_metadata), (
+        "kagent_usage_total must serialize identically to kagent_usage_metadata"
+    )
+
+
+def test_seed_from_task_accumulates_across_executions():
+    usage = TurnUsage()
+    usage.seed_from_task(
+        task_with_total(
+            {
+                "promptTokenCount": 100,
+                "candidatesTokenCount": 20,
+                "totalTokenCount": 120,
+                "modelVersion": "model-a",
+            }
+        )
+    )
+    usage.add(usage_event(200, 30, 230, None, partial=False))
+
+    assert stamped_total(usage) == {
+        "promptTokenCount": 300,
+        "candidatesTokenCount": 50,
+        "totalTokenCount": 350,
+        "modelVersion": "model-a",
+    }
+
+
+def test_seed_from_task_handles_float_counts():
+    usage = TurnUsage()
+    usage.seed_from_task(task_with_total({"promptTokenCount": 100.0, "totalTokenCount": 120.0}))
+
+    assert usage.prompt_tokens == 100
+    assert usage.total_tokens == 120
+
+
+def test_seed_from_task_ignores_missing_or_malformed():
+    usage = TurnUsage()
+    usage.seed_from_task(None)
+    usage.seed_from_task(Task(id="t", context_id="c", status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED)))
+    usage.seed_from_task(task_with_total("not-a-dict"))
+    assert usage.empty()
+
+
+@pytest.mark.asyncio
+async def test_executor_stamps_total_on_terminal_status_update():
+    message = Message(message_id="message-1", role=Role.ROLE_USER, parts=[Part(text="hi")])
+    request_context = RequestContext(
+        ServerCallContext(state={}),
+        SendMessageRequest(message=message),
+        task_id="task-1",
+        context_id="context-1",
+    )
+    executor = A2aAgentExecutor(runner=lambda: None)
+    state = _ExecutionState(request_context=request_context)
+    state.usage.seed_from_task(
+        task_with_total({"promptTokenCount": 100, "candidatesTokenCount": 20, "totalTokenCount": 120})
+    )
+    executor_context = ExecutorContext(app_name="app", user_id="user-1", session_id="context-1", runner=None)
+
+    adk_event = usage_event(10, 5, 15, "model-a", partial=False, event_id="event-1")
+    a2a_event = object()
+    for _ in range(2):
+        assert await executor._after_event(state, executor_context, a2a_event, adk_event) is a2a_event
+
+    terminal = TaskStatusUpdateEvent(
+        task_id="task-1",
+        context_id="context-1",
+        status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED),
+    )
+    await executor._after_agent(state, executor_context, terminal)
+
+    total = dict(terminal.metadata[USAGE_TOTAL_KEY].items())
+    assert total == {
+        "promptTokenCount": 110,
+        "candidatesTokenCount": 25,
+        "totalTokenCount": 135,
+        "modelVersion": "model-a",
+    }

--- a/python/packages/kagent-adk/tests/unittests/test_turn_usage.py
+++ b/python/packages/kagent-adk/tests/unittests/test_turn_usage.py
@@ -193,6 +193,58 @@ def test_derives_total_when_provider_reports_none():
     }
 
 
+def test_derives_total_per_call():
+    """A task mixing a call that reports a total with one that does not."""
+    usage = TurnUsage()
+    usage.add(usage_event(10, 5, 15, None, partial=False))
+    usage.add(
+        Event(
+            author="agent",
+            partial=False,
+            usage_metadata=genai_types.GenerateContentResponseUsageMetadata(
+                prompt_token_count=20,
+                candidates_token_count=7,
+            ),
+        )
+    )
+
+    assert stamped_total(usage) == {
+        "promptTokenCount": 30,
+        "candidatesTokenCount": 12,
+        "totalTokenCount": 42,
+    }
+
+
+def test_derived_total_grows_across_executions():
+    """A resumed task whose persisted total was itself derived."""
+    usage = TurnUsage()
+    usage.seed_from_task(
+        task_with_total(
+            {
+                "promptTokenCount": 100,
+                "candidatesTokenCount": 20,
+                "totalTokenCount": 120,
+            }
+        )
+    )
+    usage.add(
+        Event(
+            author="agent",
+            partial=False,
+            usage_metadata=genai_types.GenerateContentResponseUsageMetadata(
+                prompt_token_count=200,
+                candidates_token_count=30,
+            ),
+        )
+    )
+
+    assert stamped_total(usage) == {
+        "promptTokenCount": 300,
+        "candidatesTokenCount": 50,
+        "totalTokenCount": 350,
+    }
+
+
 @pytest.mark.asyncio
 async def test_plugin_counts_events_that_produce_no_a2a_event():
     """The event carrying the usage of the call that pauses a task has its


### PR DESCRIPTION
Supersedes #2332, which the stale bot closed and GitHub refuses to reopen. This is a reimplementation, not a rebase: both executors were rewritten to delegate to the ADK library's own A2A executor, so the manual event loop the original PR hooked into no longer exists.

## What this adds

Every terminal status update (`completed`, `input-required`, `failed`) carries a `kagent_usage_total` metadata entry with the token usage summed across the task:

```json
{
  "promptTokenCount": 300,
  "candidatesTokenCount": 50,
  "totalTokenCount": 350,
  "modelVersion": "gpt-4o-2024-11-20"
}
```

Partial (streaming chunk) events are skipped, since each LLM call reports its usage on the final non-partial event. Resumed tasks seed the accumulator from `Task.metadata`, so a task that spans several executions (HITL input-required cycles, follow-up messages) reports a task-lifetime total instead of the last segment only. The value is a running total re-emitted on each terminal update, so consumers take the latest value rather than summing across executions.

The value is serialized with the same genai `UsageMetadata` mapping as the existing per-event `adk_usage_metadata` / `kagent_usage_metadata` entries, plus `modelVersion`, so consumers can share one parser (with the caveat that `modelVersion` is not a field of the genai type). Tests in both languages assert that equality directly.

A call that reports no `totalTokenCount` gets one derived from `prompt + candidates + thoughts`, at the moment it is added rather than at the end. The Anthropic models report per-call input and output counts without a total, and a zero total next to non-zero counts reads as "no tokens were used". Deriving per call keeps the total correct for a task that mixes calls with and without a reported total, and for a resumed task whose persisted total was itself derived.

`a2a-go` and `a2a-python` both merge terminal status-update metadata into the stored task, which is how the total is persisted and how the next execution reads it back.

## How it differs from #2332

- Aggregation runs from an ADK runner plugin in both languages (`plugin.Config.OnEventCallback` in Go, `on_event_callback` in Python) instead of the A2A after-event callback. That callback only fires for ADK events the converter turns into at least one A2A event, and the event whose long-running function call is stripped before conversion produces none. That event carries the usage of the call that paused the task. The plugin sees every ADK event the runner produces, before conversion.
- Go stamps the aggregate from the new `AfterExecuteCallback` hook, which covers all three terminal states in one place.
- Test intent is ported rather than the test code; the Go tests now run end-to-end through the executor (including a full HITL pause/resume cycle) instead of unit-testing the accumulator in isolation.

## Known limits

- A cancelled task, or a client that disconnects mid-stream, does not reach the terminal status write, so the tokens of that in-flight execution are not added to the total. Earlier executions of the task keep theirs.
- `toolUsePromptTokenCount` is not aggregated. It is inside `totalTokenCount`, so the total stays correct, but the breakdown fields do not sum to it on Vertex.
- `modelVersion` is last-writer-wins over summed counts, so a task that uses more than one model reports a total that cannot be split back into per-model cost.

## Verification

- `go build ./...`, `go test ./adk/...`, `go vet`, `gofmt`
- `uv run pytest packages/kagent-adk/tests/unittests` (414 passed, 1 skipped)
