### PR TITLE
docs: fix broken relative links in docs

### DIFF
--- a/contrib/cncf/security-self-assessment.md
+++ b/contrib/cncf/security-self-assessment.md
@@ -46,7 +46,7 @@ This document provides a self-assessment of the kagent project following the gui
 |   |  |
 | - | - |
 | Software | [kagent Repository](https://github.com/kagent-dev/kagent) |
-| Security Policy | [SECURITY.md](SECURITY.md) |
+| Security Policy | [SECURITY.md](../../SECURITY.md) |
 | Security Provider | No. kagent is designed to facilitate security and compliance validation, but it should not be considered a security provider. |
 | Languages | Go, Python, TypeScript/JavaScript |
 | Security Insights | See [Project Compliance > Future State](#future-state) |

--- a/contrib/cncf/technical-review.md
+++ b/contrib/cncf/technical-review.md
@@ -221,7 +221,7 @@ Kagent addresses data sovereignty through:
 
 **Compliance:**
 
-- **Apache 2.0 License**: Clear open-source [licensing](LICENSE.md)
+- **Apache 2.0 License**: Clear open-source [licensing](../../LICENSE)
 - **OpenSSF Best Practices**: Badge at [https://www.bestpractices.dev/projects/10723](https://www.bestpractices.dev/projects/10723)
 - **Dependency Scanning**: Automated [CVE scanning via Trivy in CI/CD](https://github.com/kagent-dev/kagent/blob/9438c9c0f2c79daf632555df1d7d3cb2d04b7b81/.github/workflows/image-scan.yaml)
 - **SBOM Generation**: Part of the [future state of the project](https://github.com/kagent-dev/kagent/blob/9438c9c0f2c79daf632555df1d7d3cb2d04b7b81/contrib/cncf/security-self-assessment.md#future-state)

--- a/go/core/cmd/acp-shim/sandbox/README.md
+++ b/go/core/cmd/acp-shim/sandbox/README.md
@@ -1,10 +1,10 @@
 # acp-sandbox launcher scripts
 
 Small POSIX `sh` launchers baked into the agent images defined by
-[docker/acp-sandbox/Dockerfile](../../../../docker/acp-sandbox/Dockerfile). They
-are kept here, next to the `acp-shim` binary they wrap
-([main.go](main.go)), and `COPY`'d into `/usr/local/bin/` by the relevant agent
-target. The Dockerfile build context is `go/`, so the copy paths are
+[docker/acp-sandbox/Dockerfile](../../../../../docker/acp-sandbox/Dockerfile).
+They are kept here, next to the `acp-shim` binary they wrap
+([main.go](../main.go)), and `COPY`'d into `/usr/local/bin/` by the relevant
+agent target. The Dockerfile build context is `go/`, so the copy paths are
 `core/cmd/acp-shim/sandbox/<script>`.
 
 ## Why these scripts exist

--- a/python/packages/kagent-openai/README.md
+++ b/python/packages/kagent-openai/README.md
@@ -57,7 +57,7 @@ agent = Agent(
 )
 ```
 
-See [skills README](../../kagent-skills/README.md) for skill format and structure.
+See [skills README](../kagent-skills/README.md) for skill format and structure.
 
 ---
 
@@ -147,7 +147,7 @@ See `samples/openai/` for complete examples:
 ## See Also
 
 - [OpenAI Agents SDK Docs](https://github.com/openai/agents)
-- [KAgent Skills](../../kagent-skills/README.md)
+- [KAgent Skills](../kagent-skills/README.md)
 - [A2A Protocol](https://docs.kagent.ai/a2a)
 
 ---


### PR DESCRIPTION
## What

Fixes five relative markdown links that point at paths which do not exist, so they currently render as 404s on GitHub.

| File | Link | Resolves to today (404) | Fixed to (200) |
|---|---|---|---|
| `contrib/cncf/security-self-assessment.md` | Security Policy | `contrib/cncf/SECURITY.md` | `SECURITY.md` |
| `contrib/cncf/technical-review.md` | licensing | `contrib/cncf/LICENSE.md` | `LICENSE` |
| `python/packages/kagent-openai/README.md` | skills README (x2) | `python/kagent-skills/README.md` | `python/packages/kagent-skills/README.md` |
| `go/core/cmd/acp-shim/sandbox/README.md` | Dockerfile | `go/docker/acp-sandbox/Dockerfile` | `docker/acp-sandbox/Dockerfile` |
| `go/core/cmd/acp-shim/sandbox/README.md` | main.go | `go/core/cmd/acp-shim/sandbox/main.go` | `go/core/cmd/acp-shim/main.go` |

## Why

Each one is an off-by-one `../` depth or a wrong file extension, and the intended target is unambiguous in every case. Two of them are in the CNCF review documents, where the dead links happen to be the **Security Policy** and **License** rows.

The `acp-shim` README paragraph is re-wrapped across four lines rather than two because the corrected path would otherwise push it past the ~80 column wrapping the file already uses. No wording was changed.

Docs only — no behaviour change.

## Testing

- Verified every corrected target exists in the tree.
- Verified over HTTP against `main` that all five old paths return 404 and all five new targets return 200.
- Re-ran a repo-wide relative-link scan: 10 broken links before, 4 after.

## Not addressed here

Two further broken links are left alone deliberately, because the correct target can't be inferred without maintainer input:

- `docs/architecture/controller-reconciliation.md` and `docs/architecture/prompt-templates.md` both link to `go/core/internal/controller/agent_controller.go`, which doesn't exist anywhere in the tree. The agent controller looks to have been refactored (`agentharness_substrate_controller.go`, `sandboxagent_controller.go`, the `reconciler/` package) — happy to follow up if someone can point me at the file that replaced it.
- `docker/acp-sandbox/README.md` references `test-deployment.yaml` and `test-substrate.yaml` as being "in this folder", but that folder only contains `Dockerfile` and `README.md`. That needs the manifests added, not a link edit.