### PR TITLE
feat: expose checkpoint workflows through MCP

### DIFF
--- a/go/core/cmd/controller-v2/main.go
+++ b/go/core/cmd/controller-v2/main.go
@@ -130,7 +130,7 @@ func main() {
 	}
 	gateway := a2agateway.New(store, authorizer, gatewayDialer, instanceWorkflow,
 		env("A2A_GATEWAY_URL", "http://127.0.0.1:8084"))
-	mcpHandler, err := v2mcp.New(instances, gateway)
+	mcpHandler, err := v2mcp.New(instances, checkpoints, gateway)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/go/core/test/e2e/mcp_test.go
+++ b/go/core/test/e2e/mcp_test.go
@@ -2,6 +2,7 @@ package e2e_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net"
@@ -12,7 +13,11 @@ import (
 
 	a2atype "github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/a2aproject/a2a-go/v2/a2apb/v1/pbconv"
+	apiv1alpha1 "github.com/kagent-dev/kagent/go/api/gen/kagent/api/v1alpha1"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -101,6 +106,54 @@ func TestMCPCancelTask(t *testing.T) {
 	}
 	mcpCall(t, endpoint, "tasks/cancel", map[string]any{"taskId": handle}, true)
 	waitMCPTask(t, endpoint, handle, "cancelled")
+}
+
+func TestMCPCheckpointFork(t *testing.T) {
+	fixture := newInteractionFixture(t, interactionTarget(t), startInteractionMock(t))
+	endpoint := mcpEndpoint(t)
+	if result := mcpInvoke(t, endpoint, fixture.instanceID, "What is 2+2?", false); result["resultType"] != "complete" {
+		t.Fatalf("initial invocation = %#v", result)
+	}
+
+	created := mcpCall(t, endpoint, "tools/call", map[string]any{
+		"name":      "create_agent_instance_checkpoint",
+		"arguments": map[string]any{"namespace": "kagent", "agent_instance_id": fixture.instanceID},
+	}, false)["result"].(map[string]any)["structuredContent"].(map[string]any)["checkpoint"].(map[string]any)
+	checkpointID := created["id"].(string)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(metadata.AppendToOutgoingContext(context.Background(), "x-user-id", "e2e"), time.Minute)
+		defer cancel()
+		_, err := fixture.checkpoints.DeleteCheckpoint(ctx, &apiv1alpha1.DeleteCheckpointRequest{Namespace: "kagent", CheckpointId: checkpointID})
+		if err != nil && status.Code(err) != codes.NotFound {
+			t.Errorf("delete checkpoint: %v", err)
+		}
+	})
+
+	listed := mcpCall(t, endpoint, "tools/call", map[string]any{
+		"name":      "list_agent_instance_checkpoints",
+		"arguments": map[string]any{"namespace": "kagent", "agent_instance_id": fixture.instanceID},
+	}, false)["result"].(map[string]any)["structuredContent"].(map[string]any)["checkpoints"].([]any)
+	if len(listed) != 1 || listed[0].(map[string]any)["id"] != checkpointID {
+		t.Fatalf("listed checkpoints = %#v", listed)
+	}
+
+	forked := mcpCall(t, endpoint, "tools/call", map[string]any{
+		"name":      "fork_agent_instance",
+		"arguments": map[string]any{"namespace": "kagent", "checkpoint_id": checkpointID},
+	}, false)["result"].(map[string]any)["structuredContent"].(map[string]any)["agent_instance"].(map[string]any)
+	forkID := forked["id"].(string)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(metadata.AppendToOutgoingContext(context.Background(), "x-user-id", "e2e"), time.Minute)
+		defer cancel()
+		_, err := fixture.instances.DeleteAgentInstance(ctx, &apiv1alpha1.DeleteAgentInstanceRequest{Namespace: "kagent", AgentInstanceId: forkID})
+		if err != nil && status.Code(err) != codes.NotFound {
+			t.Errorf("delete fork AgentInstance: %v", err)
+		}
+	})
+
+	if result := mcpInvoke(t, endpoint, forkID, "What is 2+2?", false); !strings.Contains(mcpResultText(result), "The answer is 4.") {
+		t.Fatalf("fork invocation = %#v", result)
+	}
 }
 
 func mcpEndpoint(t *testing.T) string {

--- a/go/core/v2/mcp/checkpoints.go
+++ b/go/core/v2/mcp/checkpoints.go
@@ -1,0 +1,134 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	apiv1alpha1 "github.com/kagent-dev/kagent/go/api/gen/kagent/api/v1alpha1"
+	"github.com/kagent-dev/kagent/go/core/v2/checkpoint"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const (
+	createCheckpointToolName  = "create_agent_instance_checkpoint"
+	listCheckpointsToolName   = "list_agent_instance_checkpoints"
+	forkAgentInstanceToolName = "fork_agent_instance"
+)
+
+type CreateCheckpointInput struct {
+	Namespace       string `json:"namespace" jsonschema:"Kubernetes namespace containing the AgentInstance"`
+	AgentInstanceID string `json:"agent_instance_id" jsonschema:"AgentInstance UUID"`
+	RequestID       string `json:"request_id,omitempty" jsonschema:"Optional stable request ID for idempotency"`
+}
+
+type CheckpointSummary struct {
+	ID              string          `json:"id"`
+	Namespace       string          `json:"namespace"`
+	AgentInstanceID string          `json:"agent_instance_id"`
+	HeadTaskID      string          `json:"head_task_id,omitempty"`
+	HistorySequence uint64          `json:"history_sequence"`
+	State           string          `json:"state"`
+	CreatedAt       string          `json:"created_at,omitempty"`
+	Failure         *FailureSummary `json:"failure,omitempty"`
+}
+
+type FailureSummary struct {
+	Reason  string `json:"reason"`
+	Message string `json:"message"`
+}
+
+type CreateCheckpointOutput struct {
+	Checkpoint CheckpointSummary `json:"checkpoint"`
+}
+
+type ListCheckpointsInput struct {
+	Namespace       string `json:"namespace" jsonschema:"Kubernetes namespace containing the AgentInstance"`
+	AgentInstanceID string `json:"agent_instance_id" jsonschema:"AgentInstance UUID"`
+	PageSize        int    `json:"page_size,omitempty" jsonschema:"Maximum number of checkpoints to return"`
+	PageToken       string `json:"page_token,omitempty" jsonschema:"Token returned by a previous call"`
+}
+
+type ListCheckpointsOutput struct {
+	Checkpoints   []CheckpointSummary `json:"checkpoints"`
+	NextPageToken string              `json:"next_page_token,omitempty"`
+}
+
+type ForkAgentInstanceInput struct {
+	Namespace    string `json:"namespace" jsonschema:"Kubernetes namespace containing the checkpoint"`
+	CheckpointID string `json:"checkpoint_id" jsonschema:"Checkpoint UUID"`
+	RequestID    string `json:"request_id,omitempty" jsonschema:"Optional stable request ID for idempotency"`
+}
+
+type ForkAgentInstanceOutput struct {
+	AgentInstance AgentInstanceSummary `json:"agent_instance"`
+}
+
+func (h *Handler) registerCheckpointTools(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{Name: createCheckpointToolName, Description: "Create a checkpoint at an AgentInstance turn boundary"}, h.createCheckpoint)
+	mcp.AddTool(server, &mcp.Tool{Name: listCheckpointsToolName, Description: "List checkpoints for an AgentInstance"}, h.listCheckpoints)
+	mcp.AddTool(server, &mcp.Tool{Name: forkAgentInstanceToolName, Description: "Create an AgentInstance from a checkpoint"}, h.forkAgentInstance)
+}
+
+func (h *Handler) createCheckpoint(ctx context.Context, _ *mcp.CallToolRequest, input CreateCheckpointInput) (*mcp.CallToolResult, CreateCheckpointOutput, error) {
+	created, err := h.checkpoints.Create(ctx, input.Namespace, input.AgentInstanceID, stableRequestID(input.RequestID))
+	if err != nil {
+		return toolError(err), CreateCheckpointOutput{}, nil
+	}
+	output := CreateCheckpointOutput{Checkpoint: checkpointSummary(created)}
+	return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Created checkpoint %s", created.GetId())}}}, output, nil
+}
+
+func (h *Handler) listCheckpoints(ctx context.Context, _ *mcp.CallToolRequest, input ListCheckpointsInput) (*mcp.CallToolResult, ListCheckpointsOutput, error) {
+	listed, err := h.checkpoints.List(ctx, checkpoint.ListRequest{
+		Namespace: input.Namespace, InstanceID: input.AgentInstanceID,
+		PageSize: input.PageSize, PageToken: input.PageToken,
+	})
+	if err != nil {
+		return toolError(err), ListCheckpointsOutput{}, nil
+	}
+	output := ListCheckpointsOutput{Checkpoints: make([]CheckpointSummary, len(listed.Checkpoints)), NextPageToken: listed.NextPageToken}
+	for i, item := range listed.Checkpoints {
+		output.Checkpoints[i] = checkpointSummary(item)
+	}
+	return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Found %d checkpoints", len(output.Checkpoints))}}}, output, nil
+}
+
+func (h *Handler) forkAgentInstance(ctx context.Context, _ *mcp.CallToolRequest, input ForkAgentInstanceInput) (*mcp.CallToolResult, ForkAgentInstanceOutput, error) {
+	instance, err := h.checkpoints.Fork(ctx, input.Namespace, input.CheckpointID, stableRequestID(input.RequestID))
+	if err != nil {
+		return toolError(err), ForkAgentInstanceOutput{}, nil
+	}
+	output := ForkAgentInstanceOutput{AgentInstance: agentInstanceSummary(instance)}
+	return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Created AgentInstance %s", instance.GetId())}}}, output, nil
+}
+
+func stableRequestID(id string) string {
+	if id != "" {
+		return id
+	}
+	return uuid.NewString()
+}
+
+func checkpointSummary(value *apiv1alpha1.Checkpoint) CheckpointSummary {
+	result := CheckpointSummary{
+		ID: value.GetId(), Namespace: value.GetNamespace(), AgentInstanceID: value.GetAgentInstanceId(),
+		HeadTaskID: value.GetHeadTaskId(), HistorySequence: value.GetHistorySequence(), State: value.GetState().String(),
+	}
+	if value.GetCreatedAt() != nil {
+		result.CreatedAt = value.GetCreatedAt().AsTime().Format(time.RFC3339Nano)
+	}
+	if value.GetFailure() != nil {
+		result.Failure = &FailureSummary{Reason: value.GetFailure().GetReason(), Message: value.GetFailure().GetMessage()}
+	}
+	return result
+}
+
+func agentInstanceSummary(instance *apiv1alpha1.AgentInstance) AgentInstanceSummary {
+	return AgentInstanceSummary{
+		Namespace: instance.GetNamespace(), ID: instance.GetId(),
+		AgentTemplate: instance.GetAgentTemplate().GetName(), Harness: instance.GetHarness().GetName(),
+		State: instance.GetState().String(),
+	}
+}

