### PR TITLE
fix: decouple skills from the privileged sandbox and default to restricted PSS

### DIFF
--- a/go/core/internal/controller/translator/agent/manifest_builder.go
+++ b/go/core/internal/controller/translator/agent/manifest_builder.go
@@ -262,8 +262,12 @@ func buildPodRuntime(
 	volumes := append([]corev1.Volume{}, secretVolumes...)
 	volumeMounts := append([]corev1.VolumeMount{}, secretMounts...)
 
-	needCodeExecIsolation := false
-	initContainers, skillsInitCM, err := buildSkillsRuntime(manifestCtx, &sharedEnv, &volumes, &volumeMounts, &needCodeExecIsolation)
+	// The privileged in-pod srt sandbox has no opt-in on the agent API, so
+	// containers render the restricted Pod Security Standards defaults and are
+	// admitted on clusters enforcing the restricted profile.
+	const needCodeExecIsolation = false
+
+	initContainers, skillsInitCM, err := buildSkillsRuntime(manifestCtx, &sharedEnv, &volumes, &volumeMounts)
 	if err != nil {
 		return nil, err
 	}
@@ -352,7 +356,6 @@ func buildSkillsRuntime(
 	sharedEnv *[]corev1.EnvVar,
 	volumes *[]corev1.Volume,
 	volumeMounts *[]corev1.VolumeMount,
-	needCodeExecIsolation *bool,
 ) ([]corev1.Container, *corev1.ConfigMap, error) {
 	spec := manifestCtx.agent.GetAgentSpec()
 	if spec.Skills == nil {
@@ -366,7 +369,6 @@ func buildSkillsRuntime(
 		return nil, nil, nil
 	}
 
-	*needCodeExecIsolation = true
 	*sharedEnv = append(*sharedEnv, corev1.EnvVar{
 		Name:  env.KagentSkillsFolder.Name(),
 		Value: "/skills",
@@ -399,7 +401,7 @@ func buildSkillsRuntime(
 		spec.Skills.GitAuthSecretRef,
 		skills,
 		spec.Skills.InsecureSkipVerify,
-		nil,
+		buildContainerSecurityContext(nil, false),
 		initEnv,
 		getDefaultResources(initResources),
 		spec.Skills.ImagePullSecrets,
@@ -426,10 +428,26 @@ func buildContainerSecurityContext(
 	}
 
 	if !needCodeExecIsolation {
-		return nil
+		return restrictedSecurityContext()
 	}
 
 	return &corev1.SecurityContext{Privileged: new(true)}
+}
+
+// restrictedSecurityContext satisfies the Pod Security Standards "restricted"
+// profile, so agent containers are admitted on clusters enforcing it without a
+// per-agent override.
+func restrictedSecurityContext() *corev1.SecurityContext {
+	return &corev1.SecurityContext{
+		AllowPrivilegeEscalation: new(false),
+		RunAsNonRoot:             new(true),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
 }
 
 func buildPodTemplate(

--- a/go/core/internal/controller/translator/agent/security_context_test.go
+++ b/go/core/internal/controller/translator/agent/security_context_test.go
@@ -1,0 +1,95 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/kagent-dev/kagent/go/api/v1alpha3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func assertRestrictedSecurityContext(t *testing.T, securityContext *corev1.SecurityContext) {
+	t.Helper()
+	require.NotNil(t, securityContext)
+	require.NotNil(t, securityContext.AllowPrivilegeEscalation)
+	assert.False(t, *securityContext.AllowPrivilegeEscalation)
+	require.NotNil(t, securityContext.RunAsNonRoot)
+	assert.True(t, *securityContext.RunAsNonRoot)
+	require.NotNil(t, securityContext.Capabilities)
+	assert.Equal(t, []corev1.Capability{"ALL"}, securityContext.Capabilities.Drop)
+	require.NotNil(t, securityContext.SeccompProfile)
+	assert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, securityContext.SeccompProfile.Type)
+}
+
+func skillsPodRuntime(t *testing.T, agent *v1alpha3.SandboxAgent) *podRuntimeInputs {
+	t.Helper()
+	manifestCtx := newManifestContext(agent, &resolvedDeployment{Image: "example.com/kagent:test"})
+	runtimeInputs, err := buildPodRuntime(manifestCtx, nil, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, runtimeInputs)
+	return runtimeInputs
+}
+
+func TestSecurityContext_DefaultIsRestricted(t *testing.T) {
+	agent := &v1alpha3.SandboxAgent{
+		ObjectMeta: metav1.ObjectMeta{Name: "decl", Namespace: "default"},
+		Spec: v1alpha3.AgentSpec{
+			Type:        v1alpha3.AgentType_Declarative,
+			Declarative: &v1alpha3.DeclarativeAgentSpec{},
+		},
+	}
+
+	runtimeInputs := skillsPodRuntime(t, agent)
+
+	assert.Nil(t, runtimeInputs.securityContext.Privileged)
+	assertRestrictedSecurityContext(t, runtimeInputs.securityContext)
+}
+
+// TestSecurityContext_SkillsDefaultNotPrivileged pins that loading skills does
+// not by itself request the privileged in-pod srt sandbox: the skills-init
+// container clones and pulls skills without elevated privileges, and a
+// privileged agent container is rejected by restricted Pod Security admission.
+func TestSecurityContext_SkillsDefaultNotPrivileged(t *testing.T) {
+	agent := &v1alpha3.SandboxAgent{
+		ObjectMeta: metav1.ObjectMeta{Name: "skills", Namespace: "default"},
+		Spec: v1alpha3.AgentSpec{
+			Type:        v1alpha3.AgentType_Declarative,
+			Declarative: &v1alpha3.DeclarativeAgentSpec{},
+			Skills:      &v1alpha3.SkillForAgent{Refs: []string{"example.com/skill:latest"}},
+		},
+	}
+
+	runtimeInputs := skillsPodRuntime(t, agent)
+
+	assert.Nil(t, runtimeInputs.securityContext.Privileged)
+	assertRestrictedSecurityContext(t, runtimeInputs.securityContext)
+
+	require.Len(t, runtimeInputs.initContainers, 1)
+	initSecurityContext := runtimeInputs.initContainers[0].SecurityContext
+	assert.Nil(t, initSecurityContext.Privileged)
+	assertRestrictedSecurityContext(t, initSecurityContext)
+}
+
+func TestBuildContainerSecurityContext_CodeExecIsolationKeepsPrivileged(t *testing.T) {
+	securityContext := buildContainerSecurityContext(nil, true)
+
+	require.NotNil(t, securityContext)
+	require.NotNil(t, securityContext.Privileged)
+	assert.True(t, *securityContext.Privileged)
+}
+
+func TestBuildContainerSecurityContext_BaseIsPreserved(t *testing.T) {
+	base := &corev1.SecurityContext{
+		AllowPrivilegeEscalation: new(false),
+		ReadOnlyRootFilesystem:   new(true),
+	}
+
+	securityContext := buildContainerSecurityContext(base, true)
+
+	require.NotNil(t, securityContext)
+	assert.Nil(t, securityContext.Privileged, "an explicit allowPrivilegeEscalation=false suppresses Privileged")
+	require.NotNil(t, securityContext.ReadOnlyRootFilesystem)
+	assert.True(t, *securityContext.ReadOnlyRootFilesystem)
+}

--- a/python/Dockerfile.full
+++ b/python/Dockerfile.full
@@ -70,7 +70,8 @@ RUN --mount=type=cache,target=/root/.npm \
 
 ENV PATH="/opt/sandbox-runtime/node_modules/.bin:$PATH"
 
-USER python
+# Numeric USER so kubelet can verify runAsNonRoot without an explicit runAsUser.
+USER 1001:1001
 WORKDIR /.kagent
 
 ### STAGE 3: final (install project)


### PR DESCRIPTION
Supersedes #2334, which the stale bot closed and GitHub refuses to reopen. Reimplemented against `v1alpha3.SandboxAgent` after #2422 removed the deployment-backed agent API. Fixes #1997 and #2244, both re-verified against current `main` rather than taken from the issue text.

## What changes

- `buildSkillsRuntime` no longer sets `needCodeExecIsolation = true` whenever `spec.skills` is configured. Loading skills needs no elevated privileges: the `skills-init` init container does the git clone and image pull, and the privileged container only exists for the in-pod srt/bubblewrap sandbox.
- `buildContainerSecurityContext` returns a restricted-PSS-compliant default (`allowPrivilegeEscalation: false`, `runAsNonRoot: true`, `capabilities.drop: [ALL]`, `seccompProfile: RuntimeDefault`) instead of `nil` when no isolation is requested. The `skills-init` container gets the same defaults.
- `python/Dockerfile.full` uses a numeric `USER 1001:1001` so the kubelet can verify `runAsNonRoot` without an explicit `runAsUser`. The other three runtime images already use numeric users.

Without this, agent pods render with no container securityContext at all and are rejected outright on clusters enforcing `restricted` Pod Security admission.

## How it differs from #2334

The original PR seeded `needCodeExecIsolation` from the `declarative.executeCodeBlocks` opt-in and left the workaround from #1997 (`allowPrivilegeEscalation: false` on the agent CR) as the escape hatch. Neither exists anymore: `executeCodeBlocks` is gone from the API, and `v1alpha3.SandboxAgent` has no user-supplied `securityContext`, so `buildContainerSecurityContext` is always called with a `nil` base. On current `main` the only thing that can request a privileged container is `spec.skills`, and that is itself rejected by CEL on `SandboxAgent` — so restricted clusters have the bug with no way out.

I kept the `needCodeExecIsolation` parameter and the privileged branch of `buildContainerSecurityContext` rather than deleting them, since they are the seam an explicit sandbox opt-in would use when skills return to `SandboxAgent`. They are unreachable today; happy to delete them instead if you prefer.

## Verification

- `go build ./core/...`, `go test ./core/...` (1289 passed), `go vet`, `golangci-lint`
- New `security_context_test.go` covers the restricted default, the skills path, and the privileged branch. No other test in the package asserted the old `nil` default.