### PR TITLE
fix(helm): expose agent image digest override in controller chart

### DIFF
--- a/helm/kagent/templates/controller-configmap.yaml
+++ b/helm/kagent/templates/controller-configmap.yaml
@@ -16,6 +16,7 @@ data:
   IMAGE_REGISTRY: {{ .Values.controller.agentImage.registry | default .Values.registry | quote }}
   IMAGE_REPOSITORY: {{ .Values.controller.agentImage.repository | quote }}
   IMAGE_TAG: {{ coalesce .Values.controller.agentImage.tag .Values.tag .Chart.Version | quote }}
+  IMAGE_DIGEST: {{ .Values.controller.agentImage.digest | quote }}
   LEADER_ELECT: {{ include "kagent.leaderElectionEnabled" . | quote }}
   # OpenTelemetry Configuration
   OTEL_TRACING_ENABLED: {{ .Values.otel.tracing.enabled | quote }}

--- a/helm/kagent/tests/controller-configmap_test.yaml
+++ b/helm/kagent/tests/controller-configmap_test.yaml
@@ -1,0 +1,21 @@
+suite: test controller configmap
+templates:
+  - controller-configmap.yaml
+tests:
+  - it: should default IMAGE_DIGEST to empty
+    template: controller-configmap.yaml
+    asserts:
+      - equal:
+          path: data.IMAGE_DIGEST
+          value: ""
+
+  - it: should render IMAGE_DIGEST from controller.agentImage.digest
+    template: controller-configmap.yaml
+    set:
+      controller:
+        agentImage:
+          digest: sha256:deadbeef
+    asserts:
+      - equal:
+          path: data.IMAGE_DIGEST
+          value: "sha256:deadbeef"

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -99,7 +99,7 @@ database:
     # of no activity. Uses session.updated_at as a sliding idle clock (writes refresh it).
     # 0 disables cleanup (default, existing installs unchanged).
     sessionRetentionDays: 0
-    # -- Bundled PostgreSQL instance — for development and evaluation only.
+    # -- Bundled PostgreSQL instance, for development and evaluation only.
     # Not suitable for production. Deployed when enabled is true and url/urlFile are not set.
     bundled:
       # -- Set to false to disable the bundled database and provide your own via url or urlFile.
@@ -189,6 +189,10 @@ controller:
     registry: ""
     repository: kagent-dev/kagent/golang-adk
     tag: "" # Will default to global, then Chart version
+    # -- Manifest digest (sha256:...) for the agent image. Sandbox agents require a
+    # digest-pinned image ref; set this when the controller binary was not built with
+    # a digest baked in, or when a mirrored registry re-assigns digests.
+    digest: ""
   # -- @deprecated Removed in 0.10.0. The A2A SDK now handles SSE buffering and timeouts
   # internally. These values have no effect and will be removed in a future release.
   streaming: null
@@ -292,8 +296,8 @@ controller:
   # template time, so overriding `METRICS_BIND_ADDRESS` via
   # `controller.env` shifts only the runtime listener and leaves the
   # rendered Service pointing at the chart-time port. Setting
-  # `bindAddress: "0"` (or empty) is treated as a disable signal —
-  # equivalent to `enabled: false` — to keep faith with the controller
+  # `bindAddress: "0"` (or empty) is treated as a disable signal,
+  # equivalent to `enabled: false`, to keep faith with the controller
   # binary's documented contract for `--metrics-bind-address`.
   # @default -- disabled
   metrics:
@@ -350,13 +354,13 @@ controller:
   #   readOnly: true
 
   # -- Custom startup probe for the controller container.
-  # Setting a value replaces the default probe entirely — include a handler
+  # Setting a value replaces the default probe entirely, include a handler
   # (httpGet / exec / tcpSocket / grpc) when overriding.
   # @default -- httpGet /health on port http, periodSeconds=15, initialDelaySeconds=15
   startupProbe: {}
 
   # -- Custom readiness probe for the controller container.
-  # Setting a value replaces the default probe entirely — include a handler
+  # Setting a value replaces the default probe entirely, include a handler
   # (httpGet / exec / tcpSocket / grpc) when overriding.
   # @default -- httpGet /health on port http, periodSeconds=30
   readinessProbe: {}


### PR DESCRIPTION
Sandbox agents need a digest-pinned image, but the controller only gets `AgentImageDigest` from a build-time ldflag that no workflow actually sets, and the chart never exposed the existing `--image-digest` flag. Adds `controller.agentImage.digest`, wired through the same env path already used for registry, repository, and tag.

Fixes #2529
