### PR TITLE
feat(core): build the A2A handler in core instead of exposing it to extensions

### DIFF
--- a/go/core/pkg/app/app.go
+++ b/go/core/pkg/app/app.go
@@ -28,7 +28,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/a2aproject/a2a-go/v2/a2asrv"
 	"github.com/gorilla/mux"
 
 	"github.com/hashicorp/go-multierror"
@@ -51,6 +50,7 @@ import (
 	taskservice "github.com/kagent-dev/kagent/go/core/internal/service/task"
 	toolservice "github.com/kagent-dev/kagent/go/core/internal/service/tool"
 	common "github.com/kagent-dev/kagent/go/core/internal/utils"
+	"github.com/kagent-dev/kagent/go/core/v2/a2agateway"
 	"github.com/kagent-dev/kagent/go/core/v2/agentinstance"
 	v2controller "github.com/kagent-dev/kagent/go/core/v2/controller"
 
@@ -132,7 +132,7 @@ type Config struct {
 	DefaultModelConfig types.NamespacedName
 	HttpServerAddr     string
 	WatchNamespaces    string
-	A2ABaseUrl         string
+	A2AGatewayUrl      string
 	GRPC               struct {
 		BindAddress     string
 		MaxMessageBytes int
@@ -198,7 +198,7 @@ func (cfg *Config) SetFlags(commandLine *flag.FlagSet) {
 	commandLine.BoolVar(&cfg.GRPC.Reflection, "grpc-reflection", false, "Enable gRPC server reflection.")
 	commandLine.StringVar(&cfg.GRPC.TLSCertFile, "grpc-tls-cert-file", "", "Path to the optional gRPC server TLS certificate.")
 	commandLine.StringVar(&cfg.GRPC.TLSKeyFile, "grpc-tls-key-file", "", "Path to the optional gRPC server TLS private key.")
-	commandLine.StringVar(&cfg.A2ABaseUrl, "a2a-base-url", "http://127.0.0.1:8083", "The base URL of the A2A Server endpoint, as advertised to clients.")
+	commandLine.StringVar(&cfg.A2AGatewayUrl, "a2a-gateway-url", "http://127.0.0.1:8084", "The A2A gateway's gRPC endpoint, advertised to clients in agent cards. Agents are reachable only through the gateway, which is served by the gRPC listener.")
 	commandLine.StringVar(&cfg.Database.Url, "postgres-database-url", "postgres://postgres:kagent@kagent-postgresql.kagent.svc.cluster.local:5432/postgres", "The URL of the PostgreSQL database.")
 	commandLine.StringVar(&cfg.Database.UrlFile, "postgres-database-url-file", "", "Path to a file containing the PostgreSQL database URL. Takes precedence over --postgres-database-url.")
 	commandLine.BoolVar(&cfg.Database.VectorEnabled, "database-vector-enabled", true, "Enable pgvector extension and memory table. Requires pgvector to be installed on the PostgreSQL server.")
@@ -222,7 +222,7 @@ func (cfg *Config) SetFlags(commandLine *flag.FlagSet) {
 	commandLine.StringVar(&cfg.Substrate.AteAPIEndpoint, "substrate-ate-api-endpoint", "", "gRPC target for Agent Substrate ate-api (e.g. dns:///api.ate-system.svc:443).")
 	commandLine.StringVar(&cfg.Substrate.AteAPICAFile, "substrate-ate-api-ca-file", "", "Path to the CA certificates used to verify ate-api.")
 	commandLine.StringVar(&cfg.Substrate.AteAPIClientCertFile, "substrate-ate-api-client-cert-file", "", "Path to the PEM client certificate and private key used for ate-api mTLS.")
-	commandLine.StringVar(&cfg.Substrate.AtenetRouterURL, "substrate-atenet-router-url", "", "HTTP URL for Substrate atenet-router (Envoy). Defaults to http://atenet-router.ate-system.svc:80 when unset.")
+	commandLine.StringVar(&cfg.Substrate.AtenetRouterURL, "substrate-atenet-router-url", substrate.DefaultAtenetRouterURL, "HTTP URL for Substrate atenet-router (Envoy). Substrate is required; NewRuntimeDialer rejects an empty value at startup.")
 	commandLine.DurationVar(&cfg.Substrate.DialTimeout, "substrate-dial-timeout", 10*time.Second, "Timeout for the initial dial to ate-api.")
 	commandLine.DurationVar(&cfg.Substrate.CallTimeout, "substrate-call-timeout", 30*time.Second, "Per-RPC timeout for ate-api calls.")
 	commandLine.StringVar(&cfg.Substrate.DefaultWorkerPoolNamespace, "substrate-default-workerpool-namespace", kagentNamespace, "Default Agent Substrate WorkerPool namespace when spec.substrate.workerPoolRef is unset.")
@@ -287,13 +287,6 @@ type ExtensionConfig struct {
 	Authenticator    auth.AuthProvider
 	Authorizer       auth.Authorizer
 	MCPServerPlugins []translator.MCPTranslatorPlugin
-	// A2AHandler serves the A2A API. grpcserver registers that service only
-	// when this is non-nil, so leaving it unset keeps today's behaviour: the
-	// AgentInstance API is available but nothing can talk to an instance.
-	//
-	// An extension can build one with a2agateway.New, using the DbClient it is
-	// handed in BootstrapConfig.
-	A2AHandler a2asrv.RequestHandler
 }
 
 type GetExtensionConfig func(bootstrap BootstrapConfig) (*ExtensionConfig, error)
@@ -610,6 +603,24 @@ func Start(getExtensionConfig GetExtensionConfig, extraSources []migrations.Sour
 		os.Exit(1)
 	}
 
+	// The A2A gateway is assembled here rather than by an extension: every input is
+	// already in scope, and two of them -- the authenticator and the authorizer --
+	// are extension-supplied policy. Building it here is what gates A2A behind the
+	// same auth as every other gRPC method, instead of whatever an embedder happens
+	// to construct for itself.
+	gatewayDialer, err := a2agateway.NewRuntimeDialer(cfg.Substrate.AtenetRouterURL, extensionCfg.Authenticator)
+	if err != nil {
+		setupLog.Error(err, "unable to create A2A runtime dialer")
+		os.Exit(1)
+	}
+	a2aGatewayHandler := a2agateway.New(
+		dbClient,
+		extensionCfg.Authorizer,
+		gatewayDialer,
+		instanceWorkflow,
+		cfg.A2AGatewayUrl,
+	)
+
 	grpcServer, err := grpcserver.New(grpcserver.Config{
 		BindAddress:           cfg.GRPC.BindAddress,
 		MaxMessageBytes:       cfg.GRPC.MaxMessageBytes,
@@ -629,7 +640,7 @@ func Start(getExtensionConfig GetExtensionConfig, extraSources []migrations.Sour
 		SessionService:        sessionService,
 		TaskService:           taskService,
 		AgentInstanceService:  agentInstanceService,
-		A2AHandler:            extensionCfg.A2AHandler,
+		A2AHandler:            a2aGatewayHandler,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to create gRPC server")

--- a/go/core/pkg/app/app_test.go
+++ b/go/core/pkg/app/app_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kagent-dev/kagent/go/core/pkg/sandboxbackend/substrate"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -350,7 +351,7 @@ func TestLoadFromEnvIntegration(t *testing.T) {
 		"GRPC_BIND_ADDRESS":              ":9001",
 		"GRPC_MAX_MESSAGE_BYTES":         "1048576",
 		"GRPC_REFLECTION":                "true",
-		"A2A_BASE_URL":                   "http://example.com:9000",
+		"A2A_GATEWAY_URL":                "http://example.com:9000",
 		"PROXY_URL":                      "http://proxy.kagent.svc.cluster.local:8080",
 		"POSTGRES_DATABASE_URL":          "postgres://localhost:5432/testdb",
 		"WATCH_NAMESPACES":               "ns1,ns2,ns3",
@@ -405,13 +406,38 @@ func TestLoadFromEnvIntegration(t *testing.T) {
 	if cfg.Proxy.URL != "http://proxy.kagent.svc.cluster.local:8080" {
 		t.Errorf("Proxy.URL = %v, want http://proxy.kagent.svc.cluster.local:8080", cfg.Proxy.URL)
 	}
-	if cfg.A2ABaseUrl != "http://example.com:9000" {
-		t.Errorf("A2ABaseUrl = %v, want http://example.com:9000", cfg.A2ABaseUrl)
+	if cfg.A2AGatewayUrl != "http://example.com:9000" {
+		t.Errorf("A2AGatewayUrl = %v, want http://example.com:9000", cfg.A2AGatewayUrl)
 	}
 	if cfg.Database.Url != "postgres://localhost:5432/testdb" {
 		t.Errorf("Database.Url = %v, want postgres://localhost:5432/testdb", cfg.Database.Url)
 	}
 	if cfg.WatchNamespaces != "ns1,ns2,ns3" {
 		t.Errorf("WatchNamespaces = %v, want ns1,ns2,ns3", cfg.WatchNamespaces)
+	}
+}
+
+// The atenet-router URL used to default to "", which callers resolved to
+// DefaultAtenetRouterURL themselves. Substrate is required, so the flag carries
+// the real default and an empty value fails when the dialer is built.
+func TestSubstrateAtenetRouterURLFlag(t *testing.T) {
+	var cfg Config
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	cfg.SetFlags(fs)
+
+	if err := fs.Parse(nil); err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if cfg.Substrate.AtenetRouterURL != substrate.DefaultAtenetRouterURL {
+		t.Errorf("Substrate.AtenetRouterURL = %q, want %q",
+			cfg.Substrate.AtenetRouterURL, substrate.DefaultAtenetRouterURL)
+	}
+
+	if err := fs.Parse([]string{"-substrate-atenet-router-url=http://router.example:80"}); err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if cfg.Substrate.AtenetRouterURL != "http://router.example:80" {
+		t.Errorf("Substrate.AtenetRouterURL = %q, want http://router.example:80",
+			cfg.Substrate.AtenetRouterURL)
 	}
 }

--- a/helm/kagent/templates/_helpers.tpl
+++ b/helm/kagent/templates/_helpers.tpl
@@ -249,14 +249,6 @@ Password secret name - returns the chart-managed Secret name for POSTGRES_PASSWO
 A2A Base URL - computes the default URL based on the controller service name if not explicitly set.
 The `name.namespace.svc` short form is used so the URL resolves regardless of the cluster's DNS domain.
 */}}
-{{- define "kagent.a2aBaseUrl" -}}
-{{- if .Values.controller.a2aBaseUrl -}}
-{{- .Values.controller.a2aBaseUrl -}}
-{{- else -}}
-{{- printf "http://%s-controller.%s.svc:%d" (include "kagent.fullname" .) (include "kagent.namespace" .) (.Values.controller.service.ports.port | int) -}}
-{{- end -}}
-{{- end -}}
-
 {{/* Public gRPC endpoint advertised by AgentInstance Agent Cards. */}}
 {{- define "kagent.a2aGatewayUrl" -}}
 {{- if .Values.controller.a2aGatewayUrl -}}

--- a/helm/kagent/templates/controller-configmap.yaml
+++ b/helm/kagent/templates/controller-configmap.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "kagent.controller.labels" . | nindent 4 }}
 data:
-  A2A_BASE_URL: {{ include "kagent.a2aBaseUrl" . | quote }}
   A2A_GATEWAY_URL: {{ include "kagent.a2aGatewayUrl" . | quote }}
   DEFAULT_MODEL_CONFIG_NAME: {{ include "kagent.defaultModelConfigName" . | quote }}
   KAGENT_CONTROLLER_NAME: {{ include "kagent.fullname" . }}-controller

--- a/helm/kagent/tests/controller-deployment_test.yaml
+++ b/helm/kagent/tests/controller-deployment_test.yaml
@@ -176,23 +176,6 @@ tests:
           path: spec.template.spec.containers[0].volumeMounts[1].mountPath
           value: /run/substrate-podidentity
 
-  - it: should set A2A_BASE_URL with computed default value
-    template: controller-configmap.yaml
-    asserts:
-      - equal:
-          path: data.A2A_BASE_URL
-          value: "http://RELEASE-NAME-controller.NAMESPACE.svc:8083"
-
-  - it: should set A2A_BASE_URL with custom value when explicitly set
-    template: controller-configmap.yaml
-    set:
-      controller:
-        a2aBaseUrl: "https://kagent.example.com"
-    asserts:
-      - equal:
-          path: data.A2A_BASE_URL
-          value: "https://kagent.example.com"
-
   - it: should set A2A_GATEWAY_URL with computed default value
     template: controller-configmap.yaml
     asserts:

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -187,9 +187,6 @@ controller:
     # JWT claim for user identity (default: "sub")
     # Override only if your OIDC provider uses a different claim
     userIdClaim: ""
-  # -- The base URL of the A2A Server endpoint, as advertised to clients.
-  # @default -- `http://<fullname>-controller.<namespace>.svc:<port>`
-  a2aBaseUrl: ""
   # -- Public gRPC URL advertised by AgentInstance Agent Cards.
   # @default -- `http://<fullname>-controller.<namespace>.svc:<grpc-port>`
   a2aGatewayUrl: ""


### PR DESCRIPTION
The A2A gateway should not be injectable. It is a core component, not a policy
decision, and the only parts of it an extension should influence are the ones it
already supplies through pluggable interfaces: `Authenticator` and `Authorizer`.

Today `ExtensionConfig.A2AHandler` inverts that — the one gRPC service that reaches
agent runtimes gets whatever auth the embedder assembles for it, separately from the
authenticator and authorizer it hands core for every other method. Everything
`a2agateway.New` needs is already in scope in `Start`, so build it there and drop the
field.

Existing deployments are unaffected. `build-controller` builds controller-v2, which
sets `A2AHandler` on `grpcserver.Config` directly and never reads `ExtensionConfig`,
and the config that drives the gateway — `A2A_GATEWAY_URL` and
`controller.a2aGatewayUrl` — is unchanged. Only embedders of `app.Start` need a code
change.

## Breaking changes

- **`ExtensionConfig.A2AHandler` removed** — core builds the handler from the
  authenticator and authorizer embedders already supply.
- **`-a2a-base-url` → `-a2a-gateway-url`** — different endpoints. `a2a-base-url` named
  the HTTP server on `:8083` and has been dead config since #2565; the gateway URL is
  published in agent cards as the agent's *gRPC* interface and must address `:8084`.
  The new flag matches the `A2A_GATEWAY_URL` env var and `controller.a2aGatewayUrl`
  chart value already in use, so deployments need no change.
- **`-substrate-atenet-router-url` defaults to `DefaultAtenetRouterURL`** instead of
  `""`, which never meant "substrate absent". `NewRuntimeDialer` rejects an empty value
  at startup.

A stale `A2A_BASE_URL` env var is silently ignored, but a stale `-a2a-base-url`
*argument* is a hard startup failure, since `flag` rejects unknown flags. The chart
configures by env, not args.

## Testing

`go build`, `go vet`, `go test` clean. Chart suite 268/272 — the 4 failures are
`kagent-tools` subchart tests that fail identically on a clean checkout. Verified end to
end in kind with Substrate against a downstream embedder of `app.Start`:
`CreateAgentInstance`, `SendMessage`, `DeleteAgentInstance` all `OK`, agent reached
through the gateway and atenet router, no auth errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)