### PR TITLE
fix(db): revive soft-deleted push configs and checkpoints on re-upsert

### DIFF
--- a/go/core/internal/database/client_langgraph_test.go
+++ b/go/core/internal/database/client_langgraph_test.go
@@ -135,3 +135,49 @@ func TestListCheckpointsBatchesWrites(t *testing.T) {
 		}
 	}
 }
+
+// A soft-deleted thread's rows keep their key, so a checkpointer writing that
+// key again must revive the row instead of updating one that stays deleted and
+// that no read path can see.
+func TestDeletedCheckpointRowsAreRevivedByANewWrite(t *testing.T) {
+	db := setupTestDB(t)
+	client := NewClient(db)
+	ctx := context.Background()
+
+	const (
+		userID   = "alice"
+		threadID = "thread-revive"
+		ns       = ""
+		cpID     = "cp-00"
+	)
+	checkpoint := func(payload string) *dbpkg.LangGraphCheckpoint {
+		return &dbpkg.LangGraphCheckpoint{
+			UserID: userID, ThreadID: threadID, CheckpointNS: ns, CheckpointID: cpID,
+			Metadata: "{}", Checkpoint: payload, Version: 1,
+		}
+	}
+	write := func(value string) []*dbpkg.LangGraphCheckpointWrite {
+		return []*dbpkg.LangGraphCheckpointWrite{{
+			UserID: userID, ThreadID: threadID, CheckpointNS: ns, CheckpointID: cpID,
+			WriteIdx: 0, Value: value, ValueType: "json", Channel: "channel-0", TaskID: "task-0",
+		}}
+	}
+
+	require.NoError(t, client.StoreCheckpoint(ctx, checkpoint(`{"step":1}`)))
+	require.NoError(t, client.StoreCheckpointWrites(ctx, write("first")))
+	require.NoError(t, client.DeleteCheckpoint(ctx, userID, threadID))
+
+	tuples, err := client.ListCheckpoints(ctx, userID, threadID, ns, nil, 0)
+	require.NoError(t, err)
+	require.Empty(t, tuples, "the deleted thread must not be readable")
+
+	require.NoError(t, client.StoreCheckpoint(ctx, checkpoint(`{"step":2}`)))
+	require.NoError(t, client.StoreCheckpointWrites(ctx, write("second")))
+
+	tuples, err = client.ListCheckpoints(ctx, userID, threadID, ns, nil, 0)
+	require.NoError(t, err)
+	require.Len(t, tuples, 1, "the rewritten checkpoint must be readable")
+	require.Equal(t, `{"step":2}`, tuples[0].Checkpoint.Checkpoint)
+	require.Len(t, tuples[0].Writes, 1, "the rewritten write must be readable")
+	require.Equal(t, "second", tuples[0].Writes[0].Value)
+}

--- a/go/core/internal/database/client_test.go
+++ b/go/core/internal/database/client_test.go
@@ -1155,3 +1155,31 @@ func TestSingleRowReadsMapMissingToErrNotFound(t *testing.T) {
 		})
 	}
 }
+
+// A soft-deleted push config keeps its id, so re-registering that id must revive
+// the row instead of updating one that stays deleted and that no read path can
+// see.
+func TestDeletedPushConfigIsRevivedByReRegistration(t *testing.T) {
+	db := setupTestDB(t)
+	client := NewClient(db)
+	ctx := context.Background()
+
+	config := func(url string) *a2a.PushConfig {
+		return &a2a.PushConfig{ID: "cfg-1", TaskID: "task-push", URL: url}
+	}
+	require.NoError(t, client.StorePushNotification(ctx, config("https://first.example/hook")))
+	require.NoError(t, client.DeletePushNotification(ctx, "task-push"))
+
+	_, err := client.GetPushNotification(ctx, "task-push", "cfg-1")
+	require.Error(t, err, "the deleted config must not be readable")
+
+	require.NoError(t, client.StorePushNotification(ctx, config("https://second.example/hook")))
+
+	stored, err := client.GetPushNotification(ctx, "task-push", "cfg-1")
+	require.NoError(t, err, "re-registering the id must produce a readable config")
+	assert.Equal(t, "https://second.example/hook", stored.URL)
+
+	listed, err := client.ListPushNotifications(ctx, "task-push")
+	require.NoError(t, err)
+	require.Len(t, listed, 1, "the revived config must be listed once")
+}

--- a/go/core/internal/database/gen/langgraph.sql.go
+++ b/go/core/internal/database/gen/langgraph.sql.go
@@ -241,7 +241,8 @@ ON CONFLICT (user_id, thread_id, checkpoint_ns, checkpoint_id) DO UPDATE SET
     checkpoint           = EXCLUDED.checkpoint,
     checkpoint_type      = EXCLUDED.checkpoint_type,
     version              = EXCLUDED.version,
