### PR TITLE
feat(helm): allow scheduling the bundled PostgreSQL pod

### DIFF
--- a/helm/kagent/templates/postgresql.yaml
+++ b/helm/kagent/templates/postgresql.yaml
@@ -57,6 +57,18 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $pg.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $pg.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $pg.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: postgresql
           image: {{ include "kagent.postgresql.image" . }}

--- a/helm/kagent/tests/postgresql_test.yaml
+++ b/helm/kagent/tests/postgresql_test.yaml
@@ -443,3 +443,77 @@ tests:
           value:
             - name: secret1
             - name: secret2
+
+  # =============================================================================
+  # scheduling (bundled PostgreSQL pod)
+  # =============================================================================
+
+  - it: should not set scheduling fields by default
+    template: postgresql.yaml
+    documentIndex: 2
+    asserts:
+      - isKind:
+          of: Deployment
+      - notExists:
+          path: spec.template.spec.nodeSelector
+      - notExists:
+          path: spec.template.spec.tolerations
+      - notExists:
+          path: spec.template.spec.affinity
+
+  - it: should set nodeSelector
+    template: postgresql.yaml
+    documentIndex: 2
+    set:
+      database:
+        postgres:
+          bundled:
+            nodeSelector:
+              role: AI
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector
+          value:
+            role: AI
+
+  - it: should set tolerations
+    template: postgresql.yaml
+    documentIndex: 2
+    set:
+      database:
+        postgres:
+          bundled:
+            tolerations:
+              - key: dedicated
+                operator: Equal
+                value: ai
+                effect: NoSchedule
+    asserts:
+      - equal:
+          path: spec.template.spec.tolerations
+          value:
+            - key: dedicated
+              operator: Equal
+              value: ai
+              effect: NoSchedule
+
+  - it: should set affinity
+    template: postgresql.yaml
+    documentIndex: 2
+    set:
+      database:
+        postgres:
+          bundled:
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: topology.kubernetes.io/zone
+                          operator: In
+                          values:
+                            - eu-west-1a
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
+          value: topology.kubernetes.io/zone

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -129,6 +129,15 @@ database:
         limits:
           cpu: 500m
           memory: 512Mi
+      # -- Node taints which will be tolerated for `Pod` [scheduling](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).
+      tolerations: []
+
+      # -- Node labels to match for `Pod` [scheduling](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).
+      nodeSelector: {}
+
+      # -- [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) rules for the bundled PostgreSQL pod.
+      affinity: {}
+
       # -- Pod-level security context for the bundled PostgreSQL deployment.
       podSecurityContext:
         fsGroup: 999


### PR DESCRIPTION
## Summary

- The `controller` and `ui` deployments expose `nodeSelector`, `tolerations` and
`affinity`, but the bundled PostgreSQL Deployment rendered by
`templates/postgresql.yaml` has no scheduling fields at all
- This makes the bundled database impossible to place. On a cluster with a
dedicated, tainted node pool it cannot follow the rest of the control plane, and
a single-replica PVC-backed database left on an autoscaled pool gets drained
whenever that pool scales in — taking the controller down with it
- Adds `nodeSelector`, `tolerations` and `affinity` to
`database.postgres.bundled`, rendered with the same `{{- with }}` form and in the
same order `controller-deployment.yaml` already uses
- Values documentation copies the wording already used by the `controller` and
`ui` blocks, so the three read consistently
- Defaults stay empty, so rendered output is unchanged for existing installs

Follows the same shape as #2213 (`nodeSelector`/`tolerations` for the
`kagent-tools` subchart) and #2365 (`affinity`/`topologySpreadConstraints` for
controller and ui), which closed the equivalent gap for other components.

## Test plan

- [x] `helm unittest helm/kagent` passes — 274 tests, including 4 new ones in
`tests/postgresql_test.yaml` covering the unset, `nodeSelector`, `tolerations`
and `affinity` cases
- [x] `helm template` with `database.postgres.bundled.nodeSelector` and
`tolerations` set renders both fields on the `kagent-postgresql` Deployment pod
spec
- [x] `helm template` with the values unset renders no scheduling fields on that
pod spec, confirming existing installs are unaffected