### PR TITLE
ci: disable the testcontainers reaper in go-unit-tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -309,6 +309,11 @@ jobs:
 
       - name: Run Go unit tests
         working-directory: go
+        env:
+          # Runners are ephemeral, so Ryuk's leaked-container cleanup buys nothing,
+          # and its single session-scoped reaper is contended by the parallel package
+          # processes of `go test ./...`, intermittently timing out the Postgres tests.
+          TESTCONTAINERS_RYUK_DISABLED: "true"
         run: |
           make setup-envtest
           export KUBEBUILDER_ASSETS="$(make -s envtest-path)"


### PR DESCRIPTION
## Problem

`go-unit-tests` intermittently fails with two Postgres-backed packages timing out before any container starts:

```
migrate_test.go:255:         failed to start postgres container: ... reaper: from container "1c88b27d": wait for reaper 1c88b27d: context deadline exceeded
migration_000007_test.go:32: startTestDB: start container: ...     reaper: from container "1c88b27d": wait for reaper 1c88b27d: context deadline exceeded

FAIL github.com/kagent-dev/kagent/go/core/pkg/cli/db/migrate  61.298s
FAIL github.com/kagent-dev/kagent/go/core/pkg/migrations       114.543s
```

Neither is an assertion failure — both are 60s timeouts waiting on the testcontainers Ryuk reaper, so no Postgres container is ever created and the tests fail without evaluating anything.

## Cause

`go test ./...` runs each package as its own process, so every process using `internal/dbtest` contends for one session-scoped Ryuk reaper. The logs show the race directly — earlier packages obtain that exact container, then later ones wait 60s for the same ID and give up:

```
19:14:39 ⏳ Waiting for Reaper "1c88b27d" to be ready
19:14:40 🔥 Reaper obtained from Docker for this test session 1c88b27d
19:15:00 ⏳ Waiting for Reaper "1c88b27d" to be ready      <- times out
```

Observed on unrelated PRs and on `main`:

- [run 32763005552](https://github.com/kagent-dev/kagent/actions/runs/32763005552) (PR #2544, reaper `1c88b27d`)
- [run 32639919261](https://github.com/kagent-dev/kagent/actions/runs/32639919261) (`main`, reaper `69c2d478`) — same two tests, same error

## Fix

Set `TESTCONTAINERS_RYUK_DISABLED=true` on the step.

Ryuk exists to reap containers leaked by a test run that dies without cleaning up. GitHub runners are ephemeral and discarded after the job, so that cleanup has no value here, and `dbtest` already terminates its containers via `t.Cleanup`. Disabling the reaper removes the contended singleton without giving up anything CI relies on.

Scoped to `go-unit-tests`: it is the only job running testcontainers-backed tests. The `e2e` job runs just `core/test/e2e` against a Kind cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)