### PR TITLE
feat: configurable refresh interval for tool server controllers

### DIFF
--- a/go/core/internal/controller/mcp_server_tool_controller.go
+++ b/go/core/internal/controller/mcp_server_tool_controller.go
@@ -41,6 +41,8 @@ var mcpServerGK = schema.GroupKind{Group: "kagent.dev", Kind: "MCPServer"}
 type MCPServerToolController struct {
 	Scheme     *runtime.Scheme
 	Reconciler reconciler.KagentReconciler
+	// RequeueAfter is how often to refresh discovered tools. Zero uses defaultToolRefreshInterval.
+	RequeueAfter time.Duration
 }
 
 // +kubebuilder:rbac:groups=kagent.dev,resources=mcpservers,verbs=get;list;watch
@@ -60,10 +62,7 @@ func (r *MCPServerToolController) Reconcile(ctx context.Context, req ctrl.Reques
 		// Transient error - return error to trigger exponential backoff retry
 		return ctrl.Result{}, err
 	}
-	// Success - requeue after 60s to refresh tool server status
-	return ctrl.Result{
-		RequeueAfter: 60 * time.Second,
-	}, nil
+	return ctrl.Result{RequeueAfter: toolRefreshRequeueAfter(r.RequeueAfter)}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/go/core/internal/controller/remote_mcp_server_controller.go
+++ b/go/core/internal/controller/remote_mcp_server_controller.go
@@ -40,10 +40,21 @@ var (
 	remoteMCPServerControllerLog = ctrl.Log.WithName("remotemcpserver-controller")
 )
 
+const defaultToolRefreshInterval = 60 * time.Second
+
+func toolRefreshRequeueAfter(d time.Duration) time.Duration {
+	if d <= 0 {
+		return defaultToolRefreshInterval
+	}
+	return d
+}
+
 // RemoteMCPServerController reconciles a RemoteMCPServer object
 type RemoteMCPServerController struct {
 	Scheme     *runtime.Scheme
 	Reconciler reconciler.KagentReconciler
+	// RequeueAfter is how often to refresh discovered tools. Zero uses defaultToolRefreshInterval.
+	RequeueAfter time.Duration
 }
 
 // +kubebuilder:rbac:groups=kagent.dev,resources=remotemcpservers,verbs=get;list;watch;create;update;patch;delete
@@ -59,10 +70,7 @@ func (r *RemoteMCPServerController) Reconcile(ctx context.Context, req ctrl.Requ
 		// Return zero result when there's an error - controller-runtime will handle backoff
 		return ctrl.Result{}, err
 	}
