### PR TITLE
fix: ensure API key passthrough works for OpenAI embedding models

### DIFF
--- a/docs/architecture/crds-and-types.md
+++ b/docs/architecture/crds-and-types.md
@@ -161,6 +161,7 @@ ModelConfigSpec
 - Provider-specific config (e.g. `openAI`) must only be set when provider matches
 - `apiKeyPassthrough` and `apiKeySecret` are mutually exclusive
 - `apiKeyPassthrough` not allowed for Gemini/VertexAI providers
+- `apiKeyPassthrough` on a ModelConfig referenced via `memory.modelConfig` is only honored for openai, azure_openai, and foundry (other embedding providers ignore it)
 - TLS `caCertSecretRef` and `caCertSecretKey` must be set together
 
 ---

--- a/go/adk/pkg/embedding/embedding.go
+++ b/go/adk/pkg/embedding/embedding.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
 	"github.com/go-logr/logr"
 	"github.com/kagent-dev/kagent/go/adk/pkg/internal/azureai"
+	"github.com/kagent-dev/kagent/go/adk/pkg/models"
 	"github.com/kagent-dev/kagent/go/api/adk"
 	"github.com/ollama/ollama/api"
 	"github.com/openai/openai-go/v3"
@@ -110,14 +111,14 @@ func newOpenAIProvider(cfg *adk.EmbeddingConfig) (*openAIProvider, error) {
 	}, nil
 }
 
-func generateEmbeddings(ctx context.Context, client openai.Client, model, provider string, texts []string) ([][]float32, error) {
+func generateEmbeddings(ctx context.Context, client openai.Client, cfg *adk.EmbeddingConfig, provider string, isAzureFamily bool, texts []string) ([][]float32, error) {
 	log := logr.FromContextOrDiscard(ctx)
 
 	resp, err := client.Embeddings.New(ctx, openai.EmbeddingNewParams{
-		Model:      openai.EmbeddingModel(model),
+		Model:      openai.EmbeddingModel(cfg.Model),
 		Input:      openai.EmbeddingNewParamsInputUnion{OfArrayOfStrings: texts},
 		Dimensions: openai.Int(int64(TargetDimension)),
-	})
+	}, embeddingPassthroughOpts(ctx, cfg, isAzureFamily)...)
 	if err != nil {
 		return nil, fmt.Errorf("%s embeddings request failed: %w", provider, err)
 	}
@@ -129,8 +130,25 @@ func generateEmbeddings(ctx context.Context, client openai.Client, model, provid
 	return processEmbeddings(log, raw, provider)
 }
 
