### PR TITLE
feat(app): let an extension supply the A2A handler

### DIFF
--- a/go/core/pkg/app/app.go
+++ b/go/core/pkg/app/app.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/a2aproject/a2a-go/v2/a2asrv"
 	"github.com/gorilla/mux"
 
 	"github.com/hashicorp/go-multierror"
@@ -302,6 +303,13 @@ type ExtensionConfig struct {
 	AgentPlugins     []agent_translator.TranslatorPlugin
 	MCPServerPlugins []translator.MCPTranslatorPlugin
 	SandboxBackend   sandboxbackend.Backend
+	// A2AHandler serves the A2A API. grpcserver registers that service only
+	// when this is non-nil, so leaving it unset keeps today's behaviour: the
+	// AgentInstance API is available but nothing can talk to an instance.
+	//
+	// An extension can build one with a2agateway.New, using the DbClient it is
+	// handed in BootstrapConfig.
+	A2AHandler a2asrv.RequestHandler
 }
 
 type GetExtensionConfig func(bootstrap BootstrapConfig) (*ExtensionConfig, error)
@@ -800,6 +808,7 @@ func Start(getExtensionConfig GetExtensionConfig, extraSources []migrations.Sour
 		SessionService:        sessionService,
 		TaskService:           taskService,
 		AgentInstanceService:  agentInstanceService,
+		A2AHandler:            extensionCfg.A2AHandler,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to create gRPC server")


### PR DESCRIPTION
## Problem

`grpcserver` registers the A2A service only when `A2AHandler` is non-nil, and `core/pkg/app` never sets it. A controller built on `app.Start` can create AgentInstances but cannot talk to them:

```
Unimplemented: unknown service lf.a2a.v1.A2AService
```

`core/cmd/controller-v2` does set it, but that is `package main`, so the capability is unreachable to anything embedding `app.Start`.

## Change

`ExtensionConfig` gains an `A2AHandler` field, passed through to `grpcserver`. That's it — one file, two lines of code.

Nothing else changes. The field defaults to nil and `grpcserver` skips registration exactly as it does today, so this is inert unless an extension opts in.

It also needs no reordering: `getExtensionConfig` is called with the `DbClient` in `BootstrapConfig` well before the gRPC server is constructed, so an extension can build a handler with `a2agateway.New` and return it.

## Alternative considered

I first went at this by exporting `core/internal/grpcserver` and adding a public constructor for the store, so the v2 stack could be assembled outside `package main` (#2543). This is much smaller, keeps the internals internal, and covers the actual need — so I've closed that one in favour of this.

The larger export still has an independent argument: it would let an external module stand up the gRPC surface with a real Postgres and fakes for `a2agateway`'s dialer and `agentinstance`'s actor client, and test AgentInstance lifecycle, ownership checks, A2A routing and `DefaultMethodPolicies` without a cluster or Substrate. Happy to revive it if that's wanted, but it shouldn't be bundled with this.

## Testing

`go build ./...`, `go vet`, and `go test ./core/pkg/app/ ./core/internal/grpcserver/` all pass.
