### PR TITLE
fix: wire the system service into controller-v2

### DIFF
--- a/go/core/cmd/controller-v2/main.go
+++ b/go/core/cmd/controller-v2/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/kagent-dev/kagent/go/core/internal/grpcserver"
 	authimpl "github.com/kagent-dev/kagent/go/core/internal/httpserver/auth"
 	"github.com/kagent-dev/kagent/go/core/internal/service/kubecrud"
+	systemservice "github.com/kagent-dev/kagent/go/core/internal/service/system"
 	"github.com/kagent-dev/kagent/go/core/pkg/auth"
 	"github.com/kagent-dev/kagent/go/core/pkg/migrations"
 	"github.com/kagent-dev/kagent/go/core/v2/a2agateway"
@@ -142,8 +143,17 @@ func main() {
 		// the only way to author a Harness or an AgentTemplate is kubectl.
 		AgentTemplateService: kubecrud.NewService(manager.GetClient(), authorizer, &kagentv1alpha3.AgentTemplate{}, &kagentv1alpha3.AgentTemplateList{}, "AgentTemplate"),
 		HarnessService:       kubecrud.NewService(manager.GetClient(), authorizer, &kagentv1alpha3.Harness{}, &kagentv1alpha3.HarnessList{}, "Harness"),
-		CheckpointService:    checkpoints,
-		A2AHandler:           gateway,
+		// Namespaces and the substrate inventory. Without the inventory the system
+		// service holds no Kubernetes client, so every namespace read fails as an
+		// internal error — which the agents list reports as a page that cannot load.
+		SystemService: systemservice.NewService(systemservice.WithInventory(
+			manager.GetClient(),
+			namespaces(os.Getenv("WATCH_NAMESPACES")),
+			authorizer,
+			actors,
+		)),
+		CheckpointService: checkpoints,
+		A2AHandler:        gateway,
 	})
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
---
*🤖 written by Claude (start)*

## Changelog

The Agents page loads again. `controller-v2` now constructs the system service with its Kubernetes client and substrate inventory, so `ListNamespaces` succeeds instead of returning `INTERNAL` on every call.

## Why it was broken

`systemservice.WithInventory` had no caller: the wiring lived in `go/core/pkg/app/app.go`, deleted by #2595, and `controller-v2` never carried it over. `grpcserver.New` then falls back to `systemservice.NewService()` with no options, and every namespace read stops at the `kubeClient == nil` guard. The UI reads templates one namespace at a time, so the agents list reports that as `Could not load agents — internal server error`.

Two gaps from the same deletion are **not** fixed here and are described in #2613: `ModelService`, `ToolService`, `PromptTemplateService`, `FeedbackService` and `MemoryService` are still unregistered, and `managerScheme` still omits `atev1alpha1`, which `GetSubstrateStatus` needs.

## Testing

1. `scripts/setup-cluster/setup-cluster.sh`, then `kubectl -n kagent port-forward svc/kagent-ui 8080:8080`.
2. Open `localhost:8080/agents` — the list renders the harness/template pair the script created, with no error banner.

Closes #2613

---
*🤖 written by Claude (end)*
