### PR TITLE
fix(kagent-adk): surface the sub-agent's ask_user question in remote_hitl_hint

### DIFF
--- a/python/packages/kagent-adk/src/kagent/adk/_hitl.py
+++ b/python/packages/kagent-adk/src/kagent/adk/_hitl.py
@@ -104,7 +104,18 @@ def visible_tools(request: ToolApprovalRequest | AskUserRequest) -> list[HitlToo
 
 def remote_hitl_hint(state: RemoteHitlState) -> str:
     """Build the parent confirmation hint for a paused child task."""
-    names = [tool.name for tool in visible_tools(state.hitl_request)]
+    request = state.hitl_request
+    if isinstance(request, AskUserRequest):
+        # questions carries the real text whether or not nested is set (see
+        # build_hitl_status_message), so prefer it over the bare tool name.
+        question_text = " ".join(
+            question["question"]
+            for question in request.questions
+            if isinstance(question.get("question"), str) and question["question"]
+        )
+        if question_text:
+            return f"Remote agent '{state.subagent_name}' asks: {question_text}"
+    names = [tool.name for tool in visible_tools(request)]
     if names:
         return f"Remote agent '{state.subagent_name}' requires approval for tool(s): {', '.join(names)}"
     return f"Remote agent '{state.subagent_name}' requires human input before continuing."

--- a/python/packages/kagent-adk/tests/unittests/test_hitl.py
+++ b/python/packages/kagent-adk/tests/unittests/test_hitl.py
@@ -27,7 +27,9 @@ from kagent.adk._approval import make_approval_callback
 from kagent.adk._hitl import (
     RemoteHitlState,
     build_hitl_status_message,
+    build_remote_hitl_state,
     build_resume_hitl_message,
+    remote_hitl_hint,
 )
 
 
@@ -283,6 +285,54 @@ def test_resume_rejects_non_input_required_task():
             task,
             _incoming(ToolApprovalResponse(approvals=[ToolApproval(id="confirm-1", approved=True)])),
         )
+
+
+def test_remote_hitl_hint_tool_approval():
+    task = _stored_task(ToolApprovalRequest(tools=[_tool("child-confirm", "delete_pod")]))
+    state = build_remote_hitl_state(task, "k8s_agent")
+
+    assert state is not None
+    assert remote_hitl_hint(state) == "Remote agent 'k8s_agent' requires approval for tool(s): delete_pod"
+
+
+def test_remote_hitl_hint_ask_user():
+    task = _stored_task(
+        AskUserRequest(id="confirm-1", questions=[{"question": "What is the GitHub owner/org for the repo?"}])
+    )
+    state = build_remote_hitl_state(task, "github_agent")
+
+    assert state is not None
+    assert remote_hitl_hint(state) == "Remote agent 'github_agent' asks: What is the GitHub owner/org for the repo?"
+
+
+def test_remote_hitl_hint_ask_user_nested():
+    """A two-level nested ask_user pause should also surface the real question
+    from the top-level questions field, not just the bare 'ask_user' tool name."""
+    question = "What is the GitHub owner/org for the repo?"
+    task = _stored_task(
+        AskUserRequest(
+            id="confirm-1",
+            questions=[{"question": question}],
+            nested=NestedHitlRequest(
+                subagent_name="grandchild_agent",
+                task_id="grandchild-task",
+                context_id="grandchild-context",
+                tools=[
+                    HitlTool(
+                        id="confirm-2",
+                        call_id="confirm-2",
+                        name="ask_user",
+                        args={"questions": [{"question": question}]},
+                    )
+                ],
+            ),
+        )
+    )
+    state = build_remote_hitl_state(task, "github_agent")
+
+    assert state is not None
+    assert state.hitl_request.nested is not None
+    assert remote_hitl_hint(state) == f"Remote agent 'github_agent' asks: {question}"
 
 
 def test_resume_rejects_input_required_task_without_public_hitl_request():


### PR DESCRIPTION
## Summary

`remote_hitl_hint()` in the Python `kagent-adk` runtime builds the hint text shown to a human when a sub-agent's own HITL pause bubbles up to the parent agent. Unlike the Go runtime's `RemoteHitlHint()`, it only ever lists the paused tool's *name* (e.g. `ask_user`) — never the actual question — even though `AskUserRequest.questions` (set directly on the request in `build_hitl_status_message`, whether or not `nested` is populated) has the real content right there.

- Before: `"Remote agent 'github_agent' requires approval for tool(s): ask_user"`
- After: `"Remote agent 'github_agent' asks: What is the GitHub owner/org for the repo?"`

Real tool-approval hints (the non-`ask_user` case) are unaffected.

This is the Python-runtime counterpart to #2475, which fixed the same class of bug in `go/adk/pkg/a2a/hitl.go`. The Go and Python runtimes maintain independent implementations of this HITL hint logic, and the Python side never had question-surfacing added — so a parent agent built on `kagent-adk` still drops the question today even after #2475 merges.

Unlike the Go fix, there's no `[]any` vs `[]map[string]any]` JSON-decode subtlety to worry about here: Pydantic's `HitlTool.args: dict[str, Any]` keeps nested question dicts intact, so reading `AskUserRequest.questions` directly is straightforward in both the direct and nested case.

Fixes #2473

## Changes

- `python/packages/kagent-adk/src/kagent/adk/_hitl.py`: `remote_hitl_hint()` now checks `AskUserRequest.questions` first and returns `"Remote agent '{name}' asks: {question}"` when present, falling back to the existing tool-name-only wording otherwise.
- `python/packages/kagent-adk/tests/unittests/test_hitl.py`: adds `test_remote_hitl_hint_tool_approval`, `test_remote_hitl_hint_ask_user`, and `test_remote_hitl_hint_ask_user_nested` (the last covering a two-level nested `ask_user` pause).

## Test plan

- [x] `uv run pytest packages/kagent-adk/tests/unittests/test_hitl.py` — 18 passed (3 new)
- [x] `uv run ruff format --diff` / `uv run ruff check` — clean
- [x] Existing tests unaffected — no changes to tool-approval hint wording