### PR TITLE
fix(substrate): resolve env vars from Secret StringData

### DIFF
--- a/go/core/pkg/sandboxbackend/substrate/lifecycle_shared.go
+++ b/go/core/pkg/sandboxbackend/substrate/lifecycle_shared.go
@@ -161,7 +161,7 @@ func truncateDNS1123To(s string, max int) string {
 // ResolveCurrentActorTemplate returns the ActorTemplate a SandboxAgent should currently serve
 // from: the template matching the agent's CURRENT desired config whose golden is Ready, else the
 // most-recently-desired Ready template (the previous config) while the desired one is still
-// building — the blue-green pivot, with no downtime and an atomic flip once the new golden is
+// building, the blue-green pivot, with no downtime and an atomic flip once the new golden is
 // Ready.
 //
 // "Desired" is tracked by the kagent.dev/desired-generation annotation (the agent generation that
@@ -299,6 +299,15 @@ func resolvePodEnv(ctx context.Context, kube client.Reader, namespace string, en
 			return nil, err
 		}
 		value, ok := secret.Data[ref.Key]
+		if !ok {
+			// localSecret is often the translator's freshly-built, not-yet-applied Secret
+			// object, which the API server would normally fold StringData into Data on
+			// write. Since it never round-trips through the API server here, fall back to
+			// StringData directly.
+			var strValue string
+			strValue, ok = secret.StringData[ref.Key]
+			value = []byte(strValue)
+		}
 		if !ok {
 			if ref.Optional != nil && *ref.Optional {
 				resolved[i].ValueFrom = nil

--- a/go/core/pkg/sandboxbackend/substrate/lifecycle_shared_test.go
+++ b/go/core/pkg/sandboxbackend/substrate/lifecycle_shared_test.go
@@ -1,0 +1,94 @@
+package substrate
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestResolvePodEnv_LocalSecretStringData(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	kube := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	localSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "cfg", Namespace: "kagent"},
+		StringData: map[string]string{"config.json": `{"a":1}`},
+	}
+	env := []corev1.EnvVar{{
+		Name: "CONFIG",
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "cfg"},
+				Key:                  "config.json",
+			},
+		},
+	}}
+
+	resolved, err := resolvePodEnv(context.Background(), kube, "kagent", env, localSecret)
+	require.NoError(t, err)
+	require.Len(t, resolved, 1)
+	require.Nil(t, resolved[0].ValueFrom)
+	require.Equal(t, `{"a":1}`, resolved[0].Value)
+}
+
+func TestResolvePodEnv_LocalSecretDataTakesPrecedence(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	kube := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	localSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "cfg", Namespace: "kagent"},
+		Data:       map[string][]byte{"key": []byte("from-data")},
+		StringData: map[string]string{"key": "from-stringdata"},
+	}
+	env := []corev1.EnvVar{{
+		Name: "VALUE",
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "cfg"},
+				Key:                  "key",
+			},
+		},
+	}}
+
+	resolved, err := resolvePodEnv(context.Background(), kube, "kagent", env, localSecret)
+	require.NoError(t, err)
+	require.Equal(t, "from-data", resolved[0].Value)
+}
+
+func TestResolvePodEnv_MissingKeyRequired(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	kube := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	localSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "cfg", Namespace: "kagent"},
+		StringData: map[string]string{"other": "value"},
+	}
+	env := []corev1.EnvVar{{
+		Name: "MISSING",
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "cfg"},
+				Key:                  "does-not-exist",
+			},
+		},
+	}}
+
+	_, err := resolvePodEnv(context.Background(), kube, "kagent", env, localSecret)
+	require.Error(t, err)
+}


### PR DESCRIPTION
`resolvePodEnv` only checked `Secret.Data` when resolving env vars for Substrate sandbox agents. The config Secret it gets passed is built in memory by the translator and never round-trips through the API server, so its values live in `StringData`, not `Data`. Env resolution failed every time. Falls back to `StringData` when `Data` misses.

Fixes #2522
