### PR TITLE
feat(python-adk): honor isolateSessions for remote agent tools

### DIFF
--- a/python/packages/kagent-adk/src/kagent/adk/_remote_a2a_tool.py
+++ b/python/packages/kagent-adk/src/kagent/adk/_remote_a2a_tool.py
@@ -120,15 +120,23 @@ class KAgentRemoteA2ATool(BaseTool):
         agent_card_url: str,
         httpx_client: Optional[httpx.AsyncClient] = None,
         header_provider: Optional[Callable[[Optional[ReadonlyContext]], dict[str, str]]] = None,
+        isolate_sessions: bool = False,
     ) -> None:
         super().__init__(name=name, description=description)
         self._agent_card_url = agent_card_url
         self._httpx_client = httpx_client
         self._header_provider = header_provider
+        self._isolate_sessions = isolate_sessions
         self._a2a_client: Optional[A2AClient] = None
         self._agent_card: Optional[AgentCard] = None
         # Pre-generate context_id for UI session polling
         self._last_context_id: str = str(uuid.uuid4())
+
+    def _context_id_for_call(self) -> str:
+        """Return the sub-agent session for one outbound invocation."""
+        if self._isolate_sessions:
+            return str(uuid.uuid4())
+        return self._last_context_id
 
     async def _ensure_client(self) -> A2AClient:
         """Lazily initialize the A2A client."""
@@ -263,10 +271,11 @@ class KAgentRemoteA2ATool(BaseTool):
         client = await self._ensure_client()
 
         request_text = args.get("request", "")
+        context_id = self._context_id_for_call()
         message = new_text_message(
             request_text,
             role=Role.ROLE_USER,
-            context_id=self._last_context_id,
+            context_id=context_id,
         )
         send_request = SendMessageRequest(message=message)
 
@@ -301,7 +310,7 @@ class KAgentRemoteA2ATool(BaseTool):
         state = task.status.state if task.status else None
 
         if state == TaskState.TASK_STATE_INPUT_REQUIRED:
-            return self._handle_input_required(task, tool_context)
+            return self._handle_input_required(task, tool_context, context_id)
 
         if state == TaskState.TASK_STATE_FAILED:
             error_text = _extract_text_from_task(task)
@@ -312,10 +321,12 @@ class KAgentRemoteA2ATool(BaseTool):
         result_text = _extract_text_from_task(task)
         usage = _extract_usage_from_task(task)
         if usage:
-            return {"result": result_text, "kagent_usage_metadata": usage, "subagent_session_id": self._last_context_id}
-        return {"result": result_text or "", "subagent_session_id": self._last_context_id}
+            return {"result": result_text, "kagent_usage_metadata": usage, "subagent_session_id": context_id}
+        return {"result": result_text or "", "subagent_session_id": context_id}
 
