### PR TITLE
fix(ui): preserve post-login redirect target through `oauth2-proxy` sign-in

### DIFF
--- a/helm/kagent/templates/_helpers.tpl
+++ b/helm/kagent/templates/_helpers.tpl
@@ -269,3 +269,27 @@ imagePullSecrets:
 {{- end -}}
 {{- end -}}
 
+{{/*
+Body of oauth2-proxy's custom sign_in.html template (see
+templates/oauth2-proxy-templates.yaml). Kept as its own named template, rather
+than inline in that ConfigMap, so oauth2-proxy.extraEnv in values.yaml can hash
+the content.
+
+oauth2-proxy renders this as its own Go html/template (not a Helm template) when
+it shows the sign-in page to an unauthenticated visitor -- e.g. a request to
+/agents/foo is served this page at /oauth2/sign_in?rd=%2Fagents%2Ffoo.
+`Redirect` is oauth2-proxy's template variable carrying that original
+destination (escaped with a Helm string-literal action so Helm emits it for
+oauth2-proxy to evaluate, instead of trying to evaluate it itself). It is
+forwarded to kagent's branded /login page.
+*/}}
+{{- define "kagent.oauth2ProxySignInHTML" -}}
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="0;url=/login?rd={{ "{{" }} or .Redirect "/" | urlquery {{ "}}" }}">
+  <script>window.location.href = "/login?rd={{ "{{" }} or .Redirect "/" | urlquery {{ "}}" }}";</script>
+</head>
+<body>Redirecting to login...</body>
+</html>
+{{- end -}}

--- a/helm/kagent/templates/oauth2-proxy-templates.yaml
+++ b/helm/kagent/templates/oauth2-proxy-templates.yaml
@@ -7,21 +7,9 @@ metadata:
   labels:
     {{- include "kagent.labels" . | nindent 4 }}
 data:
-  # oauth2-proxy renders this as its own Go html/template (not a Helm
-  # template) when it shows the sign-in page to an unauthenticated visitor --
-  # e.g. a request to /agents/foo is served this page at
-  # /oauth2/sign_in?rd=%2Fagents%2Ffoo. Redirect is oauth2-proxy's template
-  # variable carrying that original destination. It is forwarded to kagent's
-  # branded /login page below (escaped with a Helm string-literal action so
-  # Helm emits it for oauth2-proxy to evaluate, instead of trying to evaluate
-  # it itself).
+  # The body lives in the kagent.oauth2ProxySignInHTML named template
+  # (_helpers.tpl) so oauth2-proxy.extraEnv in values.yaml can hash the content to
+  # force a rollout when it changes. 
   sign_in.html: |
-    <!DOCTYPE html>
-    <html>
-    <head>
-      <meta http-equiv="refresh" content="0;url=/login?rd={{ "{{" }} or .Redirect "/" | urlquery {{ "}}" }}">
-      <script>window.location.href = "/login?rd={{ "{{" }} or .Redirect "/" | urlquery {{ "}}" }}";</script>
-    </head>
-    <body>Redirecting to login...</body>
-    </html>
+    {{- include "kagent.oauth2ProxySignInHTML" . | nindent 4 }}
 {{- end }}

--- a/helm/kagent/templates/oauth2-proxy-templates.yaml
+++ b/helm/kagent/templates/oauth2-proxy-templates.yaml
@@ -7,12 +7,20 @@ metadata:
   labels:
     {{- include "kagent.labels" . | nindent 4 }}
 data:
+  # oauth2-proxy renders this as its own Go html/template (not a Helm
+  # template) when it shows the sign-in page to an unauthenticated visitor --
+  # e.g. a request to /agents/foo is served this page at
+  # /oauth2/sign_in?rd=%2Fagents%2Ffoo. Redirect is oauth2-proxy's template
+  # variable carrying that original destination. It is forwarded to kagent's
+  # branded /login page below (escaped with a Helm string-literal action so
+  # Helm emits it for oauth2-proxy to evaluate, instead of trying to evaluate
+  # it itself).
   sign_in.html: |
     <!DOCTYPE html>
     <html>
     <head>
