### PR TITLE
fix(go-adk): surface the sub-agent's ask_user question in RemoteHitlHint

### DIFF
--- a/go/adk/pkg/a2a/hitl.go
+++ b/go/adk/pkg/a2a/hitl.go
@@ -361,10 +361,7 @@ func VisibleTools(approval *ToolApprovalRequest, ask *AskUserRequest) []HitlTool
 	return nil
 }
 
-// askUserQuestionText extracts the human-readable question text(s) from an
-// ask_user request's typed Questions field, or "" if none carry text. This is
-// the content RemoteHitlHint would otherwise discard, surfacing only the
-// tool name ("ask_user") instead of what is actually being asked.
+// askUserQuestionText joins the question text from a typed Questions field, or "" if none carry text.
 func askUserQuestionText(questions []map[string]any) string {
 	texts := make([]string, 0, len(questions))
 	for _, q := range questions {
@@ -379,12 +376,8 @@ func RemoteHitlHint(state *RemoteHitlState) string {
 	if state == nil {
 		return "Remote agent requires human input before continuing."
 	}
-	// AskUserRequest.Questions carries the real question text whether or not
-	// Nested is set (see BuildHITLStatusMessage), so read it directly rather
-	// than re-deriving from VisibleTools()'s nested HitlTool.Args: those args
-	// round-trip through JSON into a plain map[string]any, which decodes
-	// "questions" as []any rather than []map[string]any, silently losing the
-	// question in the nested case.
+	// Read Questions directly: VisibleTools()'s nested Args round-trip through
+	// JSON to []any, silently losing the question text in the nested case.
 	if state.AskUserRequest != nil {
 		if q := askUserQuestionText(state.AskUserRequest.Questions); q != "" {
 			return fmt.Sprintf("Remote agent '%s' asks: %s", state.SubagentName, q)

--- a/go/adk/pkg/a2a/hitl.go
+++ b/go/adk/pkg/a2a/hitl.go
@@ -362,14 +362,12 @@ func VisibleTools(approval *ToolApprovalRequest, ask *AskUserRequest) []HitlTool
 }
 
 // askUserQuestionText extracts the human-readable question text(s) from an
-// ask_user HitlTool's args (see VisibleTools), or "" if the shape is
-// unexpected. This is the content RemoteHitlHint would otherwise discard,
-// surfacing only the tool name ("ask_user") instead of what is actually
-// being asked.
-func askUserQuestionText(args map[string]any) string {
-	raw, _ := args["questions"].([]map[string]any)
-	texts := make([]string, 0, len(raw))
-	for _, q := range raw {
+// ask_user request's typed Questions field, or "" if none carry text. This is
+// the content RemoteHitlHint would otherwise discard, surfacing only the
+// tool name ("ask_user") instead of what is actually being asked.
+func askUserQuestionText(questions []map[string]any) string {
+	texts := make([]string, 0, len(questions))
+	for _, q := range questions {
 		if text, ok := q["question"].(string); ok && text != "" {
 			texts = append(texts, text)
 		}
@@ -381,25 +379,23 @@ func RemoteHitlHint(state *RemoteHitlState) string {
 	if state == nil {
 		return "Remote agent requires human input before continuing."
 	}
-	tools := VisibleTools(state.ToolApprovalRequest, state.AskUserRequest)
-	names := make([]string, 0, len(tools))
-	questions := make([]string, 0, len(tools))
-	for _, tool := range tools {
-		if tool.Name == "" {
-			continue
-		}
-		names = append(names, tool.Name)
-		if tool.Name == "ask_user" {
-			if q := askUserQuestionText(tool.Args); q != "" {
-				questions = append(questions, q)
-			}
+	// AskUserRequest.Questions carries the real question text whether or not
+	// Nested is set (see BuildHITLStatusMessage), so read it directly rather
+	// than re-deriving from VisibleTools()'s nested HitlTool.Args: those args
+	// round-trip through JSON into a plain map[string]any, which decodes
+	// "questions" as []any rather than []map[string]any, silently losing the
+	// question in the nested case.
+	if state.AskUserRequest != nil {
+		if q := askUserQuestionText(state.AskUserRequest.Questions); q != "" {
+			return fmt.Sprintf("Remote agent '%s' asks: %s", state.SubagentName, q)
 		}
 	}
-	// A real ask_user question is more useful to the human than the bare
-	// tool name — surface it directly rather than "requires approval for
-	// tool(s): ask_user", which carries no actionable information.
-	if len(questions) > 0 {
-		return fmt.Sprintf("Remote agent '%s' asks: %s", state.SubagentName, strings.Join(questions, " "))
+	tools := VisibleTools(state.ToolApprovalRequest, state.AskUserRequest)
+	names := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		if tool.Name != "" {
+			names = append(names, tool.Name)
+		}
 	}
 	if len(names) > 0 {
 		return fmt.Sprintf("Remote agent '%s' requires approval for tool(s): %s",

--- a/go/adk/pkg/a2a/hitl.go
+++ b/go/adk/pkg/a2a/hitl.go
@@ -361,16 +361,45 @@ func VisibleTools(approval *ToolApprovalRequest, ask *AskUserRequest) []HitlTool
 	return nil
 }
 
+// askUserQuestionText extracts the human-readable question text(s) from an
+// ask_user HitlTool's args (see VisibleTools), or "" if the shape is
+// unexpected. This is the content RemoteHitlHint would otherwise discard,
+// surfacing only the tool name ("ask_user") instead of what is actually
+// being asked.
+func askUserQuestionText(args map[string]any) string {
+	raw, _ := args["questions"].([]map[string]any)
+	texts := make([]string, 0, len(raw))
+	for _, q := range raw {
+		if text, ok := q["question"].(string); ok && text != "" {
+			texts = append(texts, text)
+		}
+	}
+	return strings.Join(texts, " ")
+}
+
 func RemoteHitlHint(state *RemoteHitlState) string {
 	if state == nil {
 		return "Remote agent requires human input before continuing."
 	}
 	tools := VisibleTools(state.ToolApprovalRequest, state.AskUserRequest)
 	names := make([]string, 0, len(tools))
+	questions := make([]string, 0, len(tools))
 	for _, tool := range tools {
-		if tool.Name != "" {
-			names = append(names, tool.Name)
+		if tool.Name == "" {
+			continue
 		}
+		names = append(names, tool.Name)
+		if tool.Name == "ask_user" {
+			if q := askUserQuestionText(tool.Args); q != "" {
+				questions = append(questions, q)
+			}
+		}
+	}
+	// A real ask_user question is more useful to the human than the bare
+	// tool name — surface it directly rather than "requires approval for
+	// tool(s): ask_user", which carries no actionable information.
+	if len(questions) > 0 {
+		return fmt.Sprintf("Remote agent '%s' asks: %s", state.SubagentName, strings.Join(questions, " "))
 	}
 	if len(names) > 0 {
 		return fmt.Sprintf("Remote agent '%s' requires approval for tool(s): %s",

--- a/go/adk/pkg/a2a/hitl_test.go
+++ b/go/adk/pkg/a2a/hitl_test.go
@@ -260,3 +260,29 @@ func TestBuildRemoteHitlStateAndHint(t *testing.T) {
 		t.Fatalf("hint = %q", got)
 	}
 }
+
+// A sub-agent's ask_user pause should surface the actual question in the
+// hint, not just "requires approval for tool(s): ask_user" — a human can't
+// act on a tool name alone.
+func TestBuildRemoteHitlStateAndHintAskUser(t *testing.T) {
+	task := &a2atype.Task{
+		ID: "child-task", ContextID: "child-context",
+		Status: a2atype.TaskStatus{
+			Message: AttachHitlExtension(a2atype.NewMessage(a2atype.MessageRoleAgent, a2atype.NewTextPart("pause")), &AskUserRequest{
+				Type: HITLTypeAskUserRequest,
+				ID:   "confirm-1",
+				Questions: []map[string]any{
+					{"question": "What is the GitHub owner/org for the repo?"},
+				},
+			}),
+		},
+	}
+	state := BuildRemoteHitlState(task, "github_agent")
+	if state == nil || state.AskUserRequest == nil {
+		t.Fatalf("state = %#v", state)
+	}
+	want := "Remote agent 'github_agent' asks: What is the GitHub owner/org for the repo?"
+	if got := RemoteHitlHint(state); got != want {
+		t.Fatalf("hint = %q, want %q", got, want)
+	}
+}

--- a/go/adk/pkg/a2a/hitl_test.go
+++ b/go/adk/pkg/a2a/hitl_test.go
@@ -286,3 +286,40 @@ func TestBuildRemoteHitlStateAndHintAskUser(t *testing.T) {
 		t.Fatalf("hint = %q, want %q", got, want)
 	}
 }
+
+// A two-level nested ask_user pause (grandchild agent, relayed through the
+// child) should also surface the real question. The nested HitlTool's Args
+// round-trip through JSON into a plain map[string]any, decoding "questions"
+// as []any rather than []map[string]any — the hint must read
+// AskUserRequest.Questions directly instead of re-deriving from those args.
+func TestBuildRemoteHitlStateAndHintAskUserNested(t *testing.T) {
+	question := "What is the GitHub owner/org for the repo?"
+	task := &a2atype.Task{
+		ID: "child-task", ContextID: "child-context",
+		Status: a2atype.TaskStatus{
+			Message: AttachHitlExtension(a2atype.NewMessage(a2atype.MessageRoleAgent, a2atype.NewTextPart("pause")), &AskUserRequest{
+				Type:      HITLTypeAskUserRequest,
+				ID:        "confirm-1",
+				Questions: []map[string]any{{"question": question}},
+				Nested: &NestedHitlRequest{
+					TaskID: "grandchild-task", ContextID: "grandchild-context", SubagentName: "grandchild_agent",
+					Tools: []HitlTool{{
+						ID: "confirm-2", CallID: "confirm-2", Name: "ask_user",
+						Args: map[string]any{"questions": []map[string]any{{"question": question}}},
+					}},
+				},
+			}),
+		},
+	}
+	state := BuildRemoteHitlState(task, "github_agent")
+	if state == nil || state.AskUserRequest == nil || state.AskUserRequest.Nested == nil {
+		t.Fatalf("state = %#v", state)
+	}
+	if _, ok := state.AskUserRequest.Nested.Tools[0].Args["questions"].([]map[string]any); ok {
+		t.Fatalf("nested tool args decoded as []map[string]any; test no longer exercises the []any round-trip shape")
+	}
+	want := "Remote agent 'github_agent' asks: " + question
+	if got := RemoteHitlHint(state); got != want {
+		t.Fatalf("hint = %q, want %q", got, want)
+	}
+}

--- a/go/adk/pkg/a2a/hitl_test.go
+++ b/go/adk/pkg/a2a/hitl_test.go
@@ -261,9 +261,7 @@ func TestBuildRemoteHitlStateAndHint(t *testing.T) {
 	}
 }
 
-// A sub-agent's ask_user pause should surface the actual question in the
-// hint, not just "requires approval for tool(s): ask_user" — a human can't
-// act on a tool name alone.
+// A sub-agent's ask_user pause should surface the question, not just the tool name.
 func TestBuildRemoteHitlStateAndHintAskUser(t *testing.T) {
 	task := &a2atype.Task{
 		ID: "child-task", ContextID: "child-context",
@@ -287,11 +285,8 @@ func TestBuildRemoteHitlStateAndHintAskUser(t *testing.T) {
 	}
 }
 
-// A two-level nested ask_user pause (grandchild agent, relayed through the
-// child) should also surface the real question. The nested HitlTool's Args
-// round-trip through JSON into a plain map[string]any, decoding "questions"
-// as []any rather than []map[string]any — the hint must read
-// AskUserRequest.Questions directly instead of re-deriving from those args.
+// A two-level nested ask_user pause should also surface the question, since
+// the nested HitlTool's Args round-trip through JSON and lose their type.
 func TestBuildRemoteHitlStateAndHintAskUserNested(t *testing.T) {
 	question := "What is the GitHub owner/org for the repo?"
 	task := &a2atype.Task{


### PR DESCRIPTION
## Summary

`RemoteHitlHint()` builds the hint text shown to a human when a sub-agent's own HITL pause bubbles up to the parent agent. Today it only lists the paused tool's *name* (e.g. `ask_user`) — never the actual question — even though `AskUserRequest.Questions` (already threaded through `VisibleTools()` into `HitlTool.Args["questions"]`) has the real content right there.

- Before: `"Remote agent 'github_agent' requires approval for tool(s): ask_user"`
- After: `"Remote agent 'github_agent' asks: What is the GitHub owner/org for the repo?"`

Real tool-approval hints (the non-`ask_user` case) are unaffected — same wording as before, existing `TestBuildRemoteHitlStateAndHint` still passes unchanged.

Discovered while building an external A2A chat bridge that correctly renders every other kagent HITL flow (direct tool approval, direct `ask_user`) from the same session — this was the one case where the confirmation card reaching a downstream A2A client carried no actionable information, because the hint itself never had it. Confirmed by inspecting the sub-agent's own ADK session directly (`GET /api/sessions/<id>`), where the real question is visible in `adk_request_confirmation` — it's just discarded before reaching `RemoteHitlHint`.

Fixes #2473

## Changes

- `go/adk/pkg/a2a/hitl.go`: new `askUserQuestionText()` helper extracts question text from an `ask_user` `HitlTool`'s args; `RemoteHitlHint()` uses it when present, falling back to the existing tool-name-only wording otherwise.
- `go/adk/pkg/a2a/hitl_test.go`: new `TestBuildRemoteHitlStateAndHintAskUser` covering the fixed behavior.

## Test plan

- [x] `go build ./adk/...` — clean
- [x] `go test ./adk/...` — all packages pass (a2a, agent, app, tools, etc.)
- [x] `gofmt -l` / `go vet ./adk/pkg/a2a/...` — clean
- [x] Existing `TestBuildRemoteHitlStateAndHint` (tool-approval case) passes unchanged