-    def _handle_input_required(self, task: Task, tool_context: ToolContext) -> dict[str, Any]:
+    def _handle_input_required(
+        self, task: Task, tool_context: ToolContext, context_id: str | None = None
+    ) -> dict[str, Any]:
         """Handle a subagent that returned input_required (HITL).
 
         Calls request_confirmation() to pause the parent agent and surface
@@ -329,6 +340,7 @@ class KAgentRemoteA2ATool(BaseTool):
             return {
                 "status": "failed",
                 "error": f"Remote agent '{self.name}' requested input without a valid HITL extension.",
+                "subagent_session_id": task.context_id or context_id,
             }
         hint = remote_hitl_hint(state)
 
@@ -339,7 +351,12 @@ class KAgentRemoteA2ATool(BaseTool):
         )
 
         tool_context.request_confirmation(hint=hint, payload=state.model_dump(exclude_none=True))
-        return {"status": "pending", "waiting_for": "subagent_approval", "subagent": self.name}
+        return {
+            "status": "pending",
+            "waiting_for": "subagent_approval",
+            "subagent": self.name,
+            "subagent_session_id": task.context_id or context_id,
+        }
 
     async def _handle_resume(self, tool_context: ToolContext) -> Any:
         """Phase 2: Forward the user's decision to the remote agent's pending task."""
@@ -450,6 +467,7 @@ class KAgentRemoteA2AToolset(BaseToolset):
         agent_card_url: str,
         httpx_client: httpx.AsyncClient,
         header_provider: Optional[Callable[[Optional[ReadonlyContext]], dict[str, str]]] = None,
+        isolate_sessions: bool = False,
     ) -> None:
         super().__init__()
         self._httpx_client = httpx_client
@@ -459,6 +477,7 @@ class KAgentRemoteA2AToolset(BaseToolset):
             agent_card_url=agent_card_url,
             httpx_client=httpx_client,
             header_provider=header_provider,
+            isolate_sessions=isolate_sessions,
         )
 
     @property

--- a/python/packages/kagent-adk/src/kagent/adk/types.py
+++ b/python/packages/kagent-adk/src/kagent/adk/types.py
@@ -239,9 +239,6 @@ class RemoteAgentConfig(BaseModel):
     headers: dict[str, Any] | None = None
     timeout: float = DEFAULT_TIMEOUT
     description: str = ""
-    # isolate_sessions: accepted for schema parity with the declarative API
-    # (see go/api/v1alpha3.Tool.IsolateSessions). The Python low-level tool
-    # (KAgentRemoteA2AToolset / _remote_a2a_tool.py) does not yet honor it.
     isolate_sessions: bool = False
 
 
@@ -527,6 +524,7 @@ class AgentConfig(BaseModel):
                         agent_card_url=f"{remote_agent.url}{AGENT_CARD_WELL_KNOWN_PATH}",
                         httpx_client=client,
                         header_provider=a2a_header_provider,
+                        isolate_sessions=remote_agent.isolate_sessions,
                     )
                 )
 

--- a/python/packages/kagent-adk/tests/unittests/test_proxy_integration.py
+++ b/python/packages/kagent-adk/tests/unittests/test_proxy_integration.py
@@ -146,6 +146,26 @@ async def test_remote_agent_with_proxy_url():
         )
 
 
+def test_remote_agent_isolate_sessions_is_forwarded_to_toolset():
+    config = AgentConfig(
+        model=OpenAI(model="gpt-3.5-turbo", type="openai", api_key="fake"),
+        description="Test agent",
+        instruction="You are a test agent",
+        remote_agents=[
+            RemoteAgentConfig(
+                name="remote_agent",
+                url="http://remote-agent.kagent:8080",
+                isolate_sessions=True,
+            )
+        ],
+    )
+
+    agent = config.to_agent("test_agent")
+
+    remote_agent_toolset = next(tool for tool in agent.tools if isinstance(tool, KAgentRemoteA2AToolset))
+    assert remote_agent_toolset._tool._isolate_sessions is True
+
+
 def test_remote_agent_no_proxy_when_not_configured():
     """Test that KAgentRemoteA2AToolset HTTP client works without proxy."""
 

--- a/python/packages/kagent-adk/tests/unittests/test_remote_a2a_tool.py
+++ b/python/packages/kagent-adk/tests/unittests/test_remote_a2a_tool.py
@@ -140,6 +140,7 @@ def _make_tool(
     *,
     httpx_client: httpx.AsyncClient | None = None,
     header_provider: Callable[[Any], dict[str, str]] | None = None,
+    isolate_sessions: bool = False,
 ) -> KAgentRemoteA2ATool:
     return KAgentRemoteA2ATool(
         name="k8s_agent",
@@ -147,6 +148,7 @@ def _make_tool(
         agent_card_url="http://k8s-agent/.well-known/agent.json",
         httpx_client=httpx_client,
         header_provider=header_provider,
+        isolate_sessions=isolate_sessions,
     )
 
 
@@ -297,6 +299,50 @@ class TestFirstCall:
             p.stop()
 
         assert sent[0].message.context_id == tool._last_context_id
+
+    async def test_shared_session_reuses_context_id_across_calls(self):
+        """The default mode keeps stateful sub-agent calls in one session."""
+        tool = _make_tool()
+        task = _make_task(TaskState.TASK_STATE_COMPLETED, text="ok")
+        sent: list[SendMessageRequest] = []
+
+        async def capture(*, request: SendMessageRequest, **kw):
+            sent.append(request)
+            yield (task, None)
+
+        p, _ = _patch_client(tool, capture)
+        try:
+            context = MockToolContext().as_tool_context()
+            await tool.run_async(args={"request": "first"}, tool_context=context)
+            await tool.run_async(args={"request": "second"}, tool_context=context)
+        finally:
+            p.stop()
+
+        assert len(sent) == 2
+        assert sent[0].message.context_id == sent[1].message.context_id
+
+    async def test_isolated_session_mints_context_id_per_call(self):
+        """Isolation gives each sub-agent invocation a distinct session."""
+        tool = _make_tool(isolate_sessions=True)
+        task = _make_task(TaskState.TASK_STATE_COMPLETED, text="ok")
+        sent: list[SendMessageRequest] = []
+
+        async def capture(*, request: SendMessageRequest, **kw):
+            sent.append(request)
+            yield (task, None)
+
+        p, _ = _patch_client(tool, capture)
+        try:
+            context = MockToolContext().as_tool_context()
+            first = await tool.run_async(args={"request": "first"}, tool_context=context)
+            second = await tool.run_async(args={"request": "second"}, tool_context=context)
+        finally:
+            p.stop()
+
+        assert len(sent) == 2
+        assert sent[0].message.context_id != sent[1].message.context_id
+        assert first["subagent_session_id"] == sent[0].message.context_id
+        assert second["subagent_session_id"] == sent[1].message.context_id
 
     async def test_user_id_forwarded_in_call_context(self):
         """The parent session's user_id is forwarded via ClientCallContext."""