-      <meta http-equiv="refresh" content="0;url=/login">
-      <script>window.location.href = "/login";</script>
+      <meta http-equiv="refresh" content="0;url=/login?rd={{ "{{" }} or .Redirect "/" | urlquery {{ "}}" }}">
+      <script>window.location.href = "/login?rd={{ "{{" }} or .Redirect "/" | urlquery {{ "}}" }}";</script>
     </head>
     <body>Redirecting to login...</body>
     </html>

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -948,6 +948,11 @@ oauth2-proxy:
       mountPath: /templates
       readOnly: true
 
+  extraEnv:
+    # Forces a rollout whenever the sign_in.html ConfigMap's content changes.
+    - name: KAGENT_OAUTH2_PROXY_SIGNIN_TEMPLATE_CHECKSUM
+      value: '{{ include "kagent.oauth2ProxySignInHTML" . | sha256sum }}'
+
   # Mount custom CA certificate for TLS verification (if needed)
   # Add to extraVolumes:
   #   - name: custom-ca-cert

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -948,11 +948,6 @@ oauth2-proxy:
       mountPath: /templates
       readOnly: true
 
-  extraEnv:
-    # Forces a rollout whenever the sign_in.html ConfigMap's content changes.
-    - name: KAGENT_OAUTH2_PROXY_SIGNIN_TEMPLATE_CHECKSUM
-      value: '{{ include "kagent.oauth2ProxySignInHTML" . | sha256sum }}'
-
   # Mount custom CA certificate for TLS verification (if needed)
   # Add to extraVolumes:
   #   - name: custom-ca-cert
@@ -983,6 +978,9 @@ oauth2-proxy:
   # Cluster-specific OIDC settings - override these per deployment
   # These are set as env vars and referenced in args for easy patching
   extraEnv:
+    # Forces a rollout whenever the sign_in.html ConfigMap's content changes.
+    - name: KAGENT_OAUTH2_PROXY_SIGNIN_TEMPLATE_CHECKSUM
+      value: '{{ include "kagent.oauth2ProxySignInHTML" . | sha256sum }}'
     - name: OIDC_ISSUER_URL
       value: ""
     - name: OIDC_REDIRECT_URL

--- a/ui/src/app/login/page.tsx
+++ b/ui/src/app/login/page.tsx
@@ -1,12 +1,20 @@
 import Link from "next/link";
 import KagentLogo from "@/components/kagent-logo";
+import { sanitizeRedirect } from "@/lib/loginRedirect";
 import { skipToContentLinkClassName } from "@/lib/skipToContent";
 import { cn } from "@/lib/utils";
 
 // SSO redirect path - defaults to oauth2-proxy's start endpoint
 const SSO_REDIRECT_PATH = process.env.SSO_REDIRECT_PATH || "/oauth2/start";
 