+// embeddingPassthroughOpts uses models.PassthroughToken so the embedding client
+// resolves API key passthrough the same way as the chat/completions clients in
+// go/adk/pkg/models.
+func embeddingPassthroughOpts(ctx context.Context, cfg *adk.EmbeddingConfig, isAzureFamily bool) []option.RequestOption {
+	if cfg == nil {
+		return nil
+	}
+	token, ok := models.PassthroughToken(ctx, cfg.APIKeyPassthrough)
+	if !ok {
+		return nil
+	}
+	if isAzureFamily {
+		return []option.RequestOption{option.WithHeader("Api-Key", token)}
+	}
+	return []option.RequestOption{option.WithAPIKey(token)}
+}
+
 func (p *openAIProvider) generate(ctx context.Context, texts []string) ([][]float32, error) {
-	return generateEmbeddings(ctx, p.client, p.config.Model, "openai", texts)
+	return generateEmbeddings(ctx, p.client, p.config, "openai", false, texts)
 }
 
 type azureOpenAIProvider struct {
@@ -171,8 +189,16 @@ func newAzureOpenAIProvider(cfg *adk.EmbeddingConfig, cred azureai.TokenCredenti
 		APIVersion: apiVersion,
 		HTTPClient: defaultProviderHTTPClient(),
 	}
+	// Implicit auth mirrors NewAzureOpenAIModelWithLogger: the incoming bearer
+	// token when APIKeyPassthrough is enabled (a placeholder Api-Key is
+	// overwritten per request by embeddingPassthroughOpts), otherwise the
+	// AZURE_OPENAI_API_KEY Api-Key header, otherwise DefaultAzureCredential.
+	apiKey := os.Getenv("AZURE_OPENAI_API_KEY")
+	if cfg.APIKeyPassthrough {
+		apiKey = "passthrough"
+	}
 	if err := azureai.ApplyImplicitAuth(context.Background(), &clientCfg, azureai.AuthOptions{
-		APIKey:     os.Getenv("AZURE_OPENAI_API_KEY"),
+		APIKey:     apiKey,
 		Credential: cred,
 	}); err != nil {
 		return nil, err
@@ -189,7 +215,7 @@ func newAzureOpenAIProvider(cfg *adk.EmbeddingConfig, cred azureai.TokenCredenti
 }
 
 func (p *azureOpenAIProvider) generate(ctx context.Context, texts []string) ([][]float32, error) {
-	return generateEmbeddings(ctx, p.client, p.config.Model, "azure_openai", texts)
+	return generateEmbeddings(ctx, p.client, p.config, "azure_openai", true, texts)
 }
 
 type ollamaProvider struct {
@@ -408,8 +434,14 @@ func newFoundryProvider(cfg *adk.EmbeddingConfig, cred azureai.TokenCredential) 
 		APIVersion: apiVersion,
 		HTTPClient: defaultProviderHTTPClient(),
 	}
+	// See newAzureOpenAIProvider - the passthrough placeholder short-circuits
+	// past DefaultAzureCredential resolution the same way it does for chat.
+	apiKey := os.Getenv(azureai.FoundryAPIKeyEnvVar)
+	if cfg.APIKeyPassthrough {
+		apiKey = "passthrough"
+	}
 	if err := azureai.ApplyImplicitAuth(context.Background(), &clientCfg, azureai.AuthOptions{
-		APIKey:     os.Getenv(azureai.FoundryAPIKeyEnvVar),
+		APIKey:     apiKey,
 		Credential: cred,
 	}); err != nil {
 		return nil, err
@@ -423,5 +455,5 @@ func newFoundryProvider(cfg *adk.EmbeddingConfig, cred azureai.TokenCredential) 
 }
 
 func (p *foundryProvider) generate(ctx context.Context, texts []string) ([][]float32, error) {
-	return generateEmbeddings(ctx, p.client, p.config.Model, "foundry", texts)
+	return generateEmbeddings(ctx, p.client, p.config, "foundry", true, texts)
 }

--- a/go/adk/pkg/embedding/embedding_test.go
+++ b/go/adk/pkg/embedding/embedding_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/kagent-dev/kagent/go/adk/pkg/auth"
+	"github.com/kagent-dev/kagent/go/adk/pkg/models"
 	"github.com/kagent-dev/kagent/go/api/adk"
 )
 
@@ -45,15 +46,8 @@ func TestOpenAIProvider_UsesAPIKeyNotKagentToken(t *testing.T) {
 			t.Errorf("input = %v, want [hello]", req.Input)
 		}
 
-		vec := make([]float64, TargetDimension)
-		vec[0] = 1.0
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{
-			"object": "list",
-			"data":   []map[string]any{{"object": "embedding", "index": 0, "embedding": vec}},
-			"model":  req.Model,
-			"usage":  map[string]any{"prompt_tokens": 1, "total_tokens": 1},
-		})
+		json.NewEncoder(w).Encode(embeddingResponse("text-embedding-3-small"))
 	}))
 	defer srv.Close()
 
@@ -87,6 +81,69 @@ func TestOpenAIProvider_UsesAPIKeyNotKagentToken(t *testing.T) {
 	}
 }
 
