### PR TITLE
chore(deps): replace unmaintained wk8/go-ordered-map with pb33f fork

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/x/ansi v0.11.8
 	github.com/glebarez/sqlite v1.11.0
 	github.com/go-logr/logr v1.4.4
 	github.com/go-logr/zapr v1.3.0
@@ -159,7 +160,6 @@ require (
 	github.com/charithe/durationcheck v0.0.11 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20251205161215-1948445e3318 // indirect
-	github.com/charmbracelet/x/ansi v0.11.8 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
@@ -487,3 +487,7 @@ require (
 tool sigs.k8s.io/kube-api-linter/cmd/golangci-lint-kube-api-linter
 
 replace github.com/agent-substrate/substrate => github.com/kagent-dev/substrate v0.0.20
+
+// wk8/go-ordered-map is unmaintained; pb33f/ordered-map is the maintained fork
+// with the same package path and API (same approach as lima-vm/lima#4916).
+replace github.com/wk8/go-ordered-map/v2 => github.com/pb33f/ordered-map/v2 v2.1.8

--- a/go/go.sum
+++ b/go/go.sum
@@ -941,6 +941,8 @@ github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT9
 github.com/otiai10/mint v1.3.1/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
+github.com/pb33f/ordered-map/v2 v2.1.8 h1:lQMOZxmzNL3/Aol55uyEZWquGO3AmXeXxyQoFfyb8SI=
+github.com/pb33f/ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/pb33f/ordered-map/v2 v2.3.1 h1:5319HDO0aw4DA4gzi+zv4FXU9UlSs3xGZ40wcP1nBjY=
 github.com/pb33f/ordered-map/v2 v2.3.1/go.mod h1:qxFQgd0PkVUtOMCkTapqotNgzRhMPL7VvaHKbd1HnmQ=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
@@ -1175,8 +1177,6 @@ github.com/uudashr/gocognit v1.2.1 h1:CSJynt5txTnORn/DkhiB4mZjwPuifyASC8/6Q0I/QS
 github.com/uudashr/gocognit v1.2.1/go.mod h1:acaubQc6xYlXFEMb9nWX2dYBzJ/bIjEkc1zzvyIZg5Q=
 github.com/uudashr/iface v1.4.2 h1:06Vq5RKVYThBsj0Bnw4oasMjD1r+7CE/bcKOA8dVSvg=
 github.com/uudashr/iface v1.4.2/go.mod h1:pbeBPlbuU2qkNDn0mmfrxP2X+wjPMIQAy+r1MBXSXtg=
-github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
-github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xen0n/gosmopolitan v1.3.0 h1:zAZI1zefvo7gcpbCOrPSHJZJYA9ZgLfJqtKzZ5pHqQM=


### PR DESCRIPTION
## What

Add a `replace` directive swapping the unmaintained `github.com/wk8/go-ordered-map/v2` for its maintained fork `github.com/pb33f/ordered-map/v2` (same package path and API). Same approach as [lima-vm/lima#4916](https://github.com/lima-vm/lima/pull/4916).

## Why

`wk8/go-ordered-map` is unmaintained. It is still pulled into the module graph transitively by `ollama/ollama` (via `internal/orderedmap`) and `securego/gosec` (via golangci-lint), so a plain version bump cannot remove it — a `replace` is required. Neither upstream has dropped it yet (checked: Ollama v0.33.2 still requires it).

## Details

- `replace github.com/wk8/go-ordered-map/v2 => github.com/pb33f/ordered-map/v2 v2.1.8`
  - `v2.1.8` is pb33f's fork of wk8 v2.1.8, API-identical.
  - `v2.3.1` cannot be used here: it is already in the graph under its own path (via `invopop/jsonschema` / Anthropic SDK), and Go refuses to serve one module version under two paths.
- `go mod tidy` drops the wk8 hashes from `go.sum` and adds pb33f v2.1.8.
- Incidental tidy fix: `charmbracelet/x/ansi` promoted from indirect to direct — it is imported directly by `go/core/cli/internal/tui/panels.go`.

## Verification

- `go mod tidy` — clean
- `go build ./...` — pass
- `go test ./adk/pkg/embedding/...` (pulls in Ollama) — pass
- `go vet ./adk/pkg/...` — pass
- `go mod verify` — all modules verified