### PR TITLE
Backport #2637 (bump postgres to `18.6-alpine3.23`) to release/v0.10.x

### DIFF
--- a/go/core/test/upgrade/upgrade_test.go
+++ b/go/core/test/upgrade/upgrade_test.go
@@ -549,12 +549,18 @@ func podNameForSelector(t *testing.T, env upgradeEnv, selector string) string {
 
 // podNameForSelectorE is the error-returning core of podNameForSelector, for use
 // inside require.Eventually conditions (see pgQueryE).
+//
+// Newest pod: an upgrade that changes the bundled Postgres pod spec (e.g. an
+// image tag bump) recreates the pod, and the old Terminating pod can still
+// match the selector for its whole grace period. Sorting by creation time and
+// taking the last entry always targets the replacement pod.
 func podNameForSelectorE(t *testing.T, env upgradeEnv, selector string) (string, error) {
 	out, err := kubectlOutput(t, env, time.Minute,
 		"get", "pods",
 		"-n", env.namespace,
 		"-l", selector,
-		"-o", "jsonpath={.items[0].metadata.name}",
+		"--sort-by=.metadata.creationTimestamp",
+		"-o", "jsonpath={.items[-1].metadata.name}",
 	)
 	if err != nil {
 		return "", err

--- a/helm/kagent/tests/postgresql_test.yaml
+++ b/helm/kagent/tests/postgresql_test.yaml
@@ -100,7 +100,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/postgres:18.3-alpine
+          value: docker.io/library/postgres:18.6-alpine3.23
 
   - it: should render Deployment with custom image
     template: postgresql.yaml

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -112,7 +112,7 @@ database:
         # -- Bundled PostgreSQL image name
         name: postgres
         # -- Bundled PostgreSQL image tag
-        tag: "18.3-alpine"
+        tag: "18.6-alpine3.23"
         # -- Bundled PostgreSQL image pull policy
         pullPolicy: IfNotPresent
       # -- PersistentVolumeClaim size for demo PostgreSQL data


### PR DESCRIPTION
Backport of #2637 to `release/v0.10.x`.

Bumps the bundled/default PostgreSQL image from `18.3-alpine` to `18.6-alpine3.23`, resolving CVEs.

This is a safe bump based on the [pg 18.6 release notes](https://www.postgresql.org/docs/release/18.6/) — we don't use GIN indexes in any table. `alpine` is pinned to `3.23` (the variant the previous `18.3` image used); without the pin the tag would float to `3.24`.

Also carries the upgrade-test fix from the original PR: an image-tag bump recreates the Postgres pod, and the old `Terminating` pod can still match the selector for its whole grace period, so `podNameForSelectorE` now sorts by creation timestamp and takes the newest pod.

Cherry-picked cleanly from bf49169deea79b0a0ceecb528f3735e722fd3a2d — no conflicts, no manual edits.

**Verification**
- `helm unittest helm/kagent -f 'tests/postgresql_test.yaml'` — 32/32 pass
- `go vet ./core/test/upgrade/` — clean
