### PR TITLE
fix(controller): restore services and RemoteMCPServer discovery for controller-v2

### DIFF
--- a/go/core/cmd/controller-v2/main.go
+++ b/go/core/cmd/controller-v2/main.go
@@ -28,11 +28,19 @@ import (
 	"syscall"
 	"time"
 
+	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 	kagentv1alpha3 "github.com/kagent-dev/kagent/go/api/v1alpha3"
+	remotemcpcontroller "github.com/kagent-dev/kagent/go/core/internal/controller/remotemcpserver"
 	"github.com/kagent-dev/kagent/go/core/internal/database"
 	"github.com/kagent-dev/kagent/go/core/internal/grpcserver"
 	authimpl "github.com/kagent-dev/kagent/go/core/internal/httpserver/auth"
+	feedbackservice "github.com/kagent-dev/kagent/go/core/internal/service/feedback"
 	"github.com/kagent-dev/kagent/go/core/internal/service/kubecrud"
+	memoryservice "github.com/kagent-dev/kagent/go/core/internal/service/memory"
+	modelservice "github.com/kagent-dev/kagent/go/core/internal/service/model"
+	prompttemplateservice "github.com/kagent-dev/kagent/go/core/internal/service/prompttemplate"
+	systemservice "github.com/kagent-dev/kagent/go/core/internal/service/system"
+	toolservice "github.com/kagent-dev/kagent/go/core/internal/service/tool"
 	"github.com/kagent-dev/kagent/go/core/pkg/auth"
 	"github.com/kagent-dev/kagent/go/core/pkg/migrations"
 	"github.com/kagent-dev/kagent/go/core/v2/a2agateway"
@@ -41,18 +49,32 @@ import (
 	v2controller "github.com/kagent-dev/kagent/go/core/v2/controller"
 	v2mcp "github.com/kagent-dev/kagent/go/core/v2/mcp"
 	"github.com/kagent-dev/kagent/go/core/v2/substrate"
+	kmcp "github.com/kagent-dev/kmcp/api/v1alpha1"
+	"go.uber.org/zap/zapcore"
 	"golang.org/x/sync/errgroup"
+	corev1 "k8s.io/api/core/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 )
 
 func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
+
+	logLevel := zapcore.InfoLevel
+	if value := os.Getenv("ZAP_LOG_LEVEL"); value != "" {
+		if err := logLevel.Set(value); err != nil {
+			log.Fatalf("parse ZAP_LOG_LEVEL: %v", err)
+		}
+	}
+	ctrl.SetLogger(zap.New(zap.Level(logLevel)))
 
 	dbURL, err := database.ResolveURL(env("POSTGRES_DATABASE_URL", "postgres://postgres:kagent@kagent-postgresql.kagent.svc.cluster.local:5432/postgres"), os.Getenv("POSTGRES_DATABASE_URL_FILE"))
 	if err != nil {
@@ -81,8 +103,21 @@ func main() {
 	managerScheme := k8sruntime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(managerScheme))
 	utilruntime.Must(kagentv1alpha3.AddToScheme(managerScheme))
+	utilruntime.Must(atev1alpha1.AddToScheme(managerScheme))
+	utilruntime.Must(kmcp.AddToScheme(managerScheme))
+	watchNamespaces := namespaces(os.Getenv("WATCH_NAMESPACES"))
+	managerClientOptions := client.Options{}
+	managerCacheOptions := cache.Options{DefaultNamespaces: namespaceCache(watchNamespaces)}
+	if len(watchNamespaces) > 0 {
+		// A namespaced Role cannot list cluster-scoped Namespace objects. Read them
+		// directly so SystemService can fall back to the configured names on a
+		// Forbidden response without a failing Namespace informer blocking startup.
+		managerClientOptions.Cache = &client.CacheOptions{DisableFor: []client.Object{&corev1.Namespace{}}}
+	}
 	manager, err := ctrl.NewManager(kubeConfig, ctrl.Options{
 		Scheme:                  managerScheme,
+		Cache:                   managerCacheOptions,
+		Client:                  managerClientOptions,
 		Metrics:                 metricsserver.Options{BindAddress: "0"},
 		LeaderElection:          envBool("LEADER_ELECT"),
 		LeaderElectionID:        "0e9f6799.kagent.dev",
@@ -91,7 +126,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("create controller manager: %v", err)
 	}
-	runtime, err := v2controller.NewRuntime(kubeConfig, namespaces(os.Getenv("WATCH_NAMESPACES")), ctx.Done())
+	runtime, err := v2controller.NewRuntime(kubeConfig, watchNamespaces, ctx.Done())
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -101,6 +136,11 @@ func main() {
 	}
 	if err := manager.Add(reconciler); err != nil {
 		log.Fatalf("add reconciler to controller manager: %v", err)
+	}
+	mcpClient := toolservice.NewRuntimeMCPClient(manager.GetClient())
+	remoteMCPDiscovery := remotemcpcontroller.New(manager.GetClient(), mcpClient, store)
+	if err := remoteMCPDiscovery.SetupWithManager(manager); err != nil {
+		log.Fatalf("set up RemoteMCPServer discovery: %v", err)
 	}
 
 	actors, err := substrate.Dial(ctx, substrate.Config{
@@ -116,6 +156,13 @@ func main() {
 
 	authenticator := &authimpl.UnsecureAuthenticator{}
 	authorizer := &authimpl.NoopAuthorizer{}
+	resourceNamespace := env("KAGENT_NAMESPACE", "kagent")
+	models := modelservice.NewService(manager.GetClient(), authorizer, resourceNamespace)
+	tools := toolservice.NewService(manager.GetClient(), store, authorizer, resourceNamespace, mcpClient)
+	prompts := prompttemplateservice.NewService(manager.GetClient(), authorizer)
+	system := systemservice.NewService(systemservice.WithInventory(manager.GetClient(), watchNamespaces, authorizer, actors))
+	feedback := feedbackservice.NewService(store)
+	memory := memoryservice.NewService(store)
 	instanceWorkflow := agentinstance.NewActorWorkflow(store, actors)
 	instances := agentinstance.NewService(store, authorizer, instanceWorkflow)
 	checkpoints := checkpoint.NewService(store, authorizer, actors, instanceWorkflow)
@@ -133,11 +180,17 @@ func main() {
 		log.Fatal(err)
 	}
 	server, err := grpcserver.New(grpcserver.Config{
-		BindAddress:          env("GRPC_BIND_ADDRESS", ":8084"),
-		Reflection:           envBool("GRPC_REFLECTION"),
-		Authenticator:        authenticator,
-		ShareStore:           store,
-		AgentInstanceService: instances,
+		BindAddress:           env("GRPC_BIND_ADDRESS", ":8084"),
+		Reflection:            envBool("GRPC_REFLECTION"),
+		Authenticator:         authenticator,
+		ShareStore:            store,
+		ModelService:          models,
+		ToolService:           tools,
+		PromptTemplateService: prompts,
+		SystemService:         system,
+		FeedbackService:       feedback,
+		MemoryService:         memory,
+		AgentInstanceService:  instances,
 		// Both halves of the pair CreateAgentInstance names. Without these two
 		// the only way to author a Harness or an AgentTemplate is kubectl.
 		AgentTemplateService: kubecrud.NewService(manager.GetClient(), authorizer, &kagentv1alpha3.AgentTemplate{}, &kagentv1alpha3.AgentTemplateList{}, "AgentTemplate"),
@@ -202,6 +255,17 @@ func namespaces(value string) []string {
 		if namespace = strings.TrimSpace(namespace); namespace != "" {
 			result = append(result, namespace)
 		}
+	}
+	return result
+}
+
+func namespaceCache(names []string) map[string]cache.Config {
+	if len(names) == 0 {
+		return nil
+	}
+	result := make(map[string]cache.Config, len(names))
+	for _, name := range names {
+		result[name] = cache.Config{}
 	}
 	return result
 }

--- a/go/core/cmd/controller-v2/main_test.go
+++ b/go/core/cmd/controller-v2/main_test.go
@@ -11,3 +11,19 @@ func TestNamespaces(t *testing.T) {
 		t.Fatalf("namespaces() = %q, want %q", got, want)
 	}
 }
+
+func TestNamespaceCache(t *testing.T) {
+	if got := namespaceCache(nil); got != nil {
+		t.Fatalf("namespaceCache(nil) = %#v, want nil", got)
+	}
+	got := namespaceCache([]string{"team-a", "team-b"})
+	if len(got) != 2 {
+		t.Fatalf("namespaceCache() = %#v", got)
+	}
+	if _, ok := got["team-a"]; !ok {
+		t.Fatal("namespaceCache() missing team-a")
+	}
+	if _, ok := got["team-b"]; !ok {
+		t.Fatal("namespaceCache() missing team-b")
+	}
+}

--- a/go/core/internal/controller/remotemcpserver/reconciler.go
+++ b/go/core/internal/controller/remotemcpserver/reconciler.go
@@ -1,0 +1,240 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package remotemcpserver reconciles the discovered tool catalog published in
+// RemoteMCPServer status.
+package remotemcpserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"slices"
+	"strings"
+	"time"
+
+	dbmodel "github.com/kagent-dev/kagent/go/api/database"
+	"github.com/kagent-dev/kagent/go/api/v1alpha3"
+	toolservice "github.com/kagent-dev/kagent/go/core/internal/service/tool"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apiMeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	conditionAccepted = "Accepted"
+	remoteGroupKind   = "RemoteMCPServer.kagent.dev"
+	refreshInterval   = 5 * time.Minute
+)
+
+// ToolDiscoverer returns the tools currently advertised by one MCP server.
+type ToolDiscoverer interface {
+	ListTools(context.Context, toolservice.MCPServerRef) ([]toolservice.MCPAppTool, error)
+}
+
+// CatalogStore keeps the gRPC ToolService catalog aligned with Kubernetes status.
+// RemoteMCPServer status remains the source used by harness compilers, while the
+// database projection serves list RPCs without making those RPCs perform discovery.
+type CatalogStore interface {
+	StoreToolServer(context.Context, *dbmodel.ToolServer) (*dbmodel.ToolServer, error)
+	RefreshToolsForServer(context.Context, string, string, ...*v1alpha3.MCPTool) error
+	DeleteToolsForServer(context.Context, string, string) error
+	DeleteToolServer(context.Context, string, string) error
+}
+
+// Reconciler publishes RemoteMCPServer discovery results to its status.
+type Reconciler struct {
+	client     client.Client
+	discoverer ToolDiscoverer
+	catalog    CatalogStore
+}
+
+func New(client client.Client, discoverer ToolDiscoverer, catalog CatalogStore) *Reconciler {
+	return &Reconciler{client: client, discoverer: discoverer, catalog: catalog}
+}
+
+func (r *Reconciler) SetupWithManager(manager ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(manager).
+		For(&v1alpha3.RemoteMCPServer{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(r.requestsForDependency)).
+		Watches(&corev1.ConfigMap{}, handler.EnqueueRequestsFromMapFunc(r.requestsForDependency)).
+		Complete(r)
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	server := &v1alpha3.RemoteMCPServer{}
+	if err := r.client.Get(ctx, request.NamespacedName, server); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return reconcile.Result{}, err
+		}
+		return reconcile.Result{}, r.deleteCatalog(ctx, request.String())
+	}
+
+	tools, err := r.discoverer.ListTools(ctx, toolservice.MCPServerRef{
+		Ref: request.NamespacedName, GroupKind: remoteGroupKind,
+	})
+	if err != nil {
+		statusErr := r.updateStatus(ctx, server, nil, metav1.ConditionFalse, "DiscoveryFailed", err.Error())
+		catalogErr := r.updateCatalog(ctx, server, nil, false)
+		return reconcile.Result{}, errors.Join(
+			fmt.Errorf("discover RemoteMCPServer tools: %w", err),
+			wrapError("update RemoteMCPServer discovery failure", statusErr),
+			wrapError("clear RemoteMCPServer tool catalog", catalogErr),
+		)
+	}
+
+	discovered, err := normalizeTools(tools)
+	if err != nil {
+		statusErr := r.updateStatus(ctx, server, nil, metav1.ConditionFalse, "InvalidDiscovery", err.Error())
+		catalogErr := r.updateCatalog(ctx, server, nil, false)
+		return reconcile.Result{}, errors.Join(
+			err,
+			wrapError("update invalid RemoteMCPServer discovery", statusErr),
+			wrapError("clear invalid RemoteMCPServer tool catalog", catalogErr),
+		)
+	}
+	message := fmt.Sprintf("Discovered %d MCP tools", len(discovered))
+	if err := r.updateStatus(ctx, server, discovered, metav1.ConditionTrue, "DiscoverySucceeded", message); err != nil {
+		return reconcile.Result{}, fmt.Errorf("update RemoteMCPServer discovery status: %w", err)
+	}
+	if err := r.updateCatalog(ctx, server, discovered, true); err != nil {
+		return reconcile.Result{}, fmt.Errorf("update RemoteMCPServer tool catalog: %w", err)
+	}
+	return reconcile.Result{RequeueAfter: refreshInterval}, nil
+}
+
+func (r *Reconciler) updateCatalog(ctx context.Context, server *v1alpha3.RemoteMCPServer, tools []*v1alpha3.MCPTool, connected bool) error {
+	name := client.ObjectKeyFromObject(server).String()
+	var lastConnected *time.Time
+	if connected {
+		now := time.Now().UTC()
+		lastConnected = &now
+	}
+	if _, err := r.catalog.StoreToolServer(ctx, &dbmodel.ToolServer{
+		Name: name, GroupKind: remoteGroupKind, Description: server.Spec.Description, LastConnected: lastConnected,
+	}); err != nil {
+		return fmt.Errorf("store server: %w", err)
+	}
+	if err := r.catalog.RefreshToolsForServer(ctx, name, remoteGroupKind, tools...); err != nil {
+		return fmt.Errorf("refresh tools: %w", err)
+	}
+	return nil
+}
+
+func (r *Reconciler) deleteCatalog(ctx context.Context, name string) error {
+	return errors.Join(
+		wrapError("delete tools", r.catalog.DeleteToolsForServer(ctx, name, remoteGroupKind)),
+		wrapError("delete server", r.catalog.DeleteToolServer(ctx, name, remoteGroupKind)),
+	)
+}
+
+func wrapError(action string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s: %w", action, err)
+}
+
+func normalizeTools(tools []toolservice.MCPAppTool) ([]*v1alpha3.MCPTool, error) {
+	discovered := make([]*v1alpha3.MCPTool, 0, len(tools))
+	seen := make(map[string]struct{}, len(tools))
+	for _, tool := range tools {
+		if strings.TrimSpace(tool.Name) == "" {
+			return nil, fmt.Errorf("MCP discovery returned a tool with an empty name")
+		}
+		if _, exists := seen[tool.Name]; exists {
+			return nil, fmt.Errorf("MCP discovery returned duplicate tool %q", tool.Name)
+		}
+		seen[tool.Name] = struct{}{}
+		discovered = append(discovered, &v1alpha3.MCPTool{Name: tool.Name, Description: tool.Description})
+	}
+	slices.SortFunc(discovered, func(a, b *v1alpha3.MCPTool) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	return discovered, nil
+}
+
+func (r *Reconciler) updateStatus(
+	ctx context.Context,
+	server *v1alpha3.RemoteMCPServer,
+	tools []*v1alpha3.MCPTool,
+	conditionStatus metav1.ConditionStatus,
+	reason string,
+	message string,
+) error {
+	original := server.DeepCopy()
+	server.Status.ObservedGeneration = server.Generation
+	server.Status.DiscoveredTools = tools
+	apiMeta.SetStatusCondition(&server.Status.Conditions, metav1.Condition{
+		Type: conditionAccepted, Status: conditionStatus, Reason: reason, Message: message,
+		ObservedGeneration: server.Generation,
+	})
+	if reflect.DeepEqual(original.Status, server.Status) {
+		return nil
+	}
+	return r.client.Status().Patch(ctx, server, client.MergeFrom(original))
+}
+
+func (r *Reconciler) requestsForDependency(ctx context.Context, object client.Object) []reconcile.Request {
+	servers := &v1alpha3.RemoteMCPServerList{}
+	if err := r.client.List(ctx, servers, client.InNamespace(object.GetNamespace())); err != nil {
+		return nil
+	}
+	requests := make([]reconcile.Request, 0)
+	for i := range servers.Items {
+		server := &servers.Items[i]
+		if referencesDependency(server, object) {
+			requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
+				Namespace: server.Namespace, Name: server.Name,
+			}})
+		}
+	}
+	return requests
+}
+
+func referencesDependency(server *v1alpha3.RemoteMCPServer, object client.Object) bool {
+	switch object.(type) {
+	case *corev1.Secret:
+		if server.Spec.TLS != nil && server.Spec.TLS.CACertSecretRef == object.GetName() {
+			return true
+		}
+		for i := range server.Spec.HeadersFrom {
+			from := server.Spec.HeadersFrom[i].ValueFrom
+			if from != nil && from.Type == v1alpha3.SecretValueSource && from.Name == object.GetName() {
+				return true
+			}
+		}
+	case *corev1.ConfigMap:
+		for i := range server.Spec.HeadersFrom {
+			from := server.Spec.HeadersFrom[i].ValueFrom
+			if from != nil && from.Type == v1alpha3.ConfigMapValueSource && from.Name == object.GetName() {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+var _ reconcile.Reconciler = (*Reconciler)(nil)

--- a/go/core/internal/controller/remotemcpserver/reconciler_test.go
+++ b/go/core/internal/controller/remotemcpserver/reconciler_test.go
@@ -1,0 +1,229 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remotemcpserver
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	dbmodel "github.com/kagent-dev/kagent/go/api/database"
+	"github.com/kagent-dev/kagent/go/api/v1alpha3"
+	toolservice "github.com/kagent-dev/kagent/go/core/internal/service/tool"
+	corev1 "k8s.io/api/core/v1"
+	apiMeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+type fakeDiscoverer struct {
+	tools []toolservice.MCPAppTool
+	err   error
+	ref   toolservice.MCPServerRef
+}
+
+type fakeCatalog struct {
+	server       *dbmodel.ToolServer
+	tools        []*v1alpha3.MCPTool
+	deletedTools string
+	deleted      string
+}
+
+func (f *fakeCatalog) StoreToolServer(_ context.Context, server *dbmodel.ToolServer) (*dbmodel.ToolServer, error) {
+	f.server = server
+	return server, nil
+}
+
+func (f *fakeCatalog) RefreshToolsForServer(_ context.Context, name, groupKind string, tools ...*v1alpha3.MCPTool) error {
+	f.tools = tools
+	return nil
+}
+
+func (f *fakeCatalog) DeleteToolsForServer(_ context.Context, name, groupKind string) error {
+	f.deletedTools = name + "|" + groupKind
+	return nil
+}
+
+func (f *fakeCatalog) DeleteToolServer(_ context.Context, name, groupKind string) error {
+	f.deleted = name + "|" + groupKind
+	return nil
+}
+
+func (f *fakeDiscoverer) ListTools(_ context.Context, ref toolservice.MCPServerRef) ([]toolservice.MCPAppTool, error) {
+	f.ref = ref
+	return f.tools, f.err
+}
+
+func TestReconcilePublishesSortedDiscovery(t *testing.T) {
+	server := testServer()
+	kube := testClient(t, server)
+	discoverer := &fakeDiscoverer{tools: []toolservice.MCPAppTool{
+		{Name: "zeta", Description: "last"},
+		{Name: "alpha", Description: "first"},
+	}}
+	catalog := &fakeCatalog{}
+	reconciler := New(kube, discoverer, catalog)
+
+	result, err := reconciler.Reconcile(t.Context(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(server)})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	if result.RequeueAfter != 5*time.Minute {
+		t.Fatalf("Reconcile() requeue = %s, want 5m", result.RequeueAfter)
+	}
+	if discoverer.ref.Ref != client.ObjectKeyFromObject(server) || discoverer.ref.GroupKind != "RemoteMCPServer.kagent.dev" {
+		t.Fatalf("discovery ref = %#v", discoverer.ref)
+	}
+
+	updated := getServer(t, kube, server)
+	if updated.Status.ObservedGeneration != server.Generation {
+		t.Fatalf("observed generation = %d, want %d", updated.Status.ObservedGeneration, server.Generation)
+	}
+	if len(updated.Status.DiscoveredTools) != 2 || updated.Status.DiscoveredTools[0].Name != "alpha" || updated.Status.DiscoveredTools[1].Name != "zeta" {
+		t.Fatalf("discovered tools = %#v", updated.Status.DiscoveredTools)
+	}
+	condition := apiMeta.FindStatusCondition(updated.Status.Conditions, conditionAccepted)
+	if condition == nil || condition.Status != metav1.ConditionTrue || condition.Reason != "DiscoverySucceeded" {
+		t.Fatalf("Accepted condition = %#v", condition)
+	}
+	if catalog.server == nil || catalog.server.Name != "test/tools" || catalog.server.GroupKind != remoteGroupKind || catalog.server.LastConnected == nil {
+		t.Fatalf("catalog server = %#v", catalog.server)
+	}
+	if len(catalog.tools) != 2 || catalog.tools[0].Name != "alpha" || catalog.tools[1].Name != "zeta" {
+		t.Fatalf("catalog tools = %#v", catalog.tools)
+	}
+}
+
+func TestReconcilePublishesFailureAndClearsStaleTools(t *testing.T) {
+	server := testServer()
+	server.Status.DiscoveredTools = []*v1alpha3.MCPTool{{Name: "stale", Description: "stale"}}
+	kube := testClient(t, server)
+	discoverer := &fakeDiscoverer{err: errors.New("upstream unavailable")}
+	catalog := &fakeCatalog{}
+
+	_, err := New(kube, discoverer, catalog).Reconcile(t.Context(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(server)})
+	if err == nil {
+		t.Fatal("Reconcile() error = nil, want discovery failure")
+	}
+	updated := getServer(t, kube, server)
+	if updated.Status.ObservedGeneration != server.Generation || len(updated.Status.DiscoveredTools) != 0 {
+		t.Fatalf("failed discovery status = %#v", updated.Status)
+	}
+	condition := apiMeta.FindStatusCondition(updated.Status.Conditions, conditionAccepted)
+	if condition == nil || condition.Status != metav1.ConditionFalse || condition.Reason != "DiscoveryFailed" || condition.Message != "upstream unavailable" {
+		t.Fatalf("Accepted condition = %#v", condition)
+	}
+	if catalog.server == nil || catalog.server.LastConnected != nil || len(catalog.tools) != 0 {
+		t.Fatalf("failed discovery catalog = server %#v, tools %#v", catalog.server, catalog.tools)
+	}
+}
+
+func TestReconcileDeletesCatalogProjection(t *testing.T) {
+	catalog := &fakeCatalog{}
+	request := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "test", Name: "gone"}}
+
+	if _, err := New(testClient(t), &fakeDiscoverer{}, catalog).Reconcile(t.Context(), request); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	want := "test/gone|" + remoteGroupKind
+	if catalog.deletedTools != want || catalog.deleted != want {
+		t.Fatalf("catalog deletes = tools %q, server %q, want %q", catalog.deletedTools, catalog.deleted, want)
+	}
+}
+
+func TestNormalizeToolsRejectsInvalidCatalog(t *testing.T) {
+	tests := []struct {
+		name  string
+		tools []toolservice.MCPAppTool
+	}{
+		{name: "empty name", tools: []toolservice.MCPAppTool{{Name: " "}}},
+		{name: "duplicate name", tools: []toolservice.MCPAppTool{{Name: "lookup"}, {Name: "lookup"}}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := normalizeTools(test.tools); err == nil {
+				t.Fatal("normalizeTools() error = nil")
+			}
+		})
+	}
+}
+
+func TestReferencesDependency(t *testing.T) {
+	server := testServer()
+	server.Spec.HeadersFrom = []v1alpha3.ValueRef{
+		{Name: "Authorization", ValueFrom: &v1alpha3.ValueSource{Type: v1alpha3.SecretValueSource, Name: "auth", Key: "token"}},
+		{Name: "X-Config", ValueFrom: &v1alpha3.ValueSource{Type: v1alpha3.ConfigMapValueSource, Name: "headers", Key: "value"}},
+	}
+	server.Spec.TLS = &v1alpha3.TLSConfig{CACertSecretRef: "ca", CACertSecretKey: "ca.crt"}
+
+	tests := []struct {
+		name string
+		obj  client.Object
+		want bool
+	}{
+		{name: "header secret", obj: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "auth"}}, want: true},
+		{name: "CA secret", obj: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca"}}, want: true},
+		{name: "header ConfigMap", obj: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "headers"}}, want: true},
+		{name: "unrelated secret", obj: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "other"}}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := referencesDependency(server, test.obj); got != test.want {
+				t.Fatalf("referencesDependency() = %t, want %t", got, test.want)
+			}
+		})
+	}
+}
+
+func testServer() *v1alpha3.RemoteMCPServer {
+	return &v1alpha3.RemoteMCPServer{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "tools", Generation: 3},
+		Spec: v1alpha3.RemoteMCPServerSpec{
+			Description: "tools", Protocol: v1alpha3.RemoteMCPServerProtocolStreamableHttp,
+			URL: "https://tools.example/mcp",
+		},
+	}
+}
+
+func testClient(t *testing.T, objects ...client.Object) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := v1alpha3.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	return fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&v1alpha3.RemoteMCPServer{}).
+		WithObjects(objects...).Build()
+}
+
+func getServer(t *testing.T, kube client.Client, source *v1alpha3.RemoteMCPServer) *v1alpha3.RemoteMCPServer {
+	t.Helper()
+	result := &v1alpha3.RemoteMCPServer{}
+	key := types.NamespacedName{Namespace: source.Namespace, Name: source.Name}
+	if err := kube.Get(t.Context(), key, result); err != nil {
+		t.Fatal(err)
+	}
+	return result
+}


### PR DESCRIPTION
Close #2603 and #2613 

Some services are removed after #2595 such as ModelService, ToolService, PromptTemplateService, MemoryService, SystemService. They're restored in this PR. Also restores RemoteMCPController which is required by UI and some Harness compiler for tool syncing. Configures required Kubernetes schemas, namespace-scoped caching, and controller-runtime logging.