### PR TITLE
feat(helm): expose pod annotations in agent Helm charts

### DIFF
--- a/helm/agents/argo-rollouts/templates/_helpers.tpl
+++ b/helm/agents/argo-rollouts/templates/_helpers.tpl
@@ -1,4 +1,8 @@
 {{- define "agent.deploymentSpec" -}}
+{{- with .Values.annotations }}
+annotations:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- with coalesce (empty .Values.imagePullSecrets | ternary nil .Values.imagePullSecrets) .Values.global.imagePullSecrets }}
 imagePullSecrets:
   {{- toYaml . | nindent 2 }}

--- a/helm/agents/argo-rollouts/values.yaml
+++ b/helm/agents/argo-rollouts/values.yaml
@@ -15,6 +15,9 @@ env: []
 
 imagePullSecrets: []
 
+# -- Optional annotations added to the agent's pod template.
+annotations: {}
+
 resources:
   requests:
     cpu: 100m

--- a/helm/agents/cilium-debug/templates/_helpers.tpl
+++ b/helm/agents/cilium-debug/templates/_helpers.tpl
@@ -1,4 +1,8 @@
 {{- define "agent.deploymentSpec" -}}
+{{- with .Values.annotations }}
+annotations:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- with coalesce (empty .Values.imagePullSecrets | ternary nil .Values.imagePullSecrets) .Values.global.imagePullSecrets }}
 imagePullSecrets:
   {{- toYaml . | nindent 2 }}

--- a/helm/agents/cilium-debug/values.yaml
+++ b/helm/agents/cilium-debug/values.yaml
@@ -15,6 +15,9 @@ env: []
 
 imagePullSecrets: []
 
+# -- Optional annotations added to the agent's pod template.
+annotations: {}
+
 resources:
   requests:
     cpu: 100m

--- a/helm/agents/cilium-manager/templates/_helpers.tpl
+++ b/helm/agents/cilium-manager/templates/_helpers.tpl
@@ -1,4 +1,8 @@
 {{- define "agent.deploymentSpec" -}}
+{{- with .Values.annotations }}
+annotations:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- with coalesce (empty .Values.imagePullSecrets | ternary nil .Values.imagePullSecrets) .Values.global.imagePullSecrets }}
 imagePullSecrets:
   {{- toYaml . | nindent 2 }}

--- a/helm/agents/cilium-manager/values.yaml
+++ b/helm/agents/cilium-manager/values.yaml
@@ -15,6 +15,9 @@ env: []
 
 imagePullSecrets: []
 
+# -- Optional annotations added to the agent's pod template.
+annotations: {}
+
 resources:
   requests:
     cpu: 100m

--- a/helm/agents/cilium-policy/templates/_helpers.tpl
+++ b/helm/agents/cilium-policy/templates/_helpers.tpl
@@ -1,4 +1,8 @@
 {{- define "agent.deploymentSpec" -}}
+{{- with .Values.annotations }}
+annotations:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- with coalesce (empty .Values.imagePullSecrets | ternary nil .Values.imagePullSecrets) .Values.global.imagePullSecrets }}
 imagePullSecrets:
   {{- toYaml . | nindent 2 }}

--- a/helm/agents/cilium-policy/values.yaml
+++ b/helm/agents/cilium-policy/values.yaml
@@ -15,6 +15,9 @@ env: []
 
 imagePullSecrets: []
 
+# -- Optional annotations added to the agent's pod template.
+annotations: {}
+
 resources:
   requests:
     cpu: 100m

--- a/helm/agents/helm/templates/_helpers.tpl
+++ b/helm/agents/helm/templates/_helpers.tpl
@@ -1,4 +1,8 @@
 {{- define "agent.deploymentSpec" -}}
+{{- with .Values.annotations }}
+annotations:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- with coalesce (empty .Values.imagePullSecrets | ternary nil .Values.imagePullSecrets) .Values.global.imagePullSecrets }}
 imagePullSecrets:
   {{- toYaml . | nindent 2 }}

--- a/helm/agents/helm/values.yaml
+++ b/helm/agents/helm/values.yaml
@@ -15,6 +15,9 @@ env: []
 
 imagePullSecrets: []
 
+# -- Optional annotations added to the agent's pod template.
+annotations: {}
+
 resources:
   requests:
     cpu: 100m

