### PR TITLE
fix: persist HITL tasks across actor suspension

### DIFF
--- a/go/adk/cmd/main.go
+++ b/go/adk/cmd/main.go
@@ -241,6 +241,7 @@ func main() {
 		ShutdownTimeout: 5 * time.Second,
 		Logger:          logger,
 		Agent:           runnerConfig.Agent,
+		SessionDBURL:    agentConfig.SessionDBURL,
 	}, executor)
 	if err != nil {
 		logger.Error(err, "Failed to create app")

--- a/go/adk/pkg/app/app.go
+++ b/go/adk/pkg/app/app.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-logr/zapr"
 	"github.com/kagent-dev/kagent/go/adk/pkg/a2a"
 	"github.com/kagent-dev/kagent/go/adk/pkg/a2a/server"
+	localtaskstore "github.com/kagent-dev/kagent/go/adk/pkg/taskstore"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	adkagent "google.golang.org/adk/v2/agent"
@@ -55,6 +56,10 @@ type AppConfig struct {
 	// Agent is the ADK agent used to enrich the agent card with skills via
 	// adka2a.BuildAgentSkills. Optional; when nil, the card is used as-is.
 	Agent adkagent.Agent
+
+	// SessionDBURL locates actor-local durable storage. When set, A2A tasks are
+	// persisted beside the ADK session database so HITL tasks survive suspension.
+	SessionDBURL string
 }
 
 // KAgentApp wires an AgentExecutor with kagent's A2A server.
@@ -99,7 +104,17 @@ func New(cfg AppConfig, executor a2asrv.AgentExecutor) (*KAgentApp, error) {
 	log := cfg.Logger
 
 	app := &KAgentApp{logger: log}
-	tasks := a2ataskstore.NewInMemory(&a2ataskstore.InMemoryStoreConfig{Authenticator: a2asrv.NewTaskStoreAuthenticator()})
+	authenticator := a2asrv.NewTaskStoreAuthenticator()
+	var tasks a2ataskstore.Store
+	if cfg.SessionDBURL == "" {
+		tasks = a2ataskstore.NewInMemory(&a2ataskstore.InMemoryStoreConfig{Authenticator: authenticator})
+	} else {
+		var err error
+		tasks, err = localtaskstore.New(cfg.SessionDBURL, authenticator)
+		if err != nil {
+			return nil, fmt.Errorf("open local task store: %w", err)
+		}
+	}
 	handlerOpts := []a2asrv.RequestHandlerOption{a2asrv.WithTaskStore(tasks)}
 
 	// The private runtime receives a gateway-assigned ID for a new task. Seed it

--- a/go/adk/pkg/taskstore/local.go
+++ b/go/adk/pkg/taskstore/local.go
@@ -1,0 +1,260 @@
+package taskstore
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	a2atype "github.com/a2aproject/a2a-go/v2/a2a"
+	a2ataskstore "github.com/a2aproject/a2a-go/v2/a2asrv/taskstore"
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+)
+
+const defaultPageSize = 50
+
+type record struct {
+	ID              string `gorm:"primaryKey"`
+	Task            []byte
+	Version         int64
+	User            string `gorm:"index"`
+	ContextID       string `gorm:"index"`
+	State           string `gorm:"index"`
+	StatusTimestamp *time.Time
+	UpdatedAt       time.Time `gorm:"index"`
+}
+
+type Local struct {
+	db            *gorm.DB
+	authenticator a2ataskstore.Authenticator
+}
+
+var _ a2ataskstore.Store = (*Local)(nil)
+
+func New(sessionDBURL string, authenticator a2ataskstore.Authenticator) (*Local, error) {
+	path, err := pathFromSessionDBURL(sessionDBURL)
+	if err != nil {
+		return nil, err
+	}
+	db, err := gorm.Open(sqlite.Open(path), &gorm.Config{TranslateError: true})
+	if err != nil {
+		return nil, fmt.Errorf("open local task DB %q: %w", path, err)
+	}
+	if err := db.AutoMigrate(&record{}); err != nil {
+		return nil, fmt.Errorf("migrate local task DB %q: %w", path, err)
+	}
+	return &Local{db: db, authenticator: authenticator}, nil
+}
+
+func (s *Local) Create(ctx context.Context, task *a2atype.Task) (a2ataskstore.TaskVersion, error) {
+	if task == nil {
+		return a2ataskstore.TaskVersionMissing, fmt.Errorf("task cannot be nil")
+	}
+	user, err := s.user(ctx)
+	if err != nil {
+		return a2ataskstore.TaskVersionMissing, err
+	}
+	data, err := encode(task)
+	if err != nil {
+		return a2ataskstore.TaskVersionMissing, err
+	}
+	record := recordFromTask(task, data, user, 1)
+	if err := s.db.WithContext(ctx).Create(&record).Error; errors.Is(err, gorm.ErrDuplicatedKey) {
+		return a2ataskstore.TaskVersionMissing, a2ataskstore.ErrTaskAlreadyExists
+	} else if err != nil {
+		return a2ataskstore.TaskVersionMissing, fmt.Errorf("create local task: %w", err)
+	}
+	return 1, nil
+}
+
+func (s *Local) Update(ctx context.Context, req *a2ataskstore.UpdateRequest) (a2ataskstore.TaskVersion, error) {
+	if req == nil || req.Task == nil {
+		return a2ataskstore.TaskVersionMissing, fmt.Errorf("update task cannot be nil")
+	}
+	user, err := s.user(ctx)
+	if err != nil {
+		return a2ataskstore.TaskVersionMissing, err
+	}
+	data, err := encode(req.Task)
+	if err != nil {
+		return a2ataskstore.TaskVersionMissing, err
+	}
+	query := s.db.WithContext(ctx).Model(&record{}).Where("id = ? AND user = ?", req.Task.ID, user)
+	if req.PrevVersion != a2ataskstore.TaskVersionMissing {
+		query = query.Where("version = ?", req.PrevVersion)
+	}
+	result := query.Updates(map[string]any{
+		"task": data, "version": gorm.Expr("version + 1"), "context_id": req.Task.ContextID,
+		"state": req.Task.Status.State, "status_timestamp": req.Task.Status.Timestamp, "updated_at": time.Now(),
+	})
+	if result.Error != nil {
+		return a2ataskstore.TaskVersionMissing, fmt.Errorf("update local task: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		var count int64
+		if err := s.db.WithContext(ctx).Model(&record{}).Where("id = ? AND user = ?", req.Task.ID, user).Count(&count).Error; err != nil {
+			return a2ataskstore.TaskVersionMissing, fmt.Errorf("check local task: %w", err)
+		}
+		if count == 0 {
+			return a2ataskstore.TaskVersionMissing, a2atype.ErrTaskNotFound
+		}
+		return a2ataskstore.TaskVersionMissing, a2ataskstore.ErrConcurrentModification
+	}
+	var stored record
+	if err := s.db.WithContext(ctx).Select("version").First(&stored, "id = ? AND user = ?", req.Task.ID, user).Error; err != nil {
+		return a2ataskstore.TaskVersionMissing, fmt.Errorf("load updated local task: %w", err)
+	}
+	return a2ataskstore.TaskVersion(stored.Version), nil
+}
+
+func (s *Local) Get(ctx context.Context, taskID a2atype.TaskID) (*a2ataskstore.StoredTask, error) {
+	user, err := s.user(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var stored record
+	if err := s.db.WithContext(ctx).First(&stored, "id = ? AND user = ?", taskID, user).Error; errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, a2atype.ErrTaskNotFound
+	} else if err != nil {
+		return nil, fmt.Errorf("load local task: %w", err)
+	}
+	task, err := decode(stored.Task)
+	if err != nil {
+		return nil, err
+	}
+	return &a2ataskstore.StoredTask{Task: task, Version: a2ataskstore.TaskVersion(stored.Version), User: stored.User}, nil
+}
+
+func (s *Local) List(ctx context.Context, req *a2atype.ListTasksRequest) (*a2atype.ListTasksResponse, error) {
+	user, err := s.user(ctx)
+	if err != nil || user == "" {
+		return nil, a2atype.ErrUnauthenticated
+	}
+	pageSize := req.PageSize
+	if pageSize == 0 {
+		pageSize = defaultPageSize
+	} else if pageSize < 1 || pageSize > 100 {
+		return nil, fmt.Errorf("page size must be between 1 and 100 inclusive, got %d: %w", pageSize, a2atype.ErrInvalidRequest)
+	}
+	query := s.db.WithContext(ctx).Model(&record{}).Where("user = ?", user)
+	if req.ContextID != "" {
+		query = query.Where("context_id = ?", req.ContextID)
+	}
+	if req.Status != a2atype.TaskStateUnspecified {
+		query = query.Where("state = ?", req.Status)
+	}
+	if req.StatusTimestampAfter != nil {
+		query = query.Where("status_timestamp IS NULL OR status_timestamp >= ?", req.StatusTimestampAfter)
+	}
+	var total int64
+	if err := query.Count(&total).Error; err != nil {
+		return nil, fmt.Errorf("count local tasks: %w", err)
+	}
+	if req.PageToken != "" {
+		updatedAt, id, err := decodePageToken(req.PageToken)
+		if err != nil {
+			return nil, err
+		}
+		query = query.Where("updated_at < ? OR (updated_at = ? AND id < ?)", updatedAt, updatedAt, id)
+	}
+	var records []record
+	if err := query.Order("updated_at DESC, id DESC").Limit(pageSize + 1).Find(&records).Error; err != nil {
+		return nil, fmt.Errorf("list local tasks: %w", err)
+	}
+	nextPageToken := ""
+	if len(records) > pageSize {
+		last := records[pageSize-1]
+		nextPageToken = encodePageToken(last.UpdatedAt, a2atype.TaskID(last.ID))
+		records = records[:pageSize]
+	}
+	tasks := make([]*a2atype.Task, 0, len(records))
+	for _, record := range records {
+		task, err := decode(record.Task)
+		if err != nil {
+			return nil, err
+		}
+		shape(task, req)
+		tasks = append(tasks, task)
+	}
+	return &a2atype.ListTasksResponse{Tasks: tasks, TotalSize: int(total), PageSize: pageSize, NextPageToken: nextPageToken}, nil
+}
+
+func (s *Local) user(ctx context.Context) (string, error) {
+	user, err := s.authenticator(ctx)
+	if err != nil {
+		return "", fmt.Errorf("taskstore auth failed: %w", err)
+	}
+	return user, nil
+}
+
+func pathFromSessionDBURL(dbURL string) (string, error) {
+	scheme, rest, ok := strings.Cut(dbURL, ":")
+	if !ok || (scheme != "sqlite" && !strings.HasPrefix(scheme, "sqlite+")) {
+		return "", fmt.Errorf("unsupported session DB URL %q: expected sqlite[+driver]:////<path>", dbURL)
+	}
+	path := "/" + strings.TrimLeft(rest, "/")
+	if path == "/" {
+		return "", fmt.Errorf("session DB URL %q has no path", dbURL)
+	}
+	return filepath.Join(filepath.Dir(path), "tasks.db"), nil
+}
+
+func recordFromTask(task *a2atype.Task, data []byte, user string, version int64) record {
+	return record{ID: string(task.ID), Task: data, Version: version, User: user, ContextID: task.ContextID, State: string(task.Status.State), StatusTimestamp: task.Status.Timestamp}
+}
+
+func encode(task *a2atype.Task) ([]byte, error) {
+	data, err := json.Marshal(task)
+	if err != nil {
+		return nil, fmt.Errorf("encode task: %w", err)
+	}
+	return data, nil
+}
+
+func decode(data []byte) (*a2atype.Task, error) {
+	var task a2atype.Task
+	if err := json.Unmarshal(data, &task); err != nil {
+		return nil, fmt.Errorf("decode task: %w", err)
+	}
+	return &task, nil
+}
+
+func shape(task *a2atype.Task, req *a2atype.ListTasksRequest) {
+	historyLength := 100
+	if req.HistoryLength != nil {
+		historyLength = *req.HistoryLength
+	}
+	if historyLength <= 0 {
+		task.History = []*a2atype.Message{}
+	} else if len(task.History) > historyLength {
+		task.History = task.History[len(task.History)-historyLength:]
+	}
+	if !req.IncludeArtifacts {
+		task.Artifacts = nil
+	}
+}
+
+func encodePageToken(updatedAt time.Time, id a2atype.TaskID) string {
+	return base64.URLEncoding.EncodeToString(fmt.Appendf(nil, "%s_%s", updatedAt.Format(time.RFC3339Nano), id))
+}
+
+func decodePageToken(token string) (time.Time, a2atype.TaskID, error) {
+	decoded, err := base64.URLEncoding.DecodeString(token)
+	if err != nil {
+		return time.Time{}, "", a2atype.ErrParseError
+	}
+	timestamp, id, ok := strings.Cut(string(decoded), "_")
+	if !ok {
+		return time.Time{}, "", a2atype.ErrParseError
+	}
+	updatedAt, err := time.Parse(time.RFC3339Nano, timestamp)
+	if err != nil {
+		return time.Time{}, "", a2atype.ErrParseError
+	}
+	return updatedAt, a2atype.TaskID(id), nil
+}

--- a/go/adk/pkg/taskstore/local_test.go
+++ b/go/adk/pkg/taskstore/local_test.go
@@ -2,12 +2,38 @@ package taskstore
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
+	"slices"
 	"testing"
+	"time"
 
 	a2atype "github.com/a2aproject/a2a-go/v2/a2a"
 	a2ataskstore "github.com/a2aproject/a2a-go/v2/a2asrv/taskstore"
 )
+
+func newTestStore(t *testing.T, dbURL, user string) *Local {
+	t.Helper()
+	store, err := New(dbURL, func(context.Context) (string, error) { return user, nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
+func testTask(id, contextID string, state a2atype.TaskState, timestamp *time.Time) *a2atype.Task {
+	return &a2atype.Task{
+		ID:        a2atype.TaskID(id),
+		ContextID: contextID,
+		Status:    a2atype.TaskStatus{State: state, Timestamp: timestamp},
+		History: []*a2atype.Message{
+			{ID: id + "-message-1", Role: a2atype.MessageRoleUser},
+			{ID: id + "-message-2", Role: a2atype.MessageRoleAgent},
+			{ID: id + "-message-3", Role: a2atype.MessageRoleUser},
+		},
+		Artifacts: []*a2atype.Artifact{{ID: a2atype.ArtifactID(id + "-artifact")}},
+	}
+}
 
 func TestLocalPersistsInputRequiredTask(t *testing.T) {
 	dbURL := "sqlite:///" + filepath.Join(t.TempDir(), "sessions.db")
@@ -48,5 +74,199 @@ func TestLocalPersistsInputRequiredTask(t *testing.T) {
 	}
 	if _, err := reopened.Update(context.Background(), &a2ataskstore.UpdateRequest{Task: stored.Task, PrevVersion: stored.Version}); err != a2ataskstore.ErrConcurrentModification {
 		t.Fatalf("stale update error = %v, want %v", err, a2ataskstore.ErrConcurrentModification)
+	}
+}
+
+func TestLocalCreateGet(t *testing.T) {
+	dbURL := "sqlite:///" + filepath.Join(t.TempDir(), "sessions.db")
+	store := newTestStore(t, dbURL, "alice")
+	task := testTask("task", "context", a2atype.TaskStateWorking, nil)
+
+	if _, err := store.Create(t.Context(), task); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Create(t.Context(), task); !errors.Is(err, a2ataskstore.ErrTaskAlreadyExists) {
+		t.Fatalf("duplicate create error = %v, want %v", err, a2ataskstore.ErrTaskAlreadyExists)
+	}
+
+	task.ContextID = "mutated"
+	first, err := store.Get(t.Context(), task.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Task.ContextID != "context" {
+		t.Fatalf("stored context = %q, want context", first.Task.ContextID)
+	}
+	first.Task.ContextID = "also-mutated"
+	second, err := store.Get(t.Context(), task.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Task.ContextID != "context" {
+		t.Fatalf("second get context = %q, want context", second.Task.ContextID)
+	}
+}
+
+func TestLocalAuthenticationErrors(t *testing.T) {
+	want := errors.New("auth unavailable")
+	store, err := New("sqlite:///"+filepath.Join(t.TempDir(), "sessions.db"), func(context.Context) (string, error) {
+		return "", want
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	task := testTask("task", "context", a2atype.TaskStateWorking, nil)
+
+	if _, err := store.Create(t.Context(), task); !errors.Is(err, want) {
+		t.Fatalf("create error = %v, want wrapped %v", err, want)
+	}
+	if _, err := store.Get(t.Context(), task.ID); !errors.Is(err, want) {
+		t.Fatalf("get error = %v, want wrapped %v", err, want)
+	}
+	if _, err := store.List(t.Context(), &a2atype.ListTasksRequest{}); !errors.Is(err, a2atype.ErrUnauthenticated) {
+		t.Fatalf("list error = %v, want %v", err, a2atype.ErrUnauthenticated)
+	}
+}
+
+func TestLocalUpdate(t *testing.T) {
+	dbURL := "sqlite:///" + filepath.Join(t.TempDir(), "sessions.db")
+	store := newTestStore(t, dbURL, "alice")
+	task := testTask("task", "context", a2atype.TaskStateWorking, nil)
+	if _, err := store.Create(t.Context(), task); err != nil {
+		t.Fatal(err)
+	}
+
+	task.Status.State = a2atype.TaskStateCompleted
+	version, err := store.Update(t.Context(), &a2ataskstore.UpdateRequest{Task: task, PrevVersion: a2ataskstore.TaskVersionMissing})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version != 2 {
+		t.Fatalf("updated version = %d, want 2", version)
+	}
+
+	reopened := newTestStore(t, dbURL, "alice")
+	stored, err := reopened.Get(t.Context(), task.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.Version != 2 || stored.Task.Status.State != a2atype.TaskStateCompleted {
+		t.Fatalf("reopened task = (%s, %d), want (%s, 2)", stored.Task.Status.State, stored.Version, a2atype.TaskStateCompleted)
+	}
+
+	missing := testTask("missing", "context", a2atype.TaskStateWorking, nil)
+	if _, err := store.Update(t.Context(), &a2ataskstore.UpdateRequest{Task: missing}); !errors.Is(err, a2atype.ErrTaskNotFound) {
+		t.Fatalf("missing update error = %v, want %v", err, a2atype.ErrTaskNotFound)
+	}
+	otherUser := newTestStore(t, dbURL, "bob")
+	if _, err := otherUser.Update(t.Context(), &a2ataskstore.UpdateRequest{Task: task}); !errors.Is(err, a2atype.ErrTaskNotFound) {
+		t.Fatalf("other-user update error = %v, want %v", err, a2atype.ErrTaskNotFound)
+	}
+}
+
+func TestLocalList(t *testing.T) {
+	dbURL := "sqlite:///" + filepath.Join(t.TempDir(), "sessions.db")
+	alice := newTestStore(t, dbURL, "alice")
+	bob := newTestStore(t, dbURL, "bob")
+	old := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	recent := old.Add(time.Hour)
+	for _, task := range []*a2atype.Task{
+		testTask("recent", "wanted", a2atype.TaskStateInputRequired, &recent),
+		testTask("old", "wanted", a2atype.TaskStateInputRequired, &old),
+		testTask("other-context", "other", a2atype.TaskStateWorking, nil),
+	} {
+		if _, err := alice.Create(t.Context(), task); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := bob.Create(t.Context(), testTask("bob", "wanted", a2atype.TaskStateInputRequired, &recent)); err != nil {
+		t.Fatal(err)
+	}
+
+	historyLength := 2
+	response, err := alice.List(t.Context(), &a2atype.ListTasksRequest{
+		ContextID: "wanted", Status: a2atype.TaskStateInputRequired,
+		StatusTimestampAfter: &recent, HistoryLength: &historyLength,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.TotalSize != 1 || len(response.Tasks) != 1 || response.Tasks[0].ID != "recent" {
+		t.Fatalf("filtered tasks = %v (total %d), want recent", response.Tasks, response.TotalSize)
+	}
+	if len(response.Tasks[0].History) != 2 || response.Tasks[0].History[0].ID != "recent-message-2" {
+		t.Fatalf("shaped history = %v, want last two messages", response.Tasks[0].History)
+	}
+	if response.Tasks[0].Artifacts != nil {
+		t.Fatalf("artifacts = %v, want omitted", response.Tasks[0].Artifacts)
+	}
+
+	withArtifacts, err := alice.List(t.Context(), &a2atype.ListTasksRequest{ContextID: "wanted", IncludeArtifacts: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if withArtifacts.TotalSize != 2 || len(withArtifacts.Tasks[0].Artifacts) != 1 {
+		t.Fatalf("artifact response = %#v, want two owned tasks with artifacts", withArtifacts)
+	}
+
+	var ids []string
+	token := ""
+	for {
+		page, err := alice.List(t.Context(), &a2atype.ListTasksRequest{PageSize: 1, PageToken: token})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if page.TotalSize != 3 || len(page.Tasks) != 1 {
+			t.Fatalf("page = %#v, want one of three owned tasks", page)
+		}
+		ids = append(ids, string(page.Tasks[0].ID))
+		if len(ids) > 3 {
+			t.Fatal("pagination did not terminate")
+		}
+		if page.NextPageToken == "" {
+			break
+		}
+		token = page.NextPageToken
+	}
+	slices.Sort(ids)
+	if !slices.Equal(ids, []string{"old", "other-context", "recent"}) {
+		t.Fatalf("paged IDs = %v", ids)
+	}
+
+	for _, test := range []struct {
+		request *a2atype.ListTasksRequest
+		want    error
+	}{
+		{&a2atype.ListTasksRequest{PageSize: -1}, a2atype.ErrInvalidRequest},
+		{&a2atype.ListTasksRequest{PageSize: 101}, a2atype.ErrInvalidRequest},
+		{&a2atype.ListTasksRequest{PageToken: "invalid"}, a2atype.ErrParseError},
+	} {
+		if _, err := alice.List(t.Context(), test.request); !errors.Is(err, test.want) {
+			t.Fatalf("List(%+v) error = %v, want %v", test.request, err, test.want)
+		}
+	}
+}
+
+func TestPathFromSessionDBURL(t *testing.T) {
+	for _, test := range []struct {
+		url, want string
+	}{
+		{"sqlite:////data/sessions.db", "/data/tasks.db"},
+		{"sqlite:///data/sessions.db", "/data/tasks.db"},
+		{"sqlite+pysqlite:////data/sessions.db", "/data/tasks.db"},
+	} {
+		t.Run(test.url, func(t *testing.T) {
+			got, err := pathFromSessionDBURL(test.url)
+			if err != nil || got != test.want {
+				t.Fatalf("pathFromSessionDBURL(%q) = (%q, %v), want (%q, nil)", test.url, got, err, test.want)
+			}
+		})
+	}
+	for _, url := range []string{"", "postgres:///data/sessions.db", "sqlite://"} {
+		t.Run("invalid_"+url, func(t *testing.T) {
+			if _, err := pathFromSessionDBURL(url); err == nil {
+				t.Fatalf("pathFromSessionDBURL(%q) succeeded, want error", url)
+			}
+		})
 	}
 }

--- a/go/adk/pkg/taskstore/local_test.go
+++ b/go/adk/pkg/taskstore/local_test.go
@@ -1,0 +1,52 @@
+package taskstore
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	a2atype "github.com/a2aproject/a2a-go/v2/a2a"
+	a2ataskstore "github.com/a2aproject/a2a-go/v2/a2asrv/taskstore"
+)
+
+func TestLocalPersistsInputRequiredTask(t *testing.T) {
+	dbURL := "sqlite:///" + filepath.Join(t.TempDir(), "sessions.db")
+	auth := func(context.Context) (string, error) { return "alice", nil }
+	store, err := New(dbURL, auth)
+	if err != nil {
+		t.Fatal(err)
+	}
+	task := a2atype.NewSubmittedTask(&a2atype.Message{ID: "message", ContextID: "context"}, nil)
+	task.Status.State = a2atype.TaskStateInputRequired
+	version, err := store.Create(context.Background(), task)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := New(dbURL, auth)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stored, err := reopened.Get(context.Background(), task.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.Task.Status.State != a2atype.TaskStateInputRequired || stored.Version != version {
+		t.Fatalf("reopened task = (%s, %d), want (%s, %d)", stored.Task.Status.State, stored.Version, a2atype.TaskStateInputRequired, version)
+	}
+	otherUser, err := New(dbURL, func(context.Context) (string, error) { return "bob", nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := otherUser.Get(context.Background(), task.ID); err != a2atype.ErrTaskNotFound {
+		t.Fatalf("other user error = %v, want %v", err, a2atype.ErrTaskNotFound)
+	}
+
+	stored.Task.Status.State = a2atype.TaskStateCompleted
+	if _, err := reopened.Update(context.Background(), &a2ataskstore.UpdateRequest{Task: stored.Task, PrevVersion: stored.Version}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reopened.Update(context.Background(), &a2ataskstore.UpdateRequest{Task: stored.Task, PrevVersion: stored.Version}); err != a2ataskstore.ErrConcurrentModification {
+		t.Fatalf("stale update error = %v, want %v", err, a2ataskstore.ErrConcurrentModification)
+	}
+}

--- a/go/core/test/e2e/interaction_test.go
+++ b/go/core/test/e2e/interaction_test.go
@@ -69,7 +69,7 @@ func TestAgentInstanceAskUserSurvivesSuspension(t *testing.T) {
 	if request == nil {
 		t.Fatal("INPUT_REQUIRED task has no ask_user request")
 	}
-	reply := adka2a.AttachHitlExtension(a2atype.NewMessage(a2atype.MessageRoleUser), &adka2a.AskUserResponse{
+	reply := adka2a.AttachHitlExtension(a2atype.NewMessage(a2atype.MessageRoleUser, a2atype.NewTextPart("PostgreSQL")), &adka2a.AskUserResponse{
 		Type: adka2a.HITLTypeAskUserResponse, ID: request.ID,
 		Answers: []adka2a.AskUserAnswer{{Answer: []string{"PostgreSQL"}}},
 	})

--- a/go/core/test/e2e/interaction_test.go
+++ b/go/core/test/e2e/interaction_test.go
@@ -20,6 +20,7 @@ import (
 	a2apb "github.com/a2aproject/a2a-go/v2/a2apb/v1"
 	"github.com/a2aproject/a2a-go/v2/a2apb/v1/pbconv"
 	"github.com/google/uuid"
+	adka2a "github.com/kagent-dev/kagent/go/adk/pkg/a2a"
 	apiv1alpha1 "github.com/kagent-dev/kagent/go/api/gen/kagent/api/v1alpha1"
 	"github.com/kagent-dev/kagent/go/api/v1alpha3"
 	"github.com/kagent-dev/mockllm"
@@ -54,6 +55,40 @@ func TestAgentInstanceInteraction(t *testing.T) {
 	_, _, task = fixture.send(t, "What is 2+2?")
 	if task.Status.State != a2atype.TaskStateCompleted {
 		t.Fatalf("second A2A task state = %s, want COMPLETED", task.Status.State)
+	}
+}
+
+func TestAgentInstanceAskUserSurvivesSuspension(t *testing.T) {
+	fixture := newInteractionFixture(t, interactionTarget(t), startMockLLM(t, "mocks/invoke_golang_hitl_ask_user.json"))
+	fixture.ctx = metadata.AppendToOutgoingContext(fixture.ctx, strings.ToLower(a2atype.SvcParamExtensions), adka2a.HITLExtensionURI)
+	_, _, waiting := fixture.send(t, "Which database should we use for storage?")
+	if waiting.Status.State != a2atype.TaskStateInputRequired {
+		t.Fatalf("A2A task state = %s, want INPUT_REQUIRED", waiting.Status.State)
+	}
+	request := adka2a.GetAskUserRequest(waiting.Status.Message)
+	if request == nil {
+		t.Fatal("INPUT_REQUIRED task has no ask_user request")
+	}
+	reply := adka2a.AttachHitlExtension(a2atype.NewMessage(a2atype.MessageRoleUser), &adka2a.AskUserResponse{
+		Type: adka2a.HITLTypeAskUserResponse, ID: request.ID,
+		Answers: []adka2a.AskUserAnswer{{Answer: []string{"PostgreSQL"}}},
+	})
+	reply.TaskID, reply.ContextID = waiting.ID, waiting.ContextID
+	encoded, err := pbconv.ToProtoSendMessageRequest(&a2atype.SendMessageRequest{Message: reply})
+	if err != nil {
+		t.Fatal(err)
+	}
+	response, err := fixture.client.SendMessage(fixture.ctx, encoded)
+	if err != nil {
+		t.Fatalf("resume A2A task: %v", err)
+	}
+	result, err := pbconv.FromProtoSendMessageResponse(response)
+	if err != nil {
+		t.Fatal(err)
+	}
+	completed, ok := result.(*a2atype.Task)
+	if !ok || completed.Status.State != a2atype.TaskStateCompleted || !strings.Contains(taskText(completed), "Using PostgreSQL") {
+		t.Fatalf("resumed A2A task = %#v, want completed PostgreSQL response", result)
 	}
 }
 

--- a/go/core/test/e2e/interaction_test.go
+++ b/go/core/test/e2e/interaction_test.go
@@ -38,7 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
-//go:embed mocks/invoke_golang_adk_agent.json mocks/invoke_mcp_agent.json mocks/invoke_shared_agent.json
+//go:embed mocks/invoke_golang_adk_agent.json mocks/invoke_golang_hitl_ask_user.json mocks/invoke_mcp_agent.json mocks/invoke_shared_agent.json
 var interactionMocks embed.FS
 
 // TestAgentInstanceInteraction verifies the complete public interaction path:

--- a/go/core/v2/a2agateway/gateway.go
+++ b/go/core/v2/a2agateway/gateway.go
@@ -257,31 +257,31 @@ func (g *Gateway) CancelTask(ctx context.Context, req *a2atype.CancelTaskRequest
 }
 
 func (g *Gateway) SendMessage(ctx context.Context, req *a2atype.SendMessageRequest) (a2atype.SendMessageResult, error) {
-	instance, submitted, created, err := g.prepareSend(ctx, req)
+	attempt, err := g.prepareSend(ctx, req)
 	if err != nil {
 		return nil, err
 	}
-	if !created {
-		return submitted, nil
+	if !attempt.dispatch {
+		return attempt.task, nil
 	}
-	client, err := g.dialer.Dial(ctx, instance)
+	client, err := g.dialer.Dial(ctx, attempt.instance)
 	if err != nil {
-		g.failTask(ctx, instance.GetId(), submitted)
-		ctrllog.FromContext(ctx).Error(err, "failed to connect to AgentInstance runtime", "instance", instance.GetId())
+		g.failAttempt(ctx, attempt)
+		ctrllog.FromContext(ctx).Error(err, "failed to connect to AgentInstance runtime", "instance", attempt.instance.GetId())
 		return nil, a2atype.NewError(a2atype.ErrInternalError, "failed to connect to AgentInstance runtime")
 	}
 	defer client.Destroy()
 	result, err := client.SendMessage(ctx, req)
 	if err != nil {
-		g.failTask(ctx, instance.GetId(), submitted)
+		g.failAttempt(ctx, attempt)
 		return nil, err
 	}
-	task, err := taskForResult(submitted, result)
+	task, err := taskForResult(attempt.task, result)
 	if err != nil {
-		g.failTask(ctx, instance.GetId(), submitted)
+		g.failAttempt(ctx, attempt)
 		return nil, err
 	}
-	if err := g.storeEvent(ctx, instance, task, result); err != nil {
+	if err := g.storeEvent(ctx, attempt.instance, task, result); err != nil {
 		return nil, g.storeError(ctx, err)
 	}
 	return result, nil
@@ -314,7 +314,7 @@ func (g *Gateway) SubscribeToTask(ctx context.Context, req *a2atype.SubscribeToT
 		ctrllog.FromContext(ctx).Error(err, "failed to connect to AgentInstance runtime", "instance", instance.GetId())
 		return errorEvents(a2atype.NewError(a2atype.ErrInternalError, "failed to connect to AgentInstance runtime"))
 	}
-	run, reader, err := g.startTaskRun(ctx, instance, task, client, client.SubscribeToTask(context.WithoutCancel(ctx), req))
+	run, reader, err := g.startTaskRun(ctx, instance, task, nil, client, client.SubscribeToTask(context.WithoutCancel(ctx), req))
 	if err != nil {
 		_ = client.Destroy()
 		if run, ok := g.taskRun(instance.GetId(), task.ID); ok {
@@ -326,23 +326,23 @@ func (g *Gateway) SubscribeToTask(ctx context.Context, req *a2atype.SubscribeToT
 }
 
 func (g *Gateway) SendStreamingMessage(ctx context.Context, req *a2atype.SendMessageRequest) iter.Seq2[a2atype.Event, error] {
-	instance, submitted, created, err := g.prepareSend(ctx, req)
+	attempt, err := g.prepareSend(ctx, req)
 	if err != nil {
 		return errorEvents(err)
 	}
-	if !created {
-		return func(yield func(a2atype.Event, error) bool) { yield(submitted, nil) }
+	if !attempt.dispatch {
+		return func(yield func(a2atype.Event, error) bool) { yield(attempt.task, nil) }
 	}
-	client, err := g.dialer.Dial(ctx, instance)
+	client, err := g.dialer.Dial(ctx, attempt.instance)
 	if err != nil {
-		g.failTask(ctx, instance.GetId(), submitted)
-		ctrllog.FromContext(ctx).Error(err, "failed to connect to AgentInstance runtime", "instance", instance.GetId())
+		g.failAttempt(ctx, attempt)
+		ctrllog.FromContext(ctx).Error(err, "failed to connect to AgentInstance runtime", "instance", attempt.instance.GetId())
 		return errorEvents(a2atype.NewError(a2atype.ErrInternalError, "failed to connect to AgentInstance runtime"))
 	}
-	run, reader, err := g.startTaskRun(ctx, instance, submitted, client, client.SendStreamingMessage(context.WithoutCancel(ctx), req))
+	run, reader, err := g.startTaskRun(ctx, attempt.instance, attempt.task, attempt.previous, client, client.SendStreamingMessage(context.WithoutCancel(ctx), req))
 	if err != nil {
 		_ = client.Destroy()
-		g.failTask(ctx, instance.GetId(), submitted)
+		g.failAttempt(ctx, attempt)
 		return errorEvents(g.storeError(ctx, err))
 	}
 	return run.observeReader(ctx, nil, reader)
@@ -391,27 +391,38 @@ func (g *Gateway) GetExtendedAgentCard(ctx context.Context, _ *a2atype.GetExtend
 	return card, nil
 }
 
-func (g *Gateway) prepareSend(ctx context.Context, req *a2atype.SendMessageRequest) (*apiv1alpha1.AgentInstance, *a2atype.Task, bool, error) {
-	instance, err := g.instance(ctx, auth.VerbCreate)
+type preparedSend struct {
+	instance *apiv1alpha1.AgentInstance
+	task     *a2atype.Task
+	previous *a2atype.Task
+	dispatch bool
+}
+
+func (g *Gateway) prepareSend(ctx context.Context, req *a2atype.SendMessageRequest) (*preparedSend, error) {
+	verb := auth.VerbCreate
+	if req != nil && req.Message != nil && req.Message.TaskID != "" {
+		verb = auth.VerbUpdate
+	}
+	instance, err := g.instance(ctx, verb)
 	if err != nil {
-		return nil, nil, false, err
+		return nil, err
 	}
 	if req == nil || req.Message == nil {
-		return nil, nil, false, a2atype.NewError(a2atype.ErrInvalidRequest, "message is required")
+		return nil, a2atype.NewError(a2atype.ErrInvalidRequest, "message is required")
 	}
 	if req.Message.ID == "" {
-		return nil, nil, false, a2atype.NewError(a2atype.ErrInvalidRequest, "message ID is required")
+		return nil, a2atype.NewError(a2atype.ErrInvalidRequest, "message ID is required")
 	}
 	if req.Message.ContextID != "" && req.Message.ContextID != instance.GetId() {
-		return nil, nil, false, a2atype.NewError(a2atype.ErrInvalidRequest, "message context does not match AgentInstance")
+		return nil, a2atype.NewError(a2atype.ErrInvalidRequest, "message context does not match AgentInstance")
 	}
 	if req.Message.TaskID != "" {
-		return nil, nil, false, a2atype.NewError(a2atype.ErrUnsupportedOperation, "continuing a task is not supported")
+		return g.prepareReply(ctx, instance, req.Message)
 	}
 	req.Message.ContextID = instance.GetId()
 	requestHash, err := hashSendRequest(req)
 	if err != nil {
-		return nil, nil, false, a2atype.NewError(a2atype.ErrInvalidRequest, "message cannot be encoded")
+		return nil, a2atype.NewError(a2atype.ErrInvalidRequest, "message cannot be encoded")
 	}
 	req.Message.TaskID = a2atype.NewTaskID()
 	submitted := a2atype.NewSubmittedTask(req.Message, req.Message)
@@ -422,9 +433,34 @@ func (g *Gateway) prepareSend(ctx context.Context, req *a2atype.SendMessageReque
 		}
 	}
 	if err != nil {
-		return nil, nil, false, g.storeError(ctx, err)
+		return nil, g.storeError(ctx, err)
 	}
-	return instance, stored, created, nil
+	return &preparedSend{instance: instance, task: stored, dispatch: created}, nil
+}
+
+func (g *Gateway) prepareReply(ctx context.Context, instance *apiv1alpha1.AgentInstance, message *a2atype.Message) (*preparedSend, error) {
+	stored, err := g.store.GetAgentInstanceTask(ctx, instance.GetId(), string(message.TaskID))
+	if errors.Is(err, dbpkg.ErrNotFound) {
+		return nil, a2atype.ErrTaskNotFound
+	}
+	if err != nil {
+		return nil, g.storeError(ctx, err)
+	}
+	if stored.ContextID != instance.GetId() {
+		return nil, a2atype.NewError(a2atype.ErrInvalidRequest, "task context does not match AgentInstance")
+	}
+	if stored.Status.State != a2atype.TaskStateInputRequired && stored.Status.State != a2atype.TaskStateAuthRequired {
+		return nil, a2atype.NewError(a2atype.ErrUnsupportedOperation, "task is not waiting for input")
+	}
+	message.ContextID = stored.ContextID
+	attempt := *stored
+	attempt.History = append(append([]*a2atype.Message{}, stored.History...), message)
+	now := time.Now()
+	attempt.Status = a2atype.TaskStatus{State: a2atype.TaskStateSubmitted, Timestamp: &now}
+	if err := g.store.StoreAgentInstanceTaskEvent(ctx, instance.GetId(), &attempt, message, nil); err != nil {
+		return nil, g.storeError(ctx, err)
+	}
+	return &preparedSend{instance: instance, task: &attempt, previous: stored, dispatch: true}, nil
 }
 
 // reconcileActiveTask frees the task slot only when the runtime authoritatively
@@ -587,6 +623,16 @@ func (g *Gateway) failTask(ctx context.Context, instanceID string, task *a2atype
 	failed.Status = a2atype.TaskStatus{State: a2atype.TaskStateFailed, Timestamp: &now}
 	if err := g.store.StoreAgentInstanceTaskEvent(ctx, instanceID, &failed, &failed, nil); err != nil {
 		ctrllog.FromContext(ctx).Error(err, "failed to record failed AgentInstance task", "task", task.ID)
+	}
+}
+
+func (g *Gateway) failAttempt(ctx context.Context, attempt *preparedSend) {
+	if attempt.previous == nil {
+		g.failTask(ctx, attempt.instance.GetId(), attempt.task)
+		return
+	}
+	if err := g.store.StoreAgentInstanceTaskEvent(ctx, attempt.instance.GetId(), attempt.previous, attempt.previous, nil); err != nil {
+		ctrllog.FromContext(ctx).Error(err, "failed to restore task awaiting input", "task", attempt.task.ID)
 	}
 }
 

--- a/go/core/v2/a2agateway/gateway_test.go
+++ b/go/core/v2/a2agateway/gateway_test.go
@@ -308,6 +308,31 @@ func TestGatewayResolvesAuthenticatedHeadersBeforeSending(t *testing.T) {
 	}
 }
 
+func TestGatewayContinuesInputRequiredTask(t *testing.T) {
+	waiting := &a2atype.Task{
+		ID: "task-1", ContextID: gatewayTestID,
+		Status: a2atype.TaskStatus{State: a2atype.TaskStateInputRequired},
+	}
+	store := &gatewayTestStore{instance: gatewayTestInstance(), task: waiting}
+	runtime := &gatewayTestRuntime{}
+	authorizer := &gatewayTestAuthorizer{}
+	gateway := New(store, authorizer, &gatewayTestDialer{client: gatewayTestClient(t, runtime)}, &gatewayTestWorkflow{}, gatewayTestURL)
+	reply := a2atype.NewMessage(a2atype.MessageRoleUser, a2atype.NewTextPart("PostgreSQL"))
+	reply.TaskID = waiting.ID
+
+	result, err := gateway.SendMessage(gatewayTestContext(), &a2atype.SendMessageRequest{Message: reply})
+	if err != nil {
+		t.Fatal(err)
+	}
+	task, ok := result.(*a2atype.Task)
+	if !ok || task.Status.State != a2atype.TaskStateCompleted || !runtime.sent {
+		t.Fatalf("reply result = %#v, runtime sent = %v", result, runtime.sent)
+	}
+	if authorizer.verb != auth.VerbUpdate || reply.ContextID != gatewayTestID || len(store.stored) != 2 {
+		t.Fatalf("reply authorization = %s, context = %q, stored events = %d", authorizer.verb, reply.ContextID, len(store.stored))
+	}
+}
+
 func TestGatewayClosesRuntimeAfterStreaming(t *testing.T) {
 	instance := gatewayTestInstance()
 	runtime := &gatewayTestRuntime{}

--- a/go/core/v2/a2agateway/task_run.go
+++ b/go/core/v2/a2agateway/task_run.go
@@ -38,7 +38,7 @@ func (g *Gateway) taskRun(instanceID string, taskID a2atype.TaskID) (*taskRun, b
 	return run.(*taskRun), true
 }
 
-func (g *Gateway) startTaskRun(ctx context.Context, instance *apiv1alpha1.AgentInstance, task *a2atype.Task, client *a2aclient.Client, events iter.Seq2[a2atype.Event, error]) (*taskRun, eventqueue.Reader, error) {
+func (g *Gateway) startTaskRun(ctx context.Context, instance *apiv1alpha1.AgentInstance, task, previous *a2atype.Task, client *a2aclient.Client, events iter.Seq2[a2atype.Event, error]) (*taskRun, eventqueue.Reader, error) {
 	key := taskRunKey(instance.GetId(), task.ID)
 	run := &taskRun{gateway: g, key: key, queueID: a2atype.TaskID(key), done: make(chan struct{})}
 	if _, loaded := g.runs.LoadOrStore(key, run); loaded {
@@ -56,11 +56,11 @@ func (g *Gateway) startTaskRun(ctx context.Context, instance *apiv1alpha1.AgentI
 		g.runs.Delete(key)
 		return nil, nil, fmt.Errorf("create task event reader: %w", err)
 	}
-	go run.ingest(context.WithoutCancel(ctx), instance, task, client, writer, events)
+	go run.ingest(context.WithoutCancel(ctx), instance, task, previous, client, writer, events)
 	return run, reader, nil
 }
 
-func (r *taskRun) ingest(ctx context.Context, instance *apiv1alpha1.AgentInstance, task *a2atype.Task, client *a2aclient.Client, writer eventqueue.Writer, events iter.Seq2[a2atype.Event, error]) {
+func (r *taskRun) ingest(ctx context.Context, instance *apiv1alpha1.AgentInstance, task, previous *a2atype.Task, client *a2aclient.Client, writer eventqueue.Writer, events iter.Seq2[a2atype.Event, error]) {
 	defer func() {
 		_ = writer.Close()
 		_ = client.Destroy()
@@ -71,7 +71,7 @@ func (r *taskRun) ingest(ctx context.Context, instance *apiv1alpha1.AgentInstanc
 
 	for event, eventErr := range events {
 		if eventErr != nil {
-			r.gateway.failTask(ctx, instance.GetId(), task)
+			r.gateway.failAttempt(ctx, &preparedSend{instance: instance, task: task, previous: previous})
 			r.setError(eventErr)
 			return
 		}

--- a/go/go.mod
+++ b/go/go.mod
@@ -71,6 +71,7 @@ require (
 	golang.org/x/sync v0.22.0
 	golang.org/x/text v0.41.0
 	google.golang.org/adk/v2 v2.2.0
+	gorm.io/gorm v1.31.2
 	google.golang.org/genai v1.69.0
 	google.golang.org/grpc v1.83.1
 	google.golang.org/protobuf v1.36.12
@@ -458,7 +459,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
-	gorm.io/gorm v1.31.2 // indirect
 	honnef.co/go/tools v0.7.0 // indirect
 	istio.io/api v1.31.0-alpha.1.0.20260819121012-5803fb6accf7 // indirect
 	istio.io/client-go v1.31.0-alpha.0.0.20260807010324-676a810f2c1f // indirect


### PR DESCRIPTION
## Summary

- persist the actor-local A2A task store in `tasks.db` under DurableDir
- resume `INPUT_REQUIRED` and `AUTH_REQUIRED` tasks after actor quiescence while keeping failed replies retryable
- add focused persistence/continuation tests and an `ask_user` suspend-resume E2E

Fixes solo-io/kagent-enterprise#2510

## Testing

- `go test ./adk/... ./core/v2/...`
- `go test ./adk/pkg/taskstore ./adk/pkg/app ./core/v2/a2agateway`
- `go test ./core/test/e2e -run '^$'` (compile check; live E2E requires rebuilt cluster images)