### PR TITLE
fix(ui): remove empty substrate template metadata

### DIFF
--- a/go/core/internal/grpcserver/system.go
+++ b/go/core/internal/grpcserver/system.go
@@ -77,15 +77,12 @@ func (s *systemServer) GetSubstrateStatus(ctx context.Context, request *apiv1alp
 	}
 	for _, actorTemplate := range result.ActorTemplates {
 		response.ActorTemplates = append(response.ActorTemplates, &apiv1alpha1.SubstrateActorTemplate{
-			Namespace:       actorTemplate.Namespace,
-			Name:            actorTemplate.Name,
-			Phase:           actorTemplate.Phase,
-			GoldenActorId:   actorTemplate.GoldenActorID,
-			GoldenSnapshot:  actorTemplate.GoldenSnapshot,
-			SandboxClass:    actorTemplate.SandboxClass,
-			WorkerSelector:  actorTemplate.WorkerSelector,
-			HarnessName:     actorTemplate.HarnessName,
-			ManagedByKagent: actorTemplate.ManagedByKagent,
+			Namespace:      actorTemplate.Namespace,
+			Name:           actorTemplate.Name,
+			Phase:          actorTemplate.Phase,
+			GoldenSnapshot: actorTemplate.GoldenSnapshot,
+			SandboxClass:   actorTemplate.SandboxClass,
+			WorkerSelector: actorTemplate.WorkerSelector,
 		})
 	}
 	for _, actor := range result.Actors {

--- a/go/core/internal/service/system/service.go
+++ b/go/core/internal/service/system/service.go
@@ -64,15 +64,12 @@ type SubstrateWorkerPool struct {
 }
 
 type SubstrateActorTemplate struct {
-	Namespace       string
-	Name            string
-	Phase           string
-	GoldenActorID   string
-	GoldenSnapshot  string
-	SandboxClass    string
-	WorkerSelector  string
-	HarnessName     string
-	ManagedByKagent bool
+	Namespace      string
+	Name           string
+	Phase          string
+	GoldenSnapshot string
+	SandboxClass   string
+	WorkerSelector string
 }
 
 type SubstrateActor struct {

--- a/ui/playwright/tests/substrate/substrate.spec.ts
+++ b/ui/playwright/tests/substrate/substrate.spec.ts
@@ -65,14 +65,11 @@ test("substrate: the inventory renders, and partial runtime data says so", async
     await expect(templates).toContainText("kagent/coder-template");
     await expect(templates).toContainText("platform/external-template");
 
-    // The golden actor, beneath the name: it is the snapshot every new actor of this
-    // template is cut from, and the one identifier worth carrying beside the name.
-    await expect(templates).toContainText("golden: actor-golden-001");
-
     // The rest of what decides where and how a template runs.
     await expect(templates).toContainText("standard");
     await expect(templates).toContainText("pool=default-pool");
-    await expect(templates).toContainText("openclaw");
+    await expect(templates.getByRole("columnheader", { name: "Harness" })).toHaveCount(0);
+    await expect(templates).not.toContainText("golden:");
 
     // Both phases, and coloured by what they mean rather than all alike: a Ready template
     // reads as healthy, a Pending one does not.

--- a/ui/src/api/domain/substrate.ts
+++ b/ui/src/api/domain/substrate.ts
@@ -42,12 +42,9 @@ export interface SubstrateActorTemplateEntry {
   namespace: string;
   name: string;
   phase?: string;
-  goldenActorId?: string;
   goldenSnapshot?: string;
   sandboxClass?: string;
   workerSelector?: string;
-  harnessName?: string;
-  managedByKagent: boolean;
 }
 
 /** Runtime actor state, from ate-api rather than from Kubernetes. */

--- a/ui/src/api/grpc/operations.ts
+++ b/ui/src/api/grpc/operations.ts
@@ -1292,12 +1292,9 @@ function toActorTemplateEntry(
     namespace: template.namespace,
     name: template.name,
     phase: orUndefined(template.phase),
-    goldenActorId: orUndefined(template.goldenActorId),
     goldenSnapshot: orUndefined(template.goldenSnapshot),
     sandboxClass: orUndefined(template.sandboxClass),
     workerSelector: orUndefined(template.workerSelector),
-    harnessName: orUndefined(template.harnessName),
-    managedByKagent: template.managedByKagent,
   };
 }
 

--- a/ui/src/api/operations.test.ts
+++ b/ui/src/api/operations.test.ts
@@ -688,7 +688,7 @@ describe("the cluster", () => {
             { namespace: "kagent", name: "pool", replicas: 2, ateomImage: "ateom:1" },
           ],
           actorTemplates: [
-            { namespace: "kagent", name: "tpl", managedByKagent: true, phase: "Ready" },
+            { namespace: "kagent", name: "tpl", phase: "Ready" },
           ],
           actors: [{ actorId: "a1", atespace: "kagent", status: "Running", version: 3n }],
           workers: [],
@@ -703,7 +703,6 @@ describe("the cluster", () => {
     expect(status.ateApiError).toMatch(/ate-api/);
     expect(status.actors[0].atespace).toBe("kagent");
     expect(status.actors[0].version).toBe(3);
-    expect(status.actorTemplates[0].managedByKagent).toBe(true);
   });
 
   // Proto3 cannot tell an unset string from an empty one, and an empty warning

--- a/ui/src/mocks/fixtures.ts
+++ b/ui/src/mocks/fixtures.ts
@@ -479,18 +479,14 @@ export const mockSubstrateStatus: SubstrateStatusResponse = {
       namespace: "kagent",
       name: "coder-template",
       phase: "Ready",
-      goldenActorId: "actor-golden-001",
       goldenSnapshot: "snap-2026-07-28",
       sandboxClass: "standard",
       workerSelector: "pool=default-pool",
-      harnessName: "openclaw",
-      managedByKagent: true,
     },
     {
       namespace: "platform",
       name: "external-template",
       phase: "Pending",
-      managedByKagent: false,
     },
   ],
   actors: [

--- a/ui/src/mocks/transport.ts
+++ b/ui/src/mocks/transport.ts
@@ -1510,12 +1510,9 @@ on(SystemService.method.getSubstrateStatus, (input, call) => {
       namespace: template.namespace,
       name: template.name,
       phase: template.phase ?? "",
-      goldenActorId: template.goldenActorId ?? "",
       goldenSnapshot: template.goldenSnapshot ?? "",
       sandboxClass: template.sandboxClass ?? "",
       workerSelector: template.workerSelector ?? "",
-      harnessName: template.harnessName ?? "",
-      managedByKagent: template.managedByKagent ?? false,
     })),
     actors: actors.map((actor) => ({
       actorId: actor.actorId,

--- a/ui/src/pages/SubstratePage.tsx
+++ b/ui/src/pages/SubstratePage.tsx
@@ -769,11 +769,9 @@ export function SubstratePage() {
         [
           template.namespace,
           template.name,
-          template.goldenActorId,
           template.phase,
           template.sandboxClass,
           template.workerSelector,
-          template.harnessName,
         ]
           .filter(Boolean)
           .join(" "),
@@ -864,16 +862,7 @@ export function SubstratePage() {
         key: "template",
         sorter: { compare: byText((t) => `${t.namespace}/${t.name}`), multiple: 5 },
         render: (_, template) => (
-          <div>
-            {qualified(template.namespace, template.name)}
-            {/* The golden actor is the snapshot every new actor of this template is
-                cut from, so it is the one identifier worth carrying beside the name. */}
-            {template.goldenActorId ? (
-              <Text css={{ ...mono, ...muted, display: "block" }}>
-                golden: {template.goldenActorId}
-              </Text>
-            ) : null}
-          </div>
+          qualified(template.namespace, template.name)
         ),
       },
       {
@@ -900,15 +889,6 @@ export function SubstratePage() {
           ) : (
             "—"
           ),
-      },
-      {
-        // Text and not a link: the agents list has no namespace filter to send a
-        // reader to, so a link here would land them on an unfiltered page and imply
-        // otherwise.
-        title: "Harness",
-        key: "harness",
-        sorter: { compare: byText((t) => t.harnessName ?? ""), multiple: 1 },
-        render: (_, template) => template.harnessName ?? "—",
       },
     ],
     [mono, muted, qualified],


### PR DESCRIPTION
## Summary / Problem

Fixes #2653. After Actor Templates moved from Kubernetes CRDs to ate-api in #2638, `goldenActorId`, `harnessName`, and `managedByKagent` are no longer available from the served ate-api template. The Substrate page consequently exposed values that were always empty or dead.

## Changes

- Remove the unavailable metadata from the internal Go inventory model and gRPC serialization path.
- Remove the corresponding TypeScript domain fields, client mapping, mock data, and the Substrate table's golden-actor and Harness projections.
- Keep the existing v1alpha1 wire fields for backward compatibility; the server no longer populates them and the UI no longer depends on them.
- Add a browser regression assertion that the removed columns and golden-actor display do not reappear.

## Tests

- `go test -skip 'TestE2E.*' ./core/internal/service/system ./core/internal/grpcserver` — passed.
- `go vet ./core/internal/service/system ./core/internal/grpcserver` — passed.
- `golangci-lint v2.13.0` with the repository's enabled checks except the Windows-incompatible kube-api-linter plugin — 0 issues.
- `go run github.com/bufbuild/buf/cmd/buf@v1.72.0 lint` — passed.
- `go run github.com/bufbuild/buf/cmd/buf@v1.72.0 generate` — passed with no generated drift.
- `go run github.com/bufbuild/buf/cmd/buf@v1.72.0 breaking proto --against ".git#branch=main,subdir=proto"` — passed.
- `corepack yarn typecheck` — passed.
- `corepack yarn lint` — passed with 0 errors and 7 pre-existing warnings.
- `corepack yarn test` — 34 files and 412 tests passed.
- `corepack yarn build` — passed.
- `corepack yarn playwright test playwright/tests/substrate --project=chromium --project=firefox` — 16 tests passed.
- `git diff --check` — passed.

## Compatibility / Known limitations

The Substrate Actor Templates table no longer displays the three fields that ate-api cannot provide. The protobuf fields remain on the wire so existing clients are not broken, but they are no longer populated by this service. Full Go CI race tests were not completed locally because Windows has `CGO_ENABLED=0` and no cgo compiler; the repository's kube-api-linter plugin is also Unix-only. The full browser suite was attempted: 173/179 passed, with 6 unrelated Firefox concurrency/mock-stream failures; the focused Substrate suite passed in both engines.

## Issue

Issue: #2653 — https://github.com/kagent-dev/kagent/issues/2653
