### PR TITLE
test(ui): fix three flaky browser-suite waits

### DIFF
--- a/scripts/kind/setup-kind.sh
+++ b/scripts/kind/setup-kind.sh
@@ -30,7 +30,8 @@ else
   export KIND_EXPERIMENTAL_PROVIDER="${CONTAINER_RUNTIME}"
   kind create cluster --name "${KIND_CLUSTER_NAME}" \
     --config scripts/kind/kind-config.yaml \
-    --image="kindest/node:v${KIND_IMAGE_VERSION}"
+    --image="kindest/node:v${KIND_IMAGE_VERSION}" \
+    --wait 60s
 fi
 
 # 3. Add the registry config to the nodes

--- a/scripts/kind/setup-metallb.sh
+++ b/scripts/kind/setup-metallb.sh
@@ -7,6 +7,16 @@ set -o nounset
 METALLB_VERSION=${METALLB_VERSION:-v0.15.3}
 KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-kagent}
 
+# A just-created cluster can answer one request and stall on the next.
+for attempt in $(seq 1 30); do
+  kubectl --context "kind-${KIND_CLUSTER_NAME}" get --raw=/readyz >/dev/null 2>&1 && break
+  if [ "${attempt}" -eq 30 ]; then
+    echo "ERROR: apiserver for kind-${KIND_CLUSTER_NAME} was still not ready after 60s."
+    exit 1
+  fi
+  sleep 2
+done
+
 kubectl --context "kind-${KIND_CLUSTER_NAME}" apply -f https://raw.githubusercontent.com/metallb/metallb/${METALLB_VERSION}/config/manifests/metallb-native.yaml
 
 # Wait for MetalLB to become available.

--- a/ui/playwright/helpers/chat.ts
+++ b/ui/playwright/helpers/chat.ts
@@ -1,0 +1,85 @@
+/**
+ * Driving a turn, and knowing when it is over.
+ *
+ * `expect(chat-cancel).toHaveCount(0)` is a wait wearing an assertion's clothes, and
+ * its report reads "cancel should not be here" when the reply had simply not finished
+ * (#2610). `MockChatClient` publishes a tally of turns started and finished — as
+ * `src/mocks/transport.ts` does for RPC calls — so the wait can be on the event, and
+ * the assertion after it on the page, at the default budget.
+ */
+
+import { expect, type Page } from "@playwright/test";
+
+/** Where `src/api/chat/mockChatClient.ts` publishes what it is doing. */
+const PROPERTY = "__kagentMockChat";
+
+/** The tally, as the page holds it. */
+interface Turns {
+  started: number;
+  finished: number;
+}
+
+/**
+ * A sent turn, identified by the count of turns finished before it went — which is
+ * what keeps the wait below about this turn and not the previous one.
+ */
+export interface SentTurn {
+  readonly finishedBefore: number;
+}
+
+function readTurns(page: Page): Promise<Turns | null> {
+  return page.evaluate(
+    (property) =>
+      (window as unknown as Record<string, Turns | undefined>)[property] ?? null,
+    PROPERTY,
+  );
+}
+
+/**
+ * The token for the turn about to be sent. Polled because the counters are hung off
+ * the chat client, which is built the first time a conversation is read.
+ */
+export async function beginTurn(page: Page): Promise<SentTurn> {
+  await expect
+    .poll(async () => await readTurns(page), {
+      message:
+        `The chat fixture published nothing on window.${PROPERTY}. Either the app is ` +
+        `not running in mock mode, or this page never opened a conversation.`,
+    })
+    .not.toBeNull();
+
+  const turns = await readTurns(page);
+  return { finishedBefore: turns!.finished };
+}
+
+/** Types a message and sends it, returning the token its turn is waited on with. */
+export async function sendMessage(page: Page, text: string): Promise<SentTurn> {
+  const turn = await beginTurn(page);
+  await page.getByTestId("chat-input").fill(text);
+  await page.getByTestId("chat-send").click();
+  return turn;
+}
+
+/**
+ * Waits for the turn to stop streaming, then asserts the page has noticed. Both
+ * halves matter: the first alone races the script, the second alone proves nothing.
+ */
+export async function expectTurnFinished(page: Page, turn: SentTurn): Promise<void> {
+  await page.waitForFunction(
+    ({ property, after }) => {
+      const turns = (window as unknown as Record<string, Turns | undefined>)[property];
+      return turns !== undefined && turns.finished > after;
+    },
+    { property: PROPERTY, after: turn.finishedBefore },
+  );
+
+  await expect(
+    page.getByTestId("chat-cancel"),
+    "the composer should come back once the turn is over",
+  ).toHaveCount(0);
+}
+
+/** Sends a message and waits out the turn it starts, asserting nothing in between. */
+export async function sendAndAwaitTurn(page: Page, text: string): Promise<void> {
+  await expectTurnFinished(page, await sendMessage(page, text));
+}

