### PR TITLE
fix: avoid starting actors during instance creation

### DIFF
--- a/docs/plans/api-v2-execution-plan.md
+++ b/docs/plans/api-v2-execution-plan.md
@@ -165,10 +165,10 @@ Creation:
 
 - Select the latest successful prepared revision.
 - Reserve caller/namespace/request ID transactionally.
-- Execute create and delete as imperative Substrate workflows within their RPCs.
-- Create and resume the deterministic Substrate Actor through Substrate's imperative APIs; a successful resume returns it `RUNNING`, with ActorTemplate `/readyz` as the readiness contract.
+- Execute AgentInstance create and delete synchronously within their RPCs.
+- Create the deterministic Substrate Actor in its initial suspended state; Substrate establishes runtime readiness while preparing the ActorTemplate.
 - Publish the logical A2A authority and transition to `READY`.
-- Retrying a canceled create with the same request ID resumes the same deterministic workflow.
+- Retrying a canceled create with the same request ID re-enters the same deterministic workflow.
 - Never duplicate a member while creation outcome is unknown.
 
 Deletion fences interaction, deletes owned Actors, releases its prepared-revision foreign key, triggers cleanup when that was the final reference, and leaves an indefinitely retained V1 tombstone. No retention configuration is added until scale requires one.

--- a/go/core/v2/agentinstance/workflow.go
+++ b/go/core/v2/agentinstance/workflow.go
@@ -79,8 +79,7 @@ func (w *ActorWorkflow) Quiesce(ctx context.Context, instance *apiv1alpha1.Agent
 }
 
 // Create converges a persisted CREATING instance to READY. Retries discover
-// the deterministically named Actor before creating it, then resume it if a
-// previous attempt stopped before the Actor was running. An existing Actor is
+// the deterministically named Actor before creating it. An existing Actor is
 // accepted only when it still references the instance's prepared template;
 // this prevents an ID collision from attaching the instance to another
 // workload.
@@ -112,18 +111,6 @@ func (w *ActorWorkflow) Create(ctx context.Context, instance *apiv1alpha1.AgentI
 	if actor.GetActorTemplateNamespace() != revision.ActorTemplateNamespace || actor.GetActorTemplateName() != revision.ActorTemplateName {
 		return nil, fmt.Errorf("actor %s/%s uses unexpected ActorTemplate %s/%s", atespace, name, actor.GetActorTemplateNamespace(), actor.GetActorTemplateName())
 	}
-	// Substrate's resume RPC is an imperative workflow and returns only after
-	// the Actor is running.
-	if actor.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_RUNNING {
-		actor, err = w.actors.ResumeActor(ctx, atespace, name)
-		if err != nil {
-			return nil, fmt.Errorf("resume Actor %s/%s: %w", atespace, name, err)
-		}
-		if actor.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_RUNNING {
-			return nil, fmt.Errorf("resume Actor %s/%s returned status %s", atespace, name, actor.GetStatus().GetState())
-		}
-	}
-
 	instance, err = w.store.MarkAgentInstanceReady(ctx, instance.GetId(), legacysubstrate.ActorHost(atespace, name, ""))
 	if err != nil {
 		return nil, fmt.Errorf("mark AgentInstance ready: %w", err)

--- a/go/core/v2/agentinstance/workflow_test.go
+++ b/go/core/v2/agentinstance/workflow_test.go
@@ -36,7 +36,7 @@ func TestActorWorkflowLifecycle(t *testing.T) {
 	if len(actors.actors) != 1 {
 		t.Fatalf("actors = %v", actors.actors)
 	}
-	if actor := actors.actors[actorKey("team-a", actorName(instance.GetId()))]; actor.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_RUNNING {
+	if actor := actors.actors[actorKey("team-a", actorName(instance.GetId()))]; actor.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_SUSPENDED {
 		t.Fatalf("created Actor status = %s", actor.GetStatus().GetState())
 	}
 	boundary, err := workflow.Quiesce(context.Background(), created)


### PR DESCRIPTION
## Summary

- create AgentInstance Actors in their initial suspended state
- rely on Substrate ingress to resume Actors on demand
- keep Worker capacity free until an interaction needs the runtime
- correct the execution plan to reflect ActorTemplate readiness

Closes #2545

## Testing

- `go test ./v2/... ./internal/database/...`