+func TestOpenAIProvider_APIKeyPassthrough(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(embeddingResponse("text-embedding-3-small"))
+	}))
+	defer srv.Close()
+
+	client, err := New(Config{
+		EmbeddingConfig: &adk.EmbeddingConfig{
+			Provider:          "openai",
+			Model:             "text-embedding-3-small",
+			BaseUrl:           srv.URL,
+			APIKeyPassthrough: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx := context.WithValue(context.Background(), models.BearerTokenKey, "the-callers-token")
+	if _, err := client.Generate(ctx, []string{"hello"}); err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	if gotAuth != "Bearer the-callers-token" {
+		t.Errorf("Authorization = %q, want Bearer the-callers-token", gotAuth)
+	}
+}
+
+func TestOpenAIProvider_APIKeyPassthroughDisabled_IgnoresContextToken(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "sk-static-key")
+
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(embeddingResponse("text-embedding-3-small"))
+	}))
+	defer srv.Close()
+
+	client, err := New(Config{
+		EmbeddingConfig: &adk.EmbeddingConfig{
+			Provider: "openai",
+			Model:    "text-embedding-3-small",
+			BaseUrl:  srv.URL,
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx := context.WithValue(context.Background(), models.BearerTokenKey, "should-be-ignored")
+	if _, err := client.Generate(ctx, []string{"hello"}); err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	if gotAuth != "Bearer sk-static-key" {
+		t.Errorf("Authorization = %q, want Bearer sk-static-key (passthrough disabled)", gotAuth)
+	}
+}
+
 func TestNormalizeL2(t *testing.T) {
 	normed := normalizeL2([]float32{3, 4})
 	var sum float64
@@ -106,7 +163,7 @@ func TestProcessEmbeddings_RejectsUndersized(t *testing.T) {
 	}
 }
 
-func azureEmbeddingResponse(model string) map[string]any {
+func embeddingResponse(model string) map[string]any {
 	vec := make([]float64, TargetDimension)
 	vec[0] = 1.0
 	return map[string]any{
@@ -177,7 +234,7 @@ func TestAzureOpenAIProvider_RequestShape(t *testing.T) {
 				gotAPIKey = r.Header.Get("Api-Key")
 				gotAPIVersion = r.URL.Query().Get("api-version")
 				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(azureEmbeddingResponse(deployment))
+				json.NewEncoder(w).Encode(embeddingResponse(deployment))
 			}))
 			defer srv.Close()
 
@@ -215,6 +272,74 @@ func TestAzureOpenAIProvider_RequestShape(t *testing.T) {
 				t.Errorf("Api-Key = %q, want %q", gotAPIKey, apiKey)
 			}
 		})
+	}
+}
+
+func TestAzureOpenAIProvider_APIKeyPassthrough(t *testing.T) {
+	t.Setenv("AZURE_OPENAI_API_KEY", "")
+
+	var gotAPIKey, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAPIKey = r.Header.Get("Api-Key")
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(embeddingResponse("text-embedding-3-small"))
+	}))
+	defer srv.Close()
+
+	client, err := New(Config{
+		EmbeddingConfig: &adk.EmbeddingConfig{
+			Provider:          "azure_openai",
+			Model:             "text-embedding-3-small",
+			Endpoint:          srv.URL,
+			APIKeyPassthrough: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx := context.WithValue(context.Background(), models.BearerTokenKey, "the-callers-token")
+	if _, err := client.Generate(ctx, []string{"hello"}); err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	if gotAPIKey != "the-callers-token" {
+		t.Errorf("Api-Key = %q, want the-callers-token", gotAPIKey)
+	}
+	if gotAuth != "" {
+		t.Errorf("Authorization = %q, want empty (Azure uses Api-Key)", gotAuth)
+	}
+}
+
+func TestAzureOpenAIProvider_APIKeyPassthroughOverridesStaticKey(t *testing.T) {
+	t.Setenv("AZURE_OPENAI_API_KEY", "static-key-should-be-overridden")
+
+	var gotAPIKey string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAPIKey = r.Header.Get("Api-Key")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(embeddingResponse("text-embedding-3-small"))
+	}))
+	defer srv.Close()
+
+	client, err := New(Config{
+		EmbeddingConfig: &adk.EmbeddingConfig{
+			Provider:          "azure_openai",
+			Model:             "text-embedding-3-small",
+			Endpoint:          srv.URL,
+			APIKeyPassthrough: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx := context.WithValue(context.Background(), models.BearerTokenKey, "the-callers-token")
+	if _, err := client.Generate(ctx, []string{"hello"}); err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	if gotAPIKey != "the-callers-token" {
+		t.Errorf("Api-Key = %q, want the-callers-token", gotAPIKey)
 	}
 }
 

--- a/go/adk/pkg/embedding/foundry_embedding_test.go
+++ b/go/adk/pkg/embedding/foundry_embedding_test.go
@@ -2,25 +2,18 @@ package embedding
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/kagent-dev/kagent/go/adk/pkg/models"
 	"github.com/kagent-dev/kagent/go/api/adk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func openAIEmbeddingResponseBody() string {
-	vals := make([]string, TargetDimension)
-	for i := range vals {
-		vals[i] = "0.01"
-	}
-	return `{"object":"list","data":[{"object":"embedding","index":0,"embedding":[` + strings.Join(vals, ",") + `]}],"model":"text-embedding-3-small","usage":{"prompt_tokens":1,"total_tokens":1}}`
-}
 
 // TestFoundryProviderAPIKey verifies the API-key auth path: the Api-Key header
 // is set, the request targets the deployment embeddings path with the api-version
@@ -35,7 +28,7 @@ func TestFoundryProviderAPIKey(t *testing.T) {
 		gotAPIKey = r.Header.Get("Api-Key")
 		gotAuth = r.Header.Get("Authorization")
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(openAIEmbeddingResponseBody()))
+		json.NewEncoder(w).Encode(embeddingResponse("text-embedding-3-small"))
 	}))
 	defer server.Close()
 
