### PR TITLE
ci: strip the v prefix on both release version paths

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -51,12 +51,15 @@ jobs:
         DOCKER_BUILDER: "docker buildx build"
         DOCKER_REGISTRY: "ghcr.io" # prod for releases, local for dev
       run: |
-        # if workflow_dispatch is used, use the version input
+        # Resolve the release version from the dispatch input or the pushed tag.
         if [ -n "${{ github.event.inputs.version }}" ]; then
-          export VERSION=${{ github.event.inputs.version }}
+          VERSION="${{ github.event.inputs.version }}"
         else
-          export VERSION=$(echo "$GITHUB_REF" | cut -c12-)
+          VERSION="${GITHUB_REF#refs/tags/}"
         fi
+        # Tags are vX.Y.Z but image tags, chart versions and Go ldflags all want
+        # bare semver, so strip the prefix here — on both paths, not just one.
+        export VERSION="${VERSION#v}"
         make build-${{ matrix.image }}
   push-helm-chart:
     needs:
@@ -78,12 +81,15 @@ jobs:
 
     - name: 'Build Helm Chart'
       run: |
-        # if workflow_dispatch is used, use the version input
+        # Resolve the release version from the dispatch input or the pushed tag.
         if [ -n "${{ github.event.inputs.version }}" ]; then
-          export VERSION=${{ github.event.inputs.version }}
+          VERSION="${{ github.event.inputs.version }}"
         else
-          export VERSION=$(echo "$GITHUB_REF" | cut -c12-)
+          VERSION="${GITHUB_REF#refs/tags/}"
         fi
+        # Tags are vX.Y.Z but image tags, chart versions and Go ldflags all want
+        # bare semver, so strip the prefix here — on both paths, not just one.
+        export VERSION="${VERSION#v}"
         make helm-publish
   release-python-packages:
     runs-on: ubuntu-latest
@@ -98,12 +104,15 @@ jobs:
     - name: 'Release Python Packages'
       working-directory: python
       run: |
-        # if workflow_dispatch is used, use the version input
+        # Resolve the release version from the dispatch input or the pushed tag.
         if [ -n "${{ github.event.inputs.version }}" ]; then
-          export VERSION=${{ github.event.inputs.version }}
+          VERSION="${{ github.event.inputs.version }}"
         else
-          export VERSION=$(echo "$GITHUB_REF" | cut -c12-)
+          VERSION="${GITHUB_REF#refs/tags/}"
         fi
+        # Tags are vX.Y.Z but image tags, chart versions and Go ldflags all want
+        # bare semver, so strip the prefix here — on both paths, not just one.
+        export VERSION="${VERSION#v}"
         uv sync --all-extras
         # Bump every package version to $VERSION first
         uv version $VERSION --package kagent-core
@@ -148,12 +157,15 @@ jobs:
       uses: actions/checkout@v6
     - name: Build
       run: |
-        # if workflow_dispatch is used, use the version input
+        # Resolve the release version from the dispatch input or the pushed tag.
         if [ -n "${{ github.event.inputs.version }}" ]; then
-          export VERSION=${{ github.event.inputs.version }}
+          VERSION="${{ github.event.inputs.version }}"
         else
-          export VERSION=$(echo "$GITHUB_REF" | cut -c12-)
+          VERSION="${GITHUB_REF#refs/tags/}"
         fi
+        # Tags are vX.Y.Z but image tags, chart versions and Go ldflags all want
+        # bare semver, so strip the prefix here — on both paths, not just one.
+        export VERSION="${VERSION#v}"
         make build-cli
         make helm-version
     - name: Release


### PR DESCRIPTION
## What broke

Artifacts published for `v0.10.0-rc4` carry a `v` prefix that earlier releases did not:

| | v0.10.0-rc3 | v0.10.0-rc4 |
|---|---|---|
| Image tags | `ui:0.10.0-rc3` | `ui:v0.10.0-rc4` |
| Chart version / filename | `kagent-0.10.0-rc3.tgz` | `kagent-v0.10.0-rc4.tgz` |
| Chart in OCI | `helm/kagent:0.10.0-rc3` | `helm/kagent:v0.10.0-rc4` |
| Go ldflags | `version.Version=0.10.0-rc3` | `version.Version=v0.10.0-rc4` |

