### PR TITLE
fix: preserve A2A transcript order with metadata

### DIFF
--- a/go/adk/pkg/a2a/executor.go
+++ b/go/adk/pkg/a2a/executor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"iter"
 	"strings"
+	"time"
 
 	a2atype "github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/a2aproject/a2a-go/v2/a2asrv"
@@ -12,6 +13,7 @@ import (
 	"github.com/kagent-dev/kagent/go/adk/pkg/auth"
 	"github.com/kagent-dev/kagent/go/adk/pkg/models"
 	"github.com/kagent-dev/kagent/go/adk/pkg/telemetry"
+	apia2a "github.com/kagent-dev/kagent/go/api/a2a"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	adkagent "google.golang.org/adk/v2/agent"
@@ -59,9 +61,19 @@ func NewKAgentExecutor(cfg KAgentExecutorConfig) *KAgentExecutor {
 		RunConfig:          runConfig,
 		A2APartConverter:   a2aPartConverter,
 		GenAIPartConverter: genAIPartConverter,
-		AfterEventCallback: func(ctx adka2a.ExecutorContext, event *adksession.Event, _ *a2atype.TaskArtifactUpdateEvent) error {
+		AfterEventCallback: func(ctx adka2a.ExecutorContext, event *adksession.Event, processed *a2atype.TaskArtifactUpdateEvent) error {
 			if event.InvocationID != "" {
 				trace.SpanFromContext(ctx).SetAttributes(attribute.String("gcp.vertex.agent.invocation_id", event.InvocationID))
+			}
+			// Preserve the artifact's protocol type while giving current A2A clients a
+			// common ordering key. A2A #2129 will replace this with native artifact
+			// start/end generations and a task timeline.
+			if processed.Artifact != nil {
+				position := event.Timestamp
+				if position.IsZero() {
+					position = time.Now()
+				}
+				processed.Artifact.SetMeta(apia2a.TimelinePositionMetadataKey, position.UTC().Format(time.RFC3339Nano))
 			}
 			return nil
 		},
@@ -174,6 +186,11 @@ func (e *KAgentExecutor) Execute(ctx context.Context, reqCtx *a2asrv.ExecutorCon
 				update.Status.Message = BuildHITLStatusMessage(update.Status.Message, hitlActivated)
 				update.Status.Message.TaskID = update.TaskID
 				update.Status.Message.ContextID = update.ContextID
+				position := time.Now().UTC()
+				if update.Status.Timestamp != nil {
+					position = update.Status.Timestamp.UTC()
+				}
+				update.Status.Message.SetMeta(apia2a.TimelinePositionMetadataKey, position.Format(time.RFC3339Nano))
 			}
 			if !yield(event, err) {
 				return

--- a/go/adk/pkg/a2a/executor_test.go
+++ b/go/adk/pkg/a2a/executor_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/a2aproject/a2a-go/v2/a2asrv"
 	"github.com/go-logr/logr"
 	"github.com/kagent-dev/kagent/go/adk/pkg/auth"
+	apia2a "github.com/kagent-dev/kagent/go/api/a2a"
 	adkagent "google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/model"
 	"google.golang.org/adk/v2/runner"
@@ -278,6 +279,11 @@ func TestKAgentExecutor_StreamsArtifactsThroughUpstreamExecutor(t *testing.T) {
 	if updates[1].Append || !updates[1].LastChunk || updates[1].Artifact.ID != updates[0].Artifact.ID || updates[1].Artifact.Parts[0].Text() != "hello" {
 		t.Fatalf("second artifact update = %#v, want content-bearing final replacement", updates[1])
 	}
+	for index, update := range updates {
+		if _, ok := update.Artifact.Metadata[apia2a.TimelinePositionMetadataKey].(string); !ok {
+			t.Fatalf("artifact update %d metadata = %#v, want timeline position", index, update.Artifact.Metadata)
+		}
+	}
 	if completed == nil || completed.Status.Message != nil {
 		t.Fatalf("completed status = %#v, want content-free completion", completed)
 	}
@@ -345,6 +351,9 @@ func TestKAgentExecutor_HITLPauseAndResumeFlow(t *testing.T) {
 	req := GetToolApprovalRequest(pause.Status.Message)
 	if pause == nil || req == nil {
 		t.Fatalf("pause = %#v, want extension input-required", pause)
+	}
+	if _, ok := pause.Status.Message.Metadata[apia2a.TimelinePositionMetadataKey].(string); !ok {
+		t.Fatalf("pause metadata = %#v, want timeline position", pause.Status.Message.Metadata)
 	}
 	if len(req.Tools) != 1 || req.Tools[0].ID != "confirmation-call" {
 		t.Fatalf("pause tools = %#v, want per-approval correlation", req.Tools)

--- a/go/api/a2a/stored_task.go
+++ b/go/api/a2a/stored_task.go
@@ -9,6 +9,11 @@ import (
 
 const storedTaskMetadataKey = "https://kagent.dev/internal/stored-task/v1"
 
+// TimelinePositionMetadataKey temporarily orders messages and artifacts in a task.
+// Remove it when A2A's timeline and artifact generation fields are available:
+// https://github.com/a2aproject/A2A/pull/2129
+const TimelinePositionMetadataKey = "kagent.dev/timeline-position"
+
 // ClearStoredTask removes the private gateway-to-runtime continuation state.
 // Public callers may send this key, so the gateway must clear it before use.
 func ClearStoredTask(message *a2atype.Message) {

--- a/go/core/v2/a2agateway/gateway.go
+++ b/go/core/v2/a2agateway/gateway.go
@@ -469,6 +469,7 @@ func (g *Gateway) prepareSend(ctx context.Context, req *a2atype.SendMessageReque
 	if req.Message.ContextID != "" && req.Message.ContextID != instance.GetId() {
 		return nil, a2atype.NewError(a2atype.ErrInvalidRequest, "message context does not match AgentInstance")
 	}
+	delete(req.Message.Metadata, apia2a.TimelinePositionMetadataKey)
 	if req.Message.TaskID != "" {
 		return g.prepareReply(ctx, instance, req)
 	}
@@ -477,9 +478,11 @@ func (g *Gateway) prepareSend(ctx context.Context, req *a2atype.SendMessageReque
 	if err != nil {
 		return nil, a2atype.NewError(a2atype.ErrInvalidRequest, "message cannot be encoded")
 	}
+	receivedAt := time.Now().UTC()
+	req.Message.SetMeta(apia2a.TimelinePositionMetadataKey, receivedAt.Format(time.RFC3339Nano))
 	req.Message.TaskID = a2atype.NewTaskID()
 	submitted := a2atype.NewSubmittedTask(req.Message, req.Message)
-	createdAt := time.Now().UTC()
+	createdAt := receivedAt
 	if submitted.Status.Timestamp != nil {
 		createdAt = submitted.Status.Timestamp.UTC()
 	}
@@ -516,6 +519,7 @@ func (g *Gateway) prepareReply(ctx context.Context, instance *apiv1alpha1.AgentI
 		return nil, a2atype.NewError(a2atype.ErrUnsupportedOperation, "task is not waiting for input")
 	}
 	message.ContextID = stored.ContextID
+	message.SetMeta(apia2a.TimelinePositionMetadataKey, time.Now().UTC().Format(time.RFC3339Nano))
 	attempt := *stored
 	attempt.History = append([]*a2atype.Message{}, stored.History...)
 	if question := stored.Status.Message; question != nil {

--- a/go/core/v2/a2agateway/gateway_test.go
+++ b/go/core/v2/a2agateway/gateway_test.go
@@ -319,8 +319,10 @@ func TestGatewayResolvesAuthenticatedHeadersBeforeSending(t *testing.T) {
 	authorizer := &gatewayTestAuthorizer{}
 	runtime := &gatewayTestRuntime{}
 	gateway := New(store, authorizer, &gatewayTestDialer{client: gatewayTestClient(t, runtime)}, &gatewayTestWorkflow{}, gatewayTestURL)
+	request := gatewayTestRequest()
+	request.Message.SetMeta(apia2a.TimelinePositionMetadataKey, "caller-controlled")
 
-	result, err := gateway.SendMessage(gatewayTestContext(), gatewayTestRequest())
+	result, err := gateway.SendMessage(gatewayTestContext(), request)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -330,6 +332,10 @@ func TestGatewayResolvesAuthenticatedHeadersBeforeSending(t *testing.T) {
 	createdAt, ok := store.created.Metadata[TaskCreatedAtMetadataKey].(string)
 	if _, err := time.Parse(time.RFC3339Nano, createdAt); !ok || err != nil {
 		t.Fatalf("task creation timestamp = %#v: %v", store.created.Metadata[TaskCreatedAtMetadataKey], err)
+	}
+	position, ok := store.created.History[0].Metadata[apia2a.TimelinePositionMetadataKey].(string)
+	if _, err := time.Parse(time.RFC3339Nano, position); !ok || err != nil {
+		t.Fatalf("opening message timeline position = %#v: %v", store.created.History[0].Metadata[apia2a.TimelinePositionMetadataKey], err)
 	}
 	if store.namespace != "team-a" || store.id != gatewayTestID || store.userID != "alice" {
 		t.Fatalf("store lookup = %q/%q user %q", store.namespace, store.id, store.userID)
@@ -387,8 +393,9 @@ func TestGatewayContinuesInputRequiredTask(t *testing.T) {
 	if runtime.privateTask == nil || runtime.privateTask.Status.State != a2atype.TaskStateInputRequired || runtime.privateTask.Status.Message == nil || runtime.privateTask.Status.Message.ID != status.ID {
 		t.Fatalf("private continuation state = %#v", runtime.privateTask)
 	}
-	if len(reply.Metadata) != 0 {
-		t.Fatalf("private continuation state leaked into public metadata: %#v", reply.Metadata)
+	position, ok := reply.Metadata[apia2a.TimelinePositionMetadataKey].(string)
+	if _, err := time.Parse(time.RFC3339Nano, position); !ok || err != nil || len(reply.Metadata) != 1 {
+		t.Fatalf("reply metadata = %#v, want only its server-authored timeline position: %v", reply.Metadata, err)
 	}
 }
 

--- a/ui/src/api/chat/a2aGrpcChatClient.test.ts
+++ b/ui/src/api/chat/a2aGrpcChatClient.test.ts
@@ -554,6 +554,29 @@ describe("A2AGrpcChatClient.history", () => {
     });
   }
 
+  it("orders messages and artifacts by their timeline positions", async () => {
+    const position = (value: string) => ({ "kagent.dev/timeline-position": value });
+    serveTasks([
+      {
+        id: "task-1",
+        contextId: CONVERSATION.id,
+        status: { state: TaskState.COMPLETED, timestamp: { seconds: 1767225600n } },
+        history: [
+          { messageId: "u0", role: Role.USER, parts: [text("start")], metadata: position("1") },
+          { messageId: "u1", role: Role.USER, parts: [text("answer")], metadata: position("4") },
+        ],
+        artifacts: [
+          { artifactId: "a0", parts: [data({ name: "ask_user" })], metadata: position("2") },
+          { artifactId: "a1", parts: [text("Which topic?")], metadata: position("3") },
+          { artifactId: "a2", parts: [text("Thanks")], metadata: position("5") },
+        ],
+      },
+    ]);
+
+    const { messages } = await new A2AGrpcChatClient().history(CONVERSATION);
+    expect(messages.map((message) => message.id)).toEqual(["u0", "a0", "a1", "u1", "a2"]);
+  });
+
   it("keeps a tool call and its result apart when replaying", async () => {
     // Consecutive agent messages carrying data parts and no text at all: comparing
     // text made them look identical and dropped the result, so a replayed

--- a/ui/src/api/chat/a2aGrpcChatClient.ts
+++ b/ui/src/api/chat/a2aGrpcChatClient.ts
@@ -116,6 +116,12 @@ const SHARE_HEADER = "X-Share-Token";
  */
 const HISTORY_PAGE_LIMIT = 50;
 
+/*
+ * Temporary bridge to A2A's ordered task timeline and artifact generation ranges:
+ * https://github.com/a2aproject/A2A/pull/2129
+ */
+const TIMELINE_POSITION_METADATA_KEY = "kagent.dev/timeline-position";
+
 /** Ids for the messages the wire did not name. */
 let counter = 0;
 function nextId(prefix: string): string {
@@ -731,6 +737,7 @@ export class A2AGrpcChatClient implements ChatClient {
  */
 export function messagesFromTask(task: A2ATask): ChatMessage[] {
   const messages: ChatMessage[] = [];
+  const positioned: { message: ChatMessage; position?: string }[] = [];
   const taken = new Set<string>();
   const createdAt = statusTime(task.status);
 
@@ -741,7 +748,7 @@ export function messagesFromTask(task: A2ATask): ChatMessage[] {
       message.messageId || JSON.stringify(message.parts.map((part) => part.content));
     if (taken.has(identity)) return;
     taken.add(identity);
-    messages.push({
+    const converted: ChatMessage = {
       /*
        * Derived from the task and the position in it, never from a counter.
        *
@@ -762,7 +769,9 @@ export function messagesFromTask(task: A2ATask): ChatMessage[] {
       parts,
       createdAt,
       taskId: task.id || undefined,
-    });
+    };
+    messages.push(converted);
+    positioned.push({ message: converted, position: timelinePosition(message.metadata) });
   };
 
   /*
@@ -798,7 +807,7 @@ export function messagesFromTask(task: A2ATask): ChatMessage[] {
     const parts = toParts(artifact.parts);
     const body = textOf(parts);
     if (parts.length === 0 || (body !== "" && shown.has(body))) continue;
-    agent.push({
+    const converted: ChatMessage = {
       // Derived, for the reason given against the message id above: an unnamed
       // artifact renamed on every read is an artifact the merge cannot recognise.
       id: artifact.artifactId || `${task.id || "task"}-artifact-${messages.length + agent.length}`,
@@ -806,10 +815,25 @@ export function messagesFromTask(task: A2ATask): ChatMessage[] {
       parts,
       createdAt,
       taskId: task.id || undefined,
-    });
+    };
+    agent.push(converted);
+    positioned.push({ message: converted, position: timelinePosition(artifact.metadata) });
+  }
+
+  // New records carry one server-authored order across history and artifacts.
+  // Keep the positional inference below for records written before this bridge.
+  if (positioned.length > 0 && positioned.every(({ position }) => position !== undefined)) {
+    return positioned
+      .sort((left, right) => left.position!.localeCompare(right.position!))
+      .map(({ message }) => message);
   }
 
   return interleaveTaskMessages(opening, answers, agent);
+}
+
+function timelinePosition(metadata: JsonObject | undefined): string | undefined {
+  const value = metadata?.[TIMELINE_POSITION_METADATA_KEY];
+  return typeof value === "string" ? value : undefined;
 }
 
 /** Whether a reader's turn is answering an `ask_user` rather than opening a task. */

--- a/ui/src/api/chat/transcriptOrder.ts
+++ b/ui/src/api/chat/transcriptOrder.ts
@@ -1,7 +1,11 @@
 import type { ChatMessage } from "./types";
 
 /**
- * Putting one task's messages back in the order they happened.
+ * Putting a legacy task's messages back in the order they happened.
+ *
+ * New kagent records carry `kagent.dev/timeline-position`. This inference remains
+ * for older records until A2A's native timeline and artifact generation ranges land:
+ * https://github.com/a2aproject/A2A/pull/2129
  *
  * `ListTasks` answers with two parallel lists: every message the reader sent is in
  * `history`, every message the agent produced is in `artifacts`, and nothing in the


### PR DESCRIPTION
Fixes #2584.

## Summary

- preserve tool output as A2A artifacts
- add a temporary server-authored kagent.dev/timeline-position metadata key across messages and artifacts
- sort fully-positioned transcripts by that key while retaining legacy positional inference
- document removal when the native A2A task timeline and artifact generation model lands in https://github.com/a2aproject/A2A/pull/2129

## Tests

- go test ./api/a2a ./adk/pkg/a2a ./core/v2/a2agateway
- yarn test a2aGrpcChatClient.test.ts transcriptOrder.test.ts --run
- yarn typecheck
- yarn lint