-    updated_at           = NOW()
+    updated_at           = NOW(),
+    deleted_at           = NULL
 `
 
 type UpsertCheckpointParams struct {
@@ -281,7 +282,8 @@ ON CONFLICT (user_id, thread_id, checkpoint_ns, checkpoint_id, write_idx) DO UPD
     value_type = EXCLUDED.value_type,
     channel    = EXCLUDED.channel,
     task_id    = EXCLUDED.task_id,
-    updated_at = NOW()
+    updated_at = NOW(),
+    deleted_at = NULL
 `
 
 type UpsertCheckpointWriteParams struct {

--- a/go/core/internal/database/gen/push_notifications.sql.go
+++ b/go/core/internal/database/gen/push_notifications.sql.go
@@ -85,7 +85,8 @@ VALUES ($1, $2, $3, $4, NOW(), NOW())
 ON CONFLICT (id) DO UPDATE SET
     data             = EXCLUDED.data,
     protocol_version = EXCLUDED.protocol_version,
-    updated_at       = NOW()
+    updated_at       = NOW(),
+    deleted_at       = NULL
 `
 
 type UpsertPushNotificationParams struct {

--- a/go/core/internal/database/queries/langgraph.sql
+++ b/go/core/internal/database/queries/langgraph.sql
@@ -10,7 +10,8 @@ ON CONFLICT (user_id, thread_id, checkpoint_ns, checkpoint_id) DO UPDATE SET
     checkpoint           = EXCLUDED.checkpoint,
     checkpoint_type      = EXCLUDED.checkpoint_type,
     version              = EXCLUDED.version,
-    updated_at           = NOW();
+    updated_at           = NOW(),
+    deleted_at           = NULL;
 
 -- name: ListCheckpoints :many
 SELECT * FROM lg_checkpoint
@@ -47,7 +48,8 @@ ON CONFLICT (user_id, thread_id, checkpoint_ns, checkpoint_id, write_idx) DO UPD
     value_type = EXCLUDED.value_type,
     channel    = EXCLUDED.channel,
     task_id    = EXCLUDED.task_id,
-    updated_at = NOW();
+    updated_at = NOW(),
+    deleted_at = NULL;
 
 -- name: SoftDeleteCheckpoints :exec
 UPDATE lg_checkpoint SET deleted_at = NOW()

--- a/go/core/internal/database/queries/push_notifications.sql
+++ b/go/core/internal/database/queries/push_notifications.sql
@@ -14,7 +14,8 @@ VALUES ($1, $2, $3, $4, NOW(), NOW())
 ON CONFLICT (id) DO UPDATE SET
     data             = EXCLUDED.data,
     protocol_version = EXCLUDED.protocol_version,
-    updated_at       = NOW();
+    updated_at       = NOW(),
+    deleted_at       = NULL;
 
 -- name: SoftDeletePushNotification :exec
 UPDATE push_notification SET deleted_at = NOW()


### PR DESCRIPTION
Same class of bug as #2279, on the tables that issue did not cover.

## The rule

Every table with a `deleted_at` column is read through a `deleted_at IS NULL` filter. So an upsert whose `ON CONFLICT` target can match a tombstone has to say what it means:

- clear `deleted_at`, and the row comes back, or
- refuse to write, and tell the caller.

Doing neither updates a tombstone that stays deleted, so the write lands where no read can see it and the caller is told nothing.

## Where each table stood

| table | upsert on a tombstone | |
|---|---|---|
| `agent` | `deleted_at = NULL` | comes back |
| `tool`, `toolserver` | `deleted_at = NULL` | comes back |
| `crewai_agent_memory`, `crewai_flow_state` | `deleted_at = NULL` | comes back |
| `task` | `WHERE task.deleted_at IS NULL` | refuses, id stays burned |
| `session` | unguarded, fixed in #2471 | refuses, id stays burned |
| `push_notification` | **neither** | invisible write |
| `lg_checkpoint` | **neither** | invisible write |
| `lg_checkpoint_write` | **neither** | invisible write |
| `event`, `feedback` | no upsert | not affected |

`agent_instance`, `agent_instance_task` and `agent_instance_task_event` have no `deleted_at` and are hard-deleted with a cascade, so they are outside this.

## The fix

The three unguarded upserts clear `deleted_at`, which is the same choice the other state tables already make.

These three hold writer-owned state, not an audited identity. A client re-registering a push notification config under an id it used before, or a checkpointer writing a thread's state again, is describing what should be current, so the right outcome is that the row comes back. Sessions and tasks are the opposite case, an identity that must not be reused, and that decision stays as it is.

Both soft-delete paths are reachable from the database client, `DeletePushNotification` and `DeleteCheckpoint`, so this is a live trap for anything that calls them rather than a hypothetical one.

## Tests

- `TestDeletedPushConfigIsRevivedByReRegistration`: register a config, delete the task's configs, register the same id again, and it is readable and listed once.
- `TestDeletedCheckpointRowsAreRevivedByANewWrite`: write a checkpoint and its write, delete the thread, write the same checkpoint id again, and both are readable with the new content.

Both run against a real Postgres and both fail without the query change: the list comes back empty and the get returns not-found while the write reported success.