@@ -557,6 +603,18 @@ class TestHITLResume:
 
 
 class TestToolsetLifecycle:
+    async def test_isolate_sessions_is_retained_by_toolset(self):
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        toolset = KAgentRemoteA2AToolset(
+            name="agent",
+            description="desc",
+            agent_card_url="http://agent/.well-known/agent.json",
+            httpx_client=mock_client,
+            isolate_sessions=True,
+        )
+        assert toolset._tool._isolate_sessions is True
+        await toolset.close()
+
     async def test_close_closes_owned_client(self):
         mock_client = AsyncMock(spec=httpx.AsyncClient)
         toolset = KAgentRemoteA2AToolset(


### PR DESCRIPTION
## Summary

- honor the existing `isolate_sessions` configuration in the Python remote A2A tool runtime
- mint a fresh sub-agent context for each isolated invocation while preserving shared-session defaults
- return the actual invocation context in completed and HITL-pending responses

This is a Python runtime follow-up to the accepted Go implementation in #2153. It does not change the CRD, UI, lineage headers, concurrency limits, or HITL resume routing.

## Testing

- `cd python && uv run pytest -q packages/kagent-adk/tests/unittests/test_remote_a2a_tool.py packages/kagent-adk/tests/unittests/test_proxy_integration.py` (`40 passed`)
- `cd python && uv run ruff check packages/kagent-adk/src/kagent/adk/_remote_a2a_tool.py packages/kagent-adk/src/kagent/adk/types.py packages/kagent-adk/tests/unittests/test_remote_a2a_tool.py packages/kagent-adk/tests/unittests/test_proxy_integration.py`
- `git diff --check`

## Risk / Notes

- `isolate_sessions=false` remains the default and reuses one context ID for stateful sub-agents.
- Isolated calls use a local per-call ID, so concurrent fan-out does not share mutable session state.
- Existing upstream/dependency warnings remain in the test output; no new failures were introduced.

Follow-up to #2153.