--- a/ui/playwright/tests/chat/chat-errors.spec.ts
+++ b/ui/playwright/tests/chat/chat-errors.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "../../fixtures/test";
+import { sendAndAwaitTurn } from "../../helpers/chat";
 import {
   agentChat,
   agentNewChat,
@@ -238,9 +239,7 @@ test("chat: a question the agent is waiting on is said, and can be given up", as
     // The proof that the turn really closed is a *new* turn running, not an alert
     // that disappeared: a task still parked would refuse this.
     await page.goto(`${AGENT_CHAT}?chat=ok`);
-    await page.getByTestId("chat-input").fill("How many pods are running?");
-    await page.getByTestId("chat-send").click();
-    await expect(page.getByTestId("chat-cancel")).toHaveCount(0, { timeout: 30_000 });
+    await sendAndAwaitTurn(page, "How many pods are running?");
     await expect(page.getByTestId("chat-turn-error")).toHaveCount(0);
   });
 });
@@ -273,9 +272,7 @@ test("chat: a question can be discarded instead of answered", async ({ page }) =
 
   await test.step("3. and an unrelated message is accepted again", async () => {
     await page.goto(`${AGENT_CHAT}?chat=ok`);
-    await page.getByTestId("chat-input").fill("How many pods are running?");
-    await page.getByTestId("chat-send").click();
-    await expect(page.getByTestId("chat-cancel")).toHaveCount(0, { timeout: 30_000 });
+    await sendAndAwaitTurn(page, "How many pods are running?");
     await expect(page.getByTestId("chat-turn-error")).toHaveCount(0);
   });
 });

--- a/ui/playwright/tests/chat/chat.spec.ts
+++ b/ui/playwright/tests/chat/chat.spec.ts
@@ -1,5 +1,12 @@
 import { test, expect } from "../../fixtures/test";
 import { SIBLING_OF_READY, agentChat, instances, loadPage } from "../../helpers/app";