@@ -77,7 +70,7 @@ func TestFoundryProviderWorkloadIdentity(t *testing.T) {
 		gotAuth = r.Header.Get("Authorization")
 		gotAPIKey = r.Header.Get("Api-Key")
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(openAIEmbeddingResponseBody()))
+		json.NewEncoder(w).Encode(embeddingResponse("text-embedding-3-small"))
 	}))
 	defer server.Close()
 
@@ -95,4 +88,62 @@ func TestFoundryProviderWorkloadIdentity(t *testing.T) {
 	require.Len(t, embeddings, 1)
 	assert.Equal(t, "Bearer entra-token", gotAuth)
 	assert.Empty(t, gotAPIKey)
+}
+
+func TestFoundryProviderAPIKeyPassthrough(t *testing.T) {
+	t.Setenv("FOUNDRY_API_KEY", "")
+
+	var gotAPIKey, gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAPIKey = r.Header.Get("Api-Key")
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(embeddingResponse("text-embedding-3-small"))
+	}))
+	defer server.Close()
+
+	p, err := newFoundryProvider(&adk.EmbeddingConfig{
+		Provider:          "foundry",
+		Model:             "text-embedding-3-small",
+		Endpoint:          server.URL,
+		Deployment:        "text-embedding-3-small",
+		APIVersion:        "2024-10-21",
+		APIKeyPassthrough: true,
+	}, nil)
+	require.NoError(t, err)
+
+	ctx := context.WithValue(context.Background(), models.BearerTokenKey, "the-callers-token")
+	embeddings, err := p.generate(ctx, []string{"hello"})
+	require.NoError(t, err)
+	require.Len(t, embeddings, 1)
+	assert.Equal(t, "the-callers-token", gotAPIKey)
+	assert.Empty(t, gotAuth)
+}
+
+func TestFoundryProviderAPIKeyPassthroughOverridesStaticKey(t *testing.T) {
+	t.Setenv("FOUNDRY_API_KEY", "static-key-should-be-overridden")
+
+	var gotAPIKey string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAPIKey = r.Header.Get("Api-Key")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(embeddingResponse("text-embedding-3-small"))
+	}))
+	defer server.Close()
+
+	p, err := newFoundryProvider(&adk.EmbeddingConfig{
+		Provider:          "foundry",
+		Model:             "text-embedding-3-small",
+		Endpoint:          server.URL,
+		Deployment:        "text-embedding-3-small",
+		APIVersion:        "2024-10-21",
+		APIKeyPassthrough: true,
+	}, nil)
+	require.NoError(t, err)
+
+	ctx := context.WithValue(context.Background(), models.BearerTokenKey, "the-callers-token")
+	embeddings, err := p.generate(ctx, []string{"hello"})
+	require.NoError(t, err)
+	require.Len(t, embeddings, 1)
+	assert.Equal(t, "the-callers-token", gotAPIKey)
 }