--- a/go/core/v2/mcp/checkpoints_test.go
+++ b/go/core/v2/mcp/checkpoints_test.go
@@ -1,0 +1,66 @@
+package mcp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/a2aproject/a2a-go/v2/a2asrv"
+	apiv1alpha1 "github.com/kagent-dev/kagent/go/api/gen/kagent/api/v1alpha1"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestCheckpointSummary(t *testing.T) {
+	created := time.Date(2026, time.August, 26, 10, 0, 0, 123, time.UTC)
+	got := checkpointSummary(&apiv1alpha1.Checkpoint{
+		Id: "22222222-2222-4222-8222-222222222222", Namespace: "team-a",
+		AgentInstanceId: testInstanceID, HeadTaskId: testTaskID, HistorySequence: 7,
+		State: apiv1alpha1.CheckpointState_CHECKPOINT_STATE_READY, CreatedAt: timestamppb.New(created),
+		Failure: &apiv1alpha1.Failure{Message: "failed"},
+	})
+	if got.ID != "22222222-2222-4222-8222-222222222222" || got.AgentInstanceID != testInstanceID ||
+		got.HistorySequence != 7 || got.State != "CHECKPOINT_STATE_READY" || got.CreatedAt != created.Format(time.RFC3339Nano) || got.Failure.Message != "failed" {
+		t.Fatalf("checkpointSummary() = %#v", got)
+	}
+}
+
+func TestCheckpointToolsAreRegistered(t *testing.T) {
+	h, err := New(testAgentInstanceService(), testCheckpointService(), &a2asrv.InterceptedHandler{Handler: &fakeGateway{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(h.ServeHTTP))
+	defer server.Close()
+	response := rawMCPCall(t, server.URL, "tools/list", map[string]any{}, false)
+	tools := response["result"].(map[string]any)["tools"].([]any)
+	want := map[string]bool{createCheckpointToolName: false, listCheckpointsToolName: false, forkAgentInstanceToolName: false}
+	for _, value := range tools {
+		tool := value.(map[string]any)
+		if _, ok := want[tool["name"].(string)]; ok {
+			want[tool["name"].(string)] = len(tool["inputSchema"].(map[string]any)["properties"].(map[string]any)) > 0
+		}
+	}
+	for name, valid := range want {
+		if !valid {
+			t.Fatalf("tool %q missing or has no input schema: %#v", name, tools)
+		}
+	}
+}
+
+func TestCheckpointToolErrorsAreToolResults(t *testing.T) {
+	h := &Handler{checkpoints: testCheckpointService()}
+	result, _, err := h.createCheckpoint(t.Context(), nil, CreateCheckpointInput{Namespace: "team-a", AgentInstanceID: "invalid"})
+	if err != nil || !result.IsError {
+		t.Fatalf("createCheckpoint() result = %#v, error = %v", result, err)
+	}
+}
+
+func TestStableRequestID(t *testing.T) {
+	if got := stableRequestID("caller-id"); got != "caller-id" {
+		t.Fatalf("stableRequestID() = %q", got)
+	}
+	if got := stableRequestID(""); got == "" {
+		t.Fatal("stableRequestID() returned an empty generated ID")
+	}
+}

--- a/go/core/v2/mcp/server.go
+++ b/go/core/v2/mcp/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kagent-dev/kagent/go/core/internal/version"
 	"github.com/kagent-dev/kagent/go/core/v2/a2agateway"
 	"github.com/kagent-dev/kagent/go/core/v2/agentinstance"
+	"github.com/kagent-dev/kagent/go/core/v2/checkpoint"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"google.golang.org/grpc/metadata"
 )
@@ -28,9 +29,10 @@ const (
 )
 
 type Handler struct {
-	instances *agentinstance.Service
-	gateway   a2asrv.RequestHandler
-	http      http.Handler
+	instances   *agentinstance.Service
+	checkpoints *checkpoint.Service
+	gateway     a2asrv.RequestHandler
+	http        http.Handler
 }
 
 type invocationStart struct {
@@ -74,11 +76,11 @@ type InvokeAgentInstanceOutput struct {
 	Text            string `json:"text,omitempty"`
 }
 
-func New(instances *agentinstance.Service, gateway a2asrv.RequestHandler) (*Handler, error) {
-	if instances == nil || gateway == nil {
-		return nil, fmt.Errorf("AgentInstance service and A2A gateway are required")
+func New(instances *agentinstance.Service, checkpoints *checkpoint.Service, gateway a2asrv.RequestHandler) (*Handler, error) {
+	if instances == nil || checkpoints == nil || gateway == nil {
+		return nil, fmt.Errorf("AgentInstance service, checkpoint service, and A2A gateway are required")
 	}
-	h := &Handler{instances: instances, gateway: gateway}
+	h := &Handler{instances: instances, checkpoints: checkpoints, gateway: gateway}
 	capabilities := &mcp.ServerCapabilities{}
 	capabilities.AddExtension(tasksExtension, nil)
 	server := mcp.NewServer(
@@ -93,6 +95,7 @@ func New(instances *agentinstance.Service, gateway a2asrv.RequestHandler) (*Hand
 		Name:        invokeToolName,
 		Description: "Invoke an AgentInstance through the public A2A gateway",
 	}, h.invokeAgentInstance)
+	h.registerCheckpointTools(server)
 	server.AddReceivingMiddleware(h.taskAwareToolCall)
 	if err := h.registerTaskMethods(server); err != nil {
 		return nil, err
@@ -118,12 +121,7 @@ func (h *Handler) listAgentInstances(ctx context.Context, _ *mcp.CallToolRequest
 		if instance.GetState() != apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_READY {
 			continue
 		}
-		output.AgentInstances = append(output.AgentInstances, AgentInstanceSummary{
-			Namespace: instance.GetNamespace(), ID: instance.GetId(),
-			AgentTemplate: instance.GetAgentTemplate().GetName(),
-			Harness:       instance.GetHarness().GetName(),
-			State:         instance.GetState().String(),
-		})
+		output.AgentInstances = append(output.AgentInstances, agentInstanceSummary(instance))
 	}
 	var text strings.Builder
 	for i, instance := range output.AgentInstances {

--- a/go/core/v2/mcp/tasks_test.go
+++ b/go/core/v2/mcp/tasks_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kagent-dev/kagent/go/core/pkg/auth"
 	"github.com/kagent-dev/kagent/go/core/v2/a2agateway"
 	"github.com/kagent-dev/kagent/go/core/v2/agentinstance"
+	"github.com/kagent-dev/kagent/go/core/v2/checkpoint"
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -183,7 +184,7 @@ func TestTaskUpdateTranslatesAskUserResponse(t *testing.T) {
 
 func TestTaskCapableToolCallReturnsDurableHandle(t *testing.T) {
 	gateway := &fakeGateway{}
-	h, err := New(testAgentInstanceService(), &a2asrv.InterceptedHandler{Handler: gateway})
+	h, err := New(testAgentInstanceService(), testCheckpointService(), &a2asrv.InterceptedHandler{Handler: gateway})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,7 +224,7 @@ func TestTaskCapableToolCallReturnsDurableHandle(t *testing.T) {
 
 func TestToolCallWithoutTasksWaitsForResult(t *testing.T) {
 	gateway := &fakeGateway{completeOnDrain: true}
-	h, err := New(testAgentInstanceService(), &a2asrv.InterceptedHandler{Handler: gateway})
+	h, err := New(testAgentInstanceService(), testCheckpointService(), &a2asrv.InterceptedHandler{Handler: gateway})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -491,4 +492,8 @@ func (*fakeInstanceWorkflow) Delete(_ context.Context, instance *apiv1alpha1.Age
 
 func testAgentInstanceService() *agentinstance.Service {
 	return agentinstance.NewService(&fakeInstanceStore{}, &authimpl.NoopAuthorizer{}, &fakeInstanceWorkflow{})
+}
+
+func testCheckpointService() *checkpoint.Service {
+	return checkpoint.NewService(nil, nil, nil, nil)
 }


### PR DESCRIPTION
## Summary
- add synchronous MCP tools to create and list checkpoints and fork AgentInstances
- route every operation through the existing checkpoint service and preserve caller request IDs
- cover schemas and translations with unit tests and checkpoint-to-fork invocation with E2E

## Testing
- go test ./core/v2/mcp ./core/cmd/controller-v2
- go test ./core/v2/checkpoint
- go test ./core/test/e2e -run '^$'
- make -C go lint
- TestMCPCheckpointFork against local Kind cluster

Stacked on #2576.

Closes #2577