### PR TITLE
fix(controller): restore reconciler for MCPServer in controller-v2

### DIFF
--- a/go/core/cmd/controller-v2/main.go
+++ b/go/core/cmd/controller-v2/main.go
@@ -30,6 +30,7 @@ import (
 
 	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
 	kagentv1alpha3 "github.com/kagent-dev/kagent/go/api/v1alpha3"
+	mcpservercontroller "github.com/kagent-dev/kagent/go/core/internal/controller/mcpserver"
 	remotemcpcontroller "github.com/kagent-dev/kagent/go/core/internal/controller/remotemcpserver"
 	"github.com/kagent-dev/kagent/go/core/internal/database"
 	"github.com/kagent-dev/kagent/go/core/internal/grpcserver"
@@ -141,6 +142,10 @@ func main() {
 	remoteMCPDiscovery := remotemcpcontroller.New(manager.GetClient(), mcpClient, store)
 	if err := remoteMCPDiscovery.SetupWithManager(manager); err != nil {
 		log.Fatalf("set up RemoteMCPServer discovery: %v", err)
+	}
+	mcpServerDiscovery := mcpservercontroller.New(manager.GetClient(), mcpClient, store)
+	if err := mcpServerDiscovery.SetupWithManager(manager); err != nil {
+		log.Fatalf("set up MCPServer discovery: %v", err)
 	}
 
 	actors, err := substrate.Dial(ctx, substrate.Config{

--- a/go/core/internal/controller/mcpserver/reconciler.go
+++ b/go/core/internal/controller/mcpserver/reconciler.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package mcpserver projects tools discovered from KMCP MCPServers into the
+// catalog served by kagent's ToolService.
+package mcpserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	dbmodel "github.com/kagent-dev/kagent/go/api/database"
+	"github.com/kagent-dev/kagent/go/api/v1alpha3"
+	"github.com/kagent-dev/kagent/go/core/internal/controller/toolcatalog"
+	toolservice "github.com/kagent-dev/kagent/go/core/internal/service/tool"
+	kmcp "github.com/kagent-dev/kmcp/api/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apiMeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	mcpServerGroupKind    = "MCPServer.kagent.dev"
+	refreshInterval       = 5 * time.Minute
+	readinessPollInterval = 10 * time.Second
+)
+
+var mcpServerGK = schema.GroupKind{Group: kmcp.GroupVersion.Group, Kind: "MCPServer"}
+
+// ToolDiscoverer returns the tools currently advertised by one MCP server.
+type ToolDiscoverer interface {
+	ListTools(context.Context, toolservice.MCPServerRef) ([]toolservice.MCPAppTool, error)
+}
+
+// CatalogStore persists the ToolService projection of an MCPServer.
+type CatalogStore interface {
+	StoreToolServer(context.Context, *dbmodel.ToolServer) (*dbmodel.ToolServer, error)
+	RefreshToolsForServer(context.Context, string, string, ...*v1alpha3.MCPTool) error
+	DeleteToolsForServer(context.Context, string, string) error
+	DeleteToolServer(context.Context, string, string) error
+}
+
+// Reconciler keeps the catalog projection of KMCP-owned MCPServers current. It
+// deliberately does not write MCPServer status, which is owned by KMCP.
+type Reconciler struct {
+	client     client.Client
+	discoverer ToolDiscoverer
+	catalog    CatalogStore
+}
+
+func New(client client.Client, discoverer ToolDiscoverer, catalog CatalogStore) *Reconciler {
+	return &Reconciler{client: client, discoverer: discoverer, catalog: catalog}
+}
+
+func (r *Reconciler) SetupWithManager(manager ctrl.Manager) error {
+	installed, err := controllerEnabled(manager.GetRESTMapper())
+	if err != nil {
+		return err
+	}
+	if !installed {
+		ctrl.Log.Info("MCPServer CRD not found; catalog discovery will not be started")
+		return nil
+	}
+	// Status changes are intentionally observed: KMCP reports deployment
+	// readiness through status without changing the MCPServer generation.
+	return ctrl.NewControllerManagedBy(manager).
+		WithOptions(controller.Options{NeedLeaderElection: new(true)}).
+		For(&kmcp.MCPServer{}).
+		Named("mcpserver-catalog").
+		Complete(r)
+}
+
+func controllerEnabled(mapper apiMeta.RESTMapper) (bool, error) {
+	if _, err := mapper.RESTMapping(mcpServerGK); err != nil {
+		if apiMeta.IsNoMatchError(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("resolve MCPServer REST mapping: %w", err)
+	}
+	return true, nil
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	server := &kmcp.MCPServer{}
+	if err := r.client.Get(ctx, request.NamespacedName, server); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return reconcile.Result{}, fmt.Errorf("get MCPServer %s: %w", request.String(), err)
+		}
+		return reconcile.Result{}, r.deleteCatalog(ctx, request.String())
+	}
+
+	if !isReady(server) {
+		if err := r.updateCatalog(ctx, server, nil, false); err != nil {
+			return reconcile.Result{}, fmt.Errorf("clear unready MCPServer catalog: %w", err)
+		}
+		return reconcile.Result{RequeueAfter: readinessPollInterval}, nil
+	}
+
+	tools, err := r.discoverer.ListTools(ctx, toolservice.MCPServerRef{
+		Ref: request.NamespacedName, GroupKind: mcpServerGroupKind,
+	})
+	if err != nil {
+		catalogErr := r.updateCatalog(ctx, server, nil, false)
+		return reconcile.Result{}, errors.Join(
+			fmt.Errorf("discover MCPServer tools: %w", err),
+			wrapError("clear MCPServer tool catalog", catalogErr),
+		)
+	}
+
+	discovered, err := toolcatalog.NormalizeTools(tools)
+	if err != nil {
+		catalogErr := r.updateCatalog(ctx, server, nil, false)
+		return reconcile.Result{}, errors.Join(
+			err,
+			wrapError("clear invalid MCPServer tool catalog", catalogErr),
+		)
+	}
+	if err := r.updateCatalog(ctx, server, discovered, true); err != nil {
+		return reconcile.Result{}, fmt.Errorf("update MCPServer tool catalog: %w", err)
+	}
+	return reconcile.Result{RequeueAfter: refreshInterval}, nil
+}
+
+func isReady(server *kmcp.MCPServer) bool {
+	condition := apiMeta.FindStatusCondition(server.Status.Conditions, string(kmcp.MCPServerConditionReady))
+	return condition != nil && condition.Status == metav1.ConditionTrue && condition.ObservedGeneration == server.Generation
+}
+
+func (r *Reconciler) updateCatalog(ctx context.Context, server *kmcp.MCPServer, tools []*v1alpha3.MCPTool, connected bool) error {
+	name := client.ObjectKeyFromObject(server).String()
+	var lastConnected *time.Time
+	if connected {
+		now := time.Now().UTC()
+		lastConnected = &now
+	}
+	if _, err := r.catalog.StoreToolServer(ctx, &dbmodel.ToolServer{
+		Name: name, GroupKind: mcpServerGroupKind, Description: "N/A", LastConnected: lastConnected,
+	}); err != nil {
+		return fmt.Errorf("store server: %w", err)
+	}
+	if err := r.catalog.RefreshToolsForServer(ctx, name, mcpServerGroupKind, tools...); err != nil {
+		return fmt.Errorf("refresh tools: %w", err)
+	}
+	return nil
+}
+
+func (r *Reconciler) deleteCatalog(ctx context.Context, name string) error {
+	return errors.Join(
+		wrapError("delete tools", r.catalog.DeleteToolsForServer(ctx, name, mcpServerGroupKind)),
+		wrapError("delete server", r.catalog.DeleteToolServer(ctx, name, mcpServerGroupKind)),
+	)
+}
+
+func wrapError(action string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s: %w", action, err)
+}
+
+var _ reconcile.Reconciler = (*Reconciler)(nil)

--- a/go/core/internal/controller/mcpserver/reconciler_test.go
+++ b/go/core/internal/controller/mcpserver/reconciler_test.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcpserver
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	dbmodel "github.com/kagent-dev/kagent/go/api/database"
+	"github.com/kagent-dev/kagent/go/api/v1alpha3"
+	toolservice "github.com/kagent-dev/kagent/go/core/internal/service/tool"
+	kmcp "github.com/kagent-dev/kmcp/api/v1alpha1"
+	apiMeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+type fakeDiscoverer struct {
+	tools []toolservice.MCPAppTool
+	err   error
+	ref   toolservice.MCPServerRef
+	calls int
+}
+
+func (f *fakeDiscoverer) ListTools(_ context.Context, ref toolservice.MCPServerRef) ([]toolservice.MCPAppTool, error) {
+	f.calls++
+	f.ref = ref
+	return f.tools, f.err
+}
+
+type fakeCatalog struct {
+	server       *dbmodel.ToolServer
+	tools        []*v1alpha3.MCPTool
+	deletedTools string
+	deleted      string
+}
+
+func (f *fakeCatalog) StoreToolServer(_ context.Context, server *dbmodel.ToolServer) (*dbmodel.ToolServer, error) {
+	f.server = server
+	return server, nil
+}
+
+func (f *fakeCatalog) RefreshToolsForServer(_ context.Context, _, _ string, tools ...*v1alpha3.MCPTool) error {
+	f.tools = tools
+	return nil
+}
+
+func (f *fakeCatalog) DeleteToolsForServer(_ context.Context, name, groupKind string) error {
+	f.deletedTools = name + "|" + groupKind
+	return nil
+}
+
+func (f *fakeCatalog) DeleteToolServer(_ context.Context, name, groupKind string) error {
+	f.deleted = name + "|" + groupKind
+	return nil
+}
+
+func TestReconcileDiscoversReadyMCPServer(t *testing.T) {
+	server := readyServer()
+	discoverer := &fakeDiscoverer{tools: []toolservice.MCPAppTool{
+		{Name: "zeta", Description: "last"},
+		{Name: "alpha", Description: "first"},
+	}}
+	catalog := &fakeCatalog{}
+
+	result, err := New(testClient(t, server), discoverer, catalog).Reconcile(t.Context(), ctrl.Request{
+		NamespacedName: client.ObjectKeyFromObject(server),
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	if result.RequeueAfter != 5*time.Minute {
+		t.Fatalf("Reconcile() requeue = %s, want 5m", result.RequeueAfter)
+	}
+	if discoverer.ref.Ref != client.ObjectKeyFromObject(server) || discoverer.ref.GroupKind != mcpServerGroupKind {
+		t.Fatalf("discovery ref = %#v", discoverer.ref)
+	}
+	if catalog.server == nil || catalog.server.Name != "test/tools" || catalog.server.GroupKind != mcpServerGroupKind || catalog.server.LastConnected == nil {
+		t.Fatalf("catalog server = %#v", catalog.server)
+	}
+	if len(catalog.tools) != 2 || catalog.tools[0].Name != "alpha" || catalog.tools[1].Name != "zeta" {
+		t.Fatalf("catalog tools = %#v", catalog.tools)
+	}
+}
+
+func TestReconcileWaitsForCurrentReadyCondition(t *testing.T) {
+	tests := []struct {
+		name      string
+		condition *metav1.Condition
+	}{
+		{name: "condition absent"},
+		{name: "not ready", condition: &metav1.Condition{Type: string(kmcp.MCPServerConditionReady), Status: metav1.ConditionFalse, ObservedGeneration: 3}},
+		{name: "stale ready", condition: &metav1.Condition{Type: string(kmcp.MCPServerConditionReady), Status: metav1.ConditionTrue, ObservedGeneration: 2}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := testServer()
+			if test.condition != nil {
+				server.Status.Conditions = []metav1.Condition{*test.condition}
+			}
+			discoverer := &fakeDiscoverer{}
+			catalog := &fakeCatalog{tools: []*v1alpha3.MCPTool{{Name: "stale"}}}
+
+			result, err := New(testClient(t, server), discoverer, catalog).Reconcile(t.Context(), ctrl.Request{
+				NamespacedName: client.ObjectKeyFromObject(server),
+			})
+			if err != nil {
+				t.Fatalf("Reconcile() error = %v", err)
+			}
+			if result.RequeueAfter != readinessPollInterval || discoverer.calls != 0 {
+				t.Fatalf("Reconcile() = %#v, discovery calls = %d", result, discoverer.calls)
+			}
+			if catalog.server == nil || catalog.server.LastConnected != nil || len(catalog.tools) != 0 {
+				t.Fatalf("unready catalog = server %#v, tools %#v", catalog.server, catalog.tools)
+			}
+		})
+	}
+}
+
+func TestReconcileClearsCatalogAfterDiscoveryFailure(t *testing.T) {
+	server := readyServer()
+	discoverer := &fakeDiscoverer{err: errors.New("unavailable")}
+	catalog := &fakeCatalog{tools: []*v1alpha3.MCPTool{{Name: "stale"}}}
+
+	_, err := New(testClient(t, server), discoverer, catalog).Reconcile(t.Context(), ctrl.Request{
+		NamespacedName: client.ObjectKeyFromObject(server),
+	})
+	if err == nil {
+		t.Fatal("Reconcile() error = nil")
+	}
+	if catalog.server == nil || catalog.server.LastConnected != nil || len(catalog.tools) != 0 {
+		t.Fatalf("failed discovery catalog = server %#v, tools %#v", catalog.server, catalog.tools)
+	}
+}
+
+func TestReconcileDeletesCatalogProjection(t *testing.T) {
+	catalog := &fakeCatalog{}
+	request := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "test", Name: "gone"}}
+
+	if _, err := New(testClient(t), &fakeDiscoverer{}, catalog).Reconcile(t.Context(), request); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	want := "test/gone|" + mcpServerGroupKind
+	if catalog.deletedTools != want || catalog.deleted != want {
+		t.Fatalf("catalog deletes = tools %q, server %q, want %q", catalog.deletedTools, catalog.deleted, want)
+	}
+}
+
+func TestControllerEnabled(t *testing.T) {
+	mapper := apiMetaTestMapper()
+	installed, err := controllerEnabled(mapper)
+	if err != nil || installed {
+		t.Fatalf("controllerEnabled() = %t, %v; want false, nil", installed, err)
+	}
+	mapper.AddSpecific(
+		kmcp.GroupVersion.WithKind("MCPServer"),
+		kmcp.GroupVersion.WithResource("mcpservers"),
+		kmcp.GroupVersion.WithResource("mcpserver"),
+		apiMeta.RESTScopeNamespace,
+	)
+	installed, err = controllerEnabled(mapper)
+	if err != nil || !installed {
+		t.Fatalf("controllerEnabled() = %t, %v; want true, nil", installed, err)
+	}
+}
+
+func testServer() *kmcp.MCPServer {
+	return &kmcp.MCPServer{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "tools", Generation: 3}}
+}
+
+func readyServer() *kmcp.MCPServer {
+	server := testServer()
+	server.Status.Conditions = []metav1.Condition{{
+		Type: string(kmcp.MCPServerConditionReady), Status: metav1.ConditionTrue, ObservedGeneration: server.Generation,
+	}}
+	return server
+}
+
+func testClient(t *testing.T, objects ...client.Object) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := kmcp.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+}
+
+func apiMetaTestMapper() *apiMeta.DefaultRESTMapper {
+	return apiMeta.NewDefaultRESTMapper([]schema.GroupVersion{kmcp.GroupVersion})
+}