-export default function LoginPage() {
+export default async function LoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ rd?: string }>;
+}) {
+  const { rd } = await searchParams;
+  const redirectTo = sanitizeRedirect(rd);
+
   return (
     <>
       {/* Preload background image for faster rendering */}
@@ -53,7 +61,7 @@ export default function LoginPage() {
 
             <div className="relative z-10">
               <Link
-                href={`${SSO_REDIRECT_PATH}?rd=/`}
+                href={`${SSO_REDIRECT_PATH}?rd=${encodeURIComponent(redirectTo)}`}
                 className="group relative inline-flex items-center justify-center gap-3 px-9 py-4 bg-gradient-to-r from-violet-500 to-fuchsia-500 rounded-full text-white font-semibold text-lg border-2 border-white/90 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_10px_25px_-5px_rgba(139,92,246,0.5)]"
               >
                 {/* Glow ring */}

--- a/ui/src/lib/__tests__/loginRedirect.test.ts
+++ b/ui/src/lib/__tests__/loginRedirect.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from '@jest/globals';
+import { sanitizeRedirect } from '../loginRedirect';
+
+describe('sanitizeRedirect', () => {
+  it('passes through a same-origin path', () => {
+    expect(sanitizeRedirect('/agents/foo')).toBe('/agents/foo');
+  });
+
+  it('passes through a same-origin path with a query string', () => {
+    expect(sanitizeRedirect('/agents/foo?tab=history')).toBe('/agents/foo?tab=history');
+  });
+
+  it('defaults to "/" when undefined', () => {
+    expect(sanitizeRedirect(undefined)).toBe('/');
+  });
+
+  it('defaults to "/" for an empty string', () => {
+    expect(sanitizeRedirect('')).toBe('/');
+  });
+
+  it('rejects an absolute URL', () => {
+    expect(sanitizeRedirect('https://evil.example.com/phish')).toBe('/');
+  });
+
+  it('treats a bare host+path with no leading slash as a relative path segment', () => {
+    // Matches URL/browser semantics: with no scheme and no leading "/",
+    // this resolves relative to the current path rather than a new host.
+    expect(sanitizeRedirect('evil.example.com/phish')).toBe('/evil.example.com/phish');
+  });
+
+  it('rejects a protocol-relative URL', () => {
+    expect(sanitizeRedirect('//evil.example.com/phish')).toBe('/');
+  });
+
+  it('rejects a backslash-prefixed path some browsers treat as protocol-relative', () => {
+    expect(sanitizeRedirect('/\\evil.example.com/phish')).toBe('/');
+  });
+
+  it('rejects a tab-smuggled protocol-relative URL (stripped by the URL parser before host resolution)', () => {
+    expect(sanitizeRedirect('/\t/evil.example.com/phish')).toBe('/');
+  });
+
+  it('rejects a different scheme entirely', () => {
+    expect(sanitizeRedirect('javascript:alert(1)')).toBe('/');
+  });
+});

--- a/ui/src/lib/loginRedirect.ts
+++ b/ui/src/lib/loginRedirect.ts
@@ -1,0 +1,24 @@
+// Any fixed placeholder works here -- it's never dereferenced, just used as
+// the base for URL parsing so we can tell whether `rd` stayed same-origin.
+const SENTINEL_ORIGIN = "http://kagent-login-redirect.invalid";
+
+/**
+ * Validate a post-login redirect target.
+ *
+ * Only a same-origin relative path is safe to hand back to oauth2-proxy's
+ * `rd` parameter: an absolute URL, a protocol-relative `//host/...`, or a
+ * disguised variant of either (e.g. a backslash or a stripped tab/newline
+ * that the URL Standard normalizes into one of the above) would let a
+ * crafted `/login?rd=...` link send an authenticated session off to an
+ * attacker's site after sign-in.
+ */
+export function sanitizeRedirect(rd: string | undefined): string {
+  if (!rd) return "/";
+  try {
+    const url = new URL(rd, SENTINEL_ORIGIN);
+    if (url.origin !== SENTINEL_ORIGIN) return "/";
+    return url.pathname + url.search + url.hash;
+  } catch {
+    return "/";
+  }
+}

--- a/ui/src/lib/loginRedirect.ts
+++ b/ui/src/lib/loginRedirect.ts
@@ -16,7 +16,9 @@ export function sanitizeRedirect(rd: string | undefined): string {
   if (!rd) return "/";
   try {
     const url = new URL(rd, SENTINEL_ORIGIN);
-    if (url.origin !== SENTINEL_ORIGIN) return "/";
+    if (url.origin !== SENTINEL_ORIGIN || url.pathname.startsWith("//")) {
+      return "/";
+    }
     return url.pathname + url.search + url.hash;
   } catch {
     return "/";


### PR DESCRIPTION
When oauth2-proxy intercepts an unauthenticated request it serves its sign-in page carrying the original destination as `.Redirect` (e.g. `/oauth2/sign_in?rd=%2Fagents%2Ffoo`). `sign_in.html` template ignored that and unconditionally redirected to `/login`, and `/login`'s "Sign in with SSO" link was hardcoded to `rd=/` -- so any login, expired- cookie or not, always landed back on the home page instead of the page the user was trying to reach.

Also contains a Helm update that ensures that this change will result in `oauth2-proxy` being redeployed to pick up the updated sign-in page template.