+import {
+  beginTurn,
+  expectTurnFinished,
+  sendAndAwaitTurn,
+  sendMessage,
+  type SentTurn,
+} from "../../helpers/chat";
 
 /**
  * Chat — the conversation journey.
@@ -63,6 +70,8 @@ test("chat: history, sending, streaming, and tool rendering", async ({ page }) =
   // Scoped by role: the agent quotes the question back in its reply, so a plain
   // text filter matches the answer as well as the question that prompted it.
   const userMessages = page.locator('[data-testid="chat-message"][data-role="user"]');
+  // Held across steps because a turn is sent in one and finishes in another.
+  let turn: SentTurn;
 
   await test.step("1. the page opens on the conversation, ready to be typed into", async () => {
     await loadPage(page, AGENT_CHAT);
@@ -123,8 +132,7 @@ test("chat: history, sending, streaming, and tool rendering", async ({ page }) =
   });
 
   await test.step("7. sending a message adds it to the transcript immediately", async () => {
-    await page.getByTestId("chat-input").fill(FIRST_QUESTION);
-    await page.getByTestId("chat-send").click();
+    turn = await sendMessage(page, FIRST_QUESTION);
 
     // The reader's own words, before the server has said anything. The fixture
     // does not echo them back and neither does the gateway, so this can only pass
@@ -159,8 +167,8 @@ test("chat: history, sending, streaming, and tool rendering", async ({ page }) =
   });
 
   await test.step("11. the turn finishes, the composer comes back, and the indicator settles", async () => {
+    await expectTurnFinished(page, turn);
     await expect(page.getByTestId("chat-send")).toBeVisible();
-    await expect(page.getByTestId("chat-cancel")).toHaveCount(0);
     // Nothing reported once the turn is over: the status line belongs to a turn in
     // flight, so a finished one leaves it with nothing to say.
     await expect(page.getByTestId("chat-status")).toHaveCount(0);
@@ -169,15 +177,14 @@ test("chat: history, sending, streaming, and tool rendering", async ({ page }) =
   await test.step("12. a second question behaves exactly like the first", async () => {
     // The report was that further questions behaved the same way — only the agent's
     // replies appeared. So the second turn is driven, not assumed from the first.
-    await page.getByTestId("chat-input").fill(SECOND_QUESTION);
-    await page.getByTestId("chat-send").click();
+    turn = await sendMessage(page, SECOND_QUESTION);
 
     await expect(
       userMessages.filter({ hasText: SECOND_QUESTION }),
       "the second question should be on screen as soon as it is sent, like the first",
     ).toHaveCount(1);
 
-    await expect(page.getByTestId("chat-cancel")).toHaveCount(0);
+    await expectTurnFinished(page, turn);
     await expect(
       messages.last().getByTestId("chat-message-text"),
       "the second reply should assemble exactly once",
@@ -230,9 +237,7 @@ test("chat: history, sending, streaming, and tool rendering", async ({ page }) =
      * not something a glance at a still will catch.
      */
     await page.setViewportSize({ width: 1440, height: 420 });