--- a/go/core/internal/controller/remotemcpserver/reconciler.go
+++ b/go/core/internal/controller/remotemcpserver/reconciler.go
@@ -23,12 +23,11 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"slices"
-	"strings"
 	"time"
 
 	dbmodel "github.com/kagent-dev/kagent/go/api/database"
 	"github.com/kagent-dev/kagent/go/api/v1alpha3"
+	"github.com/kagent-dev/kagent/go/core/internal/controller/toolcatalog"
 	toolservice "github.com/kagent-dev/kagent/go/core/internal/service/tool"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -105,7 +104,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		)
 	}
 
-	discovered, err := normalizeTools(tools)
+	discovered, err := toolcatalog.NormalizeTools(tools)
 	if err != nil {
 		statusErr := r.updateStatus(ctx, server, nil, metav1.ConditionFalse, "InvalidDiscovery", err.Error())
 		catalogErr := r.updateCatalog(ctx, server, nil, false)
@@ -155,25 +154,6 @@ func wrapError(action string, err error) error {
 		return nil
 	}
 	return fmt.Errorf("%s: %w", action, err)
-}
-
-func normalizeTools(tools []toolservice.MCPAppTool) ([]*v1alpha3.MCPTool, error) {
-	discovered := make([]*v1alpha3.MCPTool, 0, len(tools))
-	seen := make(map[string]struct{}, len(tools))
-	for _, tool := range tools {
-		if strings.TrimSpace(tool.Name) == "" {
-			return nil, fmt.Errorf("MCP discovery returned a tool with an empty name")
-		}
-		if _, exists := seen[tool.Name]; exists {
-			return nil, fmt.Errorf("MCP discovery returned duplicate tool %q", tool.Name)
-		}
-		seen[tool.Name] = struct{}{}
-		discovered = append(discovered, &v1alpha3.MCPTool{Name: tool.Name, Description: tool.Description})
-	}
-	slices.SortFunc(discovered, func(a, b *v1alpha3.MCPTool) int {
-		return strings.Compare(a.Name, b.Name)
-	})
-	return discovered, nil
 }
 
 func (r *Reconciler) updateStatus(

--- a/go/core/internal/controller/remotemcpserver/reconciler_test.go
+++ b/go/core/internal/controller/remotemcpserver/reconciler_test.go
@@ -150,23 +150,6 @@ func TestReconcileDeletesCatalogProjection(t *testing.T) {
 	}
 }
 