--- a/go/adk/pkg/models/anthropic.go
+++ b/go/adk/pkg/models/anthropic.go
@@ -17,13 +17,11 @@ import (
 // from the bearer token in ctx when APIKeyPassthrough is enabled. The Anthropic SDK sends
 // this as the x-api-key header, which is the correct auth mechanism for Anthropic.
 func anthropicPassthroughOpts(ctx context.Context, cfg *AnthropicConfig) []option.RequestOption {
-	if !cfg.APIKeyPassthrough {
+	token, ok := PassthroughToken(ctx, cfg.APIKeyPassthrough)
+	if !ok {
 		return nil
 	}
-	if token, ok := ctx.Value(BearerTokenKey).(string); ok && token != "" {
-		return []option.RequestOption{option.WithAPIKey(token)}
-	}
-	return nil
+	return []option.RequestOption{option.WithAPIKey(token)}
 }
 
 // AnthropicConfig holds Anthropic configuration

--- a/go/adk/pkg/models/base.go
+++ b/go/adk/pkg/models/base.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -77,6 +78,21 @@ func withConnectTimeout(base http.RoundTripper, connectTimeout time.Duration) (h
 
 // BearerTokenKey is the context key for storing the bearer token for API key passthrough
 var BearerTokenKey = &contextKey{}
+
+// PassthroughToken returns the caller's bearer token from ctx when apiKeyPassthrough
+// is enabled, so every model/embedding provider resolves passthrough the same way.
+// Each caller wraps the returned token in its own SDK's request-option type, since
+// that varies by provider (e.g. Authorization vs Api-Key header).
+func PassthroughToken(ctx context.Context, apiKeyPassthrough bool) (token string, ok bool) {
+	if !apiKeyPassthrough {
+		return "", false
+	}
+	token, ok = ctx.Value(BearerTokenKey).(string)
+	if !ok || token == "" {
+		return "", false
+	}
+	return token, true
+}
 
 type contextKey struct{}
 

--- a/go/adk/pkg/models/openai.go
+++ b/go/adk/pkg/models/openai.go
@@ -201,14 +201,15 @@ func NewAzureOpenAIModelWithLogger(ctx context.Context, config *AzureOpenAIConfi
 // For OpenAI the SDK sends this as "Authorization: Bearer <token>".
 // For Azure the SDK sends this as "Api-Key: <token>" via option.WithHeader.
 func openAIPassthroughOpts(ctx context.Context, m *OpenAIModel) []option.RequestOption {
-	if m.Config == nil || !m.Config.APIKeyPassthrough {
+	if m.Config == nil {
 		return nil
 	}
-	if token, ok := ctx.Value(BearerTokenKey).(string); ok && token != "" {
-		if m.IsAzure {
-			return []option.RequestOption{option.WithHeader("Api-Key", token)}
-		}
-		return []option.RequestOption{option.WithAPIKey(token)}
+	token, ok := PassthroughToken(ctx, m.Config.APIKeyPassthrough)
+	if !ok {
+		return nil
 	}
-	return nil
+	if m.IsAzure {
+		return []option.RequestOption{option.WithHeader("Api-Key", token)}
+	}
+	return []option.RequestOption{option.WithAPIKey(token)}
 }

--- a/go/api/adk/types.go
+++ b/go/api/adk/types.go
@@ -445,9 +445,10 @@ type RemoteAgentConfig struct {
 // EmbeddingConfig is the embedding model config for memory tools.
 // JSON uses "provider" to match Python EmbeddingConfig; unmarshaling accepts "type" for backward compat.
 type EmbeddingConfig struct {
-	Provider string `json:"provider"`
-	Model    string `json:"model"`
-	BaseUrl  string `json:"base_url,omitempty"`
+	Provider          string `json:"provider"`
+	Model             string `json:"model"`
+	BaseUrl           string `json:"base_url,omitempty"`
+	APIKeyPassthrough bool   `json:"api_key_passthrough,omitempty"`
 	// Endpoint, Deployment, and APIVersion are the Azure data-plane settings,
 	// populated for the providers that use the shared azureai client.
 	Endpoint   string `json:"endpoint,omitempty"`
@@ -457,19 +458,21 @@ type EmbeddingConfig struct {
 
 func (e *EmbeddingConfig) UnmarshalJSON(data []byte) error {
 	var tmp struct {
-		Type       string `json:"type"`
-		Provider   string `json:"provider"`
-		Model      string `json:"model"`
-		BaseUrl    string `json:"base_url"`
-		Endpoint   string `json:"endpoint"`
-		Deployment string `json:"deployment"`
-		APIVersion string `json:"api_version"`
+		Type              string `json:"type"`
+		Provider          string `json:"provider"`
+		Model             string `json:"model"`
+		BaseUrl           string `json:"base_url"`
+		APIKeyPassthrough bool   `json:"api_key_passthrough"`
+		Endpoint          string `json:"endpoint"`
+		Deployment        string `json:"deployment"`
+		APIVersion        string `json:"api_version"`
 	}
 	if err := json.Unmarshal(data, &tmp); err != nil {
 		return err
 	}
 	e.Model = tmp.Model
 	e.BaseUrl = tmp.BaseUrl
+	e.APIKeyPassthrough = tmp.APIKeyPassthrough
 	e.Endpoint = tmp.Endpoint
 	e.Deployment = tmp.Deployment
 	e.APIVersion = tmp.APIVersion
@@ -492,8 +495,10 @@ func ModelToEmbeddingConfig(m Model) *EmbeddingConfig {
 	case *OpenAI:
 		e.Model = v.Model
 		e.BaseUrl = v.BaseUrl
+		e.APIKeyPassthrough = v.APIKeyPassthrough
 	case *AzureOpenAI:
 		e.Model = v.Model
+		e.APIKeyPassthrough = v.APIKeyPassthrough
 		e.Endpoint = v.Endpoint
 		e.Deployment = v.Deployment
 		e.APIVersion = v.APIVersion
@@ -515,6 +520,7 @@ func ModelToEmbeddingConfig(m Model) *EmbeddingConfig {
 		e.BaseUrl = v.BaseUrl
 	case *Foundry:
 		e.Model = v.Model
+		e.APIKeyPassthrough = v.APIKeyPassthrough
 		e.Endpoint = v.Endpoint
 		e.Deployment = v.Deployment
 		e.APIVersion = v.APIVersion

--- a/go/api/adk/types_test.go
+++ b/go/api/adk/types_test.go
@@ -925,6 +925,42 @@ func TestEmbeddingConfig_UnmarshalJSON_ProviderOverridesType(t *testing.T) {
 	}
 }
 
+func TestEmbeddingConfig_UnmarshalJSON_APIKeyPassthrough(t *testing.T) {
+	data := []byte(`{"provider":"openai","model":"m","api_key_passthrough":true}`)
+	var cfg EmbeddingConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("UnmarshalJSON() error = %v", err)
+	}
+	if !cfg.APIKeyPassthrough {
+		t.Error("APIKeyPassthrough = false, want true")
+	}
+}
+
+func TestModelToEmbeddingConfig_APIKeyPassthrough(t *testing.T) {
+	tests := []struct {
+		name string
+		m    Model
+		want bool
+	}{
+		{"OpenAI", &OpenAI{BaseModel: BaseModel{APIKeyPassthrough: true}}, true},
+		{"AzureOpenAI", &AzureOpenAI{BaseModel: BaseModel{APIKeyPassthrough: true}}, true},
+		{"Foundry", &Foundry{BaseModel: BaseModel{APIKeyPassthrough: true}}, true},
+		{"OpenAI disabled", &OpenAI{}, false},
+		// Bedrock has no embedding-side passthrough support (see
+		// go/adk/pkg/embedding), so the field is never propagated for it even
+		// when set on the chat model.
+		{"Bedrock ignored", &Bedrock{BaseModel: BaseModel{APIKeyPassthrough: true}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ModelToEmbeddingConfig(tt.m)
+			if got.APIKeyPassthrough != tt.want {
+				t.Errorf("APIKeyPassthrough = %v, want %v", got.APIKeyPassthrough, tt.want)
+			}
+		})
+	}
+}
+
 func TestAgentConfig_ScanAndValue(t *testing.T) {
 	original := AgentConfig{
 		Model:       &OpenAI{BaseModel: BaseModel{Model: "gpt-4o"}},

--- a/python/packages/kagent-adk/src/kagent/adk/_agent_executor.py
+++ b/python/packages/kagent-adk/src/kagent/adk/_agent_executor.py
@@ -51,6 +51,7 @@ from kagent.core.tracing._span_processor import (
 from pydantic import BaseModel
 from typing_extensions import override
 
+from ._bearer_token import bearer_token, extract_bearer_token
 from ._mcp_toolset import is_anyio_cross_task_cancel_scope_error
 from ._remote_a2a_tool import SubagentSessionProvider
 from .converters.event_converter import convert_event_to_a2a_events, serialize_metadata_value
@@ -540,9 +541,13 @@ class A2aAgentExecutor(UpstreamA2aAgentExecutor):
         else:
             # Normal flow: set request headers to session state
             headers = context.call_context.state.get("headers", {})
+            headers = headers if isinstance(headers, dict) else {}
             state_changes = {
                 "headers": headers,
             }
+            # Also stash the token in a ContextVar for consumers with no
+            # callback_context of their own - see _bearer_token.py.
+            bearer_token.set(extract_bearer_token(headers))
 
             actions_with_update = EventActions(state_delta=state_changes)
             system_event = Event(

--- a/python/packages/kagent-adk/src/kagent/adk/_bearer_token.py
+++ b/python/packages/kagent-adk/src/kagent/adk/_bearer_token.py
@@ -1,0 +1,27 @@
+"""Incoming request Bearer token, shared across consumers outside the
+before_model_callback pipeline LLMPassthroughPlugin hooks into.
+
+Memory (KagentMemoryService/KAgentEmbedding) is the motivating case: its
+embedding calls are triggered from add_session_to_memory (an
+asyncio.create_task background task with no callback_context of its own),
+SaveMemoryTool, and PrefetchMemoryTool - none of which run as a
+before_model_callback. A ContextVar avoids threading a token parameter
+through google.adk's own BaseMemoryService interface (add_session_to_memory's
+signature is fixed by ADK's runner, not by kagent-adk). asyncio.create_task
+copies the current contextvars.Context at task-creation time, so a background
+task still sees the token of the request that scheduled it.
+"""
+
+import contextvars
+from typing import Optional
+
+bearer_token: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar("kagent_bearer_token", default=None)
+
+
+def extract_bearer_token(headers: dict) -> Optional[str]:
+    """Extract the Bearer token from an A2A request's headers dict."""
+    auth_header = headers.get("authorization") or headers.get("Authorization", "")
+    if not auth_header.startswith("Bearer "):
+        return None
+    token = auth_header[7:].strip()
+    return token or None

--- a/python/packages/kagent-adk/src/kagent/adk/_llm_passthrough_plugin.py
+++ b/python/packages/kagent-adk/src/kagent/adk/_llm_passthrough_plugin.py
@@ -14,6 +14,8 @@ from google.adk.models.llm_request import LlmRequest
 from google.adk.models.llm_response import LlmResponse
 from google.adk.plugins.base_plugin import BasePlugin
 
+from ._bearer_token import extract_bearer_token
+
 logger = logging.getLogger(__name__)
 
 
@@ -26,16 +28,6 @@ class SupportsPassthroughAuth(Protocol):
     def set_passthrough_key(self, token: str) -> None: ...
 
 
-def _extract_bearer_token(callback_context: CallbackContext) -> Optional[str]:
-    """Extract the Bearer token from session state headers."""
-    headers = callback_context.state.get("headers", {})
-    auth_header = headers.get("authorization") or headers.get("Authorization", "")
-    if not auth_header.startswith("Bearer "):
-        return None
-    token = auth_header[7:].strip()
-    return token or None
-
-
 class LLMPassthroughPlugin(BasePlugin):
     """Sets the LLM API key from the incoming request's Bearer token."""
 
@@ -45,7 +37,7 @@ class LLMPassthroughPlugin(BasePlugin):
     async def before_model_callback(
         self, *, callback_context: CallbackContext, llm_request: LlmRequest
     ) -> Optional[LlmResponse]:
-        token = _extract_bearer_token(callback_context)
+        token = extract_bearer_token(callback_context.state.get("headers", {}))
         if not token:
             return None
 

--- a/python/packages/kagent-adk/src/kagent/adk/models/_embedding.py
+++ b/python/packages/kagent-adk/src/kagent/adk/models/_embedding.py
@@ -12,10 +12,11 @@ import asyncio
 import json
 import logging
 import os
-from typing import Any, List, Union
+from typing import Any, List, Optional, Union
 
 import numpy as np
 
+from kagent.adk._bearer_token import bearer_token
 from kagent.adk.types import EmbeddingConfig
 
 logger = logging.getLogger(__name__)
@@ -142,9 +143,20 @@ class KAgentEmbedding:
             norm = np.linalg.norm(x, 2, axis=1, keepdims=True)
             return np.where(norm == 0, x, x / norm)
 
+    def _passthrough_api_key(self) -> Optional[str]:
+        """Bearer token to use as the API key when api_key_passthrough is
+        enabled, mirroring BaseOpenAI.set_passthrough_key for chat models.
+        None falls back to the SDK's own env var lookup (OPENAI_API_KEY /
+        AZURE_OPENAI_API_KEY).
+        """
+        if not self.config.api_key_passthrough:
+            return None
+        return bearer_token.get()
+
     async def _embed_openai(self, texts: List[str]) -> List[List[float]]:
         """Embed using the OpenAI or Azure OpenAI SDK."""
         provider = self.config.provider.lower()
+        api_key = self._passthrough_api_key()
 
         if provider == "azure_openai":
             from openai import AsyncAzureOpenAI
@@ -153,11 +165,11 @@ class KAgentEmbedding:
             api_base = self.config.base_url or os.environ.get("AZURE_OPENAI_ENDPOINT")
             if not api_base:
                 raise ValueError("Azure OpenAI endpoint must be set via base_url or AZURE_OPENAI_ENDPOINT env var")
-            client = AsyncAzureOpenAI(api_version=api_version, azure_endpoint=api_base)
+            client = AsyncAzureOpenAI(api_version=api_version, azure_endpoint=api_base, api_key=api_key)
         else:
             from openai import AsyncOpenAI
 
-            client = AsyncOpenAI(base_url=self.config.base_url or None)
+            client = AsyncOpenAI(base_url=self.config.base_url or None, api_key=api_key)
 
         response = await client.embeddings.create(
             model=self.config.model,

--- a/python/packages/kagent-adk/src/kagent/adk/types.py
+++ b/python/packages/kagent-adk/src/kagent/adk/types.py
@@ -373,6 +373,7 @@ class EmbeddingConfig(BaseModel):
     model: str
     provider: str
     base_url: str | None = None
+    api_key_passthrough: bool = False
 
 
 class MemoryConfig(BaseModel):

--- a/python/packages/kagent-adk/tests/unittests/test_embedding.py
+++ b/python/packages/kagent-adk/tests/unittests/test_embedding.py
@@ -6,13 +6,25 @@ from unittest import mock
 import numpy as np
 import pytest
 
+from kagent.adk._bearer_token import bearer_token
 from kagent.adk.models import KAgentEmbedding
 from kagent.adk.types import EmbeddingConfig
 
 
-def make_client(provider: str, model: str, base_url: str | None = None) -> KAgentEmbedding:
+@pytest.fixture(autouse=True)
+def _reset_bearer_token():
+    token = bearer_token.set(None)
+    yield
+    bearer_token.reset(token)
+
+
+def make_client(
+    provider: str, model: str, base_url: str | None = None, api_key_passthrough: bool = False
+) -> KAgentEmbedding:
     return KAgentEmbedding(
-        config=EmbeddingConfig(provider=provider, model=model, base_url=base_url),
+        config=EmbeddingConfig(
+            provider=provider, model=model, base_url=base_url, api_key_passthrough=api_key_passthrough
+        ),
     )
 
 
@@ -214,6 +226,62 @@ class TestEmbeddingDispatch:
             await client.generate("test")
 
         mock_boto.assert_called_once_with("bedrock-runtime", region_name="eu-west-1")
+
+
+class TestAPIKeyPassthrough:
+    @pytest.mark.asyncio
+    async def test_openai_uses_bearer_token(self):
+        client = make_client(provider="openai", model="text-embedding-3-small", api_key_passthrough=True)
+        bearer_token.set("the-callers-token")
+        mock_response = make_openai_embedding_response([[0.1] * 768])
+        with mock.patch("openai.AsyncOpenAI") as mock_cls:
+            instance = mock.AsyncMock()
+            instance.embeddings.create = mock.AsyncMock(return_value=mock_response)
+            mock_cls.return_value = instance
+            await client.generate("hello")
+        assert mock_cls.call_args.kwargs["api_key"] == "the-callers-token"
+
+    @pytest.mark.asyncio
+    async def test_azure_openai_uses_bearer_token(self):
+        client = make_client(
+            provider="azure_openai",
+            model="text-embedding-ada-002",
+            base_url="https://myazure.openai.azure.com",
+            api_key_passthrough=True,
+        )
+        bearer_token.set("the-callers-token")
+        mock_response = make_openai_embedding_response([[0.1] * 768])
+        with mock.patch("openai.AsyncAzureOpenAI") as mock_cls:
+            instance = mock.AsyncMock()
+            instance.embeddings.create = mock.AsyncMock(return_value=mock_response)
+            mock_cls.return_value = instance
+            await client.generate("hello")
+        assert mock_cls.call_args.kwargs["api_key"] == "the-callers-token"
+
+    @pytest.mark.asyncio
+    async def test_disabled_ignores_bearer_token(self):
+        client = make_client(provider="openai", model="text-embedding-3-small", api_key_passthrough=False)
+        bearer_token.set("should-be-ignored")
+        mock_response = make_openai_embedding_response([[0.1] * 768])
+        with mock.patch("openai.AsyncOpenAI") as mock_cls:
+            instance = mock.AsyncMock()
+            instance.embeddings.create = mock.AsyncMock(return_value=mock_response)
+            mock_cls.return_value = instance
+            await client.generate("hello")
+        assert mock_cls.call_args.kwargs["api_key"] is None
+
+    @pytest.mark.asyncio
+    async def test_enabled_but_no_token_falls_back_to_none(self):
+        # No fallback credential - falls back to the SDK's own OPENAI_API_KEY
+        # env var lookup, same as before passthrough support existed.
+        client = make_client(provider="openai", model="text-embedding-3-small", api_key_passthrough=True)
+        mock_response = make_openai_embedding_response([[0.1] * 768])
+        with mock.patch("openai.AsyncOpenAI") as mock_cls:
+            instance = mock.AsyncMock()
+            instance.embeddings.create = mock.AsyncMock(return_value=mock_response)
+            mock_cls.return_value = instance
+            await client.generate("hello")
+        assert mock_cls.call_args.kwargs["api_key"] is None
 
 
 class TestEmbeddingNormalization:


### PR DESCRIPTION
Backports #2457 to `release/v0.10.x`