-	// Success - requeue after 60s to refresh tool server status
-	return ctrl.Result{
-		RequeueAfter: 60 * time.Second,
-	}, nil
+	return ctrl.Result{RequeueAfter: toolRefreshRequeueAfter(r.RequeueAfter)}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/go/core/internal/controller/service_controller.go
+++ b/go/core/internal/controller/service_controller.go
@@ -37,6 +37,8 @@ import (
 type ServiceController struct {
 	Scheme     *runtime.Scheme
 	Reconciler reconciler.KagentReconciler
+	// RequeueAfter is how often to refresh discovered tools. Zero uses defaultToolRefreshInterval.
+	RequeueAfter time.Duration
 }
 
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch
@@ -57,7 +59,7 @@ func (r *ServiceController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
-	return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
+	return ctrl.Result{RequeueAfter: toolRefreshRequeueAfter(r.RequeueAfter)}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/go/core/internal/controller/service_controller_test.go
+++ b/go/core/internal/controller/service_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -57,6 +58,11 @@ func (f *fakeServiceReconciler) GetOwnedResourceTypes() []client.Object {
 
 // TestServiceController_ErrorTypeDetection tests that the controller
 // correctly distinguishes between ValidationError and other errors.
+func TestToolRefreshRequeueAfter(t *testing.T) {
+	assert.Equal(t, defaultToolRefreshInterval, toolRefreshRequeueAfter(0))
+	assert.Equal(t, 15*time.Minute, toolRefreshRequeueAfter(15*time.Minute))
+}
+
 func TestServiceController_ErrorTypeDetection(t *testing.T) {
 	ctx := context.Background()
 

--- a/go/core/pkg/app/app.go
+++ b/go/core/pkg/app/app.go
@@ -136,6 +136,9 @@ type Config struct {
 	// http://host:<port-or-443> so traffic egresses in plaintext to a proxy
 	// that originates TLS upstream. Off by default;
 	MCPEgressPlaintext bool
+	// How often MCP tool-discovery controllers requeue to refresh the tool cache.
+	// Default 60s. Raise above the DB idle / Aurora auto-pause threshold for scale-to-zero.
+	ToolRefreshInterval time.Duration
 	Database           struct {
 		Url                  string
 		UrlFile              string
@@ -203,6 +206,8 @@ func (cfg *Config) SetFlags(commandLine *flag.FlagSet) {
 
 	commandLine.BoolVar(&cfg.MCPEgressPlaintext, "mcp-egress-plaintext", false,
 		"When set, rewrite RemoteMCPServer tool URLs and the controller's tool-discovery dial from https://host[:port] to http://host:<port-or-443> so MCP traffic egresses in plaintext to a TLS-originating proxy. Off by default.")
+	commandLine.DurationVar(&cfg.ToolRefreshInterval, "tool-refresh-interval", 60*time.Second,
+		"How often MCP tool-discovery controllers requeue to refresh the discovered-tool cache. Raise above the database idle / auto-pause threshold to allow scale-to-zero.")
 
 	commandLine.StringVar(&agent_translator.DefaultImageConfig.Registry, "image-registry", agent_translator.DefaultImageConfig.Registry, "The registry to use for the image.")
 	commandLine.StringVar(&agent_translator.DefaultImageConfig.Tag, "image-tag", agent_translator.DefaultImageConfig.Tag, "The tag to use for the image.")
@@ -611,16 +616,18 @@ func Start(getExtensionConfig GetExtensionConfig, extraSources []migrations.Sour
 	)
 
 	if err := (&controller.ServiceController{
-		Scheme:     mgr.GetScheme(),
-		Reconciler: rcnclr,
+		Scheme:       mgr.GetScheme(),
+		Reconciler:   rcnclr,
+		RequeueAfter: cfg.ToolRefreshInterval,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "MCPServerToolDiscovery")
 		os.Exit(1)
 	}
 
 	if err := (&controller.MCPServerToolController{
-		Scheme:     mgr.GetScheme(),
-		Reconciler: rcnclr,
+		Scheme:       mgr.GetScheme(),
+		Reconciler:   rcnclr,
+		RequeueAfter: cfg.ToolRefreshInterval,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Service")
 		os.Exit(1)
@@ -691,8 +698,9 @@ func Start(getExtensionConfig GetExtensionConfig, extraSources []migrations.Sour
 	}
 
 	if err = (&controller.RemoteMCPServerController{
-		Scheme:     mgr.GetScheme(),
-		Reconciler: rcnclr,
+		Scheme:       mgr.GetScheme(),
+		Reconciler:   rcnclr,
+		RequeueAfter: cfg.ToolRefreshInterval,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "RemoteMCPServer")
 		os.Exit(1)

--- a/go/core/pkg/app/app.go
+++ b/go/core/pkg/app/app.go
@@ -139,7 +139,7 @@ type Config struct {
 	// How often MCP tool-discovery controllers requeue to refresh the tool cache.
 	// Default 60s. Raise above the DB idle / Aurora auto-pause threshold for scale-to-zero.
 	ToolRefreshInterval time.Duration
-	Database           struct {
+	Database            struct {
 		Url                  string
 		UrlFile              string
 		VectorEnabled        bool

--- a/go/core/pkg/app/app_test.go
+++ b/go/core/pkg/app/app_test.go
@@ -306,6 +306,21 @@ func TestPostgresConfigFromAppUnset(t *testing.T) {
 	assert.Nil(t, pgCfg.MaxConnLifetime)
 }
 
+func TestToolRefreshIntervalFlag(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	cfg := Config{}
+	cfg.SetFlags(fs)
+
+	f := fs.Lookup("tool-refresh-interval")
+	assert.NotNil(t, f, "tool-refresh-interval flag should be registered")
+	assert.Equal(t, "1m0s", f.DefValue, "default should be 60s")
+
+	t.Setenv("TOOL_REFRESH_INTERVAL", "15m")
+	err := LoadFromEnv(fs)
+	assert.NoError(t, err)
+	assert.Equal(t, 15*time.Minute, cfg.ToolRefreshInterval)
+}
+
 func TestSessionRetentionDaysFlag(t *testing.T) {
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	cfg := Config{}

--- a/helm/kagent/templates/controller-configmap.yaml
+++ b/helm/kagent/templates/controller-configmap.yaml
@@ -77,6 +77,7 @@ data:
   SESSION_RETENTION_DAYS: {{ .Values.database.postgres.sessionRetentionDays | default 0 | quote }}
   WATCH_NAMESPACES: {{ include "kagent.watchNamespaces" . | quote }}
   MCP_EGRESS_PLAINTEXT: {{ .Values.controller.mcpEgressPlaintext | default false | quote }}
+  TOOL_REFRESH_INTERVAL: {{ .Values.controller.toolRefreshInterval | default "60s" | quote }}
   {{- if .Values.controller.a2aClientTimeout }}
   KAGENT_A2A_CLIENT_TIMEOUT: {{ .Values.controller.a2aClientTimeout | quote }}
   {{- end }}

--- a/helm/kagent/tests/controller-deployment_test.yaml
+++ b/helm/kagent/tests/controller-deployment_test.yaml
@@ -199,6 +199,23 @@ tests:
           path: data.MCP_EGRESS_PLAINTEXT
           value: "true"
 
+  - it: should default TOOL_REFRESH_INTERVAL to 60s
+    template: controller-configmap.yaml
+    asserts:
+      - equal:
+          path: data.TOOL_REFRESH_INTERVAL
+          value: "60s"
+
+  - it: should set TOOL_REFRESH_INTERVAL when configured
+    template: controller-configmap.yaml
+    set:
+      controller:
+        toolRefreshInterval: "15m"
+    asserts:
+      - equal:
+          path: data.TOOL_REFRESH_INTERVAL
+          value: "15m"
+
   - it: should use custom loglevel when set
     template: controller-configmap.yaml
     set:

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -260,6 +260,11 @@ controller:
   # off by default.
   mcpEgressPlaintext: false
 
+  # -- How often MCP tool-discovery controllers requeue to refresh the
+  # discovered-tool cache (RemoteMCPServer, MCPServer, labeled MCP Service).
+  # Default 60s.
+  toolRefreshInterval: "60s"
+
   # -- Additional annotations to add to the controller Deployment metadata
   annotations: {}
 


### PR DESCRIPTION
RemoteMCPServer, MCPServer, and Service controllers requeue requests after 60s in order to discover and update latest tool list for each server in database. This makes the interval configurable, such as `controller.toolRefreshInterval: "15m"`. This feature is only available on the 0.10.x release