### PR TITLE
fix(adk): validate ask_user questions

### DIFF
--- a/go/adk/pkg/tools/ask_user.go
+++ b/go/adk/pkg/tools/ask_user.go
@@ -20,8 +20,8 @@ type askUserInput struct {
 	Questions []askUserQuestion `json:"questions"`
 }
 
-const askUserDescription = "Ask the user one or more questions and wait for their answers " +
-	"before continuing. Use this when you need clarifying information, " +
+const askUserDescription = "Ask the user at least one question and wait for their answers before continuing. " +
+	"Every question must include non-empty text. Use this when you need clarifying information, " +
 	"preferences, or explicit confirmation from the user."
 
 // NewAskUserTool creates the ask_user tool using functiontool.New.
@@ -41,6 +41,15 @@ func NewAskUserTool() (tool.Tool, error) {
 		Name:        "ask_user",
 		Description: askUserDescription,
 	}, func(ctx adkagent.Context, in askUserInput) (map[string]any, error) {
+		if len(in.Questions) == 0 {
+			return nil, fmt.Errorf("ask_user: at least one question is required")
+		}
+		for i, q := range in.Questions {
+			if strings.TrimSpace(q.Question) == "" {
+				return nil, fmt.Errorf("ask_user: question %d must contain non-whitespace text", i+1)
+			}
+		}
+
 		if ctx.ToolConfirmation() == nil {
 			// Phase 1 — pause execution and ask the user.
 			var sb strings.Builder
@@ -51,9 +60,6 @@ func NewAskUserTool() (tool.Tool, error) {
 				sb.WriteString(q.Question)
 			}
 			hint := sb.String()
-			if hint == "" {
-				hint = "Questions for the user."
-			}
 
 			// Build questions slice for the pending response.
 			questionsSlice := make([]map[string]any, 0, len(in.Questions))

--- a/go/adk/pkg/tools/ask_user_test.go
+++ b/go/adk/pkg/tools/ask_user_test.go
@@ -1,0 +1,139 @@
+package tools
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	adkagent "google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/tool/toolconfirmation"
+)
+
+type askUserConfirmationRequest struct {
+	hint    string
+	payload any
+}
+
+type askUserTestContext struct {
+	adkagent.Context
+	confirmation *toolconfirmation.ToolConfirmation
+	requests     []askUserConfirmationRequest
+}
+
+func (c *askUserTestContext) ToolConfirmation() *toolconfirmation.ToolConfirmation {
+	return c.confirmation
+}
+
+func (c *askUserTestContext) RequestConfirmation(hint string, payload any) error {
+	c.requests = append(c.requests, askUserConfirmationRequest{hint: hint, payload: payload})
+	return nil
+}
+
+func runAskUserTool(
+	t *testing.T,
+	ctx adkagent.Context,
+	args map[string]any,
+) (map[string]any, error) {
+	t.Helper()
+
+	askUserTool, err := NewAskUserTool()
+	require.NoError(t, err)
+	runner, ok := askUserTool.(interface {
+		Run(adkagent.Context, any) (map[string]any, error)
+	})
+	require.True(t, ok, "ask_user tool %T does not implement Run", askUserTool)
+	return runner.Run(ctx, args)
+}
+
+func TestAskUserRejectsInvalidQuestionsWithoutRequestingConfirmation(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    map[string]any
+		wantErr string
+	}{
+		{
+			name:    "empty list",
+			args:    map[string]any{"questions": []any{}},
+			wantErr: "ask_user: at least one question is required",
+		},
+		{
+			name:    "empty first question",
+			args:    map[string]any{"questions": []any{map[string]any{"question": ""}}},
+			wantErr: "ask_user: question 1 must contain non-whitespace text",
+		},
+		{
+			name:    "spaces-only first question",
+			args:    map[string]any{"questions": []any{map[string]any{"question": "   "}}},
+			wantErr: "ask_user: question 1 must contain non-whitespace text",
+		},
+		{
+			name:    "tab-newline-only first question",
+			args:    map[string]any{"questions": []any{map[string]any{"question": "\t\n"}}},
+			wantErr: "ask_user: question 1 must contain non-whitespace text",
+		},
+		{
+			name: "blank second question",
+			args: map[string]any{"questions": []any{
+				map[string]any{"question": "Which environment?"},
+				map[string]any{"question": " \t\n"},
+			}},
+			wantErr: "ask_user: question 2 must contain non-whitespace text",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &askUserTestContext{}
+
+			_, err := runAskUserTool(t, ctx, tt.args)
+
+			assert.EqualError(t, err, tt.wantErr)
+			assert.Empty(t, ctx.requests)
+		})
+	}
+}
+
+func TestAskUserValidQuestionRequestsConfirmation(t *testing.T) {
+	ctx := &askUserTestContext{}
+	question := "  Which environment?  "
+
+	result, err := runAskUserTool(t, ctx, map[string]any{
+		"questions": []any{map[string]any{
+			"question": question,
+			"choices":  []any{"prod", "staging"},
+			"multiple": true,
+		}},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []askUserConfirmationRequest{{hint: question, payload: nil}}, ctx.requests)
+	assert.Equal(t, map[string]any{
+		"status": "pending",
+		"questions": []any{map[string]any{
+			"question": question,
+			"choices":  []any{"prod", "staging"},
+			"multiple": true,
+		}},
+	}, result)
+}
+
+func TestAskUserValidConfirmedQuestionReturnsAnswer(t *testing.T) {
+	ctx := &askUserTestContext{
+		confirmation: &toolconfirmation.ToolConfirmation{
+			Confirmed: true,
+			Payload: map[string]any{
+				"answers": []any{map[string]any{"answer": "prod"}},
+			},
+		},
+	}
+
+	result, err := runAskUserTool(t, ctx, map[string]any{
+		"questions": []any{map[string]any{"question": "  Which environment?  "}},
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, ctx.requests)
+	resultJSON, ok := result["result"].(string)
+	require.True(t, ok)
+	assert.JSONEq(t, `[{"answer":"prod","question":"  Which environment?  "}]`, resultJSON)
+}

--- a/python/packages/kagent-adk/src/kagent/adk/tools/ask_user_tool.py
+++ b/python/packages/kagent-adk/src/kagent/adk/tools/ask_user_tool.py
@@ -57,8 +57,8 @@ class AskUserTool(BaseTool):
         super().__init__(
             name="ask_user",
             description=(
-                "Ask the user one or more questions and wait for their answers "
-                "before continuing. Use this when you need clarifying information, "
+                "Ask the user at least one question and wait for their answers before continuing. "
+                "Every question must include non-empty text. Use this when you need clarifying information, "
                 "preferences, or explicit confirmation from the user."
             ),
         )
@@ -88,10 +88,17 @@ class AskUserTool(BaseTool):
     ) -> Any:
         questions: list[dict] = args.get("questions", [])
 
+        if not questions:
+            raise ValueError("ask_user: at least one question is required")
+        for index, question in enumerate(questions, start=1):
+            question_text = question.get("question")
+            if not isinstance(question_text, str) or not question_text.strip():
+                raise ValueError(f"ask_user: question {index} must contain non-whitespace text")
+
         if tool_context.tool_confirmation is None:
             # First invocation — pause execution and ask the user.
-            summary = "; ".join(q.get("question", "") for q in questions if q.get("question"))
-            tool_context.request_confirmation(hint=summary or "Questions for the user.")
+            summary = "; ".join(q["question"] for q in questions)
+            tool_context.request_confirmation(hint=summary)
             logger.debug("ask_user: requesting confirmation with %d question(s)", len(questions))
             return {"status": "pending", "questions": questions}
 

--- a/python/packages/kagent-adk/tests/unittests/test_ask_user_tool.py
+++ b/python/packages/kagent-adk/tests/unittests/test_ask_user_tool.py
@@ -1,0 +1,93 @@
+import json
+from unittest.mock import Mock
+
+import pytest
+from google.adk.tools.tool_confirmation import ToolConfirmation
+from google.adk.tools.tool_context import ToolContext
+
+from kagent.adk.tools.ask_user_tool import AskUserTool
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("args", "expected_error"),
+    [
+        (
+            {"questions": []},
+            "ask_user: at least one question is required",
+        ),
+        (
+            {"questions": [{"question": ""}]},
+            "ask_user: question 1 must contain non-whitespace text",
+        ),
+        (
+            {"questions": [{"question": "   "}]},
+            "ask_user: question 1 must contain non-whitespace text",
+        ),
+        (
+            {"questions": [{"question": "\t\n"}]},
+            "ask_user: question 1 must contain non-whitespace text",
+        ),
+        (
+            {
+                "questions": [
+                    {"question": "Which environment?"},
+                    {"question": " \t\n"},
+                ]
+            },
+            "ask_user: question 2 must contain non-whitespace text",
+        ),
+    ],
+)
+async def test_rejects_invalid_questions_without_requesting_confirmation(args, expected_error):
+    context = Mock(spec=ToolContext)
+    context.tool_confirmation = None
+
+    with pytest.raises(ValueError) as exc_info:
+        await AskUserTool().run_async(args=args, tool_context=context)
+
+    assert str(exc_info.value) == expected_error
+    context.request_confirmation.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_valid_question_requests_confirmation_without_rewriting_text():
+    context = Mock(spec=ToolContext)
+    context.tool_confirmation = None
+    questions = [
+        {
+            "question": "  Which environment?  ",
+            "choices": ["prod", "staging"],
+            "multiple": True,
+        }
+    ]
+
+    result = await AskUserTool().run_async(
+        args={"questions": questions},
+        tool_context=context,
+    )
+
+    assert result == {"status": "pending", "questions": questions}
+    context.request_confirmation.assert_called_once_with(hint="  Which environment?  ")
+
+
+@pytest.mark.asyncio
+async def test_valid_confirmed_question_returns_answer_without_new_confirmation():
+    context = Mock(spec=ToolContext)
+    context.tool_confirmation = ToolConfirmation(
+        confirmed=True,
+        payload={"answers": [{"answer": "prod"}]},
+    )
+
+    result = await AskUserTool().run_async(
+        args={"questions": [{"question": "  Which environment?  "}]},
+        tool_context=context,
+    )
+
+    assert json.loads(result) == [
+        {
+            "question": "  Which environment?  ",
+            "answer": "prod",
+        }
+    ]
+    context.request_confirmation.assert_not_called()


