### PR TITLE
feat: extend the AgentInstance A2A gateway

### DIFF
--- a/go/api/database/models.go
+++ b/go/api/database/models.go
@@ -261,6 +261,7 @@ type RuntimeRevision struct {
 	HarnessName            string
 	HarnessUID             string
 	SourceSnapshot         json.RawMessage
+	AgentCard              json.RawMessage
 	EgressDestinations     []string
 	ActorTemplateNamespace string
 	ActorTemplateName      string

--- a/go/core/cmd/controller-v2/main.go
+++ b/go/core/cmd/controller-v2/main.go
@@ -122,7 +122,7 @@ func main() {
 		SessionService:       sessionservice.NewService(store),
 		TaskService:          taskservice.NewService(store),
 		AgentInstanceService: instances,
-		A2AHandler:           a2agateway.New(store, authorizer, gatewayDialer),
+		A2AHandler:           a2agateway.New(store, authorizer, gatewayDialer, env("A2A_GATEWAY_URL", "http://127.0.0.1:8084")),
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/go/core/internal/database/client_agent_instance_test.go
+++ b/go/core/internal/database/client_agent_instance_test.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -156,12 +157,20 @@ func TestAgentInstanceCreateAndTransitions(t *testing.T) {
 		Revision: "revision-1", Namespace: "team-a",
 		AgentTemplateName: "assistant", AgentTemplateUID: "template-uid",
 		HarnessName: "kagent", HarnessUID: "harness-uid",
-		SourceSnapshot: []byte("{}"), EgressDestinations: []string{},
+		SourceSnapshot: []byte("{}"), AgentCard: []byte(`{"name":"assistant"}`), EgressDestinations: []string{},
 		ActorTemplateNamespace: "team-a", ActorTemplateName: "assistant-kagent-revision",
 		ActorTemplateUID: "actor-template-uid", Phase: "Ready",
 	}
 	if err := client.UpsertRuntimeRevision(ctx, revision); err != nil {
 		t.Fatal(err)
+	}
+	storedRevision, err := client.GetRuntimeRevision(ctx, revision.Revision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var storedCard map[string]string
+	if err := json.Unmarshal(storedRevision.AgentCard, &storedCard); err != nil || storedCard["name"] != "assistant" {
+		t.Fatalf("GetRuntimeRevision() Agent Card = %s: %v", storedRevision.AgentCard, err)
 	}
 	pair := dbpkg.AgentTemplateHarnessPair{
 		Namespace: "team-a", AgentTemplateName: "assistant", AgentTemplateUID: "template-uid",

--- a/go/core/internal/database/client_postgres.go
+++ b/go/core/internal/database/client_postgres.go
@@ -383,7 +383,8 @@ func (c *postgresClient) UpsertRuntimeRevision(ctx context.Context, revision dbp
 		Revision: revision.Revision, Namespace: revision.Namespace,
 		AgentTemplateName: revision.AgentTemplateName, AgentTemplateUid: revision.AgentTemplateUID,
 		HarnessName: revision.HarnessName, HarnessUid: revision.HarnessUID,
-		SourceSnapshot: revision.SourceSnapshot, EgressDestinations: revision.EgressDestinations,
+		SourceSnapshot: revision.SourceSnapshot, AgentCard: revision.AgentCard,
+		EgressDestinations:     revision.EgressDestinations,
 		ActorTemplateNamespace: revision.ActorTemplateNamespace, ActorTemplateName: revision.ActorTemplateName,
 		ActorTemplateUid: revision.ActorTemplateUID, Phase: revision.Phase, GoldenSnapshot: revision.GoldenSnapshot,
 	}); err != nil {
@@ -401,7 +402,8 @@ func (c *postgresClient) GetRuntimeRevision(ctx context.Context, revision string
 		Revision: row.Revision, Namespace: row.Namespace,
 		AgentTemplateName: row.AgentTemplateName, AgentTemplateUID: row.AgentTemplateUid,
 		HarnessName: row.HarnessName, HarnessUID: row.HarnessUid,
-		SourceSnapshot: row.SourceSnapshot, EgressDestinations: row.EgressDestinations,
+		SourceSnapshot: row.SourceSnapshot, AgentCard: row.AgentCard,
+		EgressDestinations:     row.EgressDestinations,
 		ActorTemplateNamespace: row.ActorTemplateNamespace, ActorTemplateName: row.ActorTemplateName,
 		ActorTemplateUID: row.ActorTemplateUid, Phase: row.Phase, GoldenSnapshot: row.GoldenSnapshot,
 	}, nil
@@ -440,7 +442,8 @@ func (c *postgresClient) ListUnreferencedRuntimeRevisions(ctx context.Context) (
 			Revision: row.Revision, Namespace: row.Namespace,
 			AgentTemplateName: row.AgentTemplateName, AgentTemplateUID: row.AgentTemplateUid,
 			HarnessName: row.HarnessName, HarnessUID: row.HarnessUid,
-			SourceSnapshot: row.SourceSnapshot, EgressDestinations: row.EgressDestinations,
+			SourceSnapshot: row.SourceSnapshot, AgentCard: row.AgentCard,
+			EgressDestinations:     row.EgressDestinations,
 			ActorTemplateNamespace: row.ActorTemplateNamespace, ActorTemplateName: row.ActorTemplateName,
 			ActorTemplateUID: row.ActorTemplateUid, Phase: row.Phase, GoldenSnapshot: row.GoldenSnapshot,
 		})

--- a/go/core/internal/database/gen/agent_instances.sql.go
+++ b/go/core/internal/database/gen/agent_instances.sql.go
@@ -155,7 +155,7 @@ func (q *Queries) GetAgentInstanceForUser(ctx context.Context, arg GetAgentInsta
 }
 
 const getLatestRuntimeRevisionForInstance = `-- name: GetLatestRuntimeRevisionForInstance :one
-SELECT r.revision, r.namespace, r.agent_template_name, r.agent_template_uid, r.harness_name, r.harness_uid, r.source_snapshot, r.egress_destinations, r.actor_template_namespace, r.actor_template_name, r.actor_template_uid, r.phase, r.golden_snapshot, r.created_at, r.updated_at, p.agent_template_labels
+SELECT r.revision, r.namespace, r.agent_template_name, r.agent_template_uid, r.harness_name, r.harness_uid, r.source_snapshot, r.egress_destinations, r.actor_template_namespace, r.actor_template_name, r.actor_template_uid, r.phase, r.golden_snapshot, r.created_at, r.updated_at, r.agent_card, p.agent_template_labels
 FROM agent_template_harness_pair p
 JOIN runtime_revision r ON r.revision = p.latest_successful_revision
 WHERE p.namespace = $1
@@ -186,6 +186,7 @@ type GetLatestRuntimeRevisionForInstanceRow struct {
 	GoldenSnapshot         string
 	CreatedAt              time.Time
 	UpdatedAt              time.Time
+	AgentCard              []byte
 	AgentTemplateLabels    []byte
 }
 
@@ -208,6 +209,7 @@ func (q *Queries) GetLatestRuntimeRevisionForInstance(ctx context.Context, arg G
 		&i.GoldenSnapshot,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.AgentCard,
 		&i.AgentTemplateLabels,
 	)
 	return i, err

--- a/go/core/internal/database/gen/models.go
+++ b/go/core/internal/database/gen/models.go
@@ -188,6 +188,7 @@ type RuntimeRevision struct {
 	GoldenSnapshot         string
 	CreatedAt              time.Time
 	UpdatedAt              time.Time
+	AgentCard              []byte
 }
 
 type Session struct {

--- a/go/core/internal/database/gen/runtime_revisions.sql.go
+++ b/go/core/internal/database/gen/runtime_revisions.sql.go
@@ -28,7 +28,7 @@ func (q *Queries) DeleteUnreferencedRuntimeRevision(ctx context.Context, revisio
 }
 
 const getRuntimeRevision = `-- name: GetRuntimeRevision :one
-SELECT revision, namespace, agent_template_name, agent_template_uid, harness_name, harness_uid, source_snapshot, egress_destinations, actor_template_namespace, actor_template_name, actor_template_uid, phase, golden_snapshot, created_at, updated_at FROM runtime_revision WHERE revision = $1
+SELECT revision, namespace, agent_template_name, agent_template_uid, harness_name, harness_uid, source_snapshot, egress_destinations, actor_template_namespace, actor_template_name, actor_template_uid, phase, golden_snapshot, created_at, updated_at, agent_card FROM runtime_revision WHERE revision = $1
 `
 
 func (q *Queries) GetRuntimeRevision(ctx context.Context, revision string) (RuntimeRevision, error) {
@@ -50,12 +50,13 @@ func (q *Queries) GetRuntimeRevision(ctx context.Context, revision string) (Runt
 		&i.GoldenSnapshot,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.AgentCard,
 	)
 	return i, err
 }
 
 const listUnreferencedRuntimeRevisions = `-- name: ListUnreferencedRuntimeRevisions :many
-SELECT revision, namespace, agent_template_name, agent_template_uid, harness_name, harness_uid, source_snapshot, egress_destinations, actor_template_namespace, actor_template_name, actor_template_uid, phase, golden_snapshot, created_at, updated_at FROM runtime_revision r
+SELECT revision, namespace, agent_template_name, agent_template_uid, harness_name, harness_uid, source_snapshot, egress_destinations, actor_template_namespace, actor_template_name, actor_template_uid, phase, golden_snapshot, created_at, updated_at, agent_card FROM runtime_revision r
 WHERE NOT EXISTS (
     SELECT 1 FROM agent_template_harness_pair p
     WHERE p.retired_at IS NULL
@@ -91,6 +92,7 @@ func (q *Queries) ListUnreferencedRuntimeRevisions(ctx context.Context) ([]Runti
 			&i.GoldenSnapshot,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.AgentCard,
 		); err != nil {
 			return nil, err
 		}
@@ -221,14 +223,15 @@ func (q *Queries) UpsertAgentTemplateHarnessPair(ctx context.Context, arg Upsert
 const upsertRuntimeRevision = `-- name: UpsertRuntimeRevision :exec
 INSERT INTO runtime_revision (
     revision, namespace, agent_template_name, agent_template_uid,
-    harness_name, harness_uid, source_snapshot, egress_destinations,
+    harness_name, harness_uid, source_snapshot, agent_card, egress_destinations,
     actor_template_namespace, actor_template_name, actor_template_uid,
     phase, golden_snapshot
 ) VALUES (
     $1, $2, $3, $4, $5, $6, $7, $8,
-    $9, $10, $11, $12, $13
+    $9, $10, $11, $12, $13, $14
 )
 ON CONFLICT (revision) DO UPDATE SET
+    agent_card = EXCLUDED.agent_card,
     actor_template_uid = EXCLUDED.actor_template_uid,
     phase = EXCLUDED.phase,
     golden_snapshot = EXCLUDED.golden_snapshot,
@@ -243,6 +246,7 @@ type UpsertRuntimeRevisionParams struct {
 	HarnessName            string
 	HarnessUid             string
 	SourceSnapshot         []byte
+	AgentCard              []byte
 	EgressDestinations     []string
 	ActorTemplateNamespace string
 	ActorTemplateName      string
@@ -260,6 +264,7 @@ func (q *Queries) UpsertRuntimeRevision(ctx context.Context, arg UpsertRuntimeRe
 		arg.HarnessName,
 		arg.HarnessUid,
 		arg.SourceSnapshot,
+		arg.AgentCard,
 		arg.EgressDestinations,
 		arg.ActorTemplateNamespace,
 		arg.ActorTemplateName,

--- a/go/core/internal/database/queries/runtime_revisions.sql
+++ b/go/core/internal/database/queries/runtime_revisions.sql
@@ -14,14 +14,15 @@ ON CONFLICT (namespace, agent_template_uid, harness_uid) DO UPDATE SET
 -- name: UpsertRuntimeRevision :exec
 INSERT INTO runtime_revision (
     revision, namespace, agent_template_name, agent_template_uid,
-    harness_name, harness_uid, source_snapshot, egress_destinations,
+    harness_name, harness_uid, source_snapshot, agent_card, egress_destinations,
     actor_template_namespace, actor_template_name, actor_template_uid,
     phase, golden_snapshot
 ) VALUES (
     $1, $2, $3, $4, $5, $6, $7, $8,
-    $9, $10, $11, $12, $13
+    $9, $10, $11, $12, $13, $14
 )
 ON CONFLICT (revision) DO UPDATE SET
+    agent_card = EXCLUDED.agent_card,
     actor_template_uid = EXCLUDED.actor_template_uid,
     phase = EXCLUDED.phase,
     golden_snapshot = EXCLUDED.golden_snapshot,

--- a/go/core/pkg/migrations/core/000013_runtime_revision_agent_card.down.sql
+++ b/go/core/pkg/migrations/core/000013_runtime_revision_agent_card.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE runtime_revision
+    DROP COLUMN IF EXISTS agent_card;

--- a/go/core/pkg/migrations/core/000013_runtime_revision_agent_card.up.sql
+++ b/go/core/pkg/migrations/core/000013_runtime_revision_agent_card.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE runtime_revision
+    ADD COLUMN IF NOT EXISTS agent_card JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+ALTER TABLE runtime_revision
+    ALTER COLUMN agent_card DROP DEFAULT;

--- a/go/core/v2/a2agateway/gateway.go
+++ b/go/core/v2/a2agateway/gateway.go
@@ -98,19 +98,6 @@ func (g *Gateway) instance(ctx context.Context, verb auth.Verb) (*apiv1alpha1.Ag
 	return instance, nil
 }
 
-func (g *Gateway) runtime(ctx context.Context, verb auth.Verb) (*a2aclient.Client, error) {
-	instance, err := g.instance(ctx, verb)
-	if err != nil {
-		return nil, err
-	}
-	client, err := g.dialer.Dial(ctx, instance)
-	if err != nil {
-		ctrllog.FromContext(ctx).Error(err, "failed to connect to AgentInstance runtime", "namespace", instance.GetNamespace(), "id", instance.GetId())
-		return nil, a2atype.NewError(a2atype.ErrInternalError, "failed to connect to AgentInstance runtime")
-	}
-	return client, nil
-}
-
 func route(ctx context.Context) (namespace, id string, err error) {
 	namespaces := metadata.ValueFromIncomingContext(ctx, AgentInstanceNamespaceHeader)
 	ids := metadata.ValueFromIncomingContext(ctx, AgentInstanceIDHeader)
@@ -185,12 +172,38 @@ func (g *Gateway) ListTasks(ctx context.Context, req *a2atype.ListTasksRequest) 
 }
 
 func (g *Gateway) CancelTask(ctx context.Context, req *a2atype.CancelTaskRequest) (*a2atype.Task, error) {
-	client, err := g.runtime(ctx, auth.VerbUpdate)
+	instance, err := g.instance(ctx, auth.VerbUpdate)
 	if err != nil {
 		return nil, err
 	}
+	if req == nil || req.ID == "" {
+		return nil, a2atype.NewError(a2atype.ErrInvalidRequest, "task ID is required")
+	}
+	task, err := g.store.GetAgentInstanceTask(ctx, instance.GetId(), string(req.ID))
+	if errors.Is(err, dbpkg.ErrNotFound) {
+		return nil, a2atype.ErrTaskNotFound
+	}
+	if err != nil {
+		ctrllog.FromContext(ctx).Error(err, "failed to load AgentInstance task", "task", req.ID)
+		return nil, a2atype.NewError(a2atype.ErrInternalError, "failed to load task")
+	}
+	client, err := g.dialer.Dial(ctx, instance)
+	if err != nil {
+		ctrllog.FromContext(ctx).Error(err, "failed to connect to AgentInstance runtime", "instance", instance.GetId())
+		return nil, a2atype.NewError(a2atype.ErrInternalError, "failed to connect to AgentInstance runtime")
+	}
 	defer client.Destroy()
-	return client.CancelTask(ctx, req)
+	canceled, err := client.CancelTask(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateTaskInfo(canceled, task); err != nil {
+		return nil, a2atype.NewError(a2atype.ErrInternalError, err.Error())
+	}
+	if err := g.store.StoreAgentInstanceTaskEvent(ctx, instance.GetId(), canceled, canceled); err != nil {
+		return nil, g.storeError(ctx, err)
+	}
+	return canceled, nil
 }
 
 func (g *Gateway) SendMessage(ctx context.Context, req *a2atype.SendMessageRequest) (a2atype.SendMessageResult, error) {
@@ -226,11 +239,50 @@ func (g *Gateway) SendMessage(ctx context.Context, req *a2atype.SendMessageReque
 }
 
 func (g *Gateway) SubscribeToTask(ctx context.Context, req *a2atype.SubscribeToTaskRequest) iter.Seq2[a2atype.Event, error] {
-	client, err := g.runtime(ctx, auth.VerbGet)
+	instance, err := g.instance(ctx, auth.VerbGet)
 	if err != nil {
 		return errorEvents(err)
 	}
-	return closeAfter(client, client.SubscribeToTask(ctx, req))
+	if req == nil || req.ID == "" {
+		return errorEvents(a2atype.NewError(a2atype.ErrInvalidRequest, "task ID is required"))
+	}
+	task, err := g.store.GetAgentInstanceTask(ctx, instance.GetId(), string(req.ID))
+	if errors.Is(err, dbpkg.ErrNotFound) {
+		return errorEvents(a2atype.ErrTaskNotFound)
+	}
+	if err != nil {
+		ctrllog.FromContext(ctx).Error(err, "failed to load AgentInstance task", "task", req.ID)
+		return errorEvents(a2atype.NewError(a2atype.ErrInternalError, "failed to load task"))
+	}
+	if task.Status.State.Terminal() {
+		return func(yield func(a2atype.Event, error) bool) { yield(task, nil) }
+	}
+	client, err := g.dialer.Dial(ctx, instance)
+	if err != nil {
+		ctrllog.FromContext(ctx).Error(err, "failed to connect to AgentInstance runtime", "instance", instance.GetId())
+		return errorEvents(a2atype.NewError(a2atype.ErrInternalError, "failed to connect to AgentInstance runtime"))
+	}
+	return func(yield func(a2atype.Event, error) bool) {
+		defer client.Destroy()
+		for event, eventErr := range client.SubscribeToTask(ctx, req) {
+			if eventErr != nil {
+				yield(nil, eventErr)
+				return
+			}
+			updated, err := g.taskForEvent(ctx, client, instance.GetId(), task, event)
+			if err == nil {
+				err = g.store.StoreAgentInstanceTaskEvent(ctx, instance.GetId(), updated, event)
+			}
+			if err != nil {
+				yield(nil, g.storeError(ctx, err))
+				return
+			}
+			task = updated
+			if !yield(event, nil) {
+				return
+			}
+		}
+	}
 }
 
 func (g *Gateway) SendStreamingMessage(ctx context.Context, req *a2atype.SendMessageRequest) iter.Seq2[a2atype.Event, error] {
@@ -488,16 +540,5 @@ func errorEvents(err error) iter.Seq2[a2atype.Event, error] {
 	return func(yield func(a2atype.Event, error) bool) {
 		var zero a2atype.Event
 		yield(zero, err)
-	}
-}
-
-func closeAfter(client *a2aclient.Client, events iter.Seq2[a2atype.Event, error]) iter.Seq2[a2atype.Event, error] {
-	return func(yield func(a2atype.Event, error) bool) {
-		defer client.Destroy()
-		for event, err := range events {
-			if !yield(event, err) {
-				return
-			}
-		}
 	}
 }

--- a/go/core/v2/a2agateway/gateway.go
+++ b/go/core/v2/a2agateway/gateway.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"iter"
@@ -38,6 +39,7 @@ const (
 
 type instanceStore interface {
 	GetAgentInstance(context.Context, string, string, string) (*apiv1alpha1.AgentInstance, error)
+	GetRuntimeRevision(context.Context, string) (*dbpkg.RuntimeRevision, error)
 	CreateAgentInstanceTask(context.Context, string, []byte, *a2atype.Task) (*a2atype.Task, bool, error)
 	StoreAgentInstanceTaskEvent(context.Context, string, *a2atype.Task, a2atype.Event) error
 	GetAgentInstanceTask(context.Context, string, string) (*a2atype.Task, error)
@@ -55,15 +57,16 @@ type Gateway struct {
 	store      instanceStore
 	authorizer auth.Authorizer
 	dialer     runtimeDialer
+	gatewayURL string
 }
 
 var _ a2asrv.RequestHandler = (*Gateway)(nil)
 
 // New returns the upstream A2A handler independently of any listener or gRPC
 // server, keeping deployment topology outside the gateway package.
-func New(store instanceStore, authorizer auth.Authorizer, dialer runtimeDialer) a2asrv.RequestHandler {
+func New(store instanceStore, authorizer auth.Authorizer, dialer runtimeDialer, gatewayURL string) a2asrv.RequestHandler {
 	return &a2asrv.InterceptedHandler{
-		Handler:      &Gateway{store: store, authorizer: authorizer, dialer: dialer},
+		Handler:      &Gateway{store: store, authorizer: authorizer, dialer: dialer, gatewayURL: gatewayURL},
 		Interceptors: []a2asrv.CallInterceptor{a2aext.NewServerPropagator(nil)},
 	}
 }
@@ -284,8 +287,31 @@ func (g *Gateway) DeleteTaskPushConfig(ctx context.Context, req *a2atype.DeleteT
 	return a2atype.ErrPushNotificationNotSupported
 }
 
-func (g *Gateway) GetExtendedAgentCard(ctx context.Context, req *a2atype.GetExtendedAgentCardRequest) (*a2atype.AgentCard, error) {
-	return nil, a2atype.ErrExtendedCardNotConfigured
+func (g *Gateway) GetExtendedAgentCard(ctx context.Context, _ *a2atype.GetExtendedAgentCardRequest) (*a2atype.AgentCard, error) {
+	instance, err := g.instance(ctx, auth.VerbGet)
+	if err != nil {
+		return nil, err
+	}
+	revision, err := g.store.GetRuntimeRevision(ctx, instance.GetPreparedRevision())
+	if err != nil {
+		ctrllog.FromContext(ctx).Error(err, "failed to load AgentInstance runtime revision", "revision", instance.GetPreparedRevision())
+		return nil, a2atype.NewError(a2atype.ErrInternalError, "failed to load Agent Card")
+	}
+	card := &a2atype.AgentCard{}
+	if err := json.Unmarshal(revision.AgentCard, card); err != nil {
+		ctrllog.FromContext(ctx).Error(err, "failed to decode AgentInstance Agent Card", "revision", revision.Revision)
+		return nil, a2atype.NewError(a2atype.ErrInternalError, "failed to load Agent Card")
+	}
+
+	// The compiled card provides immutable template metadata. Public transport,
+	// capabilities, security, and signatures belong to the gateway instead of
+	// the private runtime that produced that card.
+	card.SupportedInterfaces = []*a2atype.AgentInterface{a2atype.NewAgentInterface(g.gatewayURL, a2atype.TransportProtocolGRPC)}
+	card.Capabilities = a2atype.AgentCapabilities{Streaming: true, ExtendedAgentCard: true}
+	card.SecurityRequirements = nil
+	card.SecuritySchemes = nil
+	card.Signatures = nil
+	return card, nil
 }
 
 func (g *Gateway) prepareSend(ctx context.Context, req *a2atype.SendMessageRequest) (*apiv1alpha1.AgentInstance, *a2atype.Task, bool, error) {

--- a/go/core/v2/a2agateway/gateway_test.go
+++ b/go/core/v2/a2agateway/gateway_test.go
@@ -23,7 +23,10 @@ import (
 	"google.golang.org/grpc/test/bufconn"
 )
 
-const gatewayTestID = "8bd650a8-9775-488f-8bc1-0d52bf7bdcab"
+const (
+	gatewayTestID  = "8bd650a8-9775-488f-8bc1-0d52bf7bdcab"
+	gatewayTestURL = "https://gateway.example"
+)
 
 type gatewayTestSession struct{}
 
@@ -33,6 +36,7 @@ func (gatewayTestSession) Principal() auth.Principal {
 
 type gatewayTestStore struct {
 	instance              *apiv1alpha1.AgentInstance
+	revision              *dbpkg.RuntimeRevision
 	err                   error
 	task                  *a2atype.Task
 	tasks                 []*a2atype.Task
@@ -46,6 +50,10 @@ type gatewayTestStore struct {
 func (s *gatewayTestStore) GetAgentInstance(_ context.Context, namespace, id, userID string) (*apiv1alpha1.AgentInstance, error) {
 	s.namespace, s.id, s.userID = namespace, id, userID
 	return s.instance, s.err
+}
+
+func (s *gatewayTestStore) GetRuntimeRevision(context.Context, string) (*dbpkg.RuntimeRevision, error) {
+	return s.revision, nil
 }
 
 func (s *gatewayTestStore) StoreAgentInstanceTaskEvent(_ context.Context, _ string, task *a2atype.Task, event a2atype.Event) error {
@@ -153,8 +161,9 @@ func gatewayTestContextWithRoute(namespace, id string) context.Context {
 func gatewayTestInstance() *apiv1alpha1.AgentInstance {
 	return &apiv1alpha1.AgentInstance{
 		Id: gatewayTestID, Namespace: "team-a", Creator: "alice",
-		A2AAuthority: "private-runtime-authority",
-		State:        apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_READY,
+		PreparedRevision: "revision-1",
+		A2AAuthority:     "private-runtime-authority",
+		State:            apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_READY,
 	}
 }
 
@@ -167,7 +176,7 @@ func TestGatewayResolvesAuthenticatedHeadersBeforeSending(t *testing.T) {
 	store := &gatewayTestStore{instance: instance}
 	authorizer := &gatewayTestAuthorizer{}
 	runtime := &gatewayTestRuntime{}
-	gateway := New(store, authorizer, &gatewayTestDialer{client: gatewayTestClient(t, runtime)})
+	gateway := New(store, authorizer, &gatewayTestDialer{client: gatewayTestClient(t, runtime)}, gatewayTestURL)
 
 	result, err := gateway.SendMessage(gatewayTestContext(), gatewayTestRequest())
 	if err != nil {
@@ -187,7 +196,7 @@ func TestGatewayResolvesAuthenticatedHeadersBeforeSending(t *testing.T) {
 func TestGatewayClosesRuntimeAfterStreaming(t *testing.T) {
 	instance := gatewayTestInstance()
 	runtime := &gatewayTestRuntime{}
-	gateway := New(&gatewayTestStore{instance: instance}, &gatewayTestAuthorizer{}, &gatewayTestDialer{client: gatewayTestClient(t, runtime)})
+	gateway := New(&gatewayTestStore{instance: instance}, &gatewayTestAuthorizer{}, &gatewayTestDialer{client: gatewayTestClient(t, runtime)}, gatewayTestURL)
 
 	var events int
 	for _, err := range gateway.SendStreamingMessage(gatewayTestContext(), gatewayTestRequest()) {
@@ -202,7 +211,7 @@ func TestGatewayClosesRuntimeAfterStreaming(t *testing.T) {
 }
 
 func TestGatewayRequiresValidRoutingHeaders(t *testing.T) {
-	gateway := New(&gatewayTestStore{instance: gatewayTestInstance()}, &gatewayTestAuthorizer{}, &gatewayTestDialer{})
+	gateway := New(&gatewayTestStore{instance: gatewayTestInstance()}, &gatewayTestAuthorizer{}, &gatewayTestDialer{}, gatewayTestURL)
 	for _, ctx := range []context.Context{
 		auth.AuthSessionTo(context.Background(), gatewayTestSession{}),
 		gatewayTestContextWithRoute("INVALID", gatewayTestID),
@@ -226,7 +235,7 @@ func TestGatewayHidesInternalErrors(t *testing.T) {
 		{name: "dialer", store: &gatewayTestStore{instance: instance}, dialer: &gatewayTestDialer{err: errors.New("internal.host:1234")}, message: "failed to connect to AgentInstance runtime"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			gateway := New(test.store, &gatewayTestAuthorizer{}, test.dialer)
+			gateway := New(test.store, &gatewayTestAuthorizer{}, test.dialer, gatewayTestURL)
 			_, err := gateway.SendMessage(gatewayTestContext(), gatewayTestRequest())
 			if err == nil || !strings.Contains(err.Error(), test.message) {
 				t.Fatalf("SendMessage() error = %v, want %q", err, test.message)
@@ -241,7 +250,7 @@ func TestGatewayHidesInternalErrors(t *testing.T) {
 func TestGatewayReadsRoutingHeadersFromGRPC(t *testing.T) {
 	instance := gatewayTestInstance()
 	runtime := &gatewayTestRuntime{}
-	gateway := New(&gatewayTestStore{instance: instance}, &gatewayTestAuthorizer{}, &gatewayTestDialer{client: gatewayTestClient(t, runtime)})
+	gateway := New(&gatewayTestStore{instance: instance}, &gatewayTestAuthorizer{}, &gatewayTestDialer{client: gatewayTestClient(t, runtime)}, gatewayTestURL)
 	listener := bufconn.Listen(1024 * 1024)
 	server := grpc.NewServer(grpc.UnaryInterceptor(func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		return handler(auth.AuthSessionTo(ctx, gatewayTestSession{}), req)
@@ -290,7 +299,7 @@ func TestGatewayReadsTasksWithoutDialingRuntime(t *testing.T) {
 	}
 	store := &gatewayTestStore{instance: gatewayTestInstance(), task: task, tasks: []*a2atype.Task{task}, total: 1}
 	dialer := &gatewayTestDialer{}
-	gateway := New(store, &gatewayTestAuthorizer{}, dialer)
+	gateway := New(store, &gatewayTestAuthorizer{}, dialer, gatewayTestURL)
 	historyLength := 1
 
 	got, err := gateway.GetTask(gatewayTestContext(), &a2atype.GetTaskRequest{ID: task.ID, HistoryLength: &historyLength})
@@ -306,9 +315,45 @@ func TestGatewayReadsTasksWithoutDialingRuntime(t *testing.T) {
 	}
 }
 
+func TestGatewayBuildsAgentCardFromPinnedRevision(t *testing.T) {
+	store := &gatewayTestStore{
+		instance: gatewayTestInstance(),
+		revision: &dbpkg.RuntimeRevision{
+			Revision: "revision-1",
+			AgentCard: []byte(`{
+				"name":"assistant","description":"pinned description","version":"v1",
+				"supportedInterfaces":[{"url":"http://127.0.0.1:80","protocolBinding":"GRPC","protocolVersion":"1.0"}],
+				"capabilities":{"pushNotifications":true},"skills":[],
+				"defaultInputModes":["text"],"defaultOutputModes":["text"]
+			}`),
+		},
+	}
+	authorizer := &gatewayTestAuthorizer{}
+	dialer := &gatewayTestDialer{}
+	gateway := New(store, authorizer, dialer, gatewayTestURL)
+
+	card, err := gateway.GetExtendedAgentCard(gatewayTestContext(), &a2atype.GetExtendedAgentCardRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if card.Name != "assistant" || card.Description != "pinned description" || card.Version != "v1" {
+		t.Fatalf("template metadata = %#v", card)
+	}
+	if len(card.SupportedInterfaces) != 1 || card.SupportedInterfaces[0].URL != gatewayTestURL ||
+		card.SupportedInterfaces[0].ProtocolBinding != a2atype.TransportProtocolGRPC {
+		t.Fatalf("public interfaces = %#v", card.SupportedInterfaces)
+	}
+	if !card.Capabilities.Streaming || !card.Capabilities.ExtendedAgentCard || card.Capabilities.PushNotifications {
+		t.Fatalf("gateway capabilities = %#v", card.Capabilities)
+	}
+	if authorizer.verb != auth.VerbGet || dialer.instance != nil {
+		t.Fatalf("authorization verb = %q, runtime dialed = %v", authorizer.verb, dialer.instance != nil)
+	}
+}
+
 func TestGatewayPersistsBeforePublishing(t *testing.T) {
 	store := &gatewayTestStore{instance: gatewayTestInstance()}
-	gateway := New(store, &gatewayTestAuthorizer{}, &gatewayTestDialer{client: gatewayTestClient(t, &gatewayTestRuntime{})})
+	gateway := New(store, &gatewayTestAuthorizer{}, &gatewayTestDialer{client: gatewayTestClient(t, &gatewayTestRuntime{})}, gatewayTestURL)
 
 	for _, err := range gateway.SendStreamingMessage(gatewayTestContext(), gatewayTestRequest()) {
 		if err != nil {
@@ -323,7 +368,7 @@ func TestGatewayPersistsBeforePublishing(t *testing.T) {
 func TestGatewayRejectsConcurrentTaskBeforeDialing(t *testing.T) {
 	store := &gatewayTestStore{instance: gatewayTestInstance(), taskErr: dbpkg.ErrAgentInstanceTaskConflict}
 	dialer := &gatewayTestDialer{}
-	gateway := New(store, &gatewayTestAuthorizer{}, dialer)
+	gateway := New(store, &gatewayTestAuthorizer{}, dialer, gatewayTestURL)
 
 	if _, err := gateway.SendMessage(gatewayTestContext(), gatewayTestRequest()); err == nil {
 		t.Fatal("SendMessage() accepted a second active task")
@@ -337,7 +382,7 @@ func TestGatewayReplaysDuplicateMessageWithoutDialing(t *testing.T) {
 	existing := &a2atype.Task{ID: "existing-task", ContextID: gatewayTestID, Status: a2atype.TaskStatus{State: a2atype.TaskStateCompleted}}
 	store := &gatewayTestStore{instance: gatewayTestInstance(), replay: existing}
 	dialer := &gatewayTestDialer{}
-	gateway := New(store, &gatewayTestAuthorizer{}, dialer)
+	gateway := New(store, &gatewayTestAuthorizer{}, dialer, gatewayTestURL)
 
 	result, err := gateway.SendMessage(gatewayTestContext(), gatewayTestRequest())
 	if err != nil || result != existing {
@@ -351,7 +396,7 @@ func TestGatewayReplaysDuplicateMessageWithoutDialing(t *testing.T) {
 func TestGatewayRejectsConflictingMessageIDWithoutDialing(t *testing.T) {
 	store := &gatewayTestStore{instance: gatewayTestInstance(), taskErr: dbpkg.ErrIdempotencyConflict}
 	dialer := &gatewayTestDialer{}
-	gateway := New(store, &gatewayTestAuthorizer{}, dialer)
+	gateway := New(store, &gatewayTestAuthorizer{}, dialer, gatewayTestURL)
 
 	if _, err := gateway.SendMessage(gatewayTestContext(), gatewayTestRequest()); err == nil {
 		t.Fatal("SendMessage() accepted a reused message ID with different content")

--- a/go/core/v2/controller/reconciler.go
+++ b/go/core/v2/controller/reconciler.go
@@ -252,7 +252,8 @@ func (r *Reconciler) reconcilePair(ctx context.Context, key string) error {
 	revision := dbpkg.RuntimeRevision{
 		Revision: state.RevisionID.String(), Namespace: pair.Namespace, AgentTemplateName: pair.AgentTemplateName,
 		AgentTemplateUID: pair.AgentTemplateUID, HarnessName: pair.HarnessName, HarnessUID: pair.HarnessUID,
-		SourceSnapshot: state.Revision.Provenance, EgressDestinations: state.Revision.EgressDestinations,
+		SourceSnapshot: state.Revision.Provenance, AgentCard: state.Revision.AgentCardJSON,
+		EgressDestinations:     state.Revision.EgressDestinations,
 		ActorTemplateNamespace: observed.Namespace, ActorTemplateName: observed.Name, ActorTemplateUID: string(observed.UID),
 		Phase: string(observed.Status.Phase), GoldenSnapshot: observed.Status.GoldenSnapshot,
 	}

--- a/helm/kagent/templates/_helpers.tpl
+++ b/helm/kagent/templates/_helpers.tpl
@@ -257,6 +257,15 @@ The `name.namespace.svc` short form is used so the URL resolves regardless of th
 {{- end -}}
 {{- end -}}
 
+{{/* Public gRPC endpoint advertised by AgentInstance Agent Cards. */}}
+{{- define "kagent.a2aGatewayUrl" -}}
+{{- if .Values.controller.a2aGatewayUrl -}}
+{{- .Values.controller.a2aGatewayUrl -}}
+{{- else -}}
+{{- printf "http://%s-controller.%s.svc:%d" (include "kagent.fullname" .) (include "kagent.namespace" .) (.Values.controller.service.ports.grpc | int) -}}
+{{- end -}}
+{{- end -}}
+
 {{/*
 Controller Service host:port for nginx upstream (no scheme).
 */}}
@@ -290,4 +299,3 @@ imagePullSecrets:
 {{- toYaml $global | nindent 2 }}
 {{- end -}}
 {{- end -}}
-

--- a/helm/kagent/templates/controller-configmap.yaml
+++ b/helm/kagent/templates/controller-configmap.yaml
@@ -7,6 +7,7 @@ metadata:
     {{- include "kagent.controller.labels" . | nindent 4 }}
 data:
   A2A_BASE_URL: {{ include "kagent.a2aBaseUrl" . | quote }}
+  A2A_GATEWAY_URL: {{ include "kagent.a2aGatewayUrl" . | quote }}
   DEFAULT_MODEL_CONFIG_NAME: {{ include "kagent.defaultModelConfigName" . | quote }}
   KAGENT_CONTROLLER_NAME: {{ include "kagent.fullname" . }}-controller
   {{- if .Values.ui.externalUrl }}

--- a/helm/kagent/tests/controller-deployment_test.yaml
+++ b/helm/kagent/tests/controller-deployment_test.yaml
@@ -193,6 +193,23 @@ tests:
           path: data.A2A_BASE_URL
           value: "https://kagent.example.com"
 
+  - it: should set A2A_GATEWAY_URL with computed default value
+    template: controller-configmap.yaml
+    asserts:
+      - equal:
+          path: data.A2A_GATEWAY_URL
+          value: "http://RELEASE-NAME-controller.NAMESPACE.svc:8084"
+
+  - it: should set A2A_GATEWAY_URL with custom value when explicitly set
+    template: controller-configmap.yaml
+    set:
+      controller:
+        a2aGatewayUrl: "https://agents.example.com"
+    asserts:
+      - equal:
+          path: data.A2A_GATEWAY_URL
+          value: "https://agents.example.com"
+
   - it: should set PROXY_URL when set
     template: controller-configmap.yaml
     set:

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -181,6 +181,9 @@ controller:
   # -- The base URL of the A2A Server endpoint, as advertised to clients.
   # @default -- `http://<fullname>-controller.<namespace>.svc:<port>`
   a2aBaseUrl: ""
+  # -- Public gRPC URL advertised by AgentInstance Agent Cards.
+  # @default -- `http://<fullname>-controller.<namespace>.svc:<grpc-port>`
+  a2aGatewayUrl: ""
   agentImage:
     registry: ""
     repository: kagent-dev/kagent/app


### PR DESCRIPTION
## Summary

- persist the immutable compiled Agent Card on each runtime revision
- serve authenticated extended Agent Cards from the AgentInstance pinned revision
- advertise the gateway gRPC endpoint through Helm configuration
- persist cancellation results before returning them
- serve terminal subscriptions from PostgreSQL and commit live subscription updates before publishing

The public `.well-known/agent-card.json` routing contract, authorization coverage, and new lifecycle tests remain deferred.

## Validation

- `go test ./core/v2/a2agateway`
- `make -C go lint`
- focused Go race tests for gateway, database, controller, and controller-v2 before the follow-up
- Helm controller tests (58 passed)
- `git diff --check`