### PR TITLE
Backport fix(golang-adk): resolve user identity from A2A call context to 0.10.x

### DIFF
--- a/go/adk/pkg/a2a/executor.go
+++ b/go/adk/pkg/a2a/executor.go
@@ -94,7 +94,7 @@ func (u *userIDInterceptor) Before(ctx context.Context, callCtx *a2asrv.CallCont
 	}
 	// Set the authenticated user so downstream code picks up the real identity.
 	callCtx.User = &a2asrv.AuthenticatedUser{UserName: vals[0]}
-	return ctx, nil
+	return auth.WithUserID(ctx, vals[0]), nil
 }
 
 // newAgentMessage builds an agent message stamped with the request's context
@@ -134,10 +134,8 @@ func (e *KAgentExecutor) Execute(ctx context.Context, reqCtx *a2asrv.RequestCont
 
 	// 1. Derive userID / sessionID.
 	userID := "A2A_USER_" + reqCtx.ContextID
-	if callCtx, ok := a2asrv.CallContextFrom(ctx); ok {
-		if callCtx.User != nil && callCtx.User.Name() != "" {
-			userID = callCtx.User.Name()
-		}
+	if id := auth.UserIDFromContext(ctx); id != "" {
+		userID = id
 	}
 	sessionID := reqCtx.ContextID
 

--- a/go/adk/pkg/a2a/executor_test.go
+++ b/go/adk/pkg/a2a/executor_test.go
@@ -1,11 +1,30 @@
 package a2a
 
 import (
+	"context"
 	"testing"
 
 	a2atype "github.com/a2aproject/a2a-go/a2a"
 	"github.com/a2aproject/a2a-go/a2asrv"
+	"github.com/kagent-dev/kagent/go/adk/pkg/auth"
 )
+
+func TestUserIDCallInterceptor_SetsCtxUserID(t *testing.T) {
+	meta := a2asrv.NewRequestMeta(map[string][]string{"x-user-id": {"real-user"}})
+	ctx, callCtx := a2asrv.WithCallContext(context.Background(), meta)
+
+	returned, err := (&userIDInterceptor{}).Before(ctx, callCtx, &a2asrv.Request{})
+	if err != nil {
+		t.Fatalf("Before() error = %v", err)
+	}
+
+	if got := callCtx.User.Name(); got != "real-user" {
+		t.Errorf("callCtx.User.Name() = %q, want %q", got, "real-user")
+	}
+	if got := auth.UserIDFromContext(returned); got != "real-user" {
+		t.Errorf("auth.UserIDFromContext(returned) = %q, want %q", got, "real-user")
+	}
+}
 
 // TestNewAgentMessage_StampsContextAndTaskID verifies agent messages carry the
 // request's context and task ids. A2A allows omitting them (the task is the

--- a/go/adk/pkg/auth/token.go
+++ b/go/adk/pkg/auth/token.go
@@ -18,7 +18,8 @@ func WithUserID(ctx context.Context, userID string) context.Context {
 	return context.WithValue(ctx, userIDKey, userID)
 }
 
-func userIDFromContext(ctx context.Context) string {
+// UserIDFromContext returns the user ID attached by WithUserID.
+func UserIDFromContext(ctx context.Context) string {
 	id, _ := ctx.Value(userIDKey).(string)
 	return id
 }
@@ -76,7 +77,7 @@ func (s *KAgentTokenService) AddHeaders(req *http.Request) {
 	if token := s.GetToken(); token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
-	if userID := userIDFromContext(req.Context()); userID != "" {
+	if userID := UserIDFromContext(req.Context()); userID != "" {
 		req.Header.Set("X-User-Id", userID)
 	}
 }


### PR DESCRIPTION
AI Disclosure: This PR was created with an AI agent under my supervision.

Fixes #2443

This PR fixes task/chat history disappearing after 0.10 upgrade.

Backport of #2449 