### PR TITLE
feat: fork AgentInstances from checkpoints

### DIFF
--- a/go/api/database/client.go
+++ b/go/api/database/client.go
@@ -122,6 +122,7 @@ type Client interface {
 
 	// AgentInstance lifecycle methods
 	CreateAgentInstance(context.Context, *apiv1alpha1.AgentInstance, string) (*apiv1alpha1.AgentInstance, bool, error)
+	ForkAgentInstance(context.Context, string, string, string, string, string) (*apiv1alpha1.AgentInstance, bool, error)
 	GetAgentInstance(context.Context, string, string, string) (*apiv1alpha1.AgentInstance, error)
 	ListAgentInstances(context.Context, string, string, bool, map[string]string, string, int) ([]*apiv1alpha1.AgentInstance, error)
 	MarkAgentInstanceReady(context.Context, string, string) (*apiv1alpha1.AgentInstance, error)

--- a/go/api/database/models.go
+++ b/go/api/database/models.go
@@ -303,7 +303,6 @@ type AgentInstanceCheckpoint struct {
 	SnapshotUID          string
 	SnapshotContentScope string
 	PreparedRevision     string
-	SourceInstanceData   []byte
 	TagUID               string
 	State                string
 	Failure              string

--- a/go/api/database/models.go
+++ b/go/api/database/models.go
@@ -293,6 +293,7 @@ type AgentInstanceCheckpoint struct {
 	ID                   string
 	Namespace            string
 	SourceInstanceID     string
+	SourceContextID      string
 	UserID               string
 	RequestID            string
 	HeadTaskID           string
@@ -301,6 +302,8 @@ type AgentInstanceCheckpoint struct {
 	SnapshotName         string
 	SnapshotUID          string
 	SnapshotContentScope string
+	PreparedRevision     string
+	SourceInstanceData   []byte
 	TagUID               string
 	State                string
 	Failure              string

--- a/go/core/cmd/controller-v2/main.go
+++ b/go/core/cmd/controller-v2/main.go
@@ -105,7 +105,7 @@ func main() {
 	authorizer := &authimpl.NoopAuthorizer{}
 	instanceWorkflow := agentinstance.NewActorWorkflow(store, actors)
 	instances := agentinstance.NewService(store, authorizer, instanceWorkflow)
-	checkpoints := checkpoint.NewService(store, authorizer, actors)
+	checkpoints := checkpoint.NewService(store, authorizer, actors, instanceWorkflow)
 	gatewayDialer, err := a2agateway.NewRuntimeDialer(
 		env("SUBSTRATE_ATENET_ROUTER_URL", legacysubstrate.DefaultAtenetRouterURL),
 		authenticator,

--- a/go/core/internal/database/client_agent_instance_test.go
+++ b/go/core/internal/database/client_agent_instance_test.go
@@ -78,31 +78,47 @@ func TestAgentInstanceTasksAreDurableAndExclusive(t *testing.T) {
 	if err != nil || got.ID != first.ID || got.Status.State != first.Status.State || len(got.History) != 1 {
 		t.Fatalf("GetAgentInstanceTask() = %#v, %v", got, err)
 	}
+	var projectionData []byte
+	if err := db.QueryRow(ctx, `SELECT data FROM agent_instance_task WHERE context_id = 'instance-1' AND id = 'task-1'`).Scan(&projectionData); err != nil {
+		t.Fatal(err)
+	}
+	projection, err := unmarshalAgentInstanceTask(projectionData)
+	if err != nil || len(projection.History) != 0 {
+		t.Fatalf("stored task projection history = %#v, error %v", projection.History, err)
+	}
 	second := &a2a.Task{ID: "task-2", ContextID: "instance-1", Status: a2a.TaskStatus{State: a2a.TaskStateSubmitted}}
 	if err := client.StoreAgentInstanceTaskEvent(ctx, "instance-1", second, second, nil); !errors.Is(err, dbpkg.ErrAgentInstanceTaskConflict) {
 		t.Fatalf("second active task error = %v", err)
 	}
+	first.History = append(first.History, a2a.NewMessageForTask(a2a.MessageRoleAgent, first, a2a.NewTextPart("done")))
 	first.Status.State = a2a.TaskStateCompleted
 	snapshot := &dbpkg.AgentInstanceTaskSnapshot{Atespace: "team-a", Name: "snapshot-1", UID: "snapshot-uid"}
 	if err := client.StoreAgentInstanceTaskEvent(ctx, "instance-1", first, first, snapshot); err != nil {
 		t.Fatal(err)
 	}
 	var snapshotAtespace, snapshotName, snapshotUID string
-	var historySequence int64
+	var historySequence, latestSequence int64
 	if err := db.QueryRow(ctx, `
 		SELECT snapshot_atespace, snapshot_name, snapshot_uid, history_sequence
 		FROM agent_instance_task WHERE context_id = 'instance-1' AND id = 'task-1'
 	`).Scan(&snapshotAtespace, &snapshotName, &snapshotUID, &historySequence); err != nil {
 		t.Fatal(err)
 	}
-	if snapshotAtespace != snapshot.Atespace || snapshotName != snapshot.Name || snapshotUID != snapshot.UID || historySequence != 2 {
+	if err := db.QueryRow(ctx, `SELECT MAX(sequence) FROM agent_instance_task_event`).Scan(&latestSequence); err != nil {
+		t.Fatal(err)
+	}
+	if snapshotAtespace != snapshot.Atespace || snapshotName != snapshot.Name || snapshotUID != snapshot.UID || historySequence != latestSequence {
 		t.Fatalf("stored boundary = %s/%s uid %s sequence %d", snapshotAtespace, snapshotName, snapshotUID, historySequence)
+	}
+	got, err = client.GetAgentInstanceTask(ctx, "instance-1", "task-1")
+	if err != nil || len(got.History) != 2 || got.History[1].Role != a2a.MessageRoleAgent {
+		t.Fatalf("reconstructed task history = %#v, error %v", got, err)
 	}
 	if err := client.StoreAgentInstanceTaskEvent(ctx, "instance-1", second, second, nil); err != nil {
 		t.Fatal(err)
 	}
-	if events := countRows(t, db, "SELECT COUNT(*) FROM agent_instance_task_event"); events != 3 {
-		t.Fatalf("event count = %d, want 3", events)
+	if events := countRows(t, db, "SELECT COUNT(*) FROM agent_instance_task_event"); events != 4 {
+		t.Fatalf("event count = %d, want 4", events)
 	}
 
 	tasks, total, err := client.ListAgentInstanceTasks(ctx, "instance-1", "", a2a.TaskStateUnspecified, nil, 1)

--- a/go/core/internal/database/client_agent_instance_test.go
+++ b/go/core/internal/database/client_agent_instance_test.go
@@ -40,8 +40,11 @@ func TestAgentInstanceTasksAreDurableAndExclusive(t *testing.T) {
 	db := setupTestDB(t)
 	ctx := context.Background()
 	if _, err := db.Exec(ctx, `
-		INSERT INTO agent_instance (id, namespace, user_id, request_id, state, data)
-		VALUES ('instance-1', 'team-a', 'alice', 'request-1', 'READY', '\x00')
+		INSERT INTO a2a_context (id, namespace, user_id)
+		VALUES ('instance-1', 'team-a', 'alice');
+
+		INSERT INTO agent_instance (id, namespace, user_id, request_id, context_id, state, data)
+		VALUES ('instance-1', 'team-a', 'alice', 'request-1', 'instance-1', 'READY', '\x00')
 	`); err != nil {
 		t.Fatal(err)
 	}
@@ -88,7 +91,7 @@ func TestAgentInstanceTasksAreDurableAndExclusive(t *testing.T) {
 	var historySequence int64
 	if err := db.QueryRow(ctx, `
 		SELECT snapshot_atespace, snapshot_name, snapshot_uid, history_sequence
-		FROM agent_instance_task WHERE instance_id = 'instance-1' AND id = 'task-1'
+		FROM agent_instance_task WHERE context_id = 'instance-1' AND id = 'task-1'
 	`).Scan(&snapshotAtespace, &snapshotName, &snapshotUID, &historySequence); err != nil {
 		t.Fatal(err)
 	}
@@ -116,8 +119,10 @@ func TestConcurrentAgentInstanceMessageReplay(t *testing.T) {
 	db := setupTestDB(t)
 	ctx := context.Background()
 	if _, err := db.Exec(ctx, `
-		INSERT INTO agent_instance (id, namespace, user_id, request_id, state, data)
-		VALUES ('instance-1', 'team-a', 'alice', 'request-1', 'READY', '\x00')
+		INSERT INTO a2a_context (id, namespace, user_id)
+		VALUES ('instance-1', 'team-a', 'alice');
+		INSERT INTO agent_instance (id, namespace, user_id, request_id, context_id, state, data)
+		VALUES ('instance-1', 'team-a', 'alice', 'request-1', 'instance-1', 'READY', '\x00')
 	`); err != nil {
 		t.Fatal(err)
 	}
@@ -173,8 +178,14 @@ func TestAgentInstanceCheckpointRetainsRecordedBoundary(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := db.Exec(ctx, `
-		INSERT INTO agent_instance (id, namespace, user_id, request_id, state, data)
-		VALUES ('instance-1', 'team-a', 'alice', 'instance-request', 'READY', $1)
+		INSERT INTO a2a_context (id, namespace, user_id)
+		VALUES ('instance-1', 'team-a', 'alice')
+	`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(ctx, `
+		INSERT INTO agent_instance (id, namespace, user_id, request_id, context_id, state, data)
+		VALUES ('instance-1', 'team-a', 'alice', 'instance-request', 'instance-1', 'READY', $1)
 	`, instanceData); err != nil {
 		t.Fatal(err)
 	}
@@ -253,6 +264,146 @@ func TestAgentInstanceCheckpointRetainsRecordedBoundary(t *testing.T) {
 	}
 	if err := client.DeleteAgentInstanceCheckpoint(ctx, "team-a", checkpoint.ID, "alice"); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestForkAgentInstanceCopiesBoundedHistory(t *testing.T) {
+	db := setupTestDB(t)
+	client := NewClient(db)
+	ctx := context.Background()
+	revision := dbpkg.RuntimeRevision{
+		Revision: "revision-1", Namespace: "team-a",
+		AgentTemplateName: "assistant", AgentTemplateUID: "template-uid",
+		HarnessName: "kagent", HarnessUID: "harness-uid",
+		SourceSnapshot: []byte("{}"), AgentCard: []byte(`{"name":"assistant"}`), EgressDestinations: []string{},
+		ActorTemplateNamespace: "team-a", ActorTemplateName: "assistant-kagent-revision",
+		ActorTemplateUID: "actor-template-uid", Phase: "Ready",
+	}
+	if err := client.UpsertRuntimeRevision(ctx, revision); err != nil {
+		t.Fatal(err)
+	}
+	pair := dbpkg.AgentTemplateHarnessPair{
+		Namespace: "team-a", AgentTemplateName: "assistant", AgentTemplateUID: "template-uid",
+		HarnessName: "kagent", HarnessUID: "harness-uid", DesiredRevision: revision.Revision,
+	}
+	if err := client.UpsertAgentTemplateHarnessPair(ctx, pair); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.MarkRuntimeRevisionSuccessful(ctx, pair); err != nil {
+		t.Fatal(err)
+	}
+
+	source, _, err := client.CreateAgentInstance(ctx, &apiv1alpha1.AgentInstance{
+		Id: "instance-1", Namespace: "team-a", Creator: "alice",
+		Harness:       &apiv1alpha1.ResourceReference{Namespace: "team-a", Name: "kagent"},
+		AgentTemplate: &apiv1alpha1.ResourceReference{Namespace: "team-a", Name: "assistant"},
+	}, "source-request")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.MarkAgentInstanceReady(ctx, source.GetId(), "source.example"); err != nil {
+		t.Fatal(err)
+	}
+	first := newAgentInstanceTask("task-1", "message-1")
+	first.History[0].ContextID = source.GetId()
+	first.History[0].TaskID = first.ID
+	first.History[0].ReferenceTasks = []a2a.TaskID{first.ID}
+	first.Status.Message = &a2a.Message{ID: "message-1", Role: a2a.MessageRoleAgent}
+	if _, _, err := client.CreateAgentInstanceTask(ctx, source.GetId(), []byte("message-request-1"), first); err != nil {
+		t.Fatal(err)
+	}
+	first.Status.State = a2a.TaskStateCompleted
+	if err := client.StoreAgentInstanceTaskEvent(ctx, source.GetId(), first, first,
+		&dbpkg.AgentInstanceTaskSnapshot{Atespace: "team-a", Name: "snapshot-1", UID: "snapshot-uid-1", ContentScope: "DATA"}); err != nil {
+		t.Fatal(err)
+	}
+	checkpoint, err := client.ReserveAgentInstanceCheckpoint(ctx, dbpkg.AgentInstanceCheckpoint{
+		ID: "checkpoint-1", Namespace: "team-a", SourceInstanceID: source.GetId(), UserID: "alice", RequestID: "checkpoint-request-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.FinalizeAgentInstanceCheckpoint(ctx, checkpoint.ID, "tag-uid-1", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	second := newAgentInstanceTask("task-2", "message-2")
+	if _, _, err := client.CreateAgentInstanceTask(ctx, source.GetId(), []byte("message-request-2"), second); err != nil {
+		t.Fatal(err)
+	}
+	second.Status.State = a2a.TaskStateCompleted
+	if err := client.StoreAgentInstanceTaskEvent(ctx, source.GetId(), second, second,
+		&dbpkg.AgentInstanceTaskSnapshot{Atespace: "team-a", Name: "snapshot-2", UID: "snapshot-uid-2", ContentScope: "DATA"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.DeleteAgentInstance(ctx, source.GetId()); err != nil {
+		t.Fatal(err)
+	}
+
+	fork, created, err := client.ForkAgentInstance(ctx, "team-a", checkpoint.ID, "alice", "fork-request-1", "fork-1")
+	if err != nil || !created {
+		t.Fatalf("ForkAgentInstance() = %+v, created %v, error %v", fork, created, err)
+	}
+	if fork.GetId() != "fork-1" || fork.GetPreparedRevision() != revision.Revision || fork.GetA2AAuthority() != "" ||
+		fork.GetState() != apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_CREATING {
+		t.Fatalf("fork = %+v", fork)
+	}
+	instances, err := client.ListAgentInstances(ctx, "team-a", "alice", false, nil, "", 10)
+	if err != nil || len(instances) != 1 || instances[0].GetId() != fork.GetId() {
+		t.Fatalf("listed forks = %+v, error %v", instances, err)
+	}
+	tasks, total, err := client.ListAgentInstanceTasks(ctx, fork.GetId(), "", a2a.TaskStateUnspecified, nil, 10)
+	if err != nil || total != 1 || len(tasks) != 1 {
+		t.Fatalf("fork tasks = %+v, total %d, error %v", tasks, total, err)
+	}
+	copied := tasks[0]
+	if copied.ID == first.ID || copied.ContextID != fork.GetId() || len(copied.History) != 1 ||
+		copied.History[0].ID == first.History[0].ID || copied.History[0].ContextID != fork.GetId() ||
+		copied.History[0].TaskID != copied.ID || copied.History[0].ReferenceTasks[0] != copied.ID ||
+		copied.Status.Message.ID != copied.History[0].ID || copied.Status.Message.TaskID != copied.ID {
+		t.Fatalf("reidentified task = %+v", copied)
+	}
+	var initialMessageID *string
+	var requestHash []byte
+	var snapshotUID string
+	if err := db.QueryRow(ctx, `
+		SELECT initial_message_id, request_hash, snapshot_uid
+		FROM agent_instance_task WHERE context_id = $1 AND id = $2
+	`, fork.GetId(), copied.ID).Scan(&initialMessageID, &requestHash, &snapshotUID); err != nil {
+		t.Fatal(err)
+	}
+	if initialMessageID != nil || requestHash != nil || snapshotUID != "snapshot-uid-1" {
+		t.Fatalf("copied persistence metadata = message %v hash %v snapshot %q", initialMessageID, requestHash, snapshotUID)
+	}
+	replayed, created, err := client.ForkAgentInstance(ctx, "team-a", checkpoint.ID, "alice", "fork-request-1", "ignored")
+	if err != nil || created || replayed.GetId() != fork.GetId() {
+		t.Fatalf("replayed fork = %+v, created %v, error %v", replayed, created, err)
+	}
+	if _, _, err := client.ForkAgentInstance(ctx, "team-a", "other-checkpoint", "alice", "fork-request-1", "ignored"); !errors.Is(err, dbpkg.ErrIdempotencyConflict) {
+		t.Fatalf("conflicting fork request error = %v", err)
+	}
+	if _, err := client.BeginDeleteAgentInstanceCheckpoint(ctx, "team-a", checkpoint.ID, "alice"); !errors.Is(err, dbpkg.ErrNotFound) {
+		t.Fatalf("delete referenced checkpoint error = %v", err)
+	}
+
+	if _, err := client.MarkAgentInstanceReady(ctx, fork.GetId(), "fork.example"); err != nil {
+		t.Fatal(err)
+	}
+	checkpoint2, err := client.ReserveAgentInstanceCheckpoint(ctx, dbpkg.AgentInstanceCheckpoint{
+		ID: "checkpoint-2", Namespace: "team-a", SourceInstanceID: fork.GetId(), UserID: "alice", RequestID: "checkpoint-request-2",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.FinalizeAgentInstanceCheckpoint(ctx, checkpoint2.ID, "tag-uid-2", ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.DeleteAgentInstance(ctx, fork.GetId()); err != nil {
+		t.Fatal(err)
+	}
+	fork2, created, err := client.ForkAgentInstance(ctx, "team-a", checkpoint2.ID, "alice", "fork-request-2", "fork-2")
+	if err != nil || !created || fork2.GetId() != "fork-2" {
+		t.Fatalf("fork of fork = %+v, created %v, error %v", fork2, created, err)
 	}
 }
 
@@ -354,8 +505,10 @@ func TestInterruptActiveAgentInstanceTaskRequiresMatchingTaskAndReusesSlot(t *te
 	db := setupTestDB(t)
 	ctx := context.Background()
 	if _, err := db.Exec(ctx, `
-		INSERT INTO agent_instance (id, namespace, user_id, request_id, state, data)
-		VALUES ('instance-1', 'team-a', 'alice', 'request-1', 'READY', '\x00')
+		INSERT INTO a2a_context (id, namespace, user_id)
+		VALUES ('instance-1', 'team-a', 'alice');
+		INSERT INTO agent_instance (id, namespace, user_id, request_id, context_id, state, data)
+		VALUES ('instance-1', 'team-a', 'alice', 'request-1', 'instance-1', 'READY', '\x00')
 	`); err != nil {
 		t.Fatal(err)
 	}

--- a/go/core/internal/database/client_agent_instance_test.go
+++ b/go/core/internal/database/client_agent_instance_test.go
@@ -301,6 +301,7 @@ func TestForkAgentInstanceCopiesBoundedHistory(t *testing.T) {
 	pair := dbpkg.AgentTemplateHarnessPair{
 		Namespace: "team-a", AgentTemplateName: "assistant", AgentTemplateUID: "template-uid",
 		HarnessName: "kagent", HarnessUID: "harness-uid", DesiredRevision: revision.Revision,
+		AgentTemplateLabels: map[string]string{"app": "assistant"},
 	}
 	if err := client.UpsertAgentTemplateHarnessPair(ctx, pair); err != nil {
 		t.Fatal(err)
@@ -361,7 +362,9 @@ func TestForkAgentInstanceCopiesBoundedHistory(t *testing.T) {
 		t.Fatalf("ForkAgentInstance() = %+v, created %v, error %v", fork, created, err)
 	}
 	if fork.GetId() != "fork-1" || fork.GetPreparedRevision() != revision.Revision || fork.GetA2AAuthority() != "" ||
-		fork.GetState() != apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_CREATING {
+		fork.GetState() != apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_CREATING ||
+		fork.GetHarness().GetName() != "kagent" || fork.GetAgentTemplate().GetName() != "assistant" ||
+		fork.GetLabels()["app"] != "assistant" {
 		t.Fatalf("fork = %+v", fork)
 	}
 	instances, err := client.ListAgentInstances(ctx, "team-a", "alice", false, nil, "", 10)

--- a/go/core/internal/database/client_postgres.go
+++ b/go/core/internal/database/client_postgres.go
@@ -637,12 +637,19 @@ func (c *postgresClient) ForkAgentInstance(ctx context.Context, namespace, check
 			return fmt.Errorf("list checkpoint tasks: %w", err)
 		}
 		ids := newForkIDs(instanceID)
+		var copiedHistorySequence int64
 		for _, source := range tasks {
 			task, err := unmarshalAgentInstanceTask(source.Data)
 			if err != nil {
 				return fmt.Errorf("decode checkpoint task %s: %w", source.ID, err)
 			}
 			reidentifyForkTask(task, instanceID, ids)
+			if len(task.History) > 0 {
+				copiedHistorySequence, err = storeAgentInstanceTaskMessages(ctx, q, instanceID, string(task.ID), task.History)
+				if err != nil {
+					return fmt.Errorf("copy checkpoint task %s history: %w", source.ID, err)
+				}
+			}
 			data, err := marshalAgentInstanceTask(task)
 			if err != nil {
 				return fmt.Errorf("encode fork task %s: %w", task.ID, err)
@@ -652,16 +659,47 @@ func (c *postgresClient) ForkAgentInstance(ctx context.Context, namespace, check
 				StatusTimestamp: task.Status.Timestamp, Data: data,
 				CreatedAt: source.CreatedAt, UpdatedAt: source.UpdatedAt,
 			}
-			if source.ID == checkpoint.HeadTaskID {
-				copy.SnapshotAtespace = source.SnapshotAtespace
-				copy.SnapshotName = source.SnapshotName
-				copy.SnapshotUid = source.SnapshotUid
-				copy.SnapshotContentScope = source.SnapshotContentScope
-				copy.HistorySequence = source.HistorySequence
-			}
 			if err := q.InsertCopiedAgentInstanceTask(ctx, copy); err != nil {
 				return fmt.Errorf("copy checkpoint task %s: %w", source.ID, err)
 			}
+		}
+		events, err := q.ListAgentInstanceCheckpointEvents(ctx, checkpoint.ID)
+		if err != nil {
+			return fmt.Errorf("list checkpoint events: %w", err)
+		}
+		for _, source := range events {
+			event, err := unmarshalAgentInstanceTaskEvent(source.Data)
+			if err != nil {
+				return fmt.Errorf("decode checkpoint event %d: %w", source.Sequence, err)
+			}
+			reidentifyForkEvent(event, derefStr(source.TaskID), instanceID, ids)
+			data, err := marshalAgentInstanceTaskEvent(event)
+			if err != nil {
+				return fmt.Errorf("encode checkpoint event %d: %w", source.Sequence, err)
+			}
+			messageID := source.MessageID
+			if messageID != nil {
+				mapped := ids.message(*messageID)
+				messageID = &mapped
+			}
+			copiedHistorySequence, err = q.InsertAgentInstanceTaskEvent(ctx, dbgen.InsertAgentInstanceTaskEventParams{
+				ContextID: instanceID, TaskID: strPtrIfNotEmpty(string(event.TaskInfo().TaskID)),
+				MessageID: messageID, Data: data,
+			})
+			if err != nil {
+				return fmt.Errorf("copy checkpoint event %d: %w", source.Sequence, err)
+			}
+		}
+		if copiedHistorySequence == 0 {
+			return fmt.Errorf("checkpoint %s has no history events", checkpointID)
+		}
+		headID := string(ids.task(a2a.TaskID(checkpoint.HeadTaskID)))
+		if err := q.SetAgentInstanceTaskSnapshot(ctx, dbgen.SetAgentInstanceTaskSnapshotParams{
+			ContextID: instanceID, ID: headID, SnapshotAtespace: &checkpoint.SnapshotAtespace,
+			SnapshotName: &checkpoint.SnapshotName, SnapshotUid: &checkpoint.SnapshotUid,
+			SnapshotContentScope: &checkpoint.SnapshotContentScope, HistorySequence: &copiedHistorySequence,
+		}); err != nil {
+			return fmt.Errorf("store fork history boundary: %w", err)
 		}
 		return nil
 	})
@@ -735,6 +773,29 @@ func reidentifyForkMessage(message *a2a.Message, taskID a2a.TaskID, contextID st
 	message.TaskID = taskID
 	for index, reference := range message.ReferenceTasks {
 		message.ReferenceTasks[index] = ids.task(reference)
+	}
+}
+
+func reidentifyForkEvent(event a2a.Event, sourceTaskID, contextID string, ids *forkIDs) {
+	taskID := event.TaskInfo().TaskID
+	if taskID == "" {
+		taskID = a2a.TaskID(sourceTaskID)
+	}
+	switch event := event.(type) {
+	case *a2a.Message:
+		reidentifyForkMessage(event, ids.task(taskID), contextID, ids)
+	case *a2a.Task:
+		event.ID = taskID
+		reidentifyForkTask(event, contextID, ids)
+	case *a2a.TaskStatusUpdateEvent:
+		event.TaskID = ids.task(taskID)
+		event.ContextID = contextID
+		if event.Status.Message != nil {
+			reidentifyForkMessage(event.Status.Message, event.TaskID, contextID, ids)
+		}
+	case *a2a.TaskArtifactUpdateEvent:
+		event.TaskID = ids.task(taskID)
+		event.ContextID = contextID
 	}
 }
 
@@ -908,10 +969,6 @@ func (c *postgresClient) CreateAgentInstanceTask(ctx context.Context, instanceID
 	if err != nil {
 		return nil, false, err
 	}
-	eventData, err := marshalAgentInstanceTaskEvent(message)
-	if err != nil {
-		return nil, false, err
-	}
 
 	result := task
 	created := false
@@ -948,12 +1005,13 @@ func (c *postgresClient) CreateAgentInstanceTask(ctx context.Context, instanceID
 				return dbpkg.ErrIdempotencyConflict
 			}
 			result, err = unmarshalAgentInstanceTask(row.Data)
-			return err
+			if err != nil {
+				return err
+			}
+			return loadAgentInstanceTaskHistories(ctx, q, instanceID, []*a2a.Task{result})
 		}
 		created = true
-		_, err = q.InsertAgentInstanceTaskEvent(ctx, dbgen.InsertAgentInstanceTaskEventParams{
-			ContextID: instanceID, TaskID: strPtrIfNotEmpty(string(task.ID)), Data: eventData,
-		})
+		_, err = storeAgentInstanceTaskMessages(ctx, q, instanceID, string(task.ID), task.History)
 		return err
 	})
 	if err != nil {
@@ -971,7 +1029,11 @@ func (c *postgresClient) GetActiveAgentInstanceTask(ctx context.Context, instanc
 	if err != nil {
 		return nil, fmt.Errorf("get active AgentInstance task: %w", notFoundOr(err))
 	}
-	return unmarshalAgentInstanceTask(row.Data)
+	task, err := unmarshalAgentInstanceTask(row.Data)
+	if err == nil {
+		err = loadAgentInstanceTaskHistories(ctx, c.q, instanceID, []*a2a.Task{task})
+	}
+	return task, err
 }
 
 // InterruptActiveAgentInstanceTask atomically fails taskID only if it is still the
@@ -993,6 +1055,9 @@ func (c *postgresClient) InterruptActiveAgentInstanceTask(ctx context.Context, i
 		if err != nil {
 			return err
 		}
+		if err := loadAgentInstanceTaskHistories(ctx, q, instanceID, []*a2a.Task{task}); err != nil {
+			return err
+		}
 		interrupted := a2a.NewMessageForTask(a2a.MessageRoleAgent, task, a2a.NewTextPart(taskInterruptedMessage))
 		now := time.Now()
 		task.History = append(task.History, interrupted)
@@ -1007,13 +1072,7 @@ func (c *postgresClient) InterruptActiveAgentInstanceTask(ctx context.Context, i
 		}); err != nil {
 			return fmt.Errorf("interrupt AgentInstance task %s: %w", task.ID, err)
 		}
-		eventData, err := marshalAgentInstanceTaskEvent(interrupted)
-		if err != nil {
-			return err
-		}
-		if _, err := q.InsertAgentInstanceTaskEvent(ctx, dbgen.InsertAgentInstanceTaskEventParams{
-			ContextID: instanceID, TaskID: strPtrIfNotEmpty(string(task.ID)), Data: eventData,
-		}); err != nil {
+		if _, err := storeAgentInstanceTaskMessages(ctx, q, instanceID, string(task.ID), task.History); err != nil {
 			return fmt.Errorf("record AgentInstance task interruption: %w", err)
 		}
 		interruptedTask = true
@@ -1026,13 +1085,23 @@ func (c *postgresClient) InterruptActiveAgentInstanceTask(ctx context.Context, i
 }
 
 func (c *postgresClient) StoreAgentInstanceTaskEvent(ctx context.Context, instanceID string, task *a2a.Task, event a2a.Event, snapshot *dbpkg.AgentInstanceTaskSnapshot) error {
-	eventData, err := marshalAgentInstanceTaskEvent(event)
-	if err != nil {
-		return err
-	}
-
-	err = c.withTx(ctx, func(q *dbgen.Queries) error {
+	err := c.withTx(ctx, func(q *dbgen.Queries) error {
+		var sequence int64
 		if task != nil {
+			if row, err := q.GetAgentInstanceTask(ctx, dbgen.GetAgentInstanceTaskParams{ContextID: instanceID, ID: string(task.ID)}); err == nil {
+				previous, err := unmarshalAgentInstanceTask(row.Data)
+				if err != nil {
+					return err
+				}
+				if len(previous.History) > 0 {
+					sequence, err = storeAgentInstanceTaskMessages(ctx, q, instanceID, string(task.ID), previous.History)
+					if err != nil {
+						return fmt.Errorf("normalize legacy AgentInstance task history: %w", err)
+					}
+				}
+			} else if !errors.Is(err, pgx.ErrNoRows) {
+				return fmt.Errorf("get AgentInstance task %s: %w", task.ID, err)
+			}
 			data, err := marshalAgentInstanceTask(task)
 			if err != nil {
 				return err
@@ -1047,13 +1116,30 @@ func (c *postgresClient) StoreAgentInstanceTaskEvent(ctx context.Context, instan
 				return fmt.Errorf("store AgentInstance task %s: %w", task.ID, err)
 			}
 		}
-		sequence, err := q.InsertAgentInstanceTaskEvent(ctx, dbgen.InsertAgentInstanceTaskEventParams{
-			ContextID: instanceID, TaskID: strPtrIfNotEmpty(string(event.TaskInfo().TaskID)), Data: eventData,
-		})
-		if err != nil {
-			return fmt.Errorf("store AgentInstance task event: %w", err)
+		messages := agentInstanceTaskEventMessages(task, event)
+		if len(messages) > 0 {
+			var err error
+			sequence, err = storeAgentInstanceTaskMessages(ctx, q, instanceID, string(event.TaskInfo().TaskID), messages)
+			if err != nil {
+				return fmt.Errorf("store AgentInstance task history: %w", err)
+			}
+		}
+		if _, ok := event.(*a2a.Message); !ok {
+			eventData, err := marshalAgentInstanceTaskEvent(event)
+			if err != nil {
+				return err
+			}
+			sequence, err = q.InsertAgentInstanceTaskEvent(ctx, dbgen.InsertAgentInstanceTaskEventParams{
+				ContextID: instanceID, TaskID: strPtrIfNotEmpty(string(event.TaskInfo().TaskID)), Data: eventData,
+			})
+			if err != nil {
+				return fmt.Errorf("store AgentInstance task event: %w", err)
+			}
 		}
 		if snapshot != nil {
+			if sequence == 0 {
+				return fmt.Errorf("snapshot has no history boundary")
+			}
 			if err := q.SetAgentInstanceTaskSnapshot(ctx, dbgen.SetAgentInstanceTaskSnapshotParams{
 				ContextID: instanceID, ID: string(task.ID), SnapshotAtespace: &snapshot.Atespace,
 				SnapshotName: &snapshot.Name, SnapshotUid: &snapshot.UID,
@@ -1075,7 +1161,11 @@ func (c *postgresClient) GetAgentInstanceTask(ctx context.Context, instanceID, t
 	if err != nil {
 		return nil, fmt.Errorf("get AgentInstance task %s: %w", taskID, notFoundOr(err))
 	}
-	return unmarshalAgentInstanceTask(row.Data)
+	task, err := unmarshalAgentInstanceTask(row.Data)
+	if err == nil {
+		err = loadAgentInstanceTaskHistories(ctx, c.q, instanceID, []*a2a.Task{task})
+	}
+	return task, err
 }
 
 func (c *postgresClient) ListAgentInstanceTasks(ctx context.Context, instanceID, afterID string, state a2a.TaskState, statusTimestampAfter *time.Time, limit int) ([]*a2a.Task, int, error) {
@@ -1100,6 +1190,9 @@ func (c *postgresClient) ListAgentInstanceTasks(ctx context.Context, instanceID,
 			return nil, 0, fmt.Errorf("decode AgentInstance task %s: %w", row.ID, err)
 		}
 		tasks = append(tasks, task)
+	}
+	if err := loadAgentInstanceTaskHistories(ctx, c.q, instanceID, tasks); err != nil {
+		return nil, 0, err
 	}
 	return tasks, int(total), nil
 }
@@ -1234,7 +1327,9 @@ func (c *postgresClient) DeleteAgentInstanceCheckpoint(ctx context.Context, name
 }
 
 func marshalAgentInstanceTask(task *a2a.Task) ([]byte, error) {
-	pb, err := pbconv.ToProtoTask(task)
+	projection := *task
+	projection.History = nil
+	pb, err := pbconv.ToProtoTask(&projection)
 	if err != nil {
 		return nil, fmt.Errorf("convert AgentInstance task: %w", err)
 	}
@@ -1246,6 +1341,11 @@ func marshalAgentInstanceTask(task *a2a.Task) ([]byte, error) {
 }
 
 func marshalAgentInstanceTaskEvent(event a2a.Event) ([]byte, error) {
+	if task, ok := event.(*a2a.Task); ok {
+		projection := *task
+		projection.History = nil
+		event = &projection
+	}
 	pb, err := pbconv.ToProtoStreamResponse(event)
 	if err != nil {
 		return nil, fmt.Errorf("convert AgentInstance task event: %w", err)
@@ -1255,6 +1355,89 @@ func marshalAgentInstanceTaskEvent(event a2a.Event) ([]byte, error) {
 		return nil, fmt.Errorf("marshal AgentInstance task event: %w", err)
 	}
 	return data, nil
+}
+
+func unmarshalAgentInstanceTaskEvent(data []byte) (a2a.Event, error) {
+	var pb a2apb.StreamResponse
+	if err := proto.Unmarshal(data, &pb); err != nil {
+		return nil, fmt.Errorf("unmarshal AgentInstance task event: %w", err)
+	}
+	event, err := pbconv.FromProtoStreamResponse(&pb)
+	if err != nil {
+		return nil, fmt.Errorf("convert AgentInstance task event: %w", err)
+	}
+	return event, nil
+}
+
+func agentInstanceTaskEventMessages(task *a2a.Task, event a2a.Event) []*a2a.Message {
+	switch event := event.(type) {
+	case *a2a.Message:
+		return []*a2a.Message{event}
+	case *a2a.Task:
+		return event.History
+	case *a2a.TaskStatusUpdateEvent:
+		if task != nil && len(task.History) > 0 {
+			return task.History[len(task.History)-1:]
+		}
+	}
+	return nil
+}
+
+func storeAgentInstanceTaskMessages(ctx context.Context, q *dbgen.Queries, contextID, taskID string, messages []*a2a.Message) (int64, error) {
+	var sequence int64
+	for _, message := range messages {
+		if message == nil || message.ID == "" {
+			return 0, fmt.Errorf("AgentInstance task history contains a message without an ID")
+		}
+		data, err := marshalAgentInstanceTaskEvent(message)
+		if err != nil {
+			return 0, err
+		}
+		sequence, err = q.InsertAgentInstanceTaskEvent(ctx, dbgen.InsertAgentInstanceTaskEventParams{
+			ContextID: contextID, TaskID: &taskID, MessageID: &message.ID, Data: data,
+		})
+		if err != nil {
+			return 0, err
+		}
+	}
+	return sequence, nil
+}
+
+func loadAgentInstanceTaskHistories(ctx context.Context, q *dbgen.Queries, contextID string, tasks []*a2a.Task) error {
+	if len(tasks) == 0 {
+		return nil
+	}
+	ids := make([]string, len(tasks))
+	byID := make(map[string]*a2a.Task, len(tasks))
+	for index, task := range tasks {
+		ids[index] = string(task.ID)
+		byID[string(task.ID)] = task
+	}
+	rows, err := q.ListAgentInstanceTaskHistory(ctx, dbgen.ListAgentInstanceTaskHistoryParams{ContextID: contextID, TaskIds: ids})
+	if err != nil {
+		return fmt.Errorf("list AgentInstance task history: %w", err)
+	}
+	histories := make(map[string][]*a2a.Message, len(tasks))
+	for _, row := range rows {
+		if row.TaskID == nil {
+			continue
+		}
+		event, err := unmarshalAgentInstanceTaskEvent(row.Data)
+		if err != nil {
+			return err
+		}
+		message, ok := event.(*a2a.Message)
+		if !ok {
+			return fmt.Errorf("AgentInstance task history event is %T, not a message", event)
+		}
+		histories[*row.TaskID] = append(histories[*row.TaskID], message)
+	}
+	for taskID, history := range histories {
+		if task := byID[taskID]; task != nil {
+			task.History = history
+		}
+	}
+	return nil
 }
 
 func isActiveTaskConflict(err error) bool {

--- a/go/core/internal/database/client_postgres.go
+++ b/go/core/internal/database/client_postgres.go
@@ -589,32 +589,31 @@ func (c *postgresClient) ForkAgentInstance(ctx context.Context, namespace, check
 		if err != nil {
 			return fmt.Errorf("lock checkpoint: %w", err)
 		}
-		if checkpoint.PreparedRevision == nil || len(checkpoint.SourceInstanceData) == 0 {
+		if checkpoint.PreparedRevision == nil {
 			return fmt.Errorf("checkpoint %s has no fork source", checkpointID)
 		}
 
-		instance := &apiv1alpha1.AgentInstance{}
-		if err := proto.Unmarshal(checkpoint.SourceInstanceData, instance); err != nil {
-			return fmt.Errorf("decode checkpoint AgentInstance: %w", err)
+		revision, err := q.GetRuntimeRevision(ctx, *checkpoint.PreparedRevision)
+		if err != nil {
+			return fmt.Errorf("get checkpoint runtime revision: %w", err)
+		}
+		labels := map[string]string{}
+		if err := json.Unmarshal(checkpoint.SourceLabels, &labels); err != nil {
+			return fmt.Errorf("decode checkpoint labels: %w", err)
 		}
 		now := timestamppb.Now()
-		instance.Id = instanceID
-		instance.Namespace = namespace
-		instance.Creator = userID
-		instance.PreparedRevision = *checkpoint.PreparedRevision
-		instance.A2AAuthority = ""
-		instance.State = apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_CREATING
-		instance.Operation = apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_CREATE
-		instance.Failure = nil
-		instance.CreatedAt = now
-		instance.UpdatedAt = now
+		instance := &apiv1alpha1.AgentInstance{
+			Id: instanceID, Namespace: namespace, Creator: userID,
+			Harness:          &apiv1alpha1.ResourceReference{Namespace: revision.Namespace, Name: revision.HarnessName},
+			AgentTemplate:    &apiv1alpha1.ResourceReference{Namespace: revision.Namespace, Name: revision.AgentTemplateName},
+			PreparedRevision: *checkpoint.PreparedRevision,
+			State:            apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_CREATING,
+			Operation:        apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_CREATE,
+			CreatedAt:        now, UpdatedAt: now, Labels: labels,
+		}
 		data, err := marshalAgentInstance(instance)
 		if err != nil {
 			return err
-		}
-		labels := instance.GetLabels()
-		if labels == nil {
-			labels = map[string]string{}
 		}
 		encodedLabels, err := json.Marshal(labels)
 		if err != nil {
@@ -1243,7 +1242,7 @@ func (c *postgresClient) ReserveAgentInstanceCheckpoint(ctx context.Context, che
 			SnapshotName: *boundary.SnapshotName, SnapshotUid: *boundary.SnapshotUid,
 			SnapshotContentScope: *boundary.SnapshotContentScope,
 			SourceContextID:      instance.ContextID, PreparedRevision: instance.PreparedRevision,
-			SourceInstanceData: instance.Data,
+			SourceLabels: instance.Labels,
 		})
 		if errors.Is(err, pgx.ErrNoRows) {
 			existing, existingErr := q.GetAgentInstanceCheckpointByRequest(ctx, dbgen.GetAgentInstanceCheckpointByRequestParams{
@@ -2129,8 +2128,7 @@ func toAgentInstanceCheckpoint(row dbgen.AgentInstanceCheckpoint) *dbpkg.AgentIn
 		RequestID: row.RequestID, HeadTaskID: row.HeadTaskID, HistorySequence: row.HistorySequence,
 		SnapshotAtespace: row.SnapshotAtespace, SnapshotName: row.SnapshotName, SnapshotUID: row.SnapshotUid,
 		SnapshotContentScope: row.SnapshotContentScope, PreparedRevision: derefStr(row.PreparedRevision),
-		SourceInstanceData: row.SourceInstanceData,
-		TagUID:             row.TagUid, State: row.State, Failure: row.Failure, CreatedAt: row.CreatedAt,
+		TagUID: row.TagUid, State: row.State, Failure: row.Failure, CreatedAt: row.CreatedAt,
 	}
 }
 

--- a/go/core/internal/database/client_postgres.go
+++ b/go/core/internal/database/client_postgres.go
@@ -13,6 +13,7 @@ import (
 	a2a "github.com/a2aproject/a2a-go/v2/a2a"
 	a2apb "github.com/a2aproject/a2a-go/v2/a2apb/v1"
 	"github.com/a2aproject/a2a-go/v2/a2apb/v1/pbconv"
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -532,9 +533,18 @@ func (c *postgresClient) CreateAgentInstance(ctx context.Context, request *apiv1
 	if err != nil {
 		return nil, false, err
 	}
-	row, err := c.q.InsertAgentInstance(ctx, dbgen.InsertAgentInstanceParams{
-		ID: request.GetId(), Namespace: request.GetNamespace(), UserID: request.GetCreator(), RequestID: requestID,
-		PreparedRevision: &revision.Revision, Labels: revision.AgentTemplateLabels, Data: data,
+	var row dbgen.AgentInstance
+	err = c.withTx(ctx, func(q *dbgen.Queries) error {
+		if err := q.InsertA2AContext(ctx, dbgen.InsertA2AContextParams{
+			ID: request.GetId(), Namespace: request.GetNamespace(), UserID: request.GetCreator(),
+		}); err != nil {
+			return fmt.Errorf("insert A2A context: %w", err)
+		}
+		row, err = q.InsertAgentInstance(ctx, dbgen.InsertAgentInstanceParams{
+			ID: request.GetId(), Namespace: request.GetNamespace(), UserID: request.GetCreator(), RequestID: requestID,
+			ContextID: request.GetId(), PreparedRevision: &revision.Revision, Labels: revision.AgentTemplateLabels, Data: data,
+		})
+		return err
 	})
 	if errors.Is(err, pgx.ErrNoRows) {
 		existing, err = c.q.GetAgentInstanceByRequest(ctx, requestKey)
@@ -552,6 +562,180 @@ func (c *postgresClient) CreateAgentInstance(ctx context.Context, request *apiv1
 	}
 	instance, err = toAgentInstance(row)
 	return instance, err == nil, err
+}
+
+func (c *postgresClient) ForkAgentInstance(ctx context.Context, namespace, checkpointID, userID, requestID, instanceID string) (*apiv1alpha1.AgentInstance, bool, error) {
+	requestKey := dbgen.GetAgentInstanceByRequestParams{UserID: userID, Namespace: namespace, RequestID: requestID}
+	existing, err := c.q.GetAgentInstanceByRequest(ctx, requestKey)
+	if err == nil {
+		if derefStr(existing.SourceCheckpointID) != checkpointID {
+			return nil, false, dbpkg.ErrIdempotencyConflict
+		}
+		instance, err := toAgentInstance(existing)
+		return instance, false, err
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return nil, false, fmt.Errorf("get fork request: %w", err)
+	}
+
+	var row dbgen.AgentInstance
+	err = c.withTx(ctx, func(q *dbgen.Queries) error {
+		checkpoint, err := q.LockReadyAgentInstanceCheckpoint(ctx, dbgen.LockReadyAgentInstanceCheckpointParams{
+			Namespace: namespace, ID: checkpointID, UserID: userID,
+		})
+		if errors.Is(err, pgx.ErrNoRows) {
+			return dbpkg.ErrNotFound
+		}
+		if err != nil {
+			return fmt.Errorf("lock checkpoint: %w", err)
+		}
+		if checkpoint.PreparedRevision == nil || len(checkpoint.SourceInstanceData) == 0 {
+			return fmt.Errorf("checkpoint %s has no fork source", checkpointID)
+		}
+
+		instance := &apiv1alpha1.AgentInstance{}
+		if err := proto.Unmarshal(checkpoint.SourceInstanceData, instance); err != nil {
+			return fmt.Errorf("decode checkpoint AgentInstance: %w", err)
+		}
+		now := timestamppb.Now()
+		instance.Id = instanceID
+		instance.Namespace = namespace
+		instance.Creator = userID
+		instance.PreparedRevision = *checkpoint.PreparedRevision
+		instance.A2AAuthority = ""
+		instance.State = apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_CREATING
+		instance.Operation = apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_CREATE
+		instance.Failure = nil
+		instance.CreatedAt = now
+		instance.UpdatedAt = now
+		data, err := marshalAgentInstance(instance)
+		if err != nil {
+			return err
+		}
+		labels := instance.GetLabels()
+		if labels == nil {
+			labels = map[string]string{}
+		}
+		encodedLabels, err := json.Marshal(labels)
+		if err != nil {
+			return fmt.Errorf("encode fork labels: %w", err)
+		}
+		if err := q.InsertA2AContext(ctx, dbgen.InsertA2AContextParams{ID: instanceID, Namespace: namespace, UserID: userID}); err != nil {
+			return fmt.Errorf("insert fork A2A context: %w", err)
+		}
+		row, err = q.InsertForkedAgentInstance(ctx, dbgen.InsertForkedAgentInstanceParams{
+			ID: instanceID, Namespace: namespace, UserID: userID, RequestID: requestID,
+			ContextID: instanceID, PreparedRevision: checkpoint.PreparedRevision,
+			SourceCheckpointID: &checkpoint.ID, Labels: encodedLabels, Data: data,
+		})
+		if err != nil {
+			return err
+		}
+
+		tasks, err := q.ListAgentInstanceCheckpointTasks(ctx, checkpoint.ID)
+		if err != nil {
+			return fmt.Errorf("list checkpoint tasks: %w", err)
+		}
+		ids := newForkIDs(instanceID)
+		for _, source := range tasks {
+			task, err := unmarshalAgentInstanceTask(source.Data)
+			if err != nil {
+				return fmt.Errorf("decode checkpoint task %s: %w", source.ID, err)
+			}
+			reidentifyForkTask(task, instanceID, ids)
+			data, err := marshalAgentInstanceTask(task)
+			if err != nil {
+				return fmt.Errorf("encode fork task %s: %w", task.ID, err)
+			}
+			copy := dbgen.InsertCopiedAgentInstanceTaskParams{
+				ContextID: instanceID, ID: string(task.ID), State: string(task.Status.State),
+				StatusTimestamp: task.Status.Timestamp, Data: data,
+				CreatedAt: source.CreatedAt, UpdatedAt: source.UpdatedAt,
+			}
+			if source.ID == checkpoint.HeadTaskID {
+				copy.SnapshotAtespace = source.SnapshotAtespace
+				copy.SnapshotName = source.SnapshotName
+				copy.SnapshotUid = source.SnapshotUid
+				copy.SnapshotContentScope = source.SnapshotContentScope
+				copy.HistorySequence = source.HistorySequence
+			}
+			if err := q.InsertCopiedAgentInstanceTask(ctx, copy); err != nil {
+				return fmt.Errorf("copy checkpoint task %s: %w", source.ID, err)
+			}
+		}
+		return nil
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		existing, err = c.q.GetAgentInstanceByRequest(ctx, requestKey)
+		if err != nil {
+			return nil, false, fmt.Errorf("get concurrent fork request: %w", err)
+		}
+		if derefStr(existing.SourceCheckpointID) != checkpointID {
+			return nil, false, dbpkg.ErrIdempotencyConflict
+		}
+		instance, err := toAgentInstance(existing)
+		return instance, false, err
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("fork AgentInstance: %w", err)
+	}
+	instance, err := toAgentInstance(row)
+	return instance, err == nil, err
+}
+
+type forkIDs struct {
+	namespace uuid.UUID
+	tasks     map[a2a.TaskID]a2a.TaskID
+	messages  map[string]string
+}
+
+func newForkIDs(instanceID string) *forkIDs {
+	return &forkIDs{
+		namespace: uuid.NewSHA1(uuid.NameSpaceOID, []byte(instanceID)),
+		tasks:     map[a2a.TaskID]a2a.TaskID{},
+		messages:  map[string]string{},
+	}
+}
+
+func (i *forkIDs) task(id a2a.TaskID) a2a.TaskID {
+	if mapped, ok := i.tasks[id]; ok {
+		return mapped
+	}
+	mapped := a2a.TaskID(uuid.NewSHA1(i.namespace, []byte("task:"+string(id))).String())
+	i.tasks[id] = mapped
+	return mapped
+}
+
+func (i *forkIDs) message(id string) string {
+	if mapped, ok := i.messages[id]; ok {
+		return mapped
+	}
+	mapped := uuid.NewSHA1(i.namespace, []byte("message:"+id)).String()
+	i.messages[id] = mapped
+	return mapped
+}
+
+func reidentifyForkTask(task *a2a.Task, contextID string, ids *forkIDs) {
+	task.ID = ids.task(task.ID)
+	task.ContextID = contextID
+	for _, message := range task.History {
+		reidentifyForkMessage(message, task.ID, contextID, ids)
+	}
+	if task.Status.Message != nil {
+		reidentifyForkMessage(task.Status.Message, task.ID, contextID, ids)
+	}
+}
+
+func reidentifyForkMessage(message *a2a.Message, taskID a2a.TaskID, contextID string, ids *forkIDs) {
+	if message == nil {
+		return
+	}
+	message.ID = ids.message(message.ID)
+	message.ContextID = contextID
+	message.TaskID = taskID
+	for index, reference := range message.ReferenceTasks {
+		message.ReferenceTasks[index] = ids.task(reference)
+	}
 }
 
 func (c *postgresClient) GetAgentInstance(ctx context.Context, namespace, id, userID string) (*apiv1alpha1.AgentInstance, error) {
@@ -740,7 +924,7 @@ func (c *postgresClient) CreateAgentInstanceTask(ctx context.Context, instanceID
 			return dbpkg.ErrAgentInstanceTaskConflict
 		}
 		rows, err := q.CreateAgentInstanceTask(ctx, dbgen.CreateAgentInstanceTaskParams{
-			InstanceID: instanceID, ID: string(task.ID), State: string(task.Status.State),
+			ContextID: instanceID, ID: string(task.ID), State: string(task.Status.State),
 			StatusTimestamp: task.Status.Timestamp, Data: taskData,
 			InitialMessageID: &message.ID, RequestHash: requestHash,
 		})
@@ -752,7 +936,7 @@ func (c *postgresClient) CreateAgentInstanceTask(ctx context.Context, instanceID
 		}
 		if rows == 0 {
 			row, err := q.GetAgentInstanceTaskByMessageID(ctx, dbgen.GetAgentInstanceTaskByMessageIDParams{
-				InstanceID: instanceID, InitialMessageID: &message.ID,
+				ContextID: instanceID, InitialMessageID: &message.ID,
 			})
 			if errors.Is(err, pgx.ErrNoRows) {
 				return dbpkg.ErrAgentInstanceTaskConflict
@@ -768,7 +952,7 @@ func (c *postgresClient) CreateAgentInstanceTask(ctx context.Context, instanceID
 		}
 		created = true
 		_, err = q.InsertAgentInstanceTaskEvent(ctx, dbgen.InsertAgentInstanceTaskEventParams{
-			InstanceID: instanceID, TaskID: strPtrIfNotEmpty(string(task.ID)), Data: eventData,
+			ContextID: instanceID, TaskID: strPtrIfNotEmpty(string(task.ID)), Data: eventData,
 		})
 		return err
 	})
@@ -818,7 +1002,7 @@ func (c *postgresClient) InterruptActiveAgentInstanceTask(ctx context.Context, i
 			return err
 		}
 		if err := q.UpsertAgentInstanceTask(ctx, dbgen.UpsertAgentInstanceTaskParams{
-			InstanceID: instanceID, ID: string(task.ID), State: string(task.Status.State),
+			ContextID: instanceID, ID: string(task.ID), State: string(task.Status.State),
 			StatusTimestamp: task.Status.Timestamp, Data: data,
 		}); err != nil {
 			return fmt.Errorf("interrupt AgentInstance task %s: %w", task.ID, err)
@@ -828,7 +1012,7 @@ func (c *postgresClient) InterruptActiveAgentInstanceTask(ctx context.Context, i
 			return err
 		}
 		if _, err := q.InsertAgentInstanceTaskEvent(ctx, dbgen.InsertAgentInstanceTaskEventParams{
-			InstanceID: instanceID, TaskID: strPtrIfNotEmpty(string(task.ID)), Data: eventData,
+			ContextID: instanceID, TaskID: strPtrIfNotEmpty(string(task.ID)), Data: eventData,
 		}); err != nil {
 			return fmt.Errorf("record AgentInstance task interruption: %w", err)
 		}
@@ -854,7 +1038,7 @@ func (c *postgresClient) StoreAgentInstanceTaskEvent(ctx context.Context, instan
 				return err
 			}
 			if err := q.UpsertAgentInstanceTask(ctx, dbgen.UpsertAgentInstanceTaskParams{
-				InstanceID: instanceID, ID: string(task.ID), State: string(task.Status.State),
+				ContextID: instanceID, ID: string(task.ID), State: string(task.Status.State),
 				StatusTimestamp: task.Status.Timestamp, Data: data,
 			}); err != nil {
 				if isActiveTaskConflict(err) {
@@ -864,14 +1048,14 @@ func (c *postgresClient) StoreAgentInstanceTaskEvent(ctx context.Context, instan
 			}
 		}
 		sequence, err := q.InsertAgentInstanceTaskEvent(ctx, dbgen.InsertAgentInstanceTaskEventParams{
-			InstanceID: instanceID, TaskID: strPtrIfNotEmpty(string(event.TaskInfo().TaskID)), Data: eventData,
+			ContextID: instanceID, TaskID: strPtrIfNotEmpty(string(event.TaskInfo().TaskID)), Data: eventData,
 		})
 		if err != nil {
 			return fmt.Errorf("store AgentInstance task event: %w", err)
 		}
 		if snapshot != nil {
 			if err := q.SetAgentInstanceTaskSnapshot(ctx, dbgen.SetAgentInstanceTaskSnapshotParams{
-				InstanceID: instanceID, ID: string(task.ID), SnapshotAtespace: &snapshot.Atespace,
+				ContextID: instanceID, ID: string(task.ID), SnapshotAtespace: &snapshot.Atespace,
 				SnapshotName: &snapshot.Name, SnapshotUid: &snapshot.UID,
 				SnapshotContentScope: &snapshot.ContentScope, HistorySequence: &sequence,
 			}); err != nil {
@@ -887,7 +1071,7 @@ func (c *postgresClient) StoreAgentInstanceTaskEvent(ctx context.Context, instan
 }
 
 func (c *postgresClient) GetAgentInstanceTask(ctx context.Context, instanceID, taskID string) (*a2a.Task, error) {
-	row, err := c.q.GetAgentInstanceTask(ctx, dbgen.GetAgentInstanceTaskParams{InstanceID: instanceID, ID: taskID})
+	row, err := c.q.GetAgentInstanceTask(ctx, dbgen.GetAgentInstanceTaskParams{ContextID: instanceID, ID: taskID})
 	if err != nil {
 		return nil, fmt.Errorf("get AgentInstance task %s: %w", taskID, notFoundOr(err))
 	}
@@ -896,14 +1080,14 @@ func (c *postgresClient) GetAgentInstanceTask(ctx context.Context, instanceID, t
 
 func (c *postgresClient) ListAgentInstanceTasks(ctx context.Context, instanceID, afterID string, state a2a.TaskState, statusTimestampAfter *time.Time, limit int) ([]*a2a.Task, int, error) {
 	params := dbgen.CountAgentInstanceTasksParams{
-		InstanceID: instanceID, State: string(state), StatusTimestampAfter: statusTimestampAfter,
+		ContextID: instanceID, State: string(state), StatusTimestampAfter: statusTimestampAfter,
 	}
 	total, err := c.q.CountAgentInstanceTasks(ctx, params)
 	if err != nil {
 		return nil, 0, fmt.Errorf("count AgentInstance tasks: %w", err)
 	}
 	rows, err := c.q.ListAgentInstanceTasks(ctx, dbgen.ListAgentInstanceTasksParams{
-		InstanceID: instanceID, AfterID: afterID, State: params.State,
+		ContextID: instanceID, AfterID: afterID, State: params.State,
 		StatusTimestampAfter: statusTimestampAfter, PageSize: int32(limit),
 	})
 	if err != nil {
@@ -947,7 +1131,7 @@ func (c *postgresClient) ReserveAgentInstanceCheckpoint(ctx context.Context, che
 		if instance.State != "READY" || instance.Operation != "NONE" {
 			return dbpkg.ErrAgentInstanceConflict
 		}
-		boundary, err := q.GetLatestQuiescentAgentInstanceTask(ctx, checkpoint.SourceInstanceID)
+		boundary, err := q.GetLatestQuiescentAgentInstanceTask(ctx, instance.ContextID)
 		if errors.Is(err, pgx.ErrNoRows) {
 			return dbpkg.ErrAgentInstanceNotQuiescent
 		}
@@ -965,6 +1149,8 @@ func (c *postgresClient) ReserveAgentInstanceCheckpoint(ctx context.Context, che
 			HistorySequence: *boundary.HistorySequence, SnapshotAtespace: *boundary.SnapshotAtespace,
 			SnapshotName: *boundary.SnapshotName, SnapshotUid: *boundary.SnapshotUid,
 			SnapshotContentScope: *boundary.SnapshotContentScope,
+			SourceContextID:      instance.ContextID, PreparedRevision: instance.PreparedRevision,
+			SourceInstanceData: instance.Data,
 		})
 		if errors.Is(err, pgx.ErrNoRows) {
 			existing, existingErr := q.GetAgentInstanceCheckpointByRequest(ctx, dbgen.GetAgentInstanceCheckpointByRequestParams{
@@ -1755,11 +1941,13 @@ func toCheckpointWrite(r dbgen.LgCheckpointWrite) *dbpkg.LangGraphCheckpointWrit
 
 func toAgentInstanceCheckpoint(row dbgen.AgentInstanceCheckpoint) *dbpkg.AgentInstanceCheckpoint {
 	return &dbpkg.AgentInstanceCheckpoint{
-		ID: row.ID, Namespace: row.Namespace, SourceInstanceID: row.SourceInstanceID, UserID: row.UserID,
+		ID: row.ID, Namespace: row.Namespace, SourceInstanceID: row.SourceInstanceID,
+		SourceContextID: row.SourceContextID, UserID: row.UserID,
 		RequestID: row.RequestID, HeadTaskID: row.HeadTaskID, HistorySequence: row.HistorySequence,
 		SnapshotAtespace: row.SnapshotAtespace, SnapshotName: row.SnapshotName, SnapshotUID: row.SnapshotUid,
-		SnapshotContentScope: row.SnapshotContentScope,
-		TagUID:               row.TagUid, State: row.State, Failure: row.Failure, CreatedAt: row.CreatedAt,
+		SnapshotContentScope: row.SnapshotContentScope, PreparedRevision: derefStr(row.PreparedRevision),
+		SourceInstanceData: row.SourceInstanceData,
+		TagUID:             row.TagUid, State: row.State, Failure: row.Failure, CreatedAt: row.CreatedAt,
 	}
 }
 

--- a/go/core/internal/database/client_test.go
+++ b/go/core/internal/database/client_test.go
@@ -621,7 +621,7 @@ func setupTestDB(t *testing.T) *pgxpool.Pool {
 			crewai_agent_memory, crewai_flow_state, memory,
 			session_share, session_share_access,
 			agent_instance_share,
-			agent_instance, agent_template_harness_pair, runtime_revision
+			agent_instance, a2a_context, agent_template_harness_pair, runtime_revision
 		RESTART IDENTITY CASCADE
 	`)
 	require.NoError(t, err, "Failed to truncate test tables")

--- a/go/core/internal/database/gen/agent_instance_checkpoints.sql.go
+++ b/go/core/internal/database/gen/agent_instance_checkpoints.sql.go
@@ -303,6 +303,43 @@ func (q *Queries) InsertAgentInstanceCheckpoint(ctx context.Context, arg InsertA
 	return i, err
 }
 
+const listAgentInstanceCheckpointEvents = `-- name: ListAgentInstanceCheckpointEvents :many
+SELECT e.sequence, e.context_id, e.task_id, e.data, e.created_at, e.message_id
+FROM agent_instance_checkpoint c
+JOIN agent_instance_task_event e
+  ON e.context_id = c.source_context_id
+ AND e.sequence <= c.history_sequence
+WHERE c.id = $1
+ORDER BY e.sequence
+`
+
+func (q *Queries) ListAgentInstanceCheckpointEvents(ctx context.Context, checkpointID string) ([]AgentInstanceTaskEvent, error) {
+	rows, err := q.db.Query(ctx, listAgentInstanceCheckpointEvents, checkpointID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []AgentInstanceTaskEvent
+	for rows.Next() {
+		var i AgentInstanceTaskEvent
+		if err := rows.Scan(
+			&i.Sequence,
+			&i.ContextID,
+			&i.TaskID,
+			&i.Data,
+			&i.CreatedAt,
+			&i.MessageID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listAgentInstanceCheckpointTasks = `-- name: ListAgentInstanceCheckpointTasks :many
 SELECT t.context_id, t.id, t.state, t.status_timestamp, t.data, t.created_at, t.updated_at, t.initial_message_id, t.request_hash, t.snapshot_atespace, t.snapshot_name, t.snapshot_uid, t.snapshot_content_scope, t.history_sequence
 FROM agent_instance_checkpoint c

--- a/go/core/internal/database/gen/agent_instance_checkpoints.sql.go
+++ b/go/core/internal/database/gen/agent_instance_checkpoints.sql.go
@@ -17,7 +17,7 @@ WHERE agent_instance_checkpoint.namespace = $1 AND agent_instance_checkpoint.id 
   AND NOT EXISTS (
       SELECT 1 FROM agent_instance i WHERE i.source_checkpoint_id = agent_instance_checkpoint.id
   )
-RETURNING id, namespace, source_instance_id, user_id, request_id, head_task_id, history_sequence, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, tag_uid, state, failure, created_at, source_context_id, prepared_revision, source_instance_data
+RETURNING id, namespace, source_instance_id, user_id, request_id, head_task_id, history_sequence, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, tag_uid, state, failure, created_at, source_context_id, prepared_revision, source_labels
 `
 
 type BeginDeleteAgentInstanceCheckpointParams struct {
@@ -47,7 +47,7 @@ func (q *Queries) BeginDeleteAgentInstanceCheckpoint(ctx context.Context, arg Be
 		&i.CreatedAt,
 		&i.SourceContextID,
 		&i.PreparedRevision,
-		&i.SourceInstanceData,
+		&i.SourceLabels,
 	)
 	return i, err
 }
@@ -82,7 +82,7 @@ WHERE id = $1
     OR (state = 'READY' AND tag_uid = $2::text AND $3::text = '')
     OR (state = 'FAILED' AND $2::text = '' AND failure = $3::text)
   )
-RETURNING id, namespace, source_instance_id, user_id, request_id, head_task_id, history_sequence, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, tag_uid, state, failure, created_at, source_context_id, prepared_revision, source_instance_data
+RETURNING id, namespace, source_instance_id, user_id, request_id, head_task_id, history_sequence, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, tag_uid, state, failure, created_at, source_context_id, prepared_revision, source_labels
 `
 
 type FinalizeAgentInstanceCheckpointParams struct {
@@ -112,13 +112,13 @@ func (q *Queries) FinalizeAgentInstanceCheckpoint(ctx context.Context, arg Final
 		&i.CreatedAt,
 		&i.SourceContextID,
 		&i.PreparedRevision,
-		&i.SourceInstanceData,
+		&i.SourceLabels,
 	)
 	return i, err
 }
 
 const getAgentInstanceCheckpoint = `-- name: GetAgentInstanceCheckpoint :one
-SELECT id, namespace, source_instance_id, user_id, request_id, head_task_id, history_sequence, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, tag_uid, state, failure, created_at, source_context_id, prepared_revision, source_instance_data FROM agent_instance_checkpoint
+SELECT id, namespace, source_instance_id, user_id, request_id, head_task_id, history_sequence, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, tag_uid, state, failure, created_at, source_context_id, prepared_revision, source_labels FROM agent_instance_checkpoint
 WHERE namespace = $1 AND id = $2 AND user_id = $3 AND state = 'READY'
 `
 
@@ -149,13 +149,13 @@ func (q *Queries) GetAgentInstanceCheckpoint(ctx context.Context, arg GetAgentIn
 		&i.CreatedAt,
 		&i.SourceContextID,
 		&i.PreparedRevision,
-		&i.SourceInstanceData,
+		&i.SourceLabels,
 	)
 	return i, err
 }
 
 const getAgentInstanceCheckpointByRequest = `-- name: GetAgentInstanceCheckpointByRequest :one
-SELECT id, namespace, source_instance_id, user_id, request_id, head_task_id, history_sequence, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, tag_uid, state, failure, created_at, source_context_id, prepared_revision, source_instance_data FROM agent_instance_checkpoint
+SELECT id, namespace, source_instance_id, user_id, request_id, head_task_id, history_sequence, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, tag_uid, state, failure, created_at, source_context_id, prepared_revision, source_labels FROM agent_instance_checkpoint
 WHERE user_id = $1 AND namespace = $2 AND request_id = $3
 `
 
@@ -186,7 +186,7 @@ func (q *Queries) GetAgentInstanceCheckpointByRequest(ctx context.Context, arg G
 		&i.CreatedAt,
 		&i.SourceContextID,
 		&i.PreparedRevision,
-		&i.SourceInstanceData,
+		&i.SourceLabels,
 	)
 	return i, err
 }
@@ -239,10 +239,10 @@ const insertAgentInstanceCheckpoint = `-- name: InsertAgentInstanceCheckpoint :o
 INSERT INTO agent_instance_checkpoint (
     id, namespace, source_instance_id, user_id, request_id, head_task_id,
     history_sequence, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope,
-    source_context_id, prepared_revision, source_instance_data, state
+    source_context_id, prepared_revision, source_labels, state
 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, 'CREATING')
 ON CONFLICT DO NOTHING
-RETURNING id, namespace, source_instance_id, user_id, request_id, head_task_id, history_sequence, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, tag_uid, state, failure, created_at, source_context_id, prepared_revision, source_instance_data
+RETURNING id, namespace, source_instance_id, user_id, request_id, head_task_id, history_sequence, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, tag_uid, state, failure, created_at, source_context_id, prepared_revision, source_labels
 `
 
 type InsertAgentInstanceCheckpointParams struct {
@@ -259,7 +259,7 @@ type InsertAgentInstanceCheckpointParams struct {
 	SnapshotContentScope string
 	SourceContextID      string
 	PreparedRevision     *string
-	SourceInstanceData   []byte
+	SourceLabels         []byte
 }
 
 func (q *Queries) InsertAgentInstanceCheckpoint(ctx context.Context, arg InsertAgentInstanceCheckpointParams) (AgentInstanceCheckpoint, error) {
@@ -277,7 +277,7 @@ func (q *Queries) InsertAgentInstanceCheckpoint(ctx context.Context, arg InsertA
 		arg.SnapshotContentScope,
 		arg.SourceContextID,
 		arg.PreparedRevision,
-		arg.SourceInstanceData,
+		arg.SourceLabels,
 	)
 	var i AgentInstanceCheckpoint
 	err := row.Scan(
@@ -298,7 +298,7 @@ func (q *Queries) InsertAgentInstanceCheckpoint(ctx context.Context, arg InsertA
 		&i.CreatedAt,
 		&i.SourceContextID,
 		&i.PreparedRevision,
-		&i.SourceInstanceData,
+		&i.SourceLabels,
 	)
 	return i, err
 }
@@ -388,7 +388,7 @@ func (q *Queries) ListAgentInstanceCheckpointTasks(ctx context.Context, checkpoi
 }
 
 const listAgentInstanceCheckpoints = `-- name: ListAgentInstanceCheckpoints :many
-SELECT id, namespace, source_instance_id, user_id, request_id, head_task_id, history_sequence, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, tag_uid, state, failure, created_at, source_context_id, prepared_revision, source_instance_data FROM agent_instance_checkpoint
+SELECT id, namespace, source_instance_id, user_id, request_id, head_task_id, history_sequence, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, tag_uid, state, failure, created_at, source_context_id, prepared_revision, source_labels FROM agent_instance_checkpoint
 WHERE namespace = $1
   AND source_instance_id = $2
   AND user_id = $3
@@ -439,7 +439,7 @@ func (q *Queries) ListAgentInstanceCheckpoints(ctx context.Context, arg ListAgen
 			&i.CreatedAt,
 			&i.SourceContextID,
 			&i.PreparedRevision,
-			&i.SourceInstanceData,
+			&i.SourceLabels,
 		); err != nil {
 			return nil, err
 		}
@@ -452,7 +452,7 @@ func (q *Queries) ListAgentInstanceCheckpoints(ctx context.Context, arg ListAgen
 }
 
 const lockReadyAgentInstanceCheckpoint = `-- name: LockReadyAgentInstanceCheckpoint :one
-SELECT id, namespace, source_instance_id, user_id, request_id, head_task_id, history_sequence, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, tag_uid, state, failure, created_at, source_context_id, prepared_revision, source_instance_data FROM agent_instance_checkpoint
+SELECT id, namespace, source_instance_id, user_id, request_id, head_task_id, history_sequence, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, tag_uid, state, failure, created_at, source_context_id, prepared_revision, source_labels FROM agent_instance_checkpoint
 WHERE namespace = $1 AND id = $2 AND user_id = $3 AND state = 'READY'
 FOR UPDATE
 `
@@ -484,7 +484,7 @@ func (q *Queries) LockReadyAgentInstanceCheckpoint(ctx context.Context, arg Lock
 		&i.CreatedAt,
 		&i.SourceContextID,
 		&i.PreparedRevision,
-		&i.SourceInstanceData,
+		&i.SourceLabels,
 	)
 	return i, err
 }

--- a/go/core/internal/database/gen/agent_instance_checkpoints.sql.go
+++ b/go/core/internal/database/gen/agent_instance_checkpoints.sql.go
@@ -12,9 +12,12 @@ import (
 const beginDeleteAgentInstanceCheckpoint = `-- name: BeginDeleteAgentInstanceCheckpoint :one
 UPDATE agent_instance_checkpoint
 SET state = 'DELETING'
-WHERE namespace = $1 AND id = $2 AND user_id = $3
-  AND state IN ('READY', 'DELETING')
-RETURNING id, namespace, source_instance_id, user_id, request_id, head_task_id, history_sequence, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, tag_uid, state, failure, created_at
+WHERE agent_instance_checkpoint.namespace = $1 AND agent_instance_checkpoint.id = $2 AND agent_instance_checkpoint.user_id = $3
+  AND agent_instance_checkpoint.state IN ('READY', 'DELETING')
+  AND NOT EXISTS (
+      SELECT 1 FROM agent_instance i WHERE i.source_checkpoint_id = agent_instance_checkpoint.id
+  )
+RETURNING id, namespace, source_instance_id, user_id, request_id, head_task_id, history_sequence, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, tag_uid, state, failure, created_at, source_context_id, prepared_revision, source_instance_data
 `
 
 type BeginDeleteAgentInstanceCheckpointParams struct {
@@ -42,6 +45,9 @@ func (q *Queries) BeginDeleteAgentInstanceCheckpoint(ctx context.Context, arg Be
 		&i.State,
 		&i.Failure,
 		&i.CreatedAt,
+		&i.SourceContextID,
+		&i.PreparedRevision,
+		&i.SourceInstanceData,
 	)
 	return i, err
 }
@@ -76,7 +82,7 @@ WHERE id = $1
     OR (state = 'READY' AND tag_uid = $2::text AND $3::text = '')
     OR (state = 'FAILED' AND $2::text = '' AND failure = $3::text)
   )
-RETURNING id, namespace, source_instance_id, user_id, request_id, head_task_id, history_sequence, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, tag_uid, state, failure, created_at
+RETURNING id, namespace, source_instance_id, user_id, request_id, head_task_id, history_sequence, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, tag_uid, state, failure, created_at, source_context_id, prepared_revision, source_instance_data
 `
 
 type FinalizeAgentInstanceCheckpointParams struct {
@@ -104,12 +110,15 @@ func (q *Queries) FinalizeAgentInstanceCheckpoint(ctx context.Context, arg Final
 		&i.State,
 		&i.Failure,
 		&i.CreatedAt,
+		&i.SourceContextID,
+		&i.PreparedRevision,
+		&i.SourceInstanceData,
 	)
 	return i, err
 }
 
 const getAgentInstanceCheckpoint = `-- name: GetAgentInstanceCheckpoint :one
-SELECT id, namespace, source_instance_id, user_id, request_id, head_task_id, history_sequence, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, tag_uid, state, failure, created_at FROM agent_instance_checkpoint
+SELECT id, namespace, source_instance_id, user_id, request_id, head_task_id, history_sequence, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, tag_uid, state, failure, created_at, source_context_id, prepared_revision, source_instance_data FROM agent_instance_checkpoint
 WHERE namespace = $1 AND id = $2 AND user_id = $3 AND state = 'READY'
 `
 
@@ -138,12 +147,15 @@ func (q *Queries) GetAgentInstanceCheckpoint(ctx context.Context, arg GetAgentIn
 		&i.State,
 		&i.Failure,
 		&i.CreatedAt,
+		&i.SourceContextID,
+		&i.PreparedRevision,
+		&i.SourceInstanceData,
 	)
 	return i, err
 }
 
 const getAgentInstanceCheckpointByRequest = `-- name: GetAgentInstanceCheckpointByRequest :one
-SELECT id, namespace, source_instance_id, user_id, request_id, head_task_id, history_sequence, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, tag_uid, state, failure, created_at FROM agent_instance_checkpoint
+SELECT id, namespace, source_instance_id, user_id, request_id, head_task_id, history_sequence, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, tag_uid, state, failure, created_at, source_context_id, prepared_revision, source_instance_data FROM agent_instance_checkpoint
 WHERE user_id = $1 AND namespace = $2 AND request_id = $3
 `
 
@@ -172,21 +184,24 @@ func (q *Queries) GetAgentInstanceCheckpointByRequest(ctx context.Context, arg G
 		&i.State,
 		&i.Failure,
 		&i.CreatedAt,
+		&i.SourceContextID,
+		&i.PreparedRevision,
+		&i.SourceInstanceData,
 	)
 	return i, err
 }
 
 const getLatestQuiescentAgentInstanceTask = `-- name: GetLatestQuiescentAgentInstanceTask :one
-SELECT latest.instance_id, latest.id, latest.state, latest.status_timestamp, latest.data, latest.created_at, latest.updated_at, latest.initial_message_id, latest.request_hash, latest.snapshot_atespace, latest.snapshot_name, latest.snapshot_uid, latest.snapshot_content_scope, latest.history_sequence
+SELECT latest.context_id, latest.id, latest.state, latest.status_timestamp, latest.data, latest.created_at, latest.updated_at, latest.initial_message_id, latest.request_hash, latest.snapshot_atespace, latest.snapshot_name, latest.snapshot_uid, latest.snapshot_content_scope, latest.history_sequence
 FROM (
-    SELECT instance_id, id, state, status_timestamp, data, created_at, updated_at, initial_message_id, request_hash, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, history_sequence FROM agent_instance_task
-    WHERE agent_instance_task.instance_id = $1
+    SELECT context_id, id, state, status_timestamp, data, created_at, updated_at, initial_message_id, request_hash, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, history_sequence FROM agent_instance_task
+    WHERE agent_instance_task.context_id = $1
     ORDER BY created_at DESC, id DESC
     LIMIT 1
 ) latest
 WHERE NOT EXISTS (
     SELECT 1 FROM agent_instance_task active
-    WHERE active.instance_id = $1
+    WHERE active.context_id = $1
       AND active.state NOT IN (
           'TASK_STATE_COMPLETED',
           'TASK_STATE_CANCELED',
@@ -198,11 +213,11 @@ WHERE NOT EXISTS (
 )
 `
 
-func (q *Queries) GetLatestQuiescentAgentInstanceTask(ctx context.Context, instanceID string) (AgentInstanceTask, error) {
-	row := q.db.QueryRow(ctx, getLatestQuiescentAgentInstanceTask, instanceID)
+func (q *Queries) GetLatestQuiescentAgentInstanceTask(ctx context.Context, contextID string) (AgentInstanceTask, error) {
+	row := q.db.QueryRow(ctx, getLatestQuiescentAgentInstanceTask, contextID)
 	var i AgentInstanceTask
 	err := row.Scan(
-		&i.InstanceID,
+		&i.ContextID,
 		&i.ID,
 		&i.State,
 		&i.StatusTimestamp,
@@ -223,10 +238,11 @@ func (q *Queries) GetLatestQuiescentAgentInstanceTask(ctx context.Context, insta
 const insertAgentInstanceCheckpoint = `-- name: InsertAgentInstanceCheckpoint :one
 INSERT INTO agent_instance_checkpoint (
     id, namespace, source_instance_id, user_id, request_id, head_task_id,
-    history_sequence, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, state
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, 'CREATING')
+    history_sequence, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope,
+    source_context_id, prepared_revision, source_instance_data, state
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, 'CREATING')
 ON CONFLICT DO NOTHING
-RETURNING id, namespace, source_instance_id, user_id, request_id, head_task_id, history_sequence, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, tag_uid, state, failure, created_at
+RETURNING id, namespace, source_instance_id, user_id, request_id, head_task_id, history_sequence, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, tag_uid, state, failure, created_at, source_context_id, prepared_revision, source_instance_data
 `
 
 type InsertAgentInstanceCheckpointParams struct {
@@ -241,6 +257,9 @@ type InsertAgentInstanceCheckpointParams struct {
 	SnapshotName         string
 	SnapshotUid          string
 	SnapshotContentScope string
+	SourceContextID      string
+	PreparedRevision     *string
+	SourceInstanceData   []byte
 }
 
 func (q *Queries) InsertAgentInstanceCheckpoint(ctx context.Context, arg InsertAgentInstanceCheckpointParams) (AgentInstanceCheckpoint, error) {
@@ -256,6 +275,9 @@ func (q *Queries) InsertAgentInstanceCheckpoint(ctx context.Context, arg InsertA
 		arg.SnapshotName,
 		arg.SnapshotUid,
 		arg.SnapshotContentScope,
+		arg.SourceContextID,
+		arg.PreparedRevision,
+		arg.SourceInstanceData,
 	)
 	var i AgentInstanceCheckpoint
 	err := row.Scan(
@@ -274,12 +296,62 @@ func (q *Queries) InsertAgentInstanceCheckpoint(ctx context.Context, arg InsertA
 		&i.State,
 		&i.Failure,
 		&i.CreatedAt,
+		&i.SourceContextID,
+		&i.PreparedRevision,
+		&i.SourceInstanceData,
 	)
 	return i, err
 }
 
+const listAgentInstanceCheckpointTasks = `-- name: ListAgentInstanceCheckpointTasks :many
+SELECT t.context_id, t.id, t.state, t.status_timestamp, t.data, t.created_at, t.updated_at, t.initial_message_id, t.request_hash, t.snapshot_atespace, t.snapshot_name, t.snapshot_uid, t.snapshot_content_scope, t.history_sequence
+FROM agent_instance_checkpoint c
+JOIN agent_instance_task head
+  ON head.context_id = c.source_context_id AND head.id = c.head_task_id
+JOIN agent_instance_task t
+  ON t.context_id = c.source_context_id
+ AND (t.created_at, t.id) <= (head.created_at, head.id)
+WHERE c.id = $1
+ORDER BY t.created_at, t.id
+`
+
+func (q *Queries) ListAgentInstanceCheckpointTasks(ctx context.Context, checkpointID string) ([]AgentInstanceTask, error) {
+	rows, err := q.db.Query(ctx, listAgentInstanceCheckpointTasks, checkpointID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []AgentInstanceTask
+	for rows.Next() {
+		var i AgentInstanceTask
+		if err := rows.Scan(
+			&i.ContextID,
+			&i.ID,
+			&i.State,
+			&i.StatusTimestamp,
+			&i.Data,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.InitialMessageID,
+			&i.RequestHash,
+			&i.SnapshotAtespace,
+			&i.SnapshotName,
+			&i.SnapshotUid,
+			&i.SnapshotContentScope,
+			&i.HistorySequence,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listAgentInstanceCheckpoints = `-- name: ListAgentInstanceCheckpoints :many
-SELECT id, namespace, source_instance_id, user_id, request_id, head_task_id, history_sequence, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, tag_uid, state, failure, created_at FROM agent_instance_checkpoint
+SELECT id, namespace, source_instance_id, user_id, request_id, head_task_id, history_sequence, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, tag_uid, state, failure, created_at, source_context_id, prepared_revision, source_instance_data FROM agent_instance_checkpoint
 WHERE namespace = $1
   AND source_instance_id = $2
   AND user_id = $3
@@ -328,6 +400,9 @@ func (q *Queries) ListAgentInstanceCheckpoints(ctx context.Context, arg ListAgen
 			&i.State,
 			&i.Failure,
 			&i.CreatedAt,
+			&i.SourceContextID,
+			&i.PreparedRevision,
+			&i.SourceInstanceData,
 		); err != nil {
 			return nil, err
 		}
@@ -337,4 +412,42 @@ func (q *Queries) ListAgentInstanceCheckpoints(ctx context.Context, arg ListAgen
 		return nil, err
 	}
 	return items, nil
+}
+
+const lockReadyAgentInstanceCheckpoint = `-- name: LockReadyAgentInstanceCheckpoint :one
+SELECT id, namespace, source_instance_id, user_id, request_id, head_task_id, history_sequence, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, tag_uid, state, failure, created_at, source_context_id, prepared_revision, source_instance_data FROM agent_instance_checkpoint
+WHERE namespace = $1 AND id = $2 AND user_id = $3 AND state = 'READY'
+FOR UPDATE
+`
+
+type LockReadyAgentInstanceCheckpointParams struct {
+	Namespace string
+	ID        string
+	UserID    string
+}
+
+func (q *Queries) LockReadyAgentInstanceCheckpoint(ctx context.Context, arg LockReadyAgentInstanceCheckpointParams) (AgentInstanceCheckpoint, error) {
+	row := q.db.QueryRow(ctx, lockReadyAgentInstanceCheckpoint, arg.Namespace, arg.ID, arg.UserID)
+	var i AgentInstanceCheckpoint
+	err := row.Scan(
+		&i.ID,
+		&i.Namespace,
+		&i.SourceInstanceID,
+		&i.UserID,
+		&i.RequestID,
+		&i.HeadTaskID,
+		&i.HistorySequence,
+		&i.SnapshotAtespace,
+		&i.SnapshotName,
+		&i.SnapshotUid,
+		&i.SnapshotContentScope,
+		&i.TagUid,
+		&i.State,
+		&i.Failure,
+		&i.CreatedAt,
+		&i.SourceContextID,
+		&i.PreparedRevision,
+		&i.SourceInstanceData,
+	)
+	return i, err
 }

--- a/go/core/internal/database/gen/agent_instance_tasks.sql.go
+++ b/go/core/internal/database/gen/agent_instance_tasks.sql.go
@@ -12,20 +12,20 @@ import (
 
 const countAgentInstanceTasks = `-- name: CountAgentInstanceTasks :one
 SELECT COUNT(*) FROM agent_instance_task
-WHERE instance_id = $1
+WHERE context_id = $1
   AND ($2::text = '' OR state = $2)
   AND ($3::timestamptz IS NULL
        OR status_timestamp > $3)
 `
 
 type CountAgentInstanceTasksParams struct {
-	InstanceID           string
+	ContextID            string
 	State                string
 	StatusTimestampAfter *time.Time
 }
 
 func (q *Queries) CountAgentInstanceTasks(ctx context.Context, arg CountAgentInstanceTasksParams) (int64, error) {
-	row := q.db.QueryRow(ctx, countAgentInstanceTasks, arg.InstanceID, arg.State, arg.StatusTimestampAfter)
+	row := q.db.QueryRow(ctx, countAgentInstanceTasks, arg.ContextID, arg.State, arg.StatusTimestampAfter)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
@@ -33,20 +33,20 @@ func (q *Queries) CountAgentInstanceTasks(ctx context.Context, arg CountAgentIns
 
 const createAgentInstanceTask = `-- name: CreateAgentInstanceTask :execrows
 INSERT INTO agent_instance_task (
-    instance_id, id, state, status_timestamp, data, initial_message_id, request_hash
+    context_id, id, state, status_timestamp, data, initial_message_id, request_hash
 )
 SELECT $1, $2, $3, $4, $5, $6, $7
 WHERE NOT EXISTS (
     SELECT 1 FROM agent_instance_checkpoint
-    WHERE source_instance_id = $1 AND state = 'CREATING'
+    WHERE source_context_id = $1 AND state = 'CREATING'
 )
-ON CONFLICT (instance_id, initial_message_id)
+ON CONFLICT (context_id, initial_message_id)
     WHERE initial_message_id IS NOT NULL
 DO NOTHING
 `
 
 type CreateAgentInstanceTaskParams struct {
-	InstanceID       string
+	ContextID        string
 	ID               string
 	State            string
 	StatusTimestamp  *time.Time
@@ -57,7 +57,7 @@ type CreateAgentInstanceTaskParams struct {
 
 func (q *Queries) CreateAgentInstanceTask(ctx context.Context, arg CreateAgentInstanceTaskParams) (int64, error) {
 	result, err := q.db.Exec(ctx, createAgentInstanceTask,
-		arg.InstanceID,
+		arg.ContextID,
 		arg.ID,
 		arg.State,
 		arg.StatusTimestamp,
@@ -72,8 +72,8 @@ func (q *Queries) CreateAgentInstanceTask(ctx context.Context, arg CreateAgentIn
 }
 
 const getActiveAgentInstanceTask = `-- name: GetActiveAgentInstanceTask :one
-SELECT instance_id, id, state, status_timestamp, data, created_at, updated_at, initial_message_id, request_hash, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, history_sequence FROM agent_instance_task
-WHERE instance_id = $1
+SELECT context_id, id, state, status_timestamp, data, created_at, updated_at, initial_message_id, request_hash, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, history_sequence FROM agent_instance_task
+WHERE context_id = $1
   AND state NOT IN (
       'TASK_STATE_COMPLETED',
       'TASK_STATE_CANCELED',
@@ -84,11 +84,11 @@ WHERE instance_id = $1
   )
 `
 
-func (q *Queries) GetActiveAgentInstanceTask(ctx context.Context, instanceID string) (AgentInstanceTask, error) {
-	row := q.db.QueryRow(ctx, getActiveAgentInstanceTask, instanceID)
+func (q *Queries) GetActiveAgentInstanceTask(ctx context.Context, contextID string) (AgentInstanceTask, error) {
+	row := q.db.QueryRow(ctx, getActiveAgentInstanceTask, contextID)
 	var i AgentInstanceTask
 	err := row.Scan(
-		&i.InstanceID,
+		&i.ContextID,
 		&i.ID,
 		&i.State,
 		&i.StatusTimestamp,
@@ -107,20 +107,20 @@ func (q *Queries) GetActiveAgentInstanceTask(ctx context.Context, instanceID str
 }
 
 const getAgentInstanceTask = `-- name: GetAgentInstanceTask :one
-SELECT instance_id, id, state, status_timestamp, data, created_at, updated_at, initial_message_id, request_hash, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, history_sequence FROM agent_instance_task
-WHERE instance_id = $1 AND id = $2
+SELECT context_id, id, state, status_timestamp, data, created_at, updated_at, initial_message_id, request_hash, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, history_sequence FROM agent_instance_task
+WHERE context_id = $1 AND id = $2
 `
 
 type GetAgentInstanceTaskParams struct {
-	InstanceID string
-	ID         string
+	ContextID string
+	ID        string
 }
 
 func (q *Queries) GetAgentInstanceTask(ctx context.Context, arg GetAgentInstanceTaskParams) (AgentInstanceTask, error) {
-	row := q.db.QueryRow(ctx, getAgentInstanceTask, arg.InstanceID, arg.ID)
+	row := q.db.QueryRow(ctx, getAgentInstanceTask, arg.ContextID, arg.ID)
 	var i AgentInstanceTask
 	err := row.Scan(
-		&i.InstanceID,
+		&i.ContextID,
 		&i.ID,
 		&i.State,
 		&i.StatusTimestamp,
@@ -139,20 +139,20 @@ func (q *Queries) GetAgentInstanceTask(ctx context.Context, arg GetAgentInstance
 }
 
 const getAgentInstanceTaskByMessageID = `-- name: GetAgentInstanceTaskByMessageID :one
-SELECT instance_id, id, state, status_timestamp, data, created_at, updated_at, initial_message_id, request_hash, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, history_sequence FROM agent_instance_task
-WHERE instance_id = $1 AND initial_message_id = $2
+SELECT context_id, id, state, status_timestamp, data, created_at, updated_at, initial_message_id, request_hash, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, history_sequence FROM agent_instance_task
+WHERE context_id = $1 AND initial_message_id = $2
 `
 
 type GetAgentInstanceTaskByMessageIDParams struct {
-	InstanceID       string
+	ContextID        string
 	InitialMessageID *string
 }
 
 func (q *Queries) GetAgentInstanceTaskByMessageID(ctx context.Context, arg GetAgentInstanceTaskByMessageIDParams) (AgentInstanceTask, error) {
-	row := q.db.QueryRow(ctx, getAgentInstanceTaskByMessageID, arg.InstanceID, arg.InitialMessageID)
+	row := q.db.QueryRow(ctx, getAgentInstanceTaskByMessageID, arg.ContextID, arg.InitialMessageID)
 	var i AgentInstanceTask
 	err := row.Scan(
-		&i.InstanceID,
+		&i.ContextID,
 		&i.ID,
 		&i.State,
 		&i.StatusTimestamp,
@@ -171,27 +171,72 @@ func (q *Queries) GetAgentInstanceTaskByMessageID(ctx context.Context, arg GetAg
 }
 
 const insertAgentInstanceTaskEvent = `-- name: InsertAgentInstanceTaskEvent :one
-INSERT INTO agent_instance_task_event (instance_id, task_id, data)
+INSERT INTO agent_instance_task_event (context_id, task_id, data)
 VALUES ($1, $2, $3)
 RETURNING sequence
 `
 
 type InsertAgentInstanceTaskEventParams struct {
-	InstanceID string
-	TaskID     *string
-	Data       []byte
+	ContextID string
+	TaskID    *string
+	Data      []byte
 }
 
 func (q *Queries) InsertAgentInstanceTaskEvent(ctx context.Context, arg InsertAgentInstanceTaskEventParams) (int64, error) {
-	row := q.db.QueryRow(ctx, insertAgentInstanceTaskEvent, arg.InstanceID, arg.TaskID, arg.Data)
+	row := q.db.QueryRow(ctx, insertAgentInstanceTaskEvent, arg.ContextID, arg.TaskID, arg.Data)
 	var sequence int64
 	err := row.Scan(&sequence)
 	return sequence, err
 }
 
+const insertCopiedAgentInstanceTask = `-- name: InsertCopiedAgentInstanceTask :exec
+INSERT INTO agent_instance_task (
+    context_id, id, state, status_timestamp, data, created_at, updated_at,
+    initial_message_id, request_hash, snapshot_atespace, snapshot_name,
+    snapshot_uid, snapshot_content_scope, history_sequence
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+`
+
+type InsertCopiedAgentInstanceTaskParams struct {
+	ContextID            string
+	ID                   string
+	State                string
+	StatusTimestamp      *time.Time
+	Data                 []byte
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+	InitialMessageID     *string
+	RequestHash          []byte
+	SnapshotAtespace     *string
+	SnapshotName         *string
+	SnapshotUid          *string
+	SnapshotContentScope *string
+	HistorySequence      *int64
+}
+
+func (q *Queries) InsertCopiedAgentInstanceTask(ctx context.Context, arg InsertCopiedAgentInstanceTaskParams) error {
+	_, err := q.db.Exec(ctx, insertCopiedAgentInstanceTask,
+		arg.ContextID,
+		arg.ID,
+		arg.State,
+		arg.StatusTimestamp,
+		arg.Data,
+		arg.CreatedAt,
+		arg.UpdatedAt,
+		arg.InitialMessageID,
+		arg.RequestHash,
+		arg.SnapshotAtespace,
+		arg.SnapshotName,
+		arg.SnapshotUid,
+		arg.SnapshotContentScope,
+		arg.HistorySequence,
+	)
+	return err
+}
+
 const listAgentInstanceTasks = `-- name: ListAgentInstanceTasks :many
-SELECT instance_id, id, state, status_timestamp, data, created_at, updated_at, initial_message_id, request_hash, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, history_sequence FROM agent_instance_task
-WHERE instance_id = $1
+SELECT context_id, id, state, status_timestamp, data, created_at, updated_at, initial_message_id, request_hash, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, history_sequence FROM agent_instance_task
+WHERE context_id = $1
   AND id > $2
   AND ($3::text = '' OR state = $3)
   AND ($4::timestamptz IS NULL
@@ -201,7 +246,7 @@ LIMIT $5
 `
 
 type ListAgentInstanceTasksParams struct {
-	InstanceID           string
+	ContextID            string
 	AfterID              string
 	State                string
 	StatusTimestampAfter *time.Time
@@ -210,7 +255,7 @@ type ListAgentInstanceTasksParams struct {
 
 func (q *Queries) ListAgentInstanceTasks(ctx context.Context, arg ListAgentInstanceTasksParams) ([]AgentInstanceTask, error) {
 	rows, err := q.db.Query(ctx, listAgentInstanceTasks,
-		arg.InstanceID,
+		arg.ContextID,
 		arg.AfterID,
 		arg.State,
 		arg.StatusTimestampAfter,
@@ -224,7 +269,7 @@ func (q *Queries) ListAgentInstanceTasks(ctx context.Context, arg ListAgentInsta
 	for rows.Next() {
 		var i AgentInstanceTask
 		if err := rows.Scan(
-			&i.InstanceID,
+			&i.ContextID,
 			&i.ID,
 			&i.State,
 			&i.StatusTimestamp,
@@ -250,8 +295,8 @@ func (q *Queries) ListAgentInstanceTasks(ctx context.Context, arg ListAgentInsta
 }
 
 const lockActiveAgentInstanceTask = `-- name: LockActiveAgentInstanceTask :one
-SELECT instance_id, id, state, status_timestamp, data, created_at, updated_at, initial_message_id, request_hash, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, history_sequence FROM agent_instance_task
-WHERE instance_id = $1
+SELECT context_id, id, state, status_timestamp, data, created_at, updated_at, initial_message_id, request_hash, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, history_sequence FROM agent_instance_task
+WHERE context_id = $1
   AND state NOT IN (
       'TASK_STATE_COMPLETED',
       'TASK_STATE_CANCELED',
@@ -265,11 +310,11 @@ FOR UPDATE
 
 // LockActiveAgentInstanceTask holds the instance's non-terminal task for the
 // rest of the transaction so reclamation cannot overwrite concurrent progress.
-func (q *Queries) LockActiveAgentInstanceTask(ctx context.Context, instanceID string) (AgentInstanceTask, error) {
-	row := q.db.QueryRow(ctx, lockActiveAgentInstanceTask, instanceID)
+func (q *Queries) LockActiveAgentInstanceTask(ctx context.Context, contextID string) (AgentInstanceTask, error) {
+	row := q.db.QueryRow(ctx, lockActiveAgentInstanceTask, contextID)
 	var i AgentInstanceTask
 	err := row.Scan(
-		&i.InstanceID,
+		&i.ContextID,
 		&i.ID,
 		&i.State,
 		&i.StatusTimestamp,
@@ -294,11 +339,11 @@ UPDATE agent_instance_task SET
     snapshot_uid = $5,
     snapshot_content_scope = $6,
     history_sequence = $7
-WHERE instance_id = $1 AND id = $2
+WHERE context_id = $1 AND id = $2
 `
 
 type SetAgentInstanceTaskSnapshotParams struct {
-	InstanceID           string
+	ContextID            string
 	ID                   string
 	SnapshotAtespace     *string
 	SnapshotName         *string
@@ -309,7 +354,7 @@ type SetAgentInstanceTaskSnapshotParams struct {
 
 func (q *Queries) SetAgentInstanceTaskSnapshot(ctx context.Context, arg SetAgentInstanceTaskSnapshotParams) error {
 	_, err := q.db.Exec(ctx, setAgentInstanceTaskSnapshot,
-		arg.InstanceID,
+		arg.ContextID,
 		arg.ID,
 		arg.SnapshotAtespace,
 		arg.SnapshotName,
@@ -321,9 +366,9 @@ func (q *Queries) SetAgentInstanceTaskSnapshot(ctx context.Context, arg SetAgent
 }
 
 const upsertAgentInstanceTask = `-- name: UpsertAgentInstanceTask :exec
-INSERT INTO agent_instance_task (instance_id, id, state, status_timestamp, data)
+INSERT INTO agent_instance_task (context_id, id, state, status_timestamp, data)
 VALUES ($1, $2, $3, $4, $5)
-ON CONFLICT (instance_id, id) DO UPDATE SET
+ON CONFLICT (context_id, id) DO UPDATE SET
     state = EXCLUDED.state,
     status_timestamp = EXCLUDED.status_timestamp,
     data = EXCLUDED.data,
@@ -331,7 +376,7 @@ ON CONFLICT (instance_id, id) DO UPDATE SET
 `
 
 type UpsertAgentInstanceTaskParams struct {
-	InstanceID      string
+	ContextID       string
 	ID              string
 	State           string
 	StatusTimestamp *time.Time
@@ -340,7 +385,7 @@ type UpsertAgentInstanceTaskParams struct {
 
 func (q *Queries) UpsertAgentInstanceTask(ctx context.Context, arg UpsertAgentInstanceTaskParams) error {
 	_, err := q.db.Exec(ctx, upsertAgentInstanceTask,
-		arg.InstanceID,
+		arg.ContextID,
 		arg.ID,
 		arg.State,
 		arg.StatusTimestamp,

--- a/go/core/internal/database/gen/agent_instance_tasks.sql.go
+++ b/go/core/internal/database/gen/agent_instance_tasks.sql.go
@@ -171,19 +171,35 @@ func (q *Queries) GetAgentInstanceTaskByMessageID(ctx context.Context, arg GetAg
 }
 
 const insertAgentInstanceTaskEvent = `-- name: InsertAgentInstanceTaskEvent :one
-INSERT INTO agent_instance_task_event (context_id, task_id, data)
-VALUES ($1, $2, $3)
-RETURNING sequence
+WITH inserted AS (
+    INSERT INTO agent_instance_task_event (context_id, task_id, message_id, data)
+    VALUES ($1, $2, $3, $4)
+    ON CONFLICT (context_id, task_id, message_id)
+        WHERE message_id IS NOT NULL
+    DO NOTHING
+    RETURNING sequence
+)
+SELECT sequence FROM inserted
+UNION ALL
+SELECT sequence FROM agent_instance_task_event
+WHERE context_id = $1 AND task_id IS NOT DISTINCT FROM $2 AND message_id = $3
+LIMIT 1
 `
 
 type InsertAgentInstanceTaskEventParams struct {
 	ContextID string
 	TaskID    *string
+	MessageID *string
 	Data      []byte
 }
 
 func (q *Queries) InsertAgentInstanceTaskEvent(ctx context.Context, arg InsertAgentInstanceTaskEventParams) (int64, error) {
-	row := q.db.QueryRow(ctx, insertAgentInstanceTaskEvent, arg.ContextID, arg.TaskID, arg.Data)
+	row := q.db.QueryRow(ctx, insertAgentInstanceTaskEvent,
+		arg.ContextID,
+		arg.TaskID,
+		arg.MessageID,
+		arg.Data,
+	)
 	var sequence int64
 	err := row.Scan(&sequence)
 	return sequence, err
@@ -232,6 +248,45 @@ func (q *Queries) InsertCopiedAgentInstanceTask(ctx context.Context, arg InsertC
 		arg.HistorySequence,
 	)
 	return err
+}
+
+const listAgentInstanceTaskHistory = `-- name: ListAgentInstanceTaskHistory :many
+SELECT task_id, data
+FROM agent_instance_task_event
+WHERE context_id = $1
+  AND task_id = ANY($2::text[])
+  AND message_id IS NOT NULL
+ORDER BY sequence
+`
+
+type ListAgentInstanceTaskHistoryParams struct {
+	ContextID string
+	TaskIds   []string
+}
+
+type ListAgentInstanceTaskHistoryRow struct {
+	TaskID *string
+	Data   []byte
+}
+
+func (q *Queries) ListAgentInstanceTaskHistory(ctx context.Context, arg ListAgentInstanceTaskHistoryParams) ([]ListAgentInstanceTaskHistoryRow, error) {
+	rows, err := q.db.Query(ctx, listAgentInstanceTaskHistory, arg.ContextID, arg.TaskIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListAgentInstanceTaskHistoryRow
+	for rows.Next() {
+		var i ListAgentInstanceTaskHistoryRow
+		if err := rows.Scan(&i.TaskID, &i.Data); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const listAgentInstanceTasks = `-- name: ListAgentInstanceTasks :many

--- a/go/core/internal/database/gen/agent_instances.sql.go
+++ b/go/core/internal/database/gen/agent_instances.sql.go
@@ -79,7 +79,7 @@ func (q *Queries) DeleteAgentInstanceShare(ctx context.Context, arg DeleteAgentI
 }
 
 const getAgentInstanceByID = `-- name: GetAgentInstanceByID :one
-SELECT id, namespace, user_id, request_id, prepared_revision, state, labels, data, operation FROM agent_instance WHERE id = $1
+SELECT id, namespace, user_id, request_id, prepared_revision, state, labels, data, operation, context_id, source_checkpoint_id FROM agent_instance WHERE id = $1
 `
 
 func (q *Queries) GetAgentInstanceByID(ctx context.Context, id string) (AgentInstance, error) {
@@ -95,12 +95,14 @@ func (q *Queries) GetAgentInstanceByID(ctx context.Context, id string) (AgentIns
 		&i.Labels,
 		&i.Data,
 		&i.Operation,
+		&i.ContextID,
+		&i.SourceCheckpointID,
 	)
 	return i, err
 }
 
 const getAgentInstanceByRequest = `-- name: GetAgentInstanceByRequest :one
-SELECT id, namespace, user_id, request_id, prepared_revision, state, labels, data, operation FROM agent_instance
+SELECT id, namespace, user_id, request_id, prepared_revision, state, labels, data, operation, context_id, source_checkpoint_id FROM agent_instance
 WHERE user_id = $1 AND namespace = $2 AND request_id = $3
 `
 
@@ -123,12 +125,14 @@ func (q *Queries) GetAgentInstanceByRequest(ctx context.Context, arg GetAgentIns
 		&i.Labels,
 		&i.Data,
 		&i.Operation,
+		&i.ContextID,
+		&i.SourceCheckpointID,
 	)
 	return i, err
 }
 
 const getAgentInstanceForUser = `-- name: GetAgentInstanceForUser :one
-SELECT id, namespace, user_id, request_id, prepared_revision, state, labels, data, operation FROM agent_instance WHERE namespace = $1 AND id = $2 AND user_id = $3
+SELECT id, namespace, user_id, request_id, prepared_revision, state, labels, data, operation, context_id, source_checkpoint_id FROM agent_instance WHERE namespace = $1 AND id = $2 AND user_id = $3
 `
 
 type GetAgentInstanceForUserParams struct {
@@ -150,6 +154,8 @@ func (q *Queries) GetAgentInstanceForUser(ctx context.Context, arg GetAgentInsta
 		&i.Labels,
 		&i.Data,
 		&i.Operation,
+		&i.ContextID,
+		&i.SourceCheckpointID,
 	)
 	return i, err
 }
@@ -215,12 +221,28 @@ func (q *Queries) GetLatestRuntimeRevisionForInstance(ctx context.Context, arg G
 	return i, err
 }
 
+const insertA2AContext = `-- name: InsertA2AContext :exec
+INSERT INTO a2a_context (id, namespace, user_id)
+VALUES ($1, $2, $3)
+`
+
+type InsertA2AContextParams struct {
+	ID        string
+	Namespace string
+	UserID    string
+}
+
+func (q *Queries) InsertA2AContext(ctx context.Context, arg InsertA2AContextParams) error {
+	_, err := q.db.Exec(ctx, insertA2AContext, arg.ID, arg.Namespace, arg.UserID)
+	return err
+}
+
 const insertAgentInstance = `-- name: InsertAgentInstance :one
 INSERT INTO agent_instance (
-    id, namespace, user_id, request_id, prepared_revision, state, operation, labels, data
-) VALUES ($1, $2, $3, $4, $5, 'CREATING', 'CREATE', $6, $7)
+    id, namespace, user_id, request_id, context_id, prepared_revision, state, operation, labels, data
+) VALUES ($1, $2, $3, $4, $5, $6, 'CREATING', 'CREATE', $7, $8)
 ON CONFLICT (user_id, namespace, request_id) DO NOTHING
-RETURNING id, namespace, user_id, request_id, prepared_revision, state, labels, data, operation
+RETURNING id, namespace, user_id, request_id, prepared_revision, state, labels, data, operation, context_id, source_checkpoint_id
 `
 
 type InsertAgentInstanceParams struct {
@@ -228,6 +250,7 @@ type InsertAgentInstanceParams struct {
 	Namespace        string
 	UserID           string
 	RequestID        string
+	ContextID        string
 	PreparedRevision *string
 	Labels           []byte
 	Data             []byte
@@ -239,6 +262,7 @@ func (q *Queries) InsertAgentInstance(ctx context.Context, arg InsertAgentInstan
 		arg.Namespace,
 		arg.UserID,
 		arg.RequestID,
+		arg.ContextID,
 		arg.PreparedRevision,
 		arg.Labels,
 		arg.Data,
@@ -254,6 +278,58 @@ func (q *Queries) InsertAgentInstance(ctx context.Context, arg InsertAgentInstan
 		&i.Labels,
 		&i.Data,
 		&i.Operation,
+		&i.ContextID,
+		&i.SourceCheckpointID,
+	)
+	return i, err
+}
+
+const insertForkedAgentInstance = `-- name: InsertForkedAgentInstance :one
+INSERT INTO agent_instance (
+    id, namespace, user_id, request_id, context_id, prepared_revision, source_checkpoint_id,
+    state, operation, labels, data
+) VALUES ($1, $2, $3, $4, $5, $6, $7, 'CREATING', 'CREATE', $8, $9)
+ON CONFLICT (user_id, namespace, request_id) DO NOTHING
+RETURNING id, namespace, user_id, request_id, prepared_revision, state, labels, data, operation, context_id, source_checkpoint_id
+`
+
+type InsertForkedAgentInstanceParams struct {
+	ID                 string
+	Namespace          string
+	UserID             string
+	RequestID          string
+	ContextID          string
+	PreparedRevision   *string
+	SourceCheckpointID *string
+	Labels             []byte
+	Data               []byte
+}
+
+func (q *Queries) InsertForkedAgentInstance(ctx context.Context, arg InsertForkedAgentInstanceParams) (AgentInstance, error) {
+	row := q.db.QueryRow(ctx, insertForkedAgentInstance,
+		arg.ID,
+		arg.Namespace,
+		arg.UserID,
+		arg.RequestID,
+		arg.ContextID,
+		arg.PreparedRevision,
+		arg.SourceCheckpointID,
+		arg.Labels,
+		arg.Data,
+	)
+	var i AgentInstance
+	err := row.Scan(
+		&i.ID,
+		&i.Namespace,
+		&i.UserID,
+		&i.RequestID,
+		&i.PreparedRevision,
+		&i.State,
+		&i.Labels,
+		&i.Data,
+		&i.Operation,
+		&i.ContextID,
+		&i.SourceCheckpointID,
 	)
 	return i, err
 }
@@ -310,7 +386,7 @@ func (q *Queries) ListAgentInstanceShares(ctx context.Context, arg ListAgentInst
 }
 
 const listAgentInstances = `-- name: ListAgentInstances :many
-SELECT id, namespace, user_id, request_id, prepared_revision, state, labels, data, operation FROM agent_instance
+SELECT id, namespace, user_id, request_id, prepared_revision, state, labels, data, operation, context_id, source_checkpoint_id FROM agent_instance
 WHERE namespace = $1
   AND ($2::boolean OR user_id = $3)
   AND id > $4
@@ -354,6 +430,8 @@ func (q *Queries) ListAgentInstances(ctx context.Context, arg ListAgentInstances
 			&i.Labels,
 			&i.Data,
 			&i.Operation,
+			&i.ContextID,
+			&i.SourceCheckpointID,
 		); err != nil {
 			return nil, err
 		}
@@ -366,7 +444,7 @@ func (q *Queries) ListAgentInstances(ctx context.Context, arg ListAgentInstances
 }
 
 const lockAgentInstance = `-- name: LockAgentInstance :one
-SELECT id, namespace, user_id, request_id, prepared_revision, state, labels, data, operation FROM agent_instance WHERE id = $1 FOR UPDATE
+SELECT id, namespace, user_id, request_id, prepared_revision, state, labels, data, operation, context_id, source_checkpoint_id FROM agent_instance WHERE id = $1 FOR UPDATE
 `
 
 func (q *Queries) LockAgentInstance(ctx context.Context, id string) (AgentInstance, error) {
@@ -382,6 +460,8 @@ func (q *Queries) LockAgentInstance(ctx context.Context, id string) (AgentInstan
 		&i.Labels,
 		&i.Data,
 		&i.Operation,
+		&i.ContextID,
+		&i.SourceCheckpointID,
 	)
 	return i, err
 }
@@ -390,7 +470,7 @@ const markAgentInstanceReady = `-- name: MarkAgentInstanceReady :one
 UPDATE agent_instance
 SET state = 'READY', operation = 'NONE', data = $2
 WHERE id = $1 AND state = 'CREATING' AND operation = 'CREATE'
-RETURNING id, namespace, user_id, request_id, prepared_revision, state, labels, data, operation
+RETURNING id, namespace, user_id, request_id, prepared_revision, state, labels, data, operation, context_id, source_checkpoint_id
 `
 
 type MarkAgentInstanceReadyParams struct {
@@ -411,6 +491,8 @@ func (q *Queries) MarkAgentInstanceReady(ctx context.Context, arg MarkAgentInsta
 		&i.Labels,
 		&i.Data,
 		&i.Operation,
+		&i.ContextID,
+		&i.SourceCheckpointID,
 	)
 	return i, err
 }
@@ -428,7 +510,7 @@ WHERE agent_instance.id = $4
       WHERE c.source_instance_id = agent_instance.id AND c.state = 'CREATING'
     )
   )
-RETURNING id, namespace, user_id, request_id, prepared_revision, state, labels, data, operation
+RETURNING id, namespace, user_id, request_id, prepared_revision, state, labels, data, operation, context_id, source_checkpoint_id
 `
 
 type TransitionAgentInstanceParams struct {
@@ -460,6 +542,8 @@ func (q *Queries) TransitionAgentInstance(ctx context.Context, arg TransitionAge
 		&i.Labels,
 		&i.Data,
 		&i.Operation,
+		&i.ContextID,
+		&i.SourceCheckpointID,
 	)
 	return i, err
 }

--- a/go/core/internal/database/gen/models.go
+++ b/go/core/internal/database/gen/models.go
@@ -98,6 +98,7 @@ type AgentInstanceTaskEvent struct {
 	TaskID    *string
 	Data      []byte
 	CreatedAt time.Time
+	MessageID *string
 }
 
 type AgentTemplateHarnessPair struct {

--- a/go/core/internal/database/gen/models.go
+++ b/go/core/internal/database/gen/models.go
@@ -62,7 +62,7 @@ type AgentInstanceCheckpoint struct {
 	CreatedAt            time.Time
 	SourceContextID      string
 	PreparedRevision     *string
-	SourceInstanceData   []byte
+	SourceLabels         []byte
 }
 
 type AgentInstanceShare struct {

--- a/go/core/internal/database/gen/models.go
+++ b/go/core/internal/database/gen/models.go
@@ -13,6 +13,13 @@ import (
 	pgvector_go "github.com/pgvector/pgvector-go"
 )
 
+type A2aContext struct {
+	ID        string
+	Namespace string
+	UserID    string
+	CreatedAt time.Time
+}
+
 type Agent struct {
 	ID           string
 	CreatedAt    *time.Time
@@ -24,15 +31,17 @@ type Agent struct {
 }
 
 type AgentInstance struct {
-	ID               string
-	Namespace        string
-	UserID           string
-	RequestID        string
-	PreparedRevision *string
-	State            string
-	Labels           []byte
-	Data             []byte
-	Operation        string
+	ID                 string
+	Namespace          string
+	UserID             string
+	RequestID          string
+	PreparedRevision   *string
+	State              string
+	Labels             []byte
+	Data               []byte
+	Operation          string
+	ContextID          string
+	SourceCheckpointID *string
 }
 
 type AgentInstanceCheckpoint struct {
@@ -51,6 +60,9 @@ type AgentInstanceCheckpoint struct {
 	State                string
 	Failure              string
 	CreatedAt            time.Time
+	SourceContextID      string
+	PreparedRevision     *string
+	SourceInstanceData   []byte
 }
 
 type AgentInstanceShare struct {
@@ -64,7 +76,7 @@ type AgentInstanceShare struct {
 }
 
 type AgentInstanceTask struct {
-	InstanceID           string
+	ContextID            string
 	ID                   string
 	State                string
 	StatusTimestamp      *time.Time
@@ -81,11 +93,11 @@ type AgentInstanceTask struct {
 }
 
 type AgentInstanceTaskEvent struct {
-	Sequence   int64
-	InstanceID string
-	TaskID     *string
-	Data       []byte
-	CreatedAt  time.Time
+	Sequence  int64
+	ContextID string
+	TaskID    *string
+	Data      []byte
+	CreatedAt time.Time
 }
 
 type AgentTemplateHarnessPair struct {

--- a/go/core/internal/database/gen/querier.go
+++ b/go/core/internal/database/gen/querier.go
@@ -74,9 +74,11 @@ type Querier interface {
 	InsertFeedback(ctx context.Context, arg InsertFeedbackParams) error
 	InsertForkedAgentInstance(ctx context.Context, arg InsertForkedAgentInstanceParams) (AgentInstance, error)
 	InsertMemory(ctx context.Context, arg InsertMemoryParams) (string, error)
+	ListAgentInstanceCheckpointEvents(ctx context.Context, checkpointID string) ([]AgentInstanceTaskEvent, error)
 	ListAgentInstanceCheckpointTasks(ctx context.Context, checkpointID string) ([]AgentInstanceTask, error)
 	ListAgentInstanceCheckpoints(ctx context.Context, arg ListAgentInstanceCheckpointsParams) ([]AgentInstanceCheckpoint, error)
 	ListAgentInstanceShares(ctx context.Context, arg ListAgentInstanceSharesParams) ([]AgentInstanceShare, error)
+	ListAgentInstanceTaskHistory(ctx context.Context, arg ListAgentInstanceTaskHistoryParams) ([]ListAgentInstanceTaskHistoryRow, error)
 	ListAgentInstanceTasks(ctx context.Context, arg ListAgentInstanceTasksParams) ([]AgentInstanceTask, error)
 	ListAgentInstances(ctx context.Context, arg ListAgentInstancesParams) ([]AgentInstance, error)
 	ListAgentMemories(ctx context.Context, arg ListAgentMemoriesParams) ([]Memory, error)

--- a/go/core/internal/database/gen/querier.go
+++ b/go/core/internal/database/gen/querier.go
@@ -27,7 +27,7 @@ type Querier interface {
 	DeleteUnreferencedRuntimeRevision(ctx context.Context, revision string) error
 	ExtendMemoryTTL(ctx context.Context) error
 	FinalizeAgentInstanceCheckpoint(ctx context.Context, arg FinalizeAgentInstanceCheckpointParams) (AgentInstanceCheckpoint, error)
-	GetActiveAgentInstanceTask(ctx context.Context, instanceID string) (AgentInstanceTask, error)
+	GetActiveAgentInstanceTask(ctx context.Context, contextID string) (AgentInstanceTask, error)
 	GetAgent(ctx context.Context, id string) (Agent, error)
 	GetAgentInstanceByID(ctx context.Context, id string) (AgentInstance, error)
 	GetAgentInstanceByRequest(ctx context.Context, arg GetAgentInstanceByRequestParams) (AgentInstance, error)
@@ -39,7 +39,7 @@ type Querier interface {
 	GetCheckpoint(ctx context.Context, arg GetCheckpointParams) (LgCheckpoint, error)
 	GetEvent(ctx context.Context, arg GetEventParams) (Event, error)
 	GetLatestCrewAIFlowState(ctx context.Context, arg GetLatestCrewAIFlowStateParams) (CrewaiFlowState, error)
-	GetLatestQuiescentAgentInstanceTask(ctx context.Context, instanceID string) (AgentInstanceTask, error)
+	GetLatestQuiescentAgentInstanceTask(ctx context.Context, contextID string) (AgentInstanceTask, error)
 	GetLatestRuntimeRevisionForInstance(ctx context.Context, arg GetLatestRuntimeRevisionForInstanceParams) (GetLatestRuntimeRevisionForInstanceRow, error)
 	GetPushNotification(ctx context.Context, arg GetPushNotificationParams) (PushNotification, error)
 	GetRuntimeRevision(ctx context.Context, revision string) (RuntimeRevision, error)
@@ -65,12 +65,16 @@ type Querier interface {
 	HardDeleteCrewAIMemory(ctx context.Context, arg HardDeleteCrewAIMemoryParams) error
 	// Lock rows in id order to avoid deadlocks between concurrent overlapping increments.
 	IncrementMemoryAccessCount(ctx context.Context, dollar_1 []string) error
+	InsertA2AContext(ctx context.Context, arg InsertA2AContextParams) error
 	InsertAgentInstance(ctx context.Context, arg InsertAgentInstanceParams) (AgentInstance, error)
 	InsertAgentInstanceCheckpoint(ctx context.Context, arg InsertAgentInstanceCheckpointParams) (AgentInstanceCheckpoint, error)
 	InsertAgentInstanceTaskEvent(ctx context.Context, arg InsertAgentInstanceTaskEventParams) (int64, error)
+	InsertCopiedAgentInstanceTask(ctx context.Context, arg InsertCopiedAgentInstanceTaskParams) error
 	InsertEvent(ctx context.Context, arg InsertEventParams) error
 	InsertFeedback(ctx context.Context, arg InsertFeedbackParams) error
+	InsertForkedAgentInstance(ctx context.Context, arg InsertForkedAgentInstanceParams) (AgentInstance, error)
 	InsertMemory(ctx context.Context, arg InsertMemoryParams) (string, error)
+	ListAgentInstanceCheckpointTasks(ctx context.Context, checkpointID string) ([]AgentInstanceTask, error)
 	ListAgentInstanceCheckpoints(ctx context.Context, arg ListAgentInstanceCheckpointsParams) ([]AgentInstanceCheckpoint, error)
 	ListAgentInstanceShares(ctx context.Context, arg ListAgentInstanceSharesParams) ([]AgentInstanceShare, error)
 	ListAgentInstanceTasks(ctx context.Context, arg ListAgentInstanceTasksParams) ([]AgentInstanceTask, error)
@@ -99,8 +103,9 @@ type Querier interface {
 	ListUnreferencedRuntimeRevisions(ctx context.Context) ([]RuntimeRevision, error)
 	// LockActiveAgentInstanceTask holds the instance's non-terminal task for the
 	// rest of the transaction so reclamation cannot overwrite concurrent progress.
-	LockActiveAgentInstanceTask(ctx context.Context, instanceID string) (AgentInstanceTask, error)
+	LockActiveAgentInstanceTask(ctx context.Context, contextID string) (AgentInstanceTask, error)
 	LockAgentInstance(ctx context.Context, id string) (AgentInstance, error)
+	LockReadyAgentInstanceCheckpoint(ctx context.Context, arg LockReadyAgentInstanceCheckpointParams) (AgentInstanceCheckpoint, error)
 	MarkAgentInstanceReady(ctx context.Context, arg MarkAgentInstanceReadyParams) (AgentInstance, error)
 	MarkRuntimeRevisionSuccessful(ctx context.Context, arg MarkRuntimeRevisionSuccessfulParams) error
 	RetireAgentTemplateHarnessPair(ctx context.Context, arg RetireAgentTemplateHarnessPairParams) error

--- a/go/core/internal/database/queries/agent_instance_checkpoints.sql
+++ b/go/core/internal/database/queries/agent_instance_checkpoints.sql
@@ -27,7 +27,7 @@ WHERE NOT EXISTS (
 INSERT INTO agent_instance_checkpoint (
     id, namespace, source_instance_id, user_id, request_id, head_task_id,
     history_sequence, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope,
-    source_context_id, prepared_revision, source_instance_data, state
+    source_context_id, prepared_revision, source_labels, state
 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, 'CREATING')
 ON CONFLICT DO NOTHING
 RETURNING *;

--- a/go/core/internal/database/queries/agent_instance_checkpoints.sql
+++ b/go/core/internal/database/queries/agent_instance_checkpoints.sql
@@ -6,13 +6,13 @@ WHERE user_id = $1 AND namespace = $2 AND request_id = $3;
 SELECT latest.*
 FROM (
     SELECT * FROM agent_instance_task
-    WHERE agent_instance_task.instance_id = $1
+    WHERE agent_instance_task.context_id = $1
     ORDER BY created_at DESC, id DESC
     LIMIT 1
 ) latest
 WHERE NOT EXISTS (
     SELECT 1 FROM agent_instance_task active
-    WHERE active.instance_id = $1
+    WHERE active.context_id = $1
       AND active.state NOT IN (
           'TASK_STATE_COMPLETED',
           'TASK_STATE_CANCELED',
@@ -26,10 +26,22 @@ WHERE NOT EXISTS (
 -- name: InsertAgentInstanceCheckpoint :one
 INSERT INTO agent_instance_checkpoint (
     id, namespace, source_instance_id, user_id, request_id, head_task_id,
-    history_sequence, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope, state
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, 'CREATING')
+    history_sequence, snapshot_atespace, snapshot_name, snapshot_uid, snapshot_content_scope,
+    source_context_id, prepared_revision, source_instance_data, state
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, 'CREATING')
 ON CONFLICT DO NOTHING
 RETURNING *;
+
+-- name: ListAgentInstanceCheckpointTasks :many
+SELECT t.*
+FROM agent_instance_checkpoint c
+JOIN agent_instance_task head
+  ON head.context_id = c.source_context_id AND head.id = c.head_task_id
+JOIN agent_instance_task t
+  ON t.context_id = c.source_context_id
+ AND (t.created_at, t.id) <= (head.created_at, head.id)
+WHERE c.id = sqlc.arg(checkpoint_id)
+ORDER BY t.created_at, t.id;
 
 -- name: FinalizeAgentInstanceCheckpoint :one
 UPDATE agent_instance_checkpoint
@@ -61,10 +73,18 @@ LIMIT sqlc.arg(page_size);
 -- name: BeginDeleteAgentInstanceCheckpoint :one
 UPDATE agent_instance_checkpoint
 SET state = 'DELETING'
-WHERE namespace = $1 AND id = $2 AND user_id = $3
-  AND state IN ('READY', 'DELETING')
+WHERE agent_instance_checkpoint.namespace = $1 AND agent_instance_checkpoint.id = $2 AND agent_instance_checkpoint.user_id = $3
+  AND agent_instance_checkpoint.state IN ('READY', 'DELETING')
+  AND NOT EXISTS (
+      SELECT 1 FROM agent_instance i WHERE i.source_checkpoint_id = agent_instance_checkpoint.id
+  )
 RETURNING *;
 
 -- name: DeleteAgentInstanceCheckpoint :execrows
 DELETE FROM agent_instance_checkpoint
 WHERE namespace = $1 AND id = $2 AND user_id = $3 AND state = 'DELETING';
+
+-- name: LockReadyAgentInstanceCheckpoint :one
+SELECT * FROM agent_instance_checkpoint
+WHERE namespace = $1 AND id = $2 AND user_id = $3 AND state = 'READY'
+FOR UPDATE;

--- a/go/core/internal/database/queries/agent_instance_checkpoints.sql
+++ b/go/core/internal/database/queries/agent_instance_checkpoints.sql
@@ -43,6 +43,15 @@ JOIN agent_instance_task t
 WHERE c.id = sqlc.arg(checkpoint_id)
 ORDER BY t.created_at, t.id;
 
+-- name: ListAgentInstanceCheckpointEvents :many
+SELECT e.*
+FROM agent_instance_checkpoint c
+JOIN agent_instance_task_event e
+  ON e.context_id = c.source_context_id
+ AND e.sequence <= c.history_sequence
+WHERE c.id = sqlc.arg(checkpoint_id)
+ORDER BY e.sequence;
+
 -- name: FinalizeAgentInstanceCheckpoint :one
 UPDATE agent_instance_checkpoint
 SET state = CASE WHEN sqlc.arg(tag_uid)::text <> '' THEN 'READY' ELSE 'FAILED' END,

--- a/go/core/internal/database/queries/agent_instance_tasks.sql
+++ b/go/core/internal/database/queries/agent_instance_tasks.sql
@@ -21,9 +21,27 @@ ON CONFLICT (context_id, initial_message_id)
 DO NOTHING;
 
 -- name: InsertAgentInstanceTaskEvent :one
-INSERT INTO agent_instance_task_event (context_id, task_id, data)
-VALUES ($1, $2, $3)
-RETURNING sequence;
+WITH inserted AS (
+    INSERT INTO agent_instance_task_event (context_id, task_id, message_id, data)
+    VALUES ($1, $2, $3, $4)
+    ON CONFLICT (context_id, task_id, message_id)
+        WHERE message_id IS NOT NULL
+    DO NOTHING
+    RETURNING sequence
+)
+SELECT sequence FROM inserted
+UNION ALL
+SELECT sequence FROM agent_instance_task_event
+WHERE context_id = $1 AND task_id IS NOT DISTINCT FROM $2 AND message_id = $3
+LIMIT 1;
+
+-- name: ListAgentInstanceTaskHistory :many
+SELECT task_id, data
+FROM agent_instance_task_event
+WHERE context_id = sqlc.arg(context_id)
+  AND task_id = ANY(sqlc.arg(task_ids)::text[])
+  AND message_id IS NOT NULL
+ORDER BY sequence;
 
 -- name: SetAgentInstanceTaskSnapshot :exec
 UPDATE agent_instance_task SET

--- a/go/core/internal/database/queries/agent_instance_tasks.sql
+++ b/go/core/internal/database/queries/agent_instance_tasks.sql
@@ -1,7 +1,7 @@
 -- name: UpsertAgentInstanceTask :exec
-INSERT INTO agent_instance_task (instance_id, id, state, status_timestamp, data)
+INSERT INTO agent_instance_task (context_id, id, state, status_timestamp, data)
 VALUES ($1, $2, $3, $4, $5)
-ON CONFLICT (instance_id, id) DO UPDATE SET
+ON CONFLICT (context_id, id) DO UPDATE SET
     state = EXCLUDED.state,
     status_timestamp = EXCLUDED.status_timestamp,
     data = EXCLUDED.data,
@@ -9,19 +9,19 @@ ON CONFLICT (instance_id, id) DO UPDATE SET
 
 -- name: CreateAgentInstanceTask :execrows
 INSERT INTO agent_instance_task (
-    instance_id, id, state, status_timestamp, data, initial_message_id, request_hash
+    context_id, id, state, status_timestamp, data, initial_message_id, request_hash
 )
 SELECT $1, $2, $3, $4, $5, $6, $7
 WHERE NOT EXISTS (
     SELECT 1 FROM agent_instance_checkpoint
-    WHERE source_instance_id = $1 AND state = 'CREATING'
+    WHERE source_context_id = $1 AND state = 'CREATING'
 )
-ON CONFLICT (instance_id, initial_message_id)
+ON CONFLICT (context_id, initial_message_id)
     WHERE initial_message_id IS NOT NULL
 DO NOTHING;
 
 -- name: InsertAgentInstanceTaskEvent :one
-INSERT INTO agent_instance_task_event (instance_id, task_id, data)
+INSERT INTO agent_instance_task_event (context_id, task_id, data)
 VALUES ($1, $2, $3)
 RETURNING sequence;
 
@@ -32,15 +32,15 @@ UPDATE agent_instance_task SET
     snapshot_uid = $5,
     snapshot_content_scope = $6,
     history_sequence = $7
-WHERE instance_id = $1 AND id = $2;
+WHERE context_id = $1 AND id = $2;
 
 -- name: GetAgentInstanceTask :one
 SELECT * FROM agent_instance_task
-WHERE instance_id = $1 AND id = $2;
+WHERE context_id = $1 AND id = $2;
 
 -- name: GetActiveAgentInstanceTask :one
 SELECT * FROM agent_instance_task
-WHERE instance_id = $1
+WHERE context_id = $1
   AND state NOT IN (
       'TASK_STATE_COMPLETED',
       'TASK_STATE_CANCELED',
@@ -52,18 +52,18 @@ WHERE instance_id = $1
 
 -- name: GetAgentInstanceTaskByMessageID :one
 SELECT * FROM agent_instance_task
-WHERE instance_id = $1 AND initial_message_id = $2;
+WHERE context_id = $1 AND initial_message_id = $2;
 
 -- name: CountAgentInstanceTasks :one
 SELECT COUNT(*) FROM agent_instance_task
-WHERE instance_id = sqlc.arg(instance_id)
+WHERE context_id = sqlc.arg(context_id)
   AND (sqlc.arg(state)::text = '' OR state = sqlc.arg(state))
   AND (sqlc.narg(status_timestamp_after)::timestamptz IS NULL
        OR status_timestamp > sqlc.narg(status_timestamp_after));
 
 -- name: ListAgentInstanceTasks :many
 SELECT * FROM agent_instance_task
-WHERE instance_id = sqlc.arg(instance_id)
+WHERE context_id = sqlc.arg(context_id)
   AND id > sqlc.arg(after_id)
   AND (sqlc.arg(state)::text = '' OR state = sqlc.arg(state))
   AND (sqlc.narg(status_timestamp_after)::timestamptz IS NULL
@@ -71,11 +71,18 @@ WHERE instance_id = sqlc.arg(instance_id)
 ORDER BY id
 LIMIT sqlc.arg(page_size);
 
+-- name: InsertCopiedAgentInstanceTask :exec
+INSERT INTO agent_instance_task (
+    context_id, id, state, status_timestamp, data, created_at, updated_at,
+    initial_message_id, request_hash, snapshot_atespace, snapshot_name,
+    snapshot_uid, snapshot_content_scope, history_sequence
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14);
+
 -- LockActiveAgentInstanceTask holds the instance's non-terminal task for the
 -- rest of the transaction so reclamation cannot overwrite concurrent progress.
 -- name: LockActiveAgentInstanceTask :one
 SELECT * FROM agent_instance_task
-WHERE instance_id = $1
+WHERE context_id = $1
   AND state NOT IN (
       'TASK_STATE_COMPLETED',
       'TASK_STATE_CANCELED',

--- a/go/core/internal/database/queries/agent_instances.sql
+++ b/go/core/internal/database/queries/agent_instances.sql
@@ -13,8 +13,20 @@ WHERE p.namespace = $1
 
 -- name: InsertAgentInstance :one
 INSERT INTO agent_instance (
-    id, namespace, user_id, request_id, prepared_revision, state, operation, labels, data
-) VALUES ($1, $2, $3, $4, $5, 'CREATING', 'CREATE', $6, $7)
+    id, namespace, user_id, request_id, context_id, prepared_revision, state, operation, labels, data
+) VALUES ($1, $2, $3, $4, $5, $6, 'CREATING', 'CREATE', $7, $8)
+ON CONFLICT (user_id, namespace, request_id) DO NOTHING
+RETURNING *;
+
+-- name: InsertA2AContext :exec
+INSERT INTO a2a_context (id, namespace, user_id)
+VALUES ($1, $2, $3);
+
+-- name: InsertForkedAgentInstance :one
+INSERT INTO agent_instance (
+    id, namespace, user_id, request_id, context_id, prepared_revision, source_checkpoint_id,
+    state, operation, labels, data
+) VALUES ($1, $2, $3, $4, $5, $6, $7, 'CREATING', 'CREATE', $8, $9)
 ON CONFLICT (user_id, namespace, request_id) DO NOTHING
 RETURNING *;
 

--- a/go/core/pkg/migrations/core/000016_agent_instance_forks.down.sql
+++ b/go/core/pkg/migrations/core/000016_agent_instance_forks.down.sql
@@ -1,3 +1,8 @@
+DROP INDEX IF EXISTS agent_instance_task_event_message_idx;
+
+ALTER TABLE agent_instance_task_event
+    DROP COLUMN IF EXISTS message_id;
+
 ALTER TABLE agent_instance_task_event
     DROP CONSTRAINT IF EXISTS agent_instance_task_event_context_id_fkey;
 

--- a/go/core/pkg/migrations/core/000016_agent_instance_forks.down.sql
+++ b/go/core/pkg/migrations/core/000016_agent_instance_forks.down.sql
@@ -1,0 +1,30 @@
+ALTER TABLE agent_instance_task_event
+    DROP CONSTRAINT IF EXISTS agent_instance_task_event_context_id_fkey;
+
+ALTER TABLE agent_instance_task_event
+    RENAME COLUMN context_id TO instance_id;
+
+ALTER TABLE agent_instance_task_event
+    ADD CONSTRAINT agent_instance_task_event_instance_id_fkey
+        FOREIGN KEY (instance_id) REFERENCES agent_instance(id) ON DELETE CASCADE;
+
+ALTER TABLE agent_instance_task
+    DROP CONSTRAINT IF EXISTS agent_instance_task_context_id_fkey;
+
+ALTER TABLE agent_instance_task
+    RENAME COLUMN context_id TO instance_id;
+
+ALTER TABLE agent_instance_task
+    ADD CONSTRAINT agent_instance_task_instance_id_fkey
+        FOREIGN KEY (instance_id) REFERENCES agent_instance(id) ON DELETE CASCADE;
+
+ALTER TABLE agent_instance
+    DROP COLUMN IF EXISTS source_checkpoint_id,
+    DROP COLUMN IF EXISTS context_id;
+
+ALTER TABLE agent_instance_checkpoint
+    DROP COLUMN IF EXISTS source_context_id,
+    DROP COLUMN IF EXISTS source_instance_data,
+    DROP COLUMN IF EXISTS prepared_revision;
+
+DROP TABLE IF EXISTS a2a_context;

--- a/go/core/pkg/migrations/core/000016_agent_instance_forks.down.sql
+++ b/go/core/pkg/migrations/core/000016_agent_instance_forks.down.sql
@@ -29,7 +29,7 @@ ALTER TABLE agent_instance
 
 ALTER TABLE agent_instance_checkpoint
     DROP COLUMN IF EXISTS source_context_id,
-    DROP COLUMN IF EXISTS source_instance_data,
+    DROP COLUMN IF EXISTS source_labels,
     DROP COLUMN IF EXISTS prepared_revision;
 
 DROP TABLE IF EXISTS a2a_context;

--- a/go/core/pkg/migrations/core/000016_agent_instance_forks.up.sql
+++ b/go/core/pkg/migrations/core/000016_agent_instance_forks.up.sql
@@ -45,6 +45,13 @@ ALTER TABLE agent_instance_task_event
     ADD CONSTRAINT agent_instance_task_event_context_id_fkey
         FOREIGN KEY (context_id) REFERENCES a2a_context(id) ON DELETE CASCADE;
 
+ALTER TABLE agent_instance_task_event
+    ADD COLUMN IF NOT EXISTS message_id TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS agent_instance_task_event_message_idx
+    ON agent_instance_task_event (context_id, task_id, message_id)
+    WHERE message_id IS NOT NULL;
+
 ALTER TABLE agent_instance_checkpoint
     ADD COLUMN IF NOT EXISTS source_context_id TEXT,
     ADD COLUMN IF NOT EXISTS prepared_revision TEXT REFERENCES runtime_revision(revision) ON DELETE RESTRICT,

--- a/go/core/pkg/migrations/core/000016_agent_instance_forks.up.sql
+++ b/go/core/pkg/migrations/core/000016_agent_instance_forks.up.sql
@@ -1,0 +1,70 @@
+CREATE TABLE IF NOT EXISTS a2a_context (
+    id TEXT PRIMARY KEY,
+    namespace TEXT NOT NULL,
+    user_id TEXT NOT NULL CHECK (user_id <> ''),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO a2a_context (id, namespace, user_id)
+SELECT id, namespace, user_id FROM agent_instance
+ON CONFLICT DO NOTHING;
+
+INSERT INTO a2a_context (id, namespace, user_id, created_at)
+SELECT source_instance_id, namespace, user_id, MIN(created_at)
+FROM agent_instance_checkpoint
+GROUP BY source_instance_id, namespace, user_id
+ON CONFLICT DO NOTHING;
+
+ALTER TABLE agent_instance
+    ADD COLUMN IF NOT EXISTS context_id TEXT;
+
+UPDATE agent_instance SET context_id = id WHERE context_id IS NULL;
+
+ALTER TABLE agent_instance
+    ALTER COLUMN context_id SET NOT NULL,
+    ADD CONSTRAINT agent_instance_context_id_fkey
+        FOREIGN KEY (context_id) REFERENCES a2a_context(id) ON DELETE RESTRICT;
+
+ALTER TABLE agent_instance_task
+    DROP CONSTRAINT IF EXISTS agent_instance_task_instance_id_fkey;
+
+ALTER TABLE agent_instance_task
+    RENAME COLUMN instance_id TO context_id;
+
+ALTER TABLE agent_instance_task
+    ADD CONSTRAINT agent_instance_task_context_id_fkey
+        FOREIGN KEY (context_id) REFERENCES a2a_context(id) ON DELETE CASCADE;
+
+ALTER TABLE agent_instance_task_event
+    DROP CONSTRAINT IF EXISTS agent_instance_task_event_instance_id_fkey;
+
+ALTER TABLE agent_instance_task_event
+    RENAME COLUMN instance_id TO context_id;
+
+ALTER TABLE agent_instance_task_event
+    ADD CONSTRAINT agent_instance_task_event_context_id_fkey
+        FOREIGN KEY (context_id) REFERENCES a2a_context(id) ON DELETE CASCADE;
+
+ALTER TABLE agent_instance_checkpoint
+    ADD COLUMN IF NOT EXISTS source_context_id TEXT,
+    ADD COLUMN IF NOT EXISTS prepared_revision TEXT REFERENCES runtime_revision(revision) ON DELETE RESTRICT,
+    ADD COLUMN IF NOT EXISTS source_instance_data BYTEA;
+
+UPDATE agent_instance_checkpoint
+SET source_context_id = source_instance_id
+WHERE source_context_id IS NULL;
+
+ALTER TABLE agent_instance_checkpoint
+    ALTER COLUMN source_context_id SET NOT NULL,
+    ADD CONSTRAINT agent_instance_checkpoint_source_context_id_fkey
+        FOREIGN KEY (source_context_id) REFERENCES a2a_context(id) ON DELETE RESTRICT;
+
+UPDATE agent_instance_checkpoint c
+SET prepared_revision = i.prepared_revision,
+    source_instance_data = i.data
+FROM agent_instance i
+WHERE i.id = c.source_instance_id
+  AND (c.prepared_revision IS NULL OR c.source_instance_data IS NULL);
+
+ALTER TABLE agent_instance
+    ADD COLUMN IF NOT EXISTS source_checkpoint_id TEXT REFERENCES agent_instance_checkpoint(id) ON DELETE RESTRICT;

--- a/go/core/pkg/migrations/core/000016_agent_instance_forks.up.sql
+++ b/go/core/pkg/migrations/core/000016_agent_instance_forks.up.sql
@@ -55,7 +55,8 @@ CREATE UNIQUE INDEX IF NOT EXISTS agent_instance_task_event_message_idx
 ALTER TABLE agent_instance_checkpoint
     ADD COLUMN IF NOT EXISTS source_context_id TEXT,
     ADD COLUMN IF NOT EXISTS prepared_revision TEXT REFERENCES runtime_revision(revision) ON DELETE RESTRICT,
-    ADD COLUMN IF NOT EXISTS source_instance_data BYTEA;
+    ADD COLUMN IF NOT EXISTS source_labels JSONB NOT NULL DEFAULT '{}'
+        CHECK (jsonb_typeof(source_labels) = 'object');
 
 UPDATE agent_instance_checkpoint
 SET source_context_id = source_instance_id
@@ -68,10 +69,10 @@ ALTER TABLE agent_instance_checkpoint
 
 UPDATE agent_instance_checkpoint c
 SET prepared_revision = i.prepared_revision,
-    source_instance_data = i.data
+    source_labels = i.labels
 FROM agent_instance i
 WHERE i.id = c.source_instance_id
-  AND (c.prepared_revision IS NULL OR c.source_instance_data IS NULL);
+  AND c.prepared_revision IS NULL;
 
 ALTER TABLE agent_instance
     ADD COLUMN IF NOT EXISTS source_checkpoint_id TEXT REFERENCES agent_instance_checkpoint(id) ON DELETE RESTRICT;

--- a/go/core/pkg/sandboxbackend/substrate/client.go
+++ b/go/core/pkg/sandboxbackend/substrate/client.go
@@ -138,6 +138,14 @@ func (c *Client) GetActor(ctx context.Context, atespace, actorID string) (*ateap
 }
 
 func (c *Client) CreateActor(ctx context.Context, atespace, actorID, tmplNS, tmplName string) (*ateapipb.Actor, error) {
+	return c.createActor(ctx, atespace, actorID, tmplNS, tmplName, nil)
+}
+
+func (c *Client) CreateActorFromSnapshotTag(ctx context.Context, atespace, actorID, tmplNS, tmplName, tagAtespace, tagName string) (*ateapipb.Actor, error) {
+	return c.createActor(ctx, atespace, actorID, tmplNS, tmplName, &ateapipb.ObjectRef{Atespace: tagAtespace, Name: tagName})
+}
+
+func (c *Client) createActor(ctx context.Context, atespace, actorID, tmplNS, tmplName string, source *ateapipb.ObjectRef) (*ateapipb.Actor, error) {
 	ctx, cancel := c.callCtx(ctx)
 	defer cancel()
 	resp, err := c.ControlClient.CreateActor(ctx, &ateapipb.CreateActorRequest{
@@ -145,6 +153,7 @@ func (c *Client) CreateActor(ctx context.Context, atespace, actorID, tmplNS, tmp
 			Metadata:               &ateapipb.ResourceMetadata{Atespace: atespace, Name: actorID},
 			ActorTemplateNamespace: tmplNS,
 			ActorTemplateName:      tmplName,
+			SourceSnapshotTag:      source,
 		},
 	})
 	if err != nil {

--- a/go/core/test/e2e/interaction_test.go
+++ b/go/core/test/e2e/interaction_test.go
@@ -94,15 +94,58 @@ func TestAgentInstanceCheckpoint(t *testing.T) {
 	if err != nil || len(listed.GetCheckpoints()) != 1 || listed.GetCheckpoints()[0].GetId() != checkpoint.GetId() {
 		t.Fatalf("list checkpoints = %+v, error %v", listed.GetCheckpoints(), err)
 	}
+	forked, err := fixture.checkpoints.ForkAgentInstance(fixture.ctx, &apiv1alpha1.ForkAgentInstanceRequest{
+		Namespace: "kagent", CheckpointId: checkpoint.GetId(), RequestId: uuid.NewString(),
+	})
+	if err != nil {
+		t.Fatalf("fork AgentInstance: %v", err)
+	}
+	fork := forked.GetAgentInstance()
+	if fork.GetId() == fixture.instanceID || fork.GetState() != apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_READY {
+		t.Fatalf("fork = %+v", fork)
+	}
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(metadata.AppendToOutgoingContext(context.Background(), "x-user-id", "e2e"), time.Minute)
+		defer cleanupCancel()
+		_, cleanupErr := fixture.instances.DeleteAgentInstance(cleanupCtx, &apiv1alpha1.DeleteAgentInstanceRequest{
+			Namespace: "kagent", AgentInstanceId: fork.GetId(),
+		})
+		if cleanupErr != nil && status.Code(cleanupErr) != codes.NotFound {
+			t.Errorf("delete fork AgentInstance: %v", cleanupErr)
+		}
+	})
+	forkCtx, forkCancel := context.WithTimeout(metadata.AppendToOutgoingContext(t.Context(),
+		"x-user-id", "e2e",
+		"x-kagent-agent-instance-namespace", "kagent",
+		"x-kagent-agent-instance-id", fork.GetId(),
+	), 4*time.Minute)
+	t.Cleanup(forkCancel)
+	listRequest, err := pbconv.ToProtoListTasksRequest(&a2atype.ListTasksRequest{ContextID: fork.GetId(), PageSize: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	copiedResponse, err := fixture.client.ListTasks(forkCtx, listRequest)
+	if err != nil {
+		t.Fatalf("list fork tasks: %v", err)
+	}
+	copied, err := pbconv.FromProtoListTasksResponse(copiedResponse)
+	if err != nil || len(copied.Tasks) != 1 || copied.Tasks[0].ID == task.ID || copied.Tasks[0].ContextID != fork.GetId() {
+		t.Fatalf("copied fork tasks = %+v, error %v", copied, err)
+	}
+	forkFixture := &interactionFixture{ctx: forkCtx, client: fixture.client}
+	_, _, forkTask := forkFixture.send(t, "What is 2+2?")
+	if forkTask.Status.State != a2atype.TaskStateCompleted {
+		t.Fatalf("fork A2A task state = %s, want COMPLETED", forkTask.Status.State)
+	}
+	if _, err := fixture.instances.DeleteAgentInstance(forkCtx, &apiv1alpha1.DeleteAgentInstanceRequest{
+		Namespace: "kagent", AgentInstanceId: fork.GetId(),
+	}); err != nil {
+		t.Fatalf("delete fork AgentInstance: %v", err)
+	}
 	if _, err := fixture.checkpoints.DeleteCheckpoint(fixture.ctx, &apiv1alpha1.DeleteCheckpointRequest{
 		Namespace: "kagent", CheckpointId: checkpoint.GetId(),
 	}); err != nil {
 		t.Fatalf("delete checkpoint: %v", err)
-	}
-	if _, err := fixture.checkpoints.GetCheckpoint(fixture.ctx, &apiv1alpha1.GetCheckpointRequest{
-		Namespace: "kagent", CheckpointId: checkpoint.GetId(),
-	}); status.Code(err) != codes.NotFound {
-		t.Fatalf("get deleted checkpoint error = %v, want %s", err, codes.NotFound)
 	}
 }
 

--- a/go/core/v2/a2agateway/gateway.go
+++ b/go/core/v2/a2agateway/gateway.go
@@ -59,28 +59,64 @@ type instanceWorkflow interface {
 	Quiesce(context.Context, *apiv1alpha1.AgentInstance) (*dbpkg.AgentInstanceTaskSnapshot, error)
 }
 
+type runtimeCoordinator interface {
+	RuntimeCall(string) func()
+	Quiesce(string) func()
+}
+
+type memoryRuntimeCoordinator struct {
+	locks sync.Map
+}
+
+var processRuntimeCoordinator = &memoryRuntimeCoordinator{}
+
+func (c *memoryRuntimeCoordinator) lock(instanceID string) *sync.RWMutex {
+	lock, _ := c.locks.LoadOrStore(instanceID, &sync.RWMutex{})
+	return lock.(*sync.RWMutex)
+}
+
+func (c *memoryRuntimeCoordinator) RuntimeCall(instanceID string) func() {
+	lock := c.lock(instanceID)
+	lock.RLock()
+	return lock.RUnlock
+}
+
+func (c *memoryRuntimeCoordinator) Quiesce(instanceID string) func() {
+	lock := c.lock(instanceID)
+	lock.Lock()
+	return lock.Unlock
+}
+
 // Gateway is transport-neutral. The v0 deployment registers it on the
 // controller's gRPC server, while a standalone gateway can register the same
 // handler on its own server later.
 type Gateway struct {
-	store      instanceStore
-	authorizer auth.Authorizer
-	dialer     runtimeDialer
-	workflow   instanceWorkflow
-	gatewayURL string
-	events     eventqueue.Manager
-	runs       sync.Map
+	store       instanceStore
+	authorizer  auth.Authorizer
+	dialer      runtimeDialer
+	workflow    instanceWorkflow
+	gatewayURL  string
+	events      eventqueue.Manager
+	runs        sync.Map
+	coordinator runtimeCoordinator
 }
 
 var _ a2asrv.RequestHandler = (*Gateway)(nil)
 
 // New returns the upstream A2A handler independently of any listener or gRPC
 // server, keeping deployment topology outside the gateway package.
+//
+// ponytail: coordination is process-local. Gateway deployments must remain at
+// one replica until this is replaced by a PostgreSQL-backed coordinator.
 func New(store instanceStore, authorizer auth.Authorizer, dialer runtimeDialer, workflow instanceWorkflow, gatewayURL string) a2asrv.RequestHandler {
+	return newGateway(store, authorizer, dialer, workflow, gatewayURL, processRuntimeCoordinator)
+}
+
+func newGateway(store instanceStore, authorizer auth.Authorizer, dialer runtimeDialer, workflow instanceWorkflow, gatewayURL string, coordinator runtimeCoordinator) a2asrv.RequestHandler {
 	return &a2asrv.InterceptedHandler{
 		Handler: &Gateway{
 			store: store, authorizer: authorizer, dialer: dialer, workflow: workflow,
-			gatewayURL: gatewayURL, events: eventqueue.NewInMemoryManager(),
+			gatewayURL: gatewayURL, events: eventqueue.NewInMemoryManager(), coordinator: coordinator,
 		},
 		Interceptors: []a2asrv.CallInterceptor{a2aext.NewServerPropagator(nil)},
 	}
@@ -207,6 +243,8 @@ func (g *Gateway) CancelTask(ctx context.Context, req *a2atype.CancelTaskRequest
 		ctrllog.FromContext(ctx).Error(err, "failed to connect to AgentInstance runtime", "instance", instance.GetId())
 		return nil, a2atype.NewError(a2atype.ErrInternalError, "failed to connect to AgentInstance runtime")
 	}
+	release := g.coordinator.RuntimeCall(instance.GetId())
+	defer release()
 	defer client.Destroy()
 	canceled, err := client.CancelTask(ctx, req)
 	if err != nil {

--- a/go/core/v2/a2agateway/gateway_test.go
+++ b/go/core/v2/a2agateway/gateway_test.go
@@ -218,9 +218,10 @@ func gatewayTestClient(t *testing.T, runtime a2aclient.Transport) *a2aclient.Cli
 
 type blockingGatewayRuntime struct {
 	a2aclient.Transport
-	started  chan struct{}
-	canceled chan struct{}
-	once     sync.Once
+	started       chan struct{}
+	canceled      chan struct{}
+	releaseCancel chan struct{}
+	once          sync.Once
 
 	mu   sync.Mutex
 	task *a2atype.Task
@@ -244,10 +245,21 @@ func (r *blockingGatewayRuntime) CancelTask(_ context.Context, _ a2aclient.Servi
 	r.mu.Unlock()
 	task.Status.State = a2atype.TaskStateCanceled
 	r.once.Do(func() { close(r.canceled) })
+	<-r.releaseCancel
 	return &task, nil
 }
 
 func (r *blockingGatewayRuntime) Destroy() error { return nil }
+
+type gatewayTestCoordinator struct {
+	runtimeCoordinator
+	quiescing chan struct{}
+}
+
+func (c *gatewayTestCoordinator) Quiesce(instanceID string) func() {
+	close(c.quiescing)
+	return c.runtimeCoordinator.Quiesce(instanceID)
+}
 
 func gatewayTestContext() context.Context {
 	return gatewayTestContextWithRoute("team-a", gatewayTestID)
@@ -299,7 +311,9 @@ func TestGatewayResolvesAuthenticatedHeadersBeforeSending(t *testing.T) {
 func TestGatewayClosesRuntimeAfterStreaming(t *testing.T) {
 	instance := gatewayTestInstance()
 	runtime := &gatewayTestRuntime{}
-	gateway := New(&gatewayTestStore{instance: instance}, &gatewayTestAuthorizer{}, &gatewayTestDialer{client: gatewayTestClient(t, runtime)}, &gatewayTestWorkflow{}, gatewayTestURL)
+	destroyedAtQuiesce := false
+	workflow := &gatewayTestWorkflow{onQuiesce: func() { destroyedAtQuiesce = runtime.destroyed }}
+	gateway := New(&gatewayTestStore{instance: instance}, &gatewayTestAuthorizer{}, &gatewayTestDialer{client: gatewayTestClient(t, runtime)}, workflow, gatewayTestURL)
 
 	var events int
 	for _, err := range gateway.SendStreamingMessage(gatewayTestContext(), gatewayTestRequest()) {
@@ -308,8 +322,8 @@ func TestGatewayClosesRuntimeAfterStreaming(t *testing.T) {
 		}
 		events++
 	}
-	if events != 1 || !runtime.destroyed {
-		t.Fatalf("stream events = %d, destroyed %v", events, runtime.destroyed)
+	if events != 1 || !runtime.destroyed || !destroyedAtQuiesce {
+		t.Fatalf("stream events = %d, destroyed %v, destroyed at quiesce %v", events, runtime.destroyed, destroyedAtQuiesce)
 	}
 }
 
@@ -499,10 +513,12 @@ func TestGatewayPersistsBeforePublishing(t *testing.T) {
 }
 
 func TestGatewayTaskRunOwnsTerminalEventSideEffects(t *testing.T) {
-	runtime := &blockingGatewayRuntime{started: make(chan struct{}), canceled: make(chan struct{})}
+	runtime := &blockingGatewayRuntime{started: make(chan struct{}), canceled: make(chan struct{}), releaseCancel: make(chan struct{})}
 	store := &gatewayTestStore{instance: gatewayTestInstance()}
-	workflow := &gatewayTestWorkflow{}
-	gateway := New(store, &gatewayTestAuthorizer{}, &gatewayTestDialer{client: gatewayTestClient(t, runtime)}, workflow, gatewayTestURL)
+	quiesced := make(chan struct{})
+	workflow := &gatewayTestWorkflow{onQuiesce: func() { close(quiesced) }}
+	coordinator := &gatewayTestCoordinator{runtimeCoordinator: &memoryRuntimeCoordinator{}, quiescing: make(chan struct{})}
+	gateway := newGateway(store, &gatewayTestAuthorizer{}, &gatewayTestDialer{client: gatewayTestClient(t, runtime)}, workflow, gatewayTestURL, coordinator)
 
 	stream := gateway.SendStreamingMessage(gatewayTestContext(), gatewayTestRequest())
 	streamResult := make(chan a2atype.TaskState, 1)
@@ -544,7 +560,28 @@ func TestGatewayTaskRunOwnsTerminalEventSideEffects(t *testing.T) {
 		t.Fatal("task subscription did not start")
 	}
 
-	canceled, err := gateway.CancelTask(gatewayTestContext(), &a2atype.CancelTaskRequest{ID: task.ID})
+	type cancelResult struct {
+		task *a2atype.Task
+		err  error
+	}
+	cancelResultCh := make(chan cancelResult, 1)
+	go func() {
+		canceled, err := gateway.CancelTask(gatewayTestContext(), &a2atype.CancelTaskRequest{ID: task.ID})
+		cancelResultCh <- cancelResult{task: canceled, err: err}
+	}()
+	select {
+	case <-coordinator.quiescing:
+	case <-time.After(time.Second):
+		t.Fatal("terminal event did not request quiescence")
+	}
+	select {
+	case <-quiesced:
+		t.Fatal("quiescence started before cancellation returned")
+	default:
+	}
+	close(runtime.releaseCancel)
+	result := <-cancelResultCh
+	canceled, err := result.task, result.err
 	if err != nil || canceled.Status.State != a2atype.TaskStateCanceled {
 		t.Fatalf("CancelTask() = %#v, %v", canceled, err)
 	}

--- a/go/core/v2/a2agateway/task_run.go
+++ b/go/core/v2/a2agateway/task_run.go
@@ -76,7 +76,17 @@ func (r *taskRun) ingest(ctx context.Context, instance *apiv1alpha1.AgentInstanc
 			return
 		}
 		updated, err := taskForEvent(task, event)
-		if err == nil {
+		if err == nil && isQuiescent(updated.Status.State) {
+			release := r.gateway.coordinator.Quiesce(instance.GetId())
+			// Quiescence drains ingress; close this terminal stream so it cannot wait on itself.
+			if closeErr := client.Destroy(); closeErr != nil {
+				err = fmt.Errorf("close terminal runtime stream: %w", closeErr)
+			}
+			if err == nil {
+				err = r.gateway.storeEvent(ctx, instance, updated, event)
+			}
+			release()
+		} else if err == nil {
 			err = r.gateway.storeEvent(ctx, instance, updated, event)
 		}
 		if err != nil {

--- a/go/core/v2/agentinstance/workflow.go
+++ b/go/core/v2/agentinstance/workflow.go
@@ -27,6 +27,7 @@ type actorClient interface {
 	EnsureAtespace(context.Context, string) error
 	GetActor(context.Context, string, string) (*ateapipb.Actor, error)
 	CreateActor(context.Context, string, string, string, string) (*ateapipb.Actor, error)
+	CreateActorFromSnapshotTag(context.Context, string, string, string, string, string, string) (*ateapipb.Actor, error)
 	ResumeActor(context.Context, string, string) (*ateapipb.Actor, error)
 	SuspendActor(context.Context, string, string) (*ateapipb.Actor, error)
 	GetActorSnapshot(context.Context, string, string) (*ateapipb.ActorSnapshot, error)
@@ -114,6 +115,51 @@ func (w *ActorWorkflow) Create(ctx context.Context, instance *apiv1alpha1.AgentI
 	instance, err = w.store.MarkAgentInstanceReady(ctx, instance.GetId(), legacysubstrate.ActorHost(atespace, name, ""))
 	if err != nil {
 		return nil, fmt.Errorf("mark AgentInstance ready: %w", err)
+	}
+	return instance, nil
+}
+
+func (w *ActorWorkflow) Fork(ctx context.Context, instance *apiv1alpha1.AgentInstance, checkpoint *dbpkg.AgentInstanceCheckpoint) (*apiv1alpha1.AgentInstance, error) {
+	if instance.GetState() == apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_READY {
+		return instance, nil
+	}
+	if instance.GetState() != apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_CREATING {
+		return nil, fmt.Errorf("AgentInstance %s is not creating", instance.GetId())
+	}
+	revision, err := w.store.GetRuntimeRevision(ctx, instance.GetPreparedRevision())
+	if err != nil {
+		return nil, fmt.Errorf("load prepared revision: %w", err)
+	}
+	atespace, name := instance.GetNamespace(), actorName(instance.GetId())
+	if err := w.actors.EnsureAtespace(ctx, atespace); err != nil {
+		return nil, fmt.Errorf("ensure Atespace %s: %w", atespace, err)
+	}
+	tag := &ateapipb.ObjectRef{Atespace: checkpoint.SnapshotAtespace, Name: "checkpoint-" + checkpoint.ID}
+	actor, err := w.actors.GetActor(ctx, atespace, name)
+	if status.Code(err) == codes.NotFound {
+		actor, err = w.actors.CreateActorFromSnapshotTag(ctx, atespace, name,
+			revision.ActorTemplateNamespace, revision.ActorTemplateName, tag.GetAtespace(), tag.GetName())
+	}
+	if err != nil {
+		return nil, fmt.Errorf("ensure fork Actor %s/%s: %w", atespace, name, err)
+	}
+	if actor.GetActorTemplateNamespace() != revision.ActorTemplateNamespace || actor.GetActorTemplateName() != revision.ActorTemplateName {
+		return nil, fmt.Errorf("actor %s/%s uses unexpected ActorTemplate %s/%s", atespace, name, actor.GetActorTemplateNamespace(), actor.GetActorTemplateName())
+	}
+	if !proto.Equal(actor.GetSourceSnapshotTag(), tag) {
+		return nil, fmt.Errorf("actor %s/%s uses unexpected source snapshot tag", atespace, name)
+	}
+	if actor.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_SUSPENDED {
+		return nil, fmt.Errorf("fork actor %s/%s is not suspended", atespace, name)
+	}
+	source := actor.GetStatus().GetSourceSnapshot()
+	if source.GetSnapshot().GetAtespace() != checkpoint.SnapshotAtespace || source.GetSnapshot().GetName() != checkpoint.SnapshotName ||
+		source.GetSnapshotUid() != checkpoint.SnapshotUID {
+		return nil, fmt.Errorf("actor %s/%s uses unexpected source snapshot", atespace, name)
+	}
+	instance, err = w.store.MarkAgentInstanceReady(ctx, instance.GetId(), legacysubstrate.ActorHost(atespace, name, ""))
+	if err != nil {
+		return nil, fmt.Errorf("mark fork AgentInstance ready: %w", err)
 	}
 	return instance, nil
 }

--- a/go/core/v2/agentinstance/workflow_test.go
+++ b/go/core/v2/agentinstance/workflow_test.go
@@ -75,6 +75,39 @@ func TestActorWorkflowLifecycle(t *testing.T) {
 	}
 }
 
+func TestActorWorkflowForkCreatesSuspendedActorFromCheckpoint(t *testing.T) {
+	instance := &apiv1alpha1.AgentInstance{
+		Id: "fork-1", Namespace: "team-a", PreparedRevision: "revision-1",
+		State: apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_CREATING,
+	}
+	store := &lifecycleTestStore{
+		instance: instance,
+		revision: &dbpkg.RuntimeRevision{
+			Revision: "revision-1", ActorTemplateNamespace: "team-a", ActorTemplateName: "assistant-kagent-revision",
+		},
+	}
+	actors := &lifecycleTestActors{actors: map[string]*ateapipb.Actor{}}
+	checkpoint := &dbpkg.AgentInstanceCheckpoint{
+		ID: "checkpoint-1", SnapshotAtespace: "team-a", SnapshotName: "snapshot-1", SnapshotUID: "snapshot-uid",
+	}
+	fork, err := NewActorWorkflow(store, actors).Fork(context.Background(), instance, checkpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	actor := actors.actors[actorKey("team-a", actorName(instance.GetId()))]
+	if fork.GetState() != apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_READY ||
+		actor.GetStatus().GetState() != ateapipb.ActorState_ACTOR_STATE_SUSPENDED ||
+		actor.GetSourceSnapshotTag().GetName() != "checkpoint-checkpoint-1" {
+		t.Fatalf("fork = %+v, actor = %+v", fork, actor)
+	}
+	instance.State = apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_CREATING
+	store.instance = instance
+	actor.SourceSnapshotTag.Name = "wrong-tag"
+	if _, err := NewActorWorkflow(store, actors).Fork(context.Background(), instance, checkpoint); err == nil {
+		t.Fatal("Fork() accepted an existing Actor with the wrong snapshot tag")
+	}
+}
+
 type lifecycleTestStore struct {
 	instance *apiv1alpha1.AgentInstance
 	revision *dbpkg.RuntimeRevision
@@ -125,6 +158,22 @@ func (a *lifecycleTestActors) CreateActor(_ context.Context, atespace, name, tem
 		Metadata:               &ateapipb.ResourceMetadata{Atespace: atespace, Name: name, Uid: "actor-uid"},
 		ActorTemplateNamespace: templateNamespace, ActorTemplateName: templateName,
 		Status: &ateapipb.ActorStatus{State: ateapipb.ActorState_ACTOR_STATE_SUSPENDED},
+	}
+	a.actors[actorKey(atespace, name)] = actor
+	return actor, nil
+}
+
+func (a *lifecycleTestActors) CreateActorFromSnapshotTag(_ context.Context, atespace, name, templateNamespace, templateName, tagAtespace, tagName string) (*ateapipb.Actor, error) {
+	actor := &ateapipb.Actor{
+		Metadata:               &ateapipb.ResourceMetadata{Atespace: atespace, Name: name, Uid: "actor-uid"},
+		ActorTemplateNamespace: templateNamespace, ActorTemplateName: templateName,
+		SourceSnapshotTag: &ateapipb.ObjectRef{Atespace: tagAtespace, Name: tagName},
+		Status: &ateapipb.ActorStatus{
+			State: ateapipb.ActorState_ACTOR_STATE_SUSPENDED,
+			SourceSnapshot: &ateapipb.ActorSourceSnapshotStatus{
+				Snapshot: &ateapipb.ObjectRef{Atespace: tagAtespace, Name: "snapshot-1"}, SnapshotUid: "snapshot-uid",
+			},
+		},
 	}
 	a.actors[actorKey(atespace, name)] = actor
 	return actor, nil

--- a/go/core/v2/checkpoint/grpc.go
+++ b/go/core/v2/checkpoint/grpc.go
@@ -42,3 +42,8 @@ func (s *grpcServer) DeleteCheckpoint(ctx context.Context, request *apiv1alpha1.
 	err := s.service.Delete(ctx, request.GetNamespace(), request.GetCheckpointId())
 	return &apiv1alpha1.DeleteCheckpointResponse{}, err
 }
+
+func (s *grpcServer) ForkAgentInstance(ctx context.Context, request *apiv1alpha1.ForkAgentInstanceRequest) (*apiv1alpha1.ForkAgentInstanceResponse, error) {
+	instance, err := s.service.Fork(ctx, request.GetNamespace(), request.GetCheckpointId(), request.GetRequestId())
+	return &apiv1alpha1.ForkAgentInstanceResponse{AgentInstance: instance}, err
+}

--- a/go/core/v2/checkpoint/service.go
+++ b/go/core/v2/checkpoint/service.go
@@ -31,6 +31,11 @@ type store interface {
 	ListAgentInstanceCheckpoints(context.Context, string, string, string, string, int) ([]dbpkg.AgentInstanceCheckpoint, error)
 	BeginDeleteAgentInstanceCheckpoint(context.Context, string, string, string) (*dbpkg.AgentInstanceCheckpoint, error)
 	DeleteAgentInstanceCheckpoint(context.Context, string, string, string) error
+	ForkAgentInstance(context.Context, string, string, string, string, string) (*apiv1alpha1.AgentInstance, bool, error)
+}
+
+type workflow interface {
+	Fork(context.Context, *apiv1alpha1.AgentInstance, *dbpkg.AgentInstanceCheckpoint) (*apiv1alpha1.AgentInstance, error)
 }
 
 type tagClient interface {
@@ -44,6 +49,7 @@ type Service struct {
 	store      store
 	authorizer auth.Authorizer
 	tags       tagClient
+	workflow   workflow
 }
 
 type ListRequest struct {
@@ -58,8 +64,8 @@ type ListResult struct {
 	NextPageToken string
 }
 
-func NewService(store store, authorizer auth.Authorizer, tags tagClient) *Service {
-	return &Service{store: store, authorizer: authorizer, tags: tags}
+func NewService(store store, authorizer auth.Authorizer, tags tagClient, workflow workflow) *Service {
+	return &Service{store: store, authorizer: authorizer, tags: tags, workflow: workflow}
 }
 
 func (s *Service) Create(ctx context.Context, namespace, instanceID, requestID string) (*apiv1alpha1.Checkpoint, error) {
@@ -229,6 +235,45 @@ func (s *Service) Delete(ctx context.Context, namespace, checkpointID string) er
 		return serviceerrors.NewInternal("Failed to delete checkpoint", err)
 	}
 	return nil
+}
+
+func (s *Service) Fork(ctx context.Context, namespace, checkpointID, requestID string) (*apiv1alpha1.AgentInstance, error) {
+	if err := validateCreate(namespace, checkpointID, requestID); err != nil {
+		return nil, err
+	}
+	userID, err := s.authorize(ctx, auth.VerbCreate, "AgentInstance", namespace)
+	if err != nil {
+		return nil, err
+	}
+	checkpoint, err := s.store.GetAgentInstanceCheckpoint(ctx, namespace, checkpointID, userID)
+	if errors.Is(err, dbpkg.ErrNotFound) {
+		return nil, serviceerrors.NewNotFound("Checkpoint not found", err)
+	}
+	if err != nil {
+		return nil, serviceerrors.NewInternal("Failed to get checkpoint", err)
+	}
+	if checkpoint.SnapshotContentScope != "DATA" {
+		return nil, serviceerrors.NewFailedPrecondition("Checkpoint includes process state and cannot be forked", nil)
+	}
+	id, err := uuid.NewV7()
+	if err != nil {
+		return nil, serviceerrors.NewInternal("Failed to generate AgentInstance identifier", err)
+	}
+	instance, _, err := s.store.ForkAgentInstance(ctx, namespace, checkpointID, userID, requestID, id.String())
+	if errors.Is(err, dbpkg.ErrIdempotencyConflict) {
+		return nil, serviceerrors.NewAlreadyExists("request_id was already used for a different AgentInstance", err)
+	}
+	if errors.Is(err, dbpkg.ErrNotFound) {
+		return nil, serviceerrors.NewNotFound("Checkpoint not found", err)
+	}
+	if err != nil {
+		return nil, serviceerrors.NewInternal("Failed to reserve fork AgentInstance", err)
+	}
+	instance, err = s.workflow.Fork(ctx, instance, checkpoint)
+	if err != nil {
+		return nil, serviceerrors.NewUnavailable("Failed to create fork AgentInstance", err)
+	}
+	return instance, nil
 }
 
 func (s *Service) authorize(ctx context.Context, verb auth.Verb, resourceType, name string) (string, error) {

--- a/go/core/v2/checkpoint/service_test.go
+++ b/go/core/v2/checkpoint/service_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	dbpkg "github.com/kagent-dev/kagent/go/api/database"
+	apiv1alpha1 "github.com/kagent-dev/kagent/go/api/gen/kagent/api/v1alpha1"
 	"github.com/kagent-dev/kagent/go/core/pkg/auth"
 )
 
@@ -22,6 +23,7 @@ func (testAuthorizer) Check(context.Context, auth.Principal, auth.Verb, auth.Res
 
 type testStore struct {
 	prepared *dbpkg.AgentInstanceCheckpoint
+	forked   *apiv1alpha1.AgentInstance
 	failed   string
 	deleted  bool
 }
@@ -48,8 +50,11 @@ func (s *testStore) FinalizeAgentInstanceCheckpoint(_ context.Context, _ string,
 	return s.prepared, nil
 }
 
-func (*testStore) GetAgentInstanceCheckpoint(context.Context, string, string, string) (*dbpkg.AgentInstanceCheckpoint, error) {
-	return nil, dbpkg.ErrNotFound
+func (s *testStore) GetAgentInstanceCheckpoint(context.Context, string, string, string) (*dbpkg.AgentInstanceCheckpoint, error) {
+	if s.prepared == nil {
+		return nil, dbpkg.ErrNotFound
+	}
+	return s.prepared, nil
 }
 
 func (*testStore) ListAgentInstanceCheckpoints(context.Context, string, string, string, string, int) ([]dbpkg.AgentInstanceCheckpoint, error) {
@@ -67,6 +72,27 @@ func (s *testStore) BeginDeleteAgentInstanceCheckpoint(context.Context, string, 
 func (s *testStore) DeleteAgentInstanceCheckpoint(context.Context, string, string, string) error {
 	s.deleted = true
 	return nil
+}
+
+func (s *testStore) ForkAgentInstance(_ context.Context, namespace, _ string, userID, _ string, instanceID string) (*apiv1alpha1.AgentInstance, bool, error) {
+	if s.forked == nil {
+		s.forked = &apiv1alpha1.AgentInstance{
+			Id: instanceID, Namespace: namespace, Creator: userID,
+			State: apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_CREATING,
+		}
+		return s.forked, true, nil
+	}
+	return s.forked, false, nil
+}
+
+type testWorkflow struct {
+	checkpoint *dbpkg.AgentInstanceCheckpoint
+}
+
+func (w *testWorkflow) Fork(_ context.Context, instance *apiv1alpha1.AgentInstance, checkpoint *dbpkg.AgentInstanceCheckpoint) (*apiv1alpha1.AgentInstance, error) {
+	w.checkpoint = checkpoint
+	instance.State = apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_READY
+	return instance, nil
 }
 
 type testTags struct {
@@ -108,7 +134,7 @@ func (t *testTags) DeleteActorSnapshotTag(context.Context, string, string) error
 func TestCreateTagsRecordedSnapshotBoundary(t *testing.T) {
 	store := &testStore{}
 	tags := &testTags{snapshotUID: "snapshot-uid"}
-	service := NewService(store, testAuthorizer{}, tags)
+	service := NewService(store, testAuthorizer{}, tags, nil)
 	ctx := auth.AuthSessionTo(context.Background(), testSession{userID: "alice"})
 
 	checkpoint, err := service.Create(ctx, "team-a", "018f47a2-4efb-7c21-a848-123456789abc", "request-1")
@@ -126,7 +152,7 @@ func TestCreateTagsRecordedSnapshotBoundary(t *testing.T) {
 func TestCreateCleansTagBeforeFailing(t *testing.T) {
 	store := &testStore{}
 	tags := &testTags{snapshotUID: "snapshot-uid", snapshotUIDAfterCreate: "changed-snapshot-uid"}
-	service := NewService(store, testAuthorizer{}, tags)
+	service := NewService(store, testAuthorizer{}, tags, nil)
 	ctx := auth.AuthSessionTo(context.Background(), testSession{userID: "alice"})
 
 	if _, err := service.Create(ctx, "team-a", "018f47a2-4efb-7c21-a848-123456789abc", "request-1"); err == nil {
@@ -147,7 +173,7 @@ func TestDeleteHidesCheckpointBeforeDeletingTag(t *testing.T) {
 		Metadata: &ateapipb.ResourceMetadata{Atespace: "team-a", Name: tagName(checkpoint.ID), Uid: "tag-uid"},
 		Snapshot: &ateapipb.ObjectRef{Atespace: "team-a", Name: "snapshot-1"},
 	}}
-	service := NewService(store, testAuthorizer{}, tags)
+	service := NewService(store, testAuthorizer{}, tags, nil)
 	ctx := auth.AuthSessionTo(context.Background(), testSession{userID: "alice"})
 
 	if err := service.Delete(ctx, "team-a", checkpoint.ID); err != nil {
@@ -155,5 +181,25 @@ func TestDeleteHidesCheckpointBeforeDeletingTag(t *testing.T) {
 	}
 	if checkpoint.State != "DELETING" || tags.deleteCalls != 1 || !store.deleted {
 		t.Fatalf("checkpoint state = %s, tag deletes = %d, row deleted = %v", checkpoint.State, tags.deleteCalls, store.deleted)
+	}
+}
+
+func TestForkCreatesAgentInstanceFromCheckpoint(t *testing.T) {
+	checkpoint := &dbpkg.AgentInstanceCheckpoint{
+		ID: "018f47a2-4efb-7c21-a848-123456789abc", Namespace: "team-a", UserID: "alice",
+		SnapshotAtespace: "team-a", SnapshotName: "snapshot-1", SnapshotUID: "snapshot-uid", SnapshotContentScope: "DATA", State: "READY",
+	}
+	store := &testStore{prepared: checkpoint}
+	workflow := &testWorkflow{}
+	service := NewService(store, testAuthorizer{}, &testTags{}, workflow)
+	ctx := auth.AuthSessionTo(context.Background(), testSession{userID: "alice"})
+
+	instance, err := service.Fork(ctx, "team-a", checkpoint.ID, "fork-request")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if instance.GetState() != apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_READY ||
+		workflow.checkpoint != checkpoint || store.forked.GetId() == "" {
+		t.Fatalf("fork = %+v, checkpoint = %+v", instance, workflow.checkpoint)
 	}
 }


### PR DESCRIPTION
## Summary

- persist ordered AgentInstance events under durable A2A contexts and reconstruct task history from them
- keep task rows as current-state projections without embedded history
- fork AgentInstances from DATA-only checkpoint snapshot tags
- copy and reidentify bounded A2A events into the fork context
- add database, workflow, service, and end-to-end coverage

## Testing

- `go test ./core/...`
- `make -C go lint`
- `KIND_CLUSTER_NAME=sync-main-0825 KAGENT_E2E_GRPC_TARGET=127.0.0.1:18084 KAGENT_LOCAL_HOST=172.18.0.1 GOFLAGS=-run=TestAgentInstanceCheckpoint make -C go e2e`