### PR TITLE
Backport #2423 CVE fixes to release/v0.10.x

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -461,6 +461,10 @@ jobs:
       - name: Install python
         run: uv python install 3.11
 
+      - name: Verify uv.lock matches pyproject.toml
+        working-directory: ./python
+        run: uv lock --check
+
       - name: Sync dependencies
         working-directory: ./python
         run: uv sync --all-extras

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,5 +1,5 @@
 ### STAGE 1: uv binary
-ARG UV_VERSION=0.11.15
+ARG UV_VERSION=0.12.3
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv-bin
 
 ### STAGE 2: builder
@@ -52,8 +52,20 @@ ARG VERSION
 RUN --mount=type=cache,target=/.kagent/cache,rw                               \
     echo "Creating virtual environment and installing dependencies..."        \
     && uv venv --python=python$TOOLS_PYTHON_VERSION                           \
-    && uv lock && uv sync --package kagent-adk --no-editable                  \
+    && uv sync --frozen --package kagent-adk --no-editable                    \
     && uv cache prune                                                         \
+    # The standalone CPython build bundles pip (with vendored msgpack /
+    # pkg_resources) in its own site-packages. The runtime only uses the venv,
+    # so drop it rather than shipping CVE-flagged packages that nothing imports.
+    && rm -rf /python/cpython-*/lib/python*/site-packages/pip                 \
+              /python/cpython-*/lib/python*/site-packages/pip-*.dist-info     \
+              /python/cpython-*/lib/python*/site-packages/setuptools          \
+              /python/cpython-*/lib/python*/site-packages/setuptools-*.dist-info \
+              /python/cpython-*/lib/python*/site-packages/pkg_resources      \
+    # Fail the build if pip survived (rm -rf on a non-matching glob exits 0,
+    # e.g. after a Python minor bump moves site-packages). --system skips venv
+    # discovery so this probes the standalone interpreter.
+    && ! "$(uv python find --system)" -c "import pip" 2>/dev/null             \
     && echo "Installation complete."
 
 # Pre-create the config dir owned by the runtime user. On Agent Substrate the config is

--- a/python/Dockerfile.full
+++ b/python/Dockerfile.full
@@ -6,7 +6,7 @@
 # executeCodeBlocks) and for sandboxed BYO agents.
 
 ### STAGE 1: uv binary
-ARG UV_VERSION=0.11.15
+ARG UV_VERSION=0.12.3
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv-bin
 
 ### STAGE 2: base os + sandbox runtime
@@ -97,7 +97,7 @@ ARG VERSION
 RUN --mount=type=cache,target=/.kagent/cache,uid=1001,gid=1001                \
     echo "Creating virtual environment and installing dependencies..."        \
     && uv venv --python=python$TOOLS_PYTHON_VERSION                           \
-    && uv lock && uv sync --package kagent-adk                                \
+    && uv sync --frozen --package kagent-adk                                  \
     && uv cache prune                                                         \
     && echo "Installation complete."
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -14,6 +14,7 @@ constraint-dependencies = [
     "aiohttp>=3.14.3",
     "cryptography>=50.0.0",
     "httplib2>=0.32.0",
+    "idna>=3.15",
     "jaraco-context>=6.1.0",
     "joserfc>=1.6.8",
     "mako>=1.3.12",

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -28,6 +28,7 @@ constraints = [
     { name = "aiohttp", specifier = ">=3.14.3" },
     { name = "cryptography", specifier = ">=50.0.0" },
     { name = "httplib2", specifier = ">=0.32.0" },
+    { name = "idna", specifier = ">=3.15" },
     { name = "jaraco-context", specifier = ">=6.1.0" },
     { name = "joserfc", specifier = ">=1.6.8" },
     { name = "mako", specifier = ">=1.3.12" },
@@ -1930,11 +1931,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.10"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Context

- Resolving CVEs.
- Removed unused pip that led to CVEs being caught for its existence (by
Trivy, at least) -- I made a similar change in agentevals
https://github.com/agentevals-dev/agentevals/pull/182
    - Set a minimum for `idna`
    - Bumped `UV_VERSION`
- Set up a uv freeze + uv check to lint for python dependency management
safety (ensuring version are based off the uv lockfile instead of bumped
each time, possibly adding CVEs)

**backend**

| | Before | After | Fixes |
| - | ----- | ----- | ---- |
| CPython (via `UV_VERSION` `0.11.15 → 0.12.3`) | 3.13.9 | 3.13.15 |
CVE-2026-3298, CVE-2026-4786, CVE-2026-6100, CVE-2026-7210,
CVE-2026-9669, CVE-2026-1502, CVE-2026-3276, CVE-2026-6019,
CVE-2026-7774, CVE-2026-8328 |
| pip (bundled w/ interpreter) | 26.1.x | removed from image |
CVE-2026-8643, GHSA-6v7p-g79w-8964, CVE-2025-47273, CVE-2026-59890 |
| idna | 3.10 | 3.18 | CVE-2026-45409 |

**ui** (no changes here, needs a rebuild of image to bump deps
[on-release])

## Summary

**`app` image scan**
| | C | H | M | Total |
| - | - | - | - | ---- |
| `main` | 1 | 10 | 15 | 26 |
| PR | 1 | 5 | 8 | 14 |

`golang-adk` clean, `skills-init` has 4 unresolvable CVEs (Alpine
busybox/nghttp2)

## Remaining CVEs (15)

**backend**
- CPython (8): CVE-2026-11940, CVE-2026-11972, CVE-2026-15308 (high);
CVE-2025-15366, CVE-2025-15367, CVE-2026-0864, CVE-2026-12003 — fixes
exist **only** in the 3.15 line. Requires python bump 3.13 -> 3.15 (or
waiting to see if they get back-ported to 3.13.x).
- I'll re-verify this post-merge, there have been some recent python cve
fixes I believe were backported _at least_ down to 3.14, unsure about
3.13.
- Debian 12 base (6): glibc CVE-2026-5450, CVE-2026-5435, CVE-2026-5928,
CVE-2026-6238, CVE-2026-6791, libssl3 CVE-2026-42767 — no fix shipped in
bookworm image, will investigate migrating to chainguard in follow-ups.

**ui**
- CVE-2026-54876 — openssl/libssl3/libcrypto3, no wolfi patch published
yet. the floating wolfi-base:latest will pick it up automatically on the
first rebuild after wolfi ships it, so no need for updates here.

---------

Signed-off-by: Fabian Gonzalez <fabian.gonzalez@solo.io>
Co-authored-by: Eitan Yarmush <eitan.yarmush@solo.io>