### PR TITLE
Honor LOG_LEVEL in bundled agents and expose agent env config in helm

### DIFF
--- a/go/adk/cmd/main.go
+++ b/go/adk/cmd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"cmp"
 	"context"
 	"flag"
 	"net/http"
@@ -55,7 +56,7 @@ func setupLogger(logLevel string) (logr.Logger, *zap.Logger) {
 }
 
 func main() {
-	logLevel := flag.String("log-level", "info", "Set the logging level (debug, info, warn, error)")
+	logLevel := flag.String("log-level", cmp.Or(os.Getenv("LOG_LEVEL"), "info"), "Set the logging level (debug, info, warn, error)")
 	host := flag.String("host", "", "Set the host address to bind to (default: empty, binds to all interfaces)")
 	portFlag := flag.String("port", "", "Set the port to listen on (overrides PORT environment variable)")
 	filepathFlag := flag.String("filepath", "", "Set the config directory path (overrides CONFIG_DIR environment variable)")

--- a/helm/agents/argo-rollouts/templates/_helpers.tpl
+++ b/helm/agents/argo-rollouts/templates/_helpers.tpl
@@ -15,6 +15,10 @@ securityContext:
 nodeSelector:
   {{- toYaml . | nindent 2 }}
 {{- end }}
+{{- with .Values.env }}
+env:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 resources:
   {{- toYaml .Values.resources | nindent 2 }}
 {{- end }}

--- a/helm/agents/argo-rollouts/values.yaml
+++ b/helm/agents/argo-rollouts/values.yaml
@@ -10,6 +10,9 @@ memory:
 # -- Optional runtime specification for the agent. If not specified, it will default to "go". Supported runtimes include "python" and "go".
 runtime: ""
 
+# -- Additional environment variables set on the agent container.
+env: []
+
 imagePullSecrets: []
 
 resources:

--- a/helm/agents/cilium-debug/templates/_helpers.tpl
+++ b/helm/agents/cilium-debug/templates/_helpers.tpl
@@ -15,6 +15,10 @@ securityContext:
 nodeSelector:
   {{- toYaml . | nindent 2 }}
 {{- end }}
+{{- with .Values.env }}
+env:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 resources:
   {{- toYaml .Values.resources | nindent 2 }}
 {{- end }}

--- a/helm/agents/cilium-debug/values.yaml
+++ b/helm/agents/cilium-debug/values.yaml
@@ -10,6 +10,9 @@ memory:
 # -- Optional runtime specification for the agent. If not specified, it will default to "go". Supported runtimes include "python" and "go".
 runtime: ""
 
+# -- Additional environment variables set on the agent container.
+env: []
+
 imagePullSecrets: []
 
 resources:

--- a/helm/agents/cilium-manager/templates/_helpers.tpl
+++ b/helm/agents/cilium-manager/templates/_helpers.tpl
@@ -15,6 +15,10 @@ securityContext:
 nodeSelector:
   {{- toYaml . | nindent 2 }}
 {{- end }}
+{{- with .Values.env }}
+env:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 resources:
   {{- toYaml .Values.resources | nindent 2 }}
 {{- end }}

--- a/helm/agents/cilium-manager/values.yaml
+++ b/helm/agents/cilium-manager/values.yaml
@@ -10,6 +10,9 @@ memory:
 # -- Optional runtime specification for the agent. If not specified, it will default to "go". Supported runtimes include "python" and "go".
 runtime: ""
 
+# -- Additional environment variables set on the agent container.
+env: []
+
 imagePullSecrets: []
 
 resources:

--- a/helm/agents/cilium-policy/templates/_helpers.tpl
+++ b/helm/agents/cilium-policy/templates/_helpers.tpl
@@ -15,6 +15,10 @@ securityContext:
 nodeSelector:
   {{- toYaml . | nindent 2 }}
 {{- end }}
+{{- with .Values.env }}
+env:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 resources:
   {{- toYaml .Values.resources | nindent 2 }}
 {{- end }}

--- a/helm/agents/cilium-policy/values.yaml
+++ b/helm/agents/cilium-policy/values.yaml
@@ -10,6 +10,9 @@ memory:
 # -- Optional runtime specification for the agent. If not specified, it will default to "go". Supported runtimes include "python" and "go".
 runtime: ""
 
+# -- Additional environment variables set on the agent container.
+env: []
+
 imagePullSecrets: []
 
 resources:

--- a/helm/agents/helm/templates/_helpers.tpl
+++ b/helm/agents/helm/templates/_helpers.tpl
@@ -15,6 +15,10 @@ securityContext:
 nodeSelector:
   {{- toYaml . | nindent 2 }}
 {{- end }}
+{{- with .Values.env }}
+env:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 resources:
   {{- toYaml .Values.resources | nindent 2 }}
 {{- end }}

--- a/helm/agents/helm/values.yaml
+++ b/helm/agents/helm/values.yaml
@@ -10,6 +10,9 @@ memory:
 # -- Optional runtime specification for the agent. If not specified, it will default to "go". Supported runtimes include "python" and "go".
 runtime: ""
 
+# -- Additional environment variables set on the agent container.
+env: []
+
 imagePullSecrets: []
 
 resources:

--- a/helm/agents/istio/templates/_helpers.tpl
+++ b/helm/agents/istio/templates/_helpers.tpl
@@ -15,6 +15,10 @@ securityContext:
 nodeSelector:
   {{- toYaml . | nindent 2 }}
 {{- end }}
+{{- with .Values.env }}
+env:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 resources:
   {{- toYaml .Values.resources | nindent 2 }}
 {{- end }}

--- a/helm/agents/istio/values.yaml
+++ b/helm/agents/istio/values.yaml
@@ -10,6 +10,9 @@ memory:
 # -- Optional runtime specification for the agent. If not specified, it will default to "go". Supported runtimes include "python" and "go".
 runtime: ""
 
+# -- Additional environment variables set on the agent container.
+env: []
+
 imagePullSecrets: []
 
 resources:

--- a/helm/agents/k8s/templates/_helpers.tpl
+++ b/helm/agents/k8s/templates/_helpers.tpl
@@ -15,6 +15,10 @@ securityContext:
 nodeSelector:
   {{- toYaml . | nindent 2 }}
 {{- end }}
+{{- with .Values.env }}
+env:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 resources:
   {{- toYaml .Values.resources | nindent 2 }}
 {{- end }}

--- a/helm/agents/k8s/values.yaml
+++ b/helm/agents/k8s/values.yaml
@@ -10,6 +10,9 @@ memory:
 # -- Optional runtime specification for the agent. If not specified, it will default to "go". Supported runtimes include "python" and "go".
 runtime: ""
 
+# -- Additional environment variables set on the agent container.
+env: []
+
 imagePullSecrets: []
 
 resources:

--- a/helm/agents/kgateway/templates/_helpers.tpl
+++ b/helm/agents/kgateway/templates/_helpers.tpl
@@ -15,6 +15,10 @@ securityContext:
 nodeSelector:
   {{- toYaml . | nindent 2 }}
 {{- end }}
+{{- with .Values.env }}
+env:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 resources:
   {{- toYaml .Values.resources | nindent 2 }}
 {{- end }}

--- a/helm/agents/kgateway/values.yaml
+++ b/helm/agents/kgateway/values.yaml
@@ -10,6 +10,9 @@ memory:
 # -- Optional runtime specification for the agent. If not specified, it will default to "go". Supported runtimes include "python" and "go".
 runtime: ""
 
+# -- Additional environment variables set on the agent container.
+env: []
+
 imagePullSecrets: []
 
 resources:

--- a/helm/agents/observability/templates/_helpers.tpl
+++ b/helm/agents/observability/templates/_helpers.tpl
@@ -15,6 +15,10 @@ securityContext:
 nodeSelector:
   {{- toYaml . | nindent 2 }}
 {{- end }}
+{{- with .Values.env }}
+env:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 resources:
   {{- toYaml .Values.resources | nindent 2 }}
 {{- end }}

--- a/helm/agents/observability/values.yaml
+++ b/helm/agents/observability/values.yaml
@@ -10,6 +10,9 @@ memory:
 # -- Optional runtime specification for the agent. If not specified, it will default to "go". Supported runtimes include "python" and "go".
 runtime: ""
 
+# -- Additional environment variables set on the agent container.
+env: []
+
 imagePullSecrets: []
 
 resources:

--- a/helm/agents/promql/templates/_helpers.tpl
+++ b/helm/agents/promql/templates/_helpers.tpl
@@ -15,6 +15,10 @@ securityContext:
 nodeSelector:
   {{- toYaml . | nindent 2 }}
 {{- end }}
+{{- with .Values.env }}
+env:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 resources:
   {{- toYaml .Values.resources | nindent 2 }}
 {{- end }}

--- a/helm/agents/promql/values.yaml
+++ b/helm/agents/promql/values.yaml
@@ -10,6 +10,9 @@ memory:
 # -- Optional runtime specification for the agent. If not specified, it will default to "go". Supported runtimes include "python" and "go".
 runtime: ""
 
+# -- Additional environment variables set on the agent container.
+env: []
+
 imagePullSecrets: []
 
 resources:

--- a/helm/kagent/tests/agent-env_test.yaml
+++ b/helm/kagent/tests/agent-env_test.yaml
@@ -1,0 +1,36 @@
+suite: test agent environment configuration
+templates:
+  - charts/k8s-agent/templates/agent.yaml
+tests:
+  - it: should not set env by default
+    set:
+      k8s-agent.enabled: true
+    asserts:
+      - isNull:
+          path: spec.declarative.deployment.env
+
+  - it: should set env when provided
+    set:
+      k8s-agent.enabled: true
+      k8s-agent.env:
+        - name: LOG_LEVEL
+          value: debug
+        - name: TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: agent-secret
+              key: token
+    asserts:
+      - equal:
+          path: spec.declarative.deployment.env[0]
+          value:
+            name: LOG_LEVEL
+            value: debug
+      - equal:
+          path: spec.declarative.deployment.env[1]
+          value:
+            name: TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: agent-secret
+                key: token


### PR DESCRIPTION
## Summary

- honor `LOG_LEVEL` in the Go ADK runtime while preserving `--log-level` precedence
- allow all bundled agent Helm charts to pass arbitrary environment variables, including `valueFrom` references

## Testing

- `go test ./adk/cmd`
- `helm unittest helm/kagent` (304 tests)
- rendered all ten bundled agents with `LOG_LEVEL=debug`