Python packages are unaffected — `uv version` normalizes to PEP 440, so they built as `0.10.0rc4` either way.

## Root cause

This is not a code regression. It is the first release cut by `workflow_dispatch` rather than a tag push, and only the tag path stripped the `v`.

The workflow resolves `VERSION` from one of two sources, and each needs different unwrapping:

- Tag push hands over `refs/tags/v0.10.0-rc4` — the wrapper *and* the `v` must go.
- Dispatch hands over whatever was typed, `v0.10.0-rc4` — only the `v` must go.

The tag path used `cut -c12-`, which drops the first 11 characters. `refs/tags/` is exactly 10 of them, so character 11 is the `v` and the cut removed both in one move — but nothing in that expression says so. The dispatch path assigns the input verbatim and never grew an equivalent step, because nobody could see that the tag path had one.

Every release through rc3 went through the tag path, so the gap stayed latent. The rc4 tag-push run ([32985573168](https://github.com/kagent-dev/kagent/actions/runs/32985573168)) was cancelled and re-driven by hand via dispatch ([33186456713](https://github.com/kagent-dev/kagent/actions/runs/33186456713)) with the input typed as `v0.10.0-rc4` to match the tag name — the natural thing to type. Logs show `export VERSION=v0.10.0-rc4` in all four jobs, against `VERSION=0.10.0-rc3` for rc3.

## The fix

Let each path do only its own unwrapping, then strip the `v` once for both:

```bash
if [ -n "${{ github.event.inputs.version }}" ]; then
  VERSION="${{ github.event.inputs.version }}"
else
  VERSION="${GITHUB_REF#refs/tags/}"
fi
export VERSION="${VERSION#v}"
```

Replacing `cut -c12-` with `${GITHUB_REF#refs/tags/}` is not needed to fix the bug; it is so the code states what it removes instead of encoding it as a character count that only works because `refs/tags/` happens to be ten letters. The `${VERSION#v}` strip is a no-op when the input already omits the prefix, so either spelling of the dispatch input now works.

## Verification

YAML parses and all four jobs carry the normalization. The resolved shell block was simulated over both trigger paths:

| Dispatch input | `GITHUB_REF` | Result |
|---|---|---|
| *(empty)* | `refs/tags/v0.10.0-rc4` | `0.10.0-rc4` |
| *(empty)* | `refs/tags/v0.10.0` | `0.10.0` |
| `v0.10.0-rc4` | `refs/tags/v0.10.0-rc4` | `0.10.0-rc4` |
| `0.10.0-rc4` | `refs/tags/v0.10.0-rc4` | `0.10.0-rc4` |
| `v0.11.0-beta1` | `refs/heads/main` | `0.11.0-beta1` |

The workflow itself only runs on a tag push or dispatch, so the real proof is the next release.

## Notes for reviewers

- **rc4's published artifacts are not retroactively corrected.** rc4 is internally self-consistent — the CLI's v-prefixed default chart version matches the v-prefixed published chart, so `kagent install` works *within* rc4. But an rc4 CLI cannot install a correctly-tagged release, and a correctly-tagged CLI cannot install rc4. Worth deciding separately whether to re-cut rc4 or re-tag the artifacts.
- **The block is still duplicated four times**, which is what let the two paths drift in the first place. Collapsing it into one job that exposes `VERSION` as an output the others consume would remove the class of bug rather than this instance; left out here to keep the fix reviewable and backportable.
- **`Info.Short()` (`go/core/internal/version/version.go:45`) builds its output as `"v" + Version`**, so it renders `vv0.10.0-rc4` when `Version` already carries a prefix. It and `GetShort()` have no production callers — only their own tests — so this causes no visible symptom today and is left alone. It is a latent trap if either is ever wired up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