-func TestNormalizeToolsRejectsInvalidCatalog(t *testing.T) {
-	tests := []struct {
-		name  string
-		tools []toolservice.MCPAppTool
-	}{
-		{name: "empty name", tools: []toolservice.MCPAppTool{{Name: " "}}},
-		{name: "duplicate name", tools: []toolservice.MCPAppTool{{Name: "lookup"}, {Name: "lookup"}}},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			if _, err := normalizeTools(test.tools); err == nil {
-				t.Fatal("normalizeTools() error = nil")
-			}
-		})
-	}
-}
-
 func TestReferencesDependency(t *testing.T) {
 	server := testServer()
 	server.Spec.HeadersFrom = []v1alpha3.ValueRef{

--- a/go/core/internal/controller/toolcatalog/tools.go
+++ b/go/core/internal/controller/toolcatalog/tools.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package toolcatalog contains semantic operations shared by MCP catalog
+// reconcilers.
+package toolcatalog
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/kagent-dev/kagent/go/api/v1alpha3"
+	toolservice "github.com/kagent-dev/kagent/go/core/internal/service/tool"
+)
+
+// NormalizeTools validates and deterministically orders discovered MCP tools.
+func NormalizeTools(tools []toolservice.MCPAppTool) ([]*v1alpha3.MCPTool, error) {
+	discovered := make([]*v1alpha3.MCPTool, 0, len(tools))
+	seen := make(map[string]struct{}, len(tools))
+	for _, tool := range tools {
+		if strings.TrimSpace(tool.Name) == "" {
+			return nil, fmt.Errorf("MCP discovery returned a tool with an empty name")
+		}
+		if _, exists := seen[tool.Name]; exists {
+			return nil, fmt.Errorf("MCP discovery returned duplicate tool %q", tool.Name)
+		}
+		seen[tool.Name] = struct{}{}
+		discovered = append(discovered, &v1alpha3.MCPTool{Name: tool.Name, Description: tool.Description})
+	}
+	slices.SortFunc(discovered, func(a, b *v1alpha3.MCPTool) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	return discovered, nil
+}

--- a/go/core/internal/controller/toolcatalog/tools_test.go
+++ b/go/core/internal/controller/toolcatalog/tools_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package toolcatalog
+
+import (
+	"testing"
+
+	toolservice "github.com/kagent-dev/kagent/go/core/internal/service/tool"
+)
+
+func TestNormalizeTools(t *testing.T) {
+	tests := []struct {
+		name  string
+		tools []toolservice.MCPAppTool
+		want  []string
+	}{
+		{name: "sorted", tools: []toolservice.MCPAppTool{{Name: "zeta"}, {Name: "alpha"}}, want: []string{"alpha", "zeta"}},
+		{name: "empty name", tools: []toolservice.MCPAppTool{{Name: " "}}},
+		{name: "duplicate name", tools: []toolservice.MCPAppTool{{Name: "lookup"}, {Name: "lookup"}}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := NormalizeTools(test.tools)
+			if test.want == nil {
+				if err == nil {
+					t.Fatal("NormalizeTools() error = nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NormalizeTools() error = %v", err)
+			}
+			if len(got) != len(test.want) {
+				t.Fatalf("NormalizeTools() = %#v", got)
+			}
+			for index := range got {
+				if got[index].Name != test.want[index] {
+					t.Fatalf("NormalizeTools()[%d] = %q, want %q", index, got[index].Name, test.want[index])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Follow up to #2639, this controller watches `MCPServer` and populates the DB with its tools and record, which is used by the UI. It is only enabled when the `MCPServer` CRD is installed. Note that AgentTemplate does not yet support `MCPServer` (only `RemoteMCPServer`), but that is outside the scope of this PR.