-    await page.getByTestId("chat-input").fill("one more, to make the page scroll");
-    await page.getByTestId("chat-send").click();
-    await expect(page.getByTestId("chat-cancel")).toHaveCount(0);
+    await sendAndAwaitTurn(page, "one more, to make the page scroll");
 
     /*
      * The box that scrolls must end above the box you type in.
@@ -388,6 +393,8 @@ test("chat: an agent's Markdown renders as elements, not as characters", async (
   // the render, and the assertion below is about the render.
   await expect(page.getByTestId("chat-message")).toHaveCount(4);
 
+  // Taken before the message is sent, so the wait below is about this turn.
+  const turn = await beginTurn(page);
   await page.getByTestId("chat-input").fill("How many pods are running?");
   await expect(page.getByTestId("chat-send")).toBeEnabled();
   await page.getByTestId("chat-send").click();
@@ -396,7 +403,7 @@ test("chat: an agent's Markdown renders as elements, not as characters", async (
   // transcript before the reply exists, and without the second it can read a half-streamed
   // list whose item count is whatever had arrived.
   await expect(page.getByTestId("chat-cancel")).toBeVisible();
-  await expect(page.getByTestId("chat-cancel")).toHaveCount(0);
+  await expectTurnFinished(page, turn);
 
   const answer = page.getByTestId("chat-message").last().getByTestId("chat-message-text");
 

--- a/ui/playwright/tests/lists/list-filters.spec.ts
+++ b/ui/playwright/tests/lists/list-filters.spec.ts
@@ -34,9 +34,29 @@ import { dataRows, expectSettled, loadPage, rowNamed, routes } from "../../helpe
 /** Opens a filter's popup and ticks one option by the label the reader sees. */
 async function chooseFilter(page: Page, filterTestId: string, label: string) {
   await page.getByTestId(filterTestId).click();
-  await page.locator(`.ant-select-item-option[title="${label}"]`).click();
+  const option = page.locator(`.ant-select-item-option[title="${label}"]`);
+  await option.click();
+  // The click, confirmed where it happened: a click on a popup that has moved or
+  // closed under it selects nothing, silently, and is reported much later as a pill
+  // that never appeared.
+  await expect(option).toHaveAttribute("aria-selected", "true");
   // Otherwise the popup covers the pill row the next step asserts on.
   await page.keyboard.press("Escape");
+}
+
+/**
+ * The same choice, made from the keyboard.
+ *
+ * For the step that deliberately does not wait: a popup is hit-tested where it is
+ * drawn, so clicking one while another write is re-rendering the page underneath is a
+ * race of the test's own making, on top of the race it is trying to observe. Typing
+ * and pressing Enter goes to the control's own input, which does not move.
+ */
+async function typeFilter(page: Page, filterTestId: string, label: string) {
+  const input = page.getByTestId(filterTestId).locator("input");
+  await input.fill(label);
+  await input.press("Enter");
+  await input.press("Escape");
 }
 
 test("lists: a page's filter narrows that page's own rows", async ({ page }) => {
@@ -82,8 +102,19 @@ test("lists: a page's filter narrows that page's own rows", async ({ page }) => 
      */
     await loadPage(page, routes.models, { title: "Models" });
     await expectSettled(page);
+
     await page.getByTestId("models-filters-search").fill("model");
-    await chooseFilter(page, "models-filters-filter-ns", "kagent");
+    await typeFilter(page, "models-filters-filter-ns", "kagent");
+
+    // Read from the address first: not a longer wait, a more specific one. Stopping
+    // here names the write that went missing, where a pill that never appeared could
+    // be that or a page that failed to draw what it had.
+    await expect(page, "the search term should survive the filter write").toHaveURL(
+      /[?&]q=model(&|$)/,
+    );
+    await expect(page, "the filter should survive the search write").toHaveURL(
+      /[?&]ns=kagent(&|$)/,
+    );
 
     await expect(page.getByTestId("models-filters-pill-search")).toBeVisible();
     await expect(page.getByTestId("models-filters-pill-ns-kagent")).toBeVisible();
@@ -97,11 +128,12 @@ test("lists: a narrowed view is an address, so it survives a reload", async ({ p
     await expectSettled(page);
 
     await page.getByTestId("models-filters-search").fill("config");
-    await chooseFilter(page, "models-filters-filter-ns", "kagent");
+    await typeFilter(page, "models-filters-filter-ns", "kagent");
 
-    const url = new URL(page.url());
-    expect(url.searchParams.get("q")).toBe("config");
-    expect(url.searchParams.getAll("ns")).toEqual(["kagent"]);
+    // `page.url()` was a bare read with no retry, so it reported the address as it
+    // was a tick before the second write reached it.
+    await expect(page).toHaveURL(/[?&]q=config(&|$)/);
+    await expect(page).toHaveURL(/[?&]ns=kagent(&|$)/);
   });
 
   await test.step("2. sorting is in the address too, and the header shows it", async () => {

--- a/ui/playwright/tests/shell-chrome.spec.ts
+++ b/ui/playwright/tests/shell-chrome.spec.ts
@@ -84,40 +84,95 @@ test("app shell: the sidebar's footer controls", async ({ page }) => {
   });
 });
 
-test("app shell: collapsed, every nav icon sits on the rail's centre line", async ({
+test("app shell: collapsed, every nav icon is centred in its row", async ({
   page,
 }) => {
   await page.goto("/agents");
   await expect(page.getByTestId("nav-agents")).toBeVisible();
-  await page.getByText("Collapse", { exact: true }).click();
+  await page.getByTestId("sidebar-collapse").click();
+
+  await expect(page.getByTestId("sidebar-collapse")).toHaveAttribute(
+    "aria-expanded",
+    "false",
+  );
+  await expect(page.locator(".ant-menu-inline-collapsed")).toHaveCount(1);
+
+  /*
+   * Then wait out the collapse, asked of the animations rather than of the clock: the
+   * rows' padding is genuinely asymmetric mid-transition, and it settles a frame or
+   * two after the width does. Not the fix for what was reported — a settled rail was
+   * still out against its own centre line — only the precondition for measuring.
+   */
+  await page.waitForFunction(() => {
+    const rail = document.querySelector('[data-testid="app-sidebar"]')!;
+    return rail
+      .getAnimations({ subtree: true })
+      .every((animation) => animation.playState !== "running");
+  });
 
   // Measured rather than eyeballed: the rows carry a left-measured padding for the label
   // they no longer show, which displaced the library's own collapsed centring and left
   // every icon a few pixels to the left — visible as sloppiness, invisible to a
   // screenshot test that only asks whether the rail rendered.
-  const offsets = await page.evaluate(() => {
+  const rows = await page.evaluate(() => {
     const rail = document.querySelector('[data-testid="app-sidebar"]')!;
-    const box = rail.getBoundingClientRect();
+    const railBox = rail.getBoundingClientRect();
     // Excluding the 1px right border, which is not part of the space icons sit in.
-    const centre = box.left + (box.width - 1) / 2;
+    const railCentre = railBox.left + (railBox.width - 1) / 2;
     return [...document.querySelectorAll('[data-testid^="nav-"]')].map((row) => {
+      const box = row.getBoundingClientRect();
       const icon = row.querySelector("svg")!.getBoundingClientRect();
-      return { key: (row as HTMLElement).dataset.testid, off: icon.left + icon.width / 2 - centre };
+      /*
+       * The row's whole content, margins included, rather than the icon alone: a
+       * collapsed row still holds the hidden label, whose width and margin are a font
+       * and engine question. Flex centres the outer boxes of what it is given, so
+       * measuring those is the form of the question with no renderer in the answer.
+       */
+      const children = [...row.children].map((child) => {
+        const rect = child.getBoundingClientRect();
+        const style = getComputedStyle(child);
+        return {
+          left: rect.left - Number.parseFloat(style.marginLeft),
+          right: rect.right + Number.parseFloat(style.marginRight),
+        };
+      });
+      const contentLeft = Math.min(...children.map((child) => child.left));
+      const contentRight = Math.max(...children.map((child) => child.right));
+      return {
+        key: (row as HTMLElement).dataset.testid,
+        iconWidth: icon.width,
+        before: contentLeft - box.left,
+        after: box.right - contentRight,
+        // And where the icon lands against the rail, which is the thing a reader
+        // actually sees. Kept loose, for the reason given below.
+        offCentre: icon.left + icon.width / 2 - railCentre,
+      };
     });
   });
 
-  expect(offsets.length).toBeGreaterThan(3);
-  for (const { key, off } of offsets) {
+  expect(rows.length).toBeGreaterThan(3);
+  for (const { key, iconWidth, before, after, offCentre } of rows) {
     /*
-     * Two pixels, which is a tolerance rather than a target.
-     *
-     * An icon of even width in a rail of odd width cannot land dead centre, and the
-     * leftover is rounded differently by each engine on each platform — Firefox on
-     * Linux lands 1.4px out where Chromium on macOS lands under 1. Neither is visible.
-     * The displacement this test exists to catch was the label's padding pushing every
-     * icon several pixels left, which 2px still fails on; tightening it further only
-     * makes the suite report the renderer rather than the layout.
+     * The strict half, and the one that catches the defect: the padding the collapsed
+     * row must not keep shows up here as the whole padding's worth of asymmetry,
+     * against a free space flex splits evenly. Measured against the rail instead there
+     * is a leftover nothing can settle — an even-width icon in an odd-width rail,
+     * rounded per engine — which is what the 2px tolerance had come to report.
      */
-    expect(Math.abs(off), `${key} is ${off.toFixed(1)}px off the centre line`).toBeLessThanOrEqual(2);
+    expect(
+      Math.abs(before - after),
+      `${key}'s contents sit ${before.toFixed(1)}px from one edge of its row and ` +
+        `${after.toFixed(1)}px from the other`,
+    ).toBeLessThanOrEqual(1);
+
+    /*
+     * The loose half, a different claim: the row itself is where it should be, which
+     * nothing above would notice. Half the icon's width, so the tolerance comes from
+     * the layout — it says the rail's centre line passes through the icon.
+     */
+    expect(
+      Math.abs(offCentre),
+      `${key} is ${offCentre.toFixed(1)}px off the rail's centre line`,
+    ).toBeLessThan(iconWidth / 2);
   }
 });

--- a/ui/src/api/chat/mockChatClient.ts
+++ b/ui/src/api/chat/mockChatClient.ts
@@ -57,6 +57,32 @@ const REQUEST_ID = "adk-mock-ask-1";
 const FAILURE_MESSAGE =
   "The agent stopped responding. The connection to the runtime was lost.";
 
+/**
+ * Where this fixture says what it is doing, for the browser suite to wait on — the
+ * same instrument `src/mocks/transport.ts` publishes for RPC calls, and for the same
+ * reason: under a substituted transport there is no request on the wire to watch.
+ * Counters rather than a boolean, so a waiter can name the turn it means.
+ */
+export const MOCK_CHAT_PROPERTY = "__kagentMockChat";
+
+export interface MockChatActivity {
+  /** Turns this fixture has begun streaming since the page loaded. */
+  started: number;
+  /** Turns it has stopped streaming — completed, failed, parked, or cancelled. */
+  finished: number;
+}
+
+const activity: MockChatActivity = { started: 0, finished: 0 };
+
+/**
+ * Called from the constructor rather than at module load: this module is imported in
+ * every build and instantiated only in mock mode.
+ */
+function publishActivity(): void {
+  if (typeof window === "undefined") return;
+  (window as unknown as Record<string, unknown>)[MOCK_CHAT_PROPERTY] = activity;
+}
+
 export class MockChatClient implements ChatClient {
   readonly protocolVersion = "mock";
 
@@ -72,6 +98,10 @@ export class MockChatClient implements ChatClient {
    * of the first turn before it, and React sees two children with the same key.
    */
   private readonly runId = Math.random().toString(36).slice(2, 10);
+
+  constructor() {
+    publishActivity();
+  }
 
   async history(
     conversation: ChatConversationRef,
@@ -94,7 +124,21 @@ export class MockChatClient implements ChatClient {
     };
   }
 
+  /**
+   * One turn, counted at both ends. Kept out of the script below because `finally` is
+   * the one place that sees every ending — completed, refused, failed, parked, or
+   * cancelled by a consumer that stopped iterating.
+   */
   async *send(input: SendMessageInput): AsyncIterable<ChatEvent> {
+    activity.started += 1;
+    try {
+      yield* this.stream(input);
+    } finally {
+      activity.finished += 1;
+    }
+  }
+
+  private async *stream(input: SendMessageInput): AsyncIterable<ChatEvent> {
     const { conversation, text, signal } = input;
     const sessionId = conversationKey(conversation);
     const scenario = currentChatScenario();


### PR DESCRIPTION
---
*🤖 written by Claude (start)*

## Overview

- **#2609** — the collapsed nav icon is measured against its own row rather than the rail's centre line, so the assertion no longer reports which engine drew the frame.
- **#2610** — the chat fixture now says when a turn has finished, so the specs wait on that instead of on a 5s deadline over a ~3s scripted stream.
- **#2611** — the step that deliberately does not wait chooses its namespace from the keyboard rather than by clicking a popup that is hit-tested where it is drawn, and the sibling test reads the address with `toHaveURL` instead of a bare `page.url()` that had no retry at all.
- **Cluster setup** — `make create-kind-cluster` no longer races the apiserver it just created. `kind create cluster` waits for the control plane, and the MetalLB step waits on `/readyz` before its first apply — which had been failing with `net/http: TLS handshake timeout`.

No timeouts were raised and no retries added; everything runs on Playwright's defaults, and the two writes #2611 exists for still land with nothing waited between them.

## Changelog

Three flaky browser-suite waits now watch the signal they were standing in for.

Closes #2609
Closes #2610
Closes #2611

## Testing

1. `cd ui && yarn test:pw`.
2. Drop the `& .ant-menu-inline-collapsed .ant-menu-item` block from `ui/src/components/Structure/AppSidebar.tsx` and rerun `yarn playwright test shell-chrome` — it fails naming the row and both gaps.

## Release note

```
NONE
```

---
*🤖 written by Claude (end)*