### PR DESCRIPTION
## Summary

Validate built-in `ask_user` inputs in both Go and Python ADK runtimes on `release/v0.10.x` before confirmation handling.

Fixes #2468.

## Problem

Both implementations accepted an empty `questions` list and entries whose question text was empty or whitespace-only. Those invalid calls could pause a task without presenting a usable question.

An invalid model tool call should return an error the model can correct; it should not create an unanswerable `input-required` interaction.

## Change

Both runtimes now:

- require at least one question;
- require nonblank question text for every entry;
- reject invalid input before requesting confirmation;
- tell the model to provide at least one question; and
- preserve existing pending and confirmed behavior for valid questions.

Runtime validation remains authoritative and does not depend on a provider enforcing a generated schema.

## Tests

Go:

- `go test ./adk/pkg/tools`
- `go test -race ./adk/pkg/tools`

Python:

- `uv run pytest packages/kagent-adk/tests/unittests/test_ask_user_tool.py packages/kagent-adk/tests/unittests/test_hitl.py -q`
- Ruff checks on the touched Python files

Coverage verifies empty-list rejection, blank-text rejection, no confirmation call for invalid input, and unchanged valid pending/confirmed behavior in both runtimes.

## Validation

An independent A2A client against a compatible v0.10 deployment completed a valid structured-question round trip: one nonblank question was returned, a later process answered the retained interaction, and the same task reached terminal completion without resending the original request.

This PR changes only built-in `ask_user` validation; it does not change identity propagation, persistence, or A2A transport formats.