--- a/helm/agents/istio/templates/_helpers.tpl
+++ b/helm/agents/istio/templates/_helpers.tpl
@@ -1,4 +1,8 @@
 {{- define "agent.deploymentSpec" -}}
+{{- with .Values.annotations }}
+annotations:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- with coalesce (empty .Values.imagePullSecrets | ternary nil .Values.imagePullSecrets) .Values.global.imagePullSecrets }}
 imagePullSecrets:
   {{- toYaml . | nindent 2 }}

--- a/helm/agents/istio/values.yaml
+++ b/helm/agents/istio/values.yaml
@@ -15,6 +15,9 @@ env: []
 
 imagePullSecrets: []
 
+# -- Optional annotations added to the agent's pod template.
+annotations: {}
+
 resources:
   requests:
     cpu: 100m

--- a/helm/agents/k8s/templates/_helpers.tpl
+++ b/helm/agents/k8s/templates/_helpers.tpl
@@ -1,4 +1,8 @@
 {{- define "agent.deploymentSpec" -}}
+{{- with .Values.annotations }}
+annotations:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- with coalesce (empty .Values.imagePullSecrets | ternary nil .Values.imagePullSecrets) .Values.global.imagePullSecrets }}
 imagePullSecrets:
   {{- toYaml . | nindent 2 }}

--- a/helm/agents/k8s/values.yaml
+++ b/helm/agents/k8s/values.yaml
@@ -15,6 +15,9 @@ env: []
 
 imagePullSecrets: []
 
+# -- Optional annotations added to the agent's pod template.
+annotations: {}
+
 resources:
   requests:
     cpu: 100m

--- a/helm/agents/kgateway/templates/_helpers.tpl
+++ b/helm/agents/kgateway/templates/_helpers.tpl
@@ -1,4 +1,8 @@
 {{- define "agent.deploymentSpec" -}}
+{{- with .Values.annotations }}
+annotations:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- with coalesce (empty .Values.imagePullSecrets | ternary nil .Values.imagePullSecrets) .Values.global.imagePullSecrets }}
 imagePullSecrets:
   {{- toYaml . | nindent 2 }}

--- a/helm/agents/kgateway/values.yaml
+++ b/helm/agents/kgateway/values.yaml
@@ -15,6 +15,9 @@ env: []
 
 imagePullSecrets: []
 
+# -- Optional annotations added to the agent's pod template.
+annotations: {}
+
 resources:
   requests:
     cpu: 100m

--- a/helm/agents/observability/templates/_helpers.tpl
+++ b/helm/agents/observability/templates/_helpers.tpl
@@ -1,4 +1,8 @@
 {{- define "agent.deploymentSpec" -}}
+{{- with .Values.annotations }}
+annotations:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- with coalesce (empty .Values.imagePullSecrets | ternary nil .Values.imagePullSecrets) .Values.global.imagePullSecrets }}
 imagePullSecrets:
   {{- toYaml . | nindent 2 }}

--- a/helm/agents/observability/values.yaml
+++ b/helm/agents/observability/values.yaml
@@ -15,6 +15,9 @@ env: []
 
 imagePullSecrets: []
 
+# -- Optional annotations added to the agent's pod template.
+annotations: {}
+
 resources:
   requests:
     cpu: 100m

--- a/helm/agents/promql/templates/_helpers.tpl
+++ b/helm/agents/promql/templates/_helpers.tpl
@@ -1,4 +1,8 @@
 {{- define "agent.deploymentSpec" -}}
+{{- with .Values.annotations }}
+annotations:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- with coalesce (empty .Values.imagePullSecrets | ternary nil .Values.imagePullSecrets) .Values.global.imagePullSecrets }}
 imagePullSecrets:
   {{- toYaml . | nindent 2 }}

--- a/helm/agents/promql/values.yaml
+++ b/helm/agents/promql/values.yaml
@@ -15,6 +15,9 @@ env: []
 
 imagePullSecrets: []
 
+# -- Optional annotations added to the agent's pod template.
+annotations: {}
+
 resources:
   requests:
     cpu: 100m


### PR DESCRIPTION
The Agent CRD supports spec.declarative.deployment.annotations, but the charts under helm/agents/* had no way to set it. Each agent chart gains an annotations value, rendered into the Agent CR by agent.deploymentSpec.

Refs https://github.com/kagent-dev/kagent/issues/2594