### PR TITLE
[UI] Prompts edit support added and form polished

### DIFF
--- a/ui/playwright/tests/prompts/prompt-editing.spec.ts
+++ b/ui/playwright/tests/prompts/prompt-editing.spec.ts
@@ -53,8 +53,16 @@ test("prompt libraries: the edit form opens from the list and from the library, 
     await expect(page.getByTestId("prompt-fragments-note")).toContainText("is deleted");
     // And the identity is locked, because the ref addresses the ConfigMap: an edit
     // cannot rename a library or move it to another namespace.
-    await expect(page.getByTestId("prompt-name")).toBeDisabled();
-    await expect(page.getByTestId("prompt-namespace")).toBeDisabled();
+    /*
+     * Read-only rather than disabled, and the difference is the point: these two are
+     * shown so the reader is sure which library they are editing, and a disabled field
+     * is dimmed. Both attributes are asserted so a change back to `disabled` fails
+     * here rather than only being noticed as a colour.
+     */
+    for (const field of ["prompt-name", "prompt-namespace"]) {
+      await expect(page.getByTestId(field)).toHaveAttribute("readonly", "");
+      await expect(page.getByTestId(field)).toBeEnabled();
+    }
   });
 
   await test.step("4. leaving with a draft asks before throwing it away", async () => {
@@ -84,6 +92,9 @@ test("prompt libraries: the edit form opens from the list and from the library, 
       await leave.click();
       await expect(page.getByTestId("prompt-discard-body")).toBeVisible();
       await page.getByRole("button", { name: "Keep editing" }).click();
+      // Waited out before the next exit is tried: the dialog's overlay outlives the
+      // click that dismissed it, and swallows whatever is aimed at the page beneath.
+      await expect(page.getByTestId("prompt-discard-body")).toBeHidden();
       await expect(page).toHaveURL(/\/edit$/);
       await expect(fragmentValue(page, 2)).toHaveValue("Edited by the suite.");
     }
@@ -205,8 +216,10 @@ test("prompt libraries: the create form is the same form, and refuses the same t
     // The other half of the shared form: these two are editable when the library
     // does not exist yet, and marked required because nothing can be created
     // without them.
-    await expect(page.getByTestId("prompt-name")).toBeEnabled();
-    await expect(page.getByTestId("prompt-namespace")).toBeEnabled();
+    for (const field of ["prompt-name", "prompt-namespace"]) {
+      await expect(page.getByTestId(field)).toBeEnabled();
+      await expect(page.getByTestId(field)).not.toHaveAttribute("readonly", "");
+    }
 
     await page.getByTestId("prompt-submit").click();
     await expect(page.getByTestId("prompt-form-errors")).toContainText(

--- a/ui/playwright/tests/prompts/prompt-editing.spec.ts
+++ b/ui/playwright/tests/prompts/prompt-editing.spec.ts
@@ -1,0 +1,203 @@
+import type { Page } from "@playwright/test";
+import { test, expect } from "../../fixtures/test";
+import { dataRows, loadPage, rowNamed, routes } from "../../helpers/app";
+
+/**
+ * Editing a prompt library, from the action that used to go nowhere.
+ *
+ * The list's edit action landed on the read-only detail page: it promised an edit and
+ * delivered the same place the library's name already opened, while
+ * `UpdatePromptTemplate` — implemented end to end, from the RPC down to the ConfigMap
+ * write — was reachable from nowhere in the app. So a library could be created and
+ * read and then never changed.
+ *
+ * Driven as journeys rather than as page tests because the interesting parts are the
+ * joins: that both edit actions reach the form, that a save replaces the library
+ * rather than merging into it, and that the list behind it is re-read. The order the
+ * rows arrive in is asserted too — `data` is a map on the wire, so the order is the
+ * app's to impose, and the reading page and the form have to agree on it.
+ */
+
+/** `kagent/shared-fragments`, whose three keys sort into this order. */
+const SEEDED_KEYS = ["escalation", "safety", "tone"];
+
+/** The nth fragment row's key and text boxes. */
+const fragmentKey = (page: Page, index: number) =>
+  page.getByTestId("fragment-key").nth(index);
+const fragmentValue = (page: Page, index: number) =>
+  page.getByTestId("fragment-value").nth(index);
+
+test("prompt libraries: the edit form opens from the list and from the library, and a save sticks", async ({
+  page,
+}) => {
+  await test.step("1. the list's edit action opens the form, not the reading page", async () => {
+    await loadPage(page, routes.prompts, { title: "Prompts" });
+    await expect(rowNamed(page, "shared-fragments")).toHaveCount(1, { timeout: 30_000 });
+
+    await page.getByTestId("edit-shared-fragments").click();
+    await expect(page).toHaveURL(/\/prompts\/kagent\/shared-fragments\/edit$/);
+    await expect(page.getByTestId("prompt-submit")).toBeVisible();
+  });
+
+  await test.step("2. the rows are the library's fragments, in key order", async () => {
+    await expect(page.getByTestId("fragment-row")).toHaveCount(SEEDED_KEYS.length);
+    for (const [index, key] of SEEDED_KEYS.entries()) {
+      await expect(fragmentKey(page, index)).toHaveValue(key);
+    }
+    await expect(fragmentValue(page, 2)).toHaveValue(/Be concise/);
+  });
+
+  await test.step("3. the form says a save replaces the library, because it does", async () => {
+    // `UpdatePromptTemplate` assigns the ConfigMap's whole `data` map, so removing a
+    // row deletes a fragment. Nothing else on screen would tell a reader that.
+    await expect(page.getByTestId("prompt-fragments-note")).toContainText("is deleted");
+    // And the identity is locked, because the ref addresses the ConfigMap: an edit
+    // cannot rename a library or move it to another namespace.
+    await expect(page.getByTestId("prompt-name")).toBeDisabled();
+    await expect(page.getByTestId("prompt-namespace")).toBeDisabled();
+  });
+
+  await test.step("4. leaving with a draft asks before throwing it away", async () => {
+    await fragmentValue(page, 2).fill("Edited by the suite.");
+    await page.getByTestId("prompt-cancel").click();
+    // The body rather than the modal: antd hangs the outer testid on a wrapper it
+    // keeps hidden, so asserting on that one passes without the dialog being up.
+    await expect(page.getByTestId("prompt-discard-body")).toBeVisible();
+
+    await page.getByRole("button", { name: "Keep editing" }).click();
+    // Kept, not lost — the point of asking. A prompt fragment is prose somebody
+    // wrote, which is exactly the thing a silent discard costs most.
+    await expect(fragmentValue(page, 2)).toHaveValue("Edited by the suite.");
+  });
+
+  await test.step("5. a fragment can be added alongside the edit", async () => {
+    await page.getByTestId("fragment-add").click();
+    await fragmentKey(page, 3).fill("handoff");
+    await fragmentValue(page, 3).fill("Name the next owner explicitly.");
+    // The include tag is what the fragment is for, and it is offered before the save
+    // rather than only after it.
+    await expect(page.getByTestId("fragment-include-preview").last()).toContainText(
+      '{{include "shared-fragments/handoff"}}',
+    );
+  });
+
+  await test.step("6. saving lands on the library, showing what was saved", async () => {
+    await page.getByTestId("prompt-submit").click();
+    await expect(page).toHaveURL(/\/prompts\/kagent\/shared-fragments$/, {
+      timeout: 30_000,
+    });
+
+    const fragments = page.getByTestId("prompt-fragments");
+    // Read back from the re-read library rather than from the draft: a save that
+    // never reached the backend would leave the old text here.
+    await expect(fragments).toContainText("Edited by the suite.");
+    await expect(fragments).toContainText("Name the next owner explicitly.");
+    await expect(page.getByTestId("prompt-detail-meta")).toContainText("4 fragments");
+  });
+
+  await test.step("7. the library's own Edit action reaches the same form", async () => {
+    await page.getByTestId("prompt-edit").click();
+    await expect(page).toHaveURL(/\/prompts\/kagent\/shared-fragments\/edit$/);
+    // Seeded from the saved library, so the form and the page it came from agree.
+    await expect(page.getByTestId("fragment-row")).toHaveCount(4);
+    await expect(fragmentKey(page, 1)).toHaveValue("handoff");
+
+    // And Cancel with nothing typed goes straight back, with nothing to confirm.
+    await page.getByTestId("prompt-cancel").click();
+    await expect(page).toHaveURL(/\/prompts\/kagent\/shared-fragments$/);
+  });
+
+  await test.step("8. the list behind it was re-read, not left stale", async () => {
+    await page.getByRole("link", { name: "Back to libraries" }).click();
+    const row = rowNamed(page, "shared-fragments");
+    await expect(row).toContainText("4 keys", { timeout: 30_000 });
+    // The keys column too, which is what the search on this page also covers.
+    await expect(row).toContainText("handoff");
+  });
+
+  await test.step("9. and nothing else on the list moved", async () => {
+    await expect(dataRows(page)).toHaveCount(2);
+    await expect(rowNamed(page, "incident-playbooks")).toContainText("2 keys");
+  });
+});
+
+test("prompt libraries: an edit that would empty a library is refused before it is sent", async ({
+  page,
+}) => {
+  await loadPage(page, routes.prompts, { title: "Prompts" });
+  await expect(rowNamed(page, "shared-fragments")).toHaveCount(1, { timeout: 30_000 });
+  await page.getByTestId("edit-shared-fragments").click();
+  await expect(page.getByTestId("prompt-submit")).toBeVisible();
+
+  await test.step("clearing every key blocks the save and says why", async () => {
+    // The controller rejects an empty map — "at least one template key is required" —
+    // so this is its own rule stated before the request rather than a second opinion.
+    for (const index of [0, 1, 2]) await fragmentKey(page, index).fill("");
+
+    await page.getByTestId("prompt-submit").click();
+    await expect(page.getByTestId("prompt-form-errors")).toContainText(
+      "Add at least one fragment key",
+    );
+    // Still on the form, with the text intact: a refused save must not read as a
+    // save, and must not navigate as one either.
+    await expect(page).toHaveURL(/\/edit$/);
+    await expect(fragmentValue(page, 2)).toHaveValue(/Be concise/);
+  });
+
+  await test.step("two rows sharing a key are named, not silently merged", async () => {
+    await fragmentKey(page, 0).fill("tone");
+    await fragmentKey(page, 1).fill("tone");
+
+    await page.getByTestId("prompt-submit").click();
+    // The payload is a map, so the second value would win and the first fragment
+    // would vanish without a word.
+    await expect(page.getByTestId("prompt-form-errors")).toContainText(
+      'Two fragments share the key "tone"',
+    );
+  });
+});
+
+test("prompt libraries: a library that has gone says so instead of offering a form", async ({
+  page,
+}) => {
+  // Deep-linked, the way a stale tab or a shared address arrives. An edit form over a
+  // library the cluster does not have would take input for a save that cannot land.
+  await page.goto("/prompts/kagent/not-a-library/edit?mock=ok");
+  await expect(page.getByTestId("prompt-edit-not-found")).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(page.getByTestId("prompt-submit")).toHaveCount(0);
+});
+
+test("prompt libraries: the create form is the same form, and refuses the same things", async ({
+  page,
+}) => {
+  await loadPage(page, routes.prompts, { title: "Prompts" });
+  await page.getByTestId("prompts-new").click();
+  await expect(page.getByTestId("prompt-submit")).toBeVisible();
+
+  await test.step("the identity is asked for here, unlike an edit", async () => {
+    // The other half of the shared form: these two are editable when the library
+    // does not exist yet, and marked required because nothing can be created
+    // without them.
+    await expect(page.getByTestId("prompt-name")).toBeEnabled();
+    await expect(page.getByTestId("prompt-namespace")).toBeEnabled();
+
+    await page.getByTestId("prompt-submit").click();
+    await expect(page.getByTestId("prompt-form-errors")).toContainText(
+      "A library name is required",
+    );
+  });
+
+  await test.step("a filled-in library is created and appears on the list", async () => {
+    await page.getByTestId("prompt-name").fill("release-notes");
+    await page.getByTestId("fragment-key").first().fill("changelog");
+    await page.getByTestId("fragment-value").first().fill("Group by user impact.");
+    await page.getByTestId("prompt-submit").click();
+
+    await expect(page).toHaveURL(/\/prompts$/, { timeout: 30_000 });
+    const row = rowNamed(page, "release-notes");
+    await expect(row).toContainText("1 key", { timeout: 30_000 });
+    await expect(row).toContainText("changelog");
+  });
+});

--- a/ui/playwright/tests/prompts/prompt-editing.spec.ts
+++ b/ui/playwright/tests/prompts/prompt-editing.spec.ts
@@ -222,10 +222,15 @@ test("prompt libraries: the create form is the same form, and refuses the same t
     await expect(page.getByTestId("prompt-discard-body")).toBeVisible();
     await page.getByRole("button", { name: "Keep editing" }).click();
     await expect(page).toHaveURL(/\/prompts\/new$/);
+    // Waited out rather than assumed gone: a field filled while the dialog is still
+    // closing can be re-rendered back to its previous value by the state change that
+    // closes it, which is a race in this test and not something a reader can hit.
+    await expect(page.getByTestId("prompt-discard-body")).toBeHidden();
   });
 
   await test.step("a filled-in library is created and appears on the list", async () => {
     await page.getByTestId("prompt-name").fill("release-notes");
+    await expect(page.getByTestId("prompt-name")).toHaveValue("release-notes");
     await page.getByTestId("fragment-key").first().fill("changelog");
     await page.getByTestId("fragment-value").first().fill("Group by user impact.");
     await page.getByTestId("prompt-submit").click();

--- a/ui/playwright/tests/prompts/prompt-editing.spec.ts
+++ b/ui/playwright/tests/prompts/prompt-editing.spec.ts
@@ -70,6 +70,25 @@ test("prompt libraries: the edit form opens from the list and from the library, 
     await expect(fragmentValue(page, 2)).toHaveValue("Edited by the suite.");
   });
 
+  await test.step("4b. and asks on every other way out, not just Cancel", async () => {
+    /*
+     * The header link and the sidebar, which is where a guard on the Cancel button
+     * alone fails: it teaches a reader the work is held safe and then the two more
+     * obvious exits throw it away without a word. Both are ordinary links, so what
+     * is being asserted is that leaving is blocked rather than that a button asks.
+     */
+    for (const leave of [
+      page.getByRole("link", { name: "Back to library" }),
+      page.getByRole("link", { name: "Models" }),
+    ]) {
+      await leave.click();
+      await expect(page.getByTestId("prompt-discard-body")).toBeVisible();
+      await page.getByRole("button", { name: "Keep editing" }).click();
+      await expect(page).toHaveURL(/\/edit$/);
+      await expect(fragmentValue(page, 2)).toHaveValue("Edited by the suite.");
+    }
+  });
+
   await test.step("5. a fragment can be added alongside the edit", async () => {
     await page.getByTestId("fragment-add").click();
     await fragmentKey(page, 3).fill("handoff");
@@ -82,6 +101,9 @@ test("prompt libraries: the edit form opens from the list and from the library, 
   });
 
   await test.step("6. saving lands on the library, showing what was saved", async () => {
+    // And is not itself treated as leaving with unsaved work: the draft stops being
+    // unsaved before the caller navigates, so a save is never asked to confirm
+    // itself. This URL assertion is what would fail if it were.
     await page.getByTestId("prompt-submit").click();
     await expect(page).toHaveURL(/\/prompts\/kagent\/shared-fragments$/, {
       timeout: 30_000,
@@ -102,9 +124,12 @@ test("prompt libraries: the edit form opens from the list and from the library, 
     await expect(page.getByTestId("fragment-row")).toHaveCount(4);
     await expect(fragmentKey(page, 1)).toHaveValue("handoff");
 
-    // And Cancel with nothing typed goes straight back, with nothing to confirm.
+    // And Cancel with nothing typed goes straight back, with nothing to confirm:
+    // a question over a form nobody has touched is a question that teaches readers
+    // to click through the next one.
     await page.getByTestId("prompt-cancel").click();
     await expect(page).toHaveURL(/\/prompts\/kagent\/shared-fragments$/);
+    await expect(page.getByTestId("prompt-discard-body")).toHaveCount(0);
   });
 
   await test.step("8. the list behind it was re-read, not left stale", async () => {
@@ -187,6 +212,16 @@ test("prompt libraries: the create form is the same form, and refuses the same t
     await expect(page.getByTestId("prompt-form-errors")).toContainText(
       "A library name is required",
     );
+  });
+
+  await test.step("leaving a half-typed new library asks first as well", async () => {
+    // The baseline is the empty draft rather than a loaded resource, so a library
+    // being written for the first time counts as work to lose too.
+    await page.getByTestId("prompt-name").fill("half-typed");
+    await page.getByTestId("prompt-cancel").click();
+    await expect(page.getByTestId("prompt-discard-body")).toBeVisible();
+    await page.getByRole("button", { name: "Keep editing" }).click();
+    await expect(page).toHaveURL(/\/prompts\/new$/);
   });
 
   await test.step("a filled-in library is created and appears on the list", async () => {

--- a/ui/src/api/hooks/useInvalidatePrompts.ts
+++ b/ui/src/api/hooks/useInvalidatePrompts.ts
@@ -1,0 +1,31 @@
+import { useCallback } from "react";
+import { useSWRConfig } from "swr";
+
+/** The prefix every prompt library read is keyed under — see `usePrompts`. */
+const PROMPT_KEY_PREFIX = "prompts.";
+
+/**
+ * Re-reads every prompt library on screen, wherever it is being shown.
+ *
+ * A key sweep rather than a pair of `refresh()` calls, because the list's key carries
+ * the namespace filter — `["prompts.list", "kagent,platform"]` — so a save that
+ * refreshed `usePrompts()` would refresh the unfiltered read and leave whichever
+ * filtered one the list actually holds still showing the old key count. The detail
+ * read is keyed per library besides. SWR already knows who is reading what, so this
+ * asks it to revalidate anything keyed as a prompt library.
+ *
+ * Resolves once the re-reads have landed, so a caller can await it before saying the
+ * write succeeded.
+ */
+export function useInvalidatePrompts(): () => Promise<void> {
+  const { mutate } = useSWRConfig();
+
+  return useCallback(async () => {
+    await mutate(
+      (key) =>
+        Array.isArray(key) &&
+        typeof key[0] === "string" &&
+        key[0].startsWith(PROMPT_KEY_PREFIX),
+    );
+  }, [mutate]);
+}

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -111,6 +111,7 @@ export {
   useAgentInstancesAcrossNamespaces,
 } from "./hooks/useAgentInstances";
 export { useInvalidateConversations } from "./hooks/useInvalidateConversations";
+export { useInvalidatePrompts } from "./hooks/useInvalidatePrompts";
 export type {
   AgentConversations,
   AgentInstancesAcrossNamespaces,

--- a/ui/src/components/prompts/FragmentEditor.tsx
+++ b/ui/src/components/prompts/FragmentEditor.tsx
@@ -67,6 +67,7 @@ export function FragmentEditor({
             <Button
               data-testid="fragment-remove"
               aria-label={`Remove fragment ${index + 1}`}
+              danger
               icon={<Trash2 size={14} />}
               disabled={disabled}
               onClick={() => remove(row.id)}

--- a/ui/src/components/prompts/FragmentEditor.tsx
+++ b/ui/src/components/prompts/FragmentEditor.tsx
@@ -69,7 +69,7 @@ export function FragmentEditor({
               aria-label={`Remove fragment ${index + 1}`}
               danger
               icon={<Trash2 size={14} />}
-              disabled={disabled}
+              disabled={disabled || rows.length === 1}
               onClick={() => remove(row.id)}
             />
           </div>

--- a/ui/src/components/prompts/FragmentEditor.tsx
+++ b/ui/src/components/prompts/FragmentEditor.tsx
@@ -69,7 +69,7 @@ export function FragmentEditor({
               aria-label={`Remove fragment ${index + 1}`}
               danger
               icon={<Trash2 size={14} />}
-              disabled={disabled || rows.length === 1}
+              disabled={disabled || (rows.length === 1 && !row.key && !row.value)}
               onClick={() => remove(row.id)}
             />
           </div>

--- a/ui/src/components/prompts/PromptForm.tsx
+++ b/ui/src/components/prompts/PromptForm.tsx
@@ -1,0 +1,271 @@
+import { useMemo, useState } from "react";
+import { Alert, Button, Form, Input, Modal, Space, Typography } from "antd";
+import { useTheme } from "@emotion/react";
+import { Link } from "react-router-dom";
+import type { CreatePromptTemplateRequest } from "@/api";
+import { RFC1123_SUBDOMAIN } from "@/components/common/resourceName";
+import { SubmitError } from "@/components/common/SubmitError";
+import { paths } from "@/router/routes";
+import { FragmentEditor } from "./FragmentEditor";
+import {
+  type PromptDraft,
+  emptyPromptDraft,
+  promptDraftIssues,
+  promptPayloadFrom,
+} from "./promptDraft";
+
+const { Text, Paragraph } = Typography;
+
+interface PromptFormProps {
+  onSubmit: (payload: CreatePromptTemplateRequest) => Promise<void>;
+  initial?: PromptDraft;
+  outcome?: "created" | "saved";
+  submitLabel?: string;
+  /**
+   * The name and namespace address the ConfigMap the library is stored as, so an edit
+   * cannot move or rename one. Locked, they are shown rather than hidden: which
+   * library is being changed is the first thing to be sure of.
+   */
+  identityLocked?: boolean;
+  /**
+   * What Cancel does when the form is not a page of its own.
+   *
+   * Given, the form asks before calling it if there is a draft to lose — the caller
+   * that stays on the page is the caller whose Cancel throws work away invisibly.
+   * Omitted, Cancel is a link back to the library list, which is a navigation the
+   * browser can undo.
+   */
+  onCancel?: () => void;
+}
+
+/**
+ * The fields of a prompt library, for creating one or changing one.
+ *
+ * Shared by the create page and the detail page's edit mode, on the same division of
+ * labour the model form uses: the form owns the fields, the rules and whether a
+ * submit is allowed through; the caller owns the request and what happens afterwards.
+ *
+ * Shared rather than written twice because the two surfaces are the same fields, and
+ * two renderings of one thing drift — the one nobody edits is the one that quietly
+ * stops offering something the API gained.
+ */
+export function PromptForm({
+  onSubmit,
+  initial,
+  outcome = "created",
+  submitLabel = "Create library",
+  identityLocked = false,
+  onCancel,
+}: PromptFormProps) {
+  const theme = useTheme();
+  const [draft, setDraft] = useState<PromptDraft>(initial ?? emptyPromptDraft);
+  const [submitted, setSubmitted] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [failure, setFailure] = useState<unknown>();
+  const [isConfirmingDiscard, setConfirmingDiscard] = useState(false);
+
+  const issues = useMemo(
+    () => promptDraftIssues(draft, { identityLocked }),
+    [draft, identityLocked],
+  );
+
+  /*
+   * Whether the draft differs from what it started as, compared by value: somebody who
+   * types a character and deletes it again has not changed anything, and being asked
+   * to confirm a discard of nothing teaches them to click through the question. Row
+   * ids are left out — they are the editor's own bookkeeping, not the library.
+   */
+  const contents = (of: PromptDraft) =>
+    JSON.stringify(of.rows.map((row) => [row.key, row.value]));
+  const isDirty = initial !== undefined && contents(draft) !== contents(initial);
+
+  const update = (patch: Partial<PromptDraft>) => {
+    setDraft((current) => ({ ...current, ...patch }));
+    // A previous failure described values that no longer hold.
+    setFailure(undefined);
+  };
+
+  const submit = async () => {
+    setSubmitted(true);
+    setFailure(undefined);
+    if (issues.length > 0) return;
+
+    setSaving(true);
+    try {
+      await onSubmit(promptPayloadFrom(draft));
+    } catch (error) {
+      setFailure(error);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const cancel = () => {
+    if (isDirty) {
+      setConfirmingDiscard(true);
+      return;
+    }
+    onCancel?.();
+  };
+
+  /*
+   * Whether to mark the identity fields. Only the create caller can get them wrong —
+   * locked, they are the resource's own — so a locked form never shows an error on a
+   * field the reader cannot change.
+   */
+  const checkIdentity = submitted && !identityLocked;
+  const nameAccepted = RFC1123_SUBDOMAIN.test(draft.name.trim());
+
+  return (
+    <Space
+      orientation="vertical"
+      size="middle"
+      css={{ display: "flex", maxWidth: 720 }}
+    >
+      <Form layout="vertical" component="div">
+        <Form.Item
+          label="Namespace"
+          required={!identityLocked}
+          validateStatus={
+            checkIdentity && !draft.namespace.trim() ? "error" : undefined
+          }
+          help={
+            checkIdentity && !draft.namespace.trim()
+              ? "A namespace is required."
+              : undefined
+          }
+        >
+          <Input
+            data-testid="prompt-namespace"
+            placeholder="kagent"
+            value={draft.namespace}
+            disabled={identityLocked}
+            onChange={(event) => update({ namespace: event.target.value })}
+          />
+        </Form.Item>
+
+        <Form.Item
+          label="Name"
+          required={!identityLocked}
+          validateStatus={checkIdentity && !nameAccepted ? "error" : undefined}
+          help={
+            checkIdentity && !draft.name.trim()
+              ? "A library name is required."
+              : checkIdentity && !nameAccepted
+                ? "Lowercase letters, numbers and hyphens only."
+                : undefined
+          }
+        >
+          <Input
+            data-testid="prompt-name"
+            placeholder="team-prompts"
+            value={draft.name}
+            disabled={identityLocked}
+            onChange={(event) => update({ name: event.target.value })}
+            css={{ fontFamily: theme.font.mono }}
+          />
+        </Form.Item>
+      </Form>
+
+      <div>
+        <Text strong css={{ display: "block", marginBottom: theme.space(1) }}>
+          Fragments
+        </Text>
+        <Text
+          data-testid="prompt-fragments-note"
+          css={{
+            display: "block",
+            marginBottom: theme.space(3),
+            color: theme.color.textMuted,
+          }}
+        >
+          {identityLocked
+            ? /* The replace semantics, said where they apply. `UpdatePromptTemplate`
+                 assigns the library's whole `data` map, so a row removed here is a
+                 fragment deleted on save, and nothing else on screen says so. */
+              "Each key is an include target. Saving replaces this library's fragments with what is below, so a fragment removed here is deleted."
+            : "Each key becomes an include target. An agent pulls one in with the tag shown beside it."}
+        </Text>
+        <FragmentEditor
+          rows={draft.rows}
+          onChange={(rows) => update({ rows })}
+          library={draft.name.trim() || undefined}
+          disabled={saving}
+        />
+      </div>
+
+      {submitted && issues.length > 0 ? (
+        <Alert
+          type="error"
+          showIcon
+          title={
+            identityLocked
+              ? "These changes cannot be saved yet"
+              : "This library cannot be created yet"
+          }
+          data-testid="prompt-form-errors"
+          description={
+            <ul css={{ margin: 0, paddingLeft: theme.space(5) }}>
+              {issues.map((issue) => (
+                <li key={issue}>{issue}</li>
+              ))}
+            </ul>
+          }
+        />
+      ) : null}
+
+      {failure !== undefined ? (
+        <SubmitError
+          error={failure}
+          what="prompt library"
+          outcome={outcome}
+          onRetry={() => void submit()}
+          data-testid="prompt-submit-error"
+        />
+      ) : null}
+
+      <Space size={8}>
+        <Button
+          type="primary"
+          data-testid="prompt-submit"
+          loading={saving}
+          onClick={() => void submit()}
+        >
+          {submitLabel}
+        </Button>
+        {onCancel ? (
+          <Button onClick={cancel} data-testid="prompt-cancel">
+            Cancel
+          </Button>
+        ) : (
+          <Link to={paths.prompts}>
+            <Button data-testid="prompt-cancel">Cancel</Button>
+          </Link>
+        )}
+      </Space>
+
+      {/*
+        A controlled modal rather than `Modal.confirm`: antd 6's static methods cannot
+        read context, and the warning they log is a failure in the browser suite.
+      */}
+      <Modal
+        open={isConfirmingDiscard}
+        title="Discard your changes?"
+        okText="Discard"
+        okButtonProps={{ danger: true }}
+        cancelText="Keep editing"
+        onOk={() => {
+          setConfirmingDiscard(false);
+          onCancel?.();
+        }}
+        onCancel={() => setConfirmingDiscard(false)}
+        data-testid="prompt-discard-modal"
+      >
+        <Paragraph css={{ margin: 0 }} data-testid="prompt-discard-body">
+          This library has edits that have not been saved. Leaving throws them away; the
+          library on the cluster is unchanged either way.
+        </Paragraph>
+      </Modal>
+    </Space>
+  );
+}

--- a/ui/src/components/prompts/PromptForm.tsx
+++ b/ui/src/components/prompts/PromptForm.tsx
@@ -151,28 +151,11 @@ export function PromptForm({
       size="middle"
       css={{ display: "flex", maxWidth: 720 }}
     >
+      {/* Name before namespace, as every other authoring form in the app has it. The
+          namespace arrives filled in with a default and is usually left alone; the
+          name is the empty field the reader came to fill, and leading with the
+          pre-filled one puts a box to tab past in front of it. */}
       <Form layout="vertical" component="div">
-        <Form.Item
-          label="Namespace"
-          required={!identityLocked}
-          validateStatus={
-            checkIdentity && !draft.namespace.trim() ? "error" : undefined
-          }
-          help={
-            checkIdentity && !draft.namespace.trim()
-              ? "A namespace is required."
-              : undefined
-          }
-        >
-          <Input
-            data-testid="prompt-namespace"
-            placeholder="kagent"
-            value={draft.namespace}
-            disabled={identityLocked}
-            onChange={(event) => update({ namespace: event.target.value })}
-          />
-        </Form.Item>
-
         <Form.Item
           label="Name"
           required={!identityLocked}
@@ -192,6 +175,27 @@ export function PromptForm({
             disabled={identityLocked}
             onChange={(event) => update({ name: event.target.value })}
             css={{ fontFamily: theme.font.mono }}
+          />
+        </Form.Item>
+
+        <Form.Item
+          label="Namespace"
+          required={!identityLocked}
+          validateStatus={
+            checkIdentity && !draft.namespace.trim() ? "error" : undefined
+          }
+          help={
+            checkIdentity && !draft.namespace.trim()
+              ? "A namespace is required."
+              : undefined
+          }
+        >
+          <Input
+            data-testid="prompt-namespace"
+            placeholder="kagent"
+            value={draft.namespace}
+            disabled={identityLocked}
+            onChange={(event) => update({ namespace: event.target.value })}
           />
         </Form.Item>
       </Form>

--- a/ui/src/components/prompts/PromptForm.tsx
+++ b/ui/src/components/prompts/PromptForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Alert, Button, Form, Input, Modal, Space, Typography } from "antd";
 import { useTheme } from "@emotion/react";
 import { Link, useBlocker } from "react-router-dom";
@@ -80,9 +80,15 @@ export function PromptForm({
    */
   const contents = (of: PromptDraft) =>
     JSON.stringify([of.namespace, of.name, of.rows.map((row) => [row.key, row.value])]);
-  const baseline = useRef(contents(draft));
-  const saved = useRef(false);
-  const isDirty = !saved.current && contents(draft) !== baseline.current;
+  /*
+   * Both are state rather than refs, and not only because reading a ref during render
+   * is against the rules of React — which `react-hooks/refs` says out loud. A ref
+   * cannot re-render, so the guard below would re-arm on whatever render happened
+   * next: as refs, `saved` worked only because the `setSaving` beside it forced one.
+   */
+  const [baseline] = useState(() => contents(draft));
+  const [saved, setSaved] = useState(false);
+  const isDirty = !saved && contents(draft) !== baseline;
 
   /*
    * Leaving with a draft asks first — every way out, not just this form's Cancel.
@@ -125,12 +131,12 @@ export function PromptForm({
       // Marked before the call, because the caller navigates as part of a successful
       // save: a draft still counted as unsaved at that moment would have the guard
       // above stop the save's own navigation and ask whether to discard it.
-      saved.current = true;
+      setSaved(true);
       await onSubmit(promptPayloadFrom(draft));
     } catch (error) {
       // Nothing was written, so the work on screen is unsaved again and worth
       // guarding — the reader is still on the form with it.
-      saved.current = false;
+      setSaved(false);
       setFailure(error);
     } finally {
       setSaving(false);
@@ -172,7 +178,11 @@ export function PromptForm({
             data-testid="prompt-name"
             placeholder="team-prompts"
             value={draft.name}
-            disabled={identityLocked}
+            /* `readOnly` rather than `disabled`: these two are shown so the reader is
+               sure which library they are editing, and a disabled field is dimmed —
+               which makes the answer to that question the least legible thing on the
+               form. Uneditable either way. */
+            readOnly={identityLocked}
             onChange={(event) => update({ name: event.target.value })}
             css={{ fontFamily: theme.font.mono }}
           />
@@ -194,7 +204,7 @@ export function PromptForm({
             data-testid="prompt-namespace"
             placeholder="kagent"
             value={draft.namespace}
-            disabled={identityLocked}
+            readOnly={identityLocked}
             onChange={(event) => update({ namespace: event.target.value })}
           />
         </Form.Item>

--- a/ui/src/components/prompts/PromptForm.tsx
+++ b/ui/src/components/prompts/PromptForm.tsx
@@ -1,7 +1,7 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Alert, Button, Form, Input, Modal, Space, Typography } from "antd";
 import { useTheme } from "@emotion/react";
-import { Link } from "react-router-dom";
+import { Link, useBlocker } from "react-router-dom";
 import type { CreatePromptTemplateRequest } from "@/api";
 import { RFC1123_SUBDOMAIN } from "@/components/common/resourceName";
 import { SubmitError } from "@/components/common/SubmitError";
@@ -62,7 +62,6 @@ export function PromptForm({
   const [submitted, setSubmitted] = useState(false);
   const [saving, setSaving] = useState(false);
   const [failure, setFailure] = useState<unknown>();
-  const [isConfirmingDiscard, setConfirmingDiscard] = useState(false);
 
   const issues = useMemo(
     () => promptDraftIssues(draft, { identityLocked }),
@@ -74,10 +73,41 @@ export function PromptForm({
    * types a character and deletes it again has not changed anything, and being asked
    * to confirm a discard of nothing teaches them to click through the question. Row
    * ids are left out — they are the editor's own bookkeeping, not the library.
+   *
+   * The baseline is captured at mount rather than read from the `initial` prop, so a
+   * created library counts as work too: its baseline is the empty draft, and a typed
+   * name is something to lose.
    */
   const contents = (of: PromptDraft) =>
-    JSON.stringify(of.rows.map((row) => [row.key, row.value]));
-  const isDirty = initial !== undefined && contents(draft) !== contents(initial);
+    JSON.stringify([of.namespace, of.name, of.rows.map((row) => [row.key, row.value])]);
+  const baseline = useRef(contents(draft));
+  const saved = useRef(false);
+  const isDirty = !saved.current && contents(draft) !== baseline.current;
+
+  /*
+   * Leaving with a draft asks first — every way out, not just this form's Cancel.
+   *
+   * A confirmation on one button is worse than none: it teaches a reader that the
+   * work is guarded, and then the header link, the sidebar and the back button throw
+   * it away without a word. Blocking the navigation catches all of them, Cancel
+   * included, which is why Cancel below is an ordinary link or callback with no
+   * question of its own.
+   */
+  const blocker = useBlocker(
+    ({ currentLocation, nextLocation }) =>
+      isDirty && currentLocation.pathname !== nextLocation.pathname,
+  );
+
+  /*
+   * And the exits the router cannot see: a reload, a closed tab, a typed address. The
+   * browser shows its own wording here — a page may ask, not choose the words.
+   */
+  useEffect(() => {
+    if (!isDirty) return;
+    const warn = (event: BeforeUnloadEvent) => event.preventDefault();
+    window.addEventListener("beforeunload", warn);
+    return () => window.removeEventListener("beforeunload", warn);
+  }, [isDirty]);
 
   const update = (patch: Partial<PromptDraft>) => {
     setDraft((current) => ({ ...current, ...patch }));
@@ -92,20 +122,19 @@ export function PromptForm({
 
     setSaving(true);
     try {
+      // Marked before the call, because the caller navigates as part of a successful
+      // save: a draft still counted as unsaved at that moment would have the guard
+      // above stop the save's own navigation and ask whether to discard it.
+      saved.current = true;
       await onSubmit(promptPayloadFrom(draft));
     } catch (error) {
+      // Nothing was written, so the work on screen is unsaved again and worth
+      // guarding — the reader is still on the form with it.
+      saved.current = false;
       setFailure(error);
     } finally {
       setSaving(false);
     }
-  };
-
-  const cancel = () => {
-    if (isDirty) {
-      setConfirmingDiscard(true);
-      return;
-    }
-    onCancel?.();
   };
 
   /*
@@ -234,7 +263,7 @@ export function PromptForm({
           {submitLabel}
         </Button>
         {onCancel ? (
-          <Button onClick={cancel} data-testid="prompt-cancel">
+          <Button onClick={onCancel} data-testid="prompt-cancel">
             Cancel
           </Button>
         ) : (
@@ -249,20 +278,19 @@ export function PromptForm({
         read context, and the warning they log is a failure in the browser suite.
       */}
       <Modal
-        open={isConfirmingDiscard}
+        open={blocker.state === "blocked"}
         title="Discard your changes?"
         okText="Discard"
         okButtonProps={{ danger: true }}
         cancelText="Keep editing"
-        onOk={() => {
-          setConfirmingDiscard(false);
-          onCancel?.();
-        }}
-        onCancel={() => setConfirmingDiscard(false)}
+        // `proceed` resumes the navigation that was blocked, so Discard leaves for
+        // wherever the reader was going rather than for one place this form chose.
+        onOk={() => blocker.proceed?.()}
+        onCancel={() => blocker.reset?.()}
         data-testid="prompt-discard-modal"
       >
         <Paragraph css={{ margin: 0 }} data-testid="prompt-discard-body">
-          This library has edits that have not been saved. Leaving throws them away; the
+          This form has edits that have not been saved. Leaving throws them away; the
           library on the cluster is unchanged either way.
         </Paragraph>
       </Modal>

--- a/ui/src/components/prompts/fragmentRows.test.ts
+++ b/ui/src/components/prompts/fragmentRows.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  fragmentIssues,
+  fragmentsToData,
+  newFragmentRow,
+  rowsFromData,
+} from "./fragmentRows";
+
+/** Rows as the editor holds them, without the ids each test would have to invent. */
+const rows = (...pairs: [string, string][]) =>
+  pairs.map(([key, value]) => ({ ...newFragmentRow(), key, value }));
+
+describe("rowsFromData", () => {
+  it("seeds one row per fragment, ordered by key", () => {
+    // Insertion order is deliberately not key order here: `data` is a map on the
+    // wire, so the editor cannot inherit an order from it and has to impose one.
+    const seeded = rowsFromData({ tone: "Be concise.", escalation: "Hand off." });
+    expect(seeded.map((row) => [row.key, row.value])).toEqual([
+      ["escalation", "Hand off."],
+      ["tone", "Be concise."],
+    ]);
+  });
+
+  it("gives distinct ids, so editing one row does not rename another", () => {
+    const seeded = rowsFromData({ a: "1", b: "2" });
+    expect(new Set(seeded.map((row) => row.id)).size).toBe(2);
+  });
+
+  it("offers a blank row for a library with no fragments", () => {
+    // The API can hand one back — a ConfigMap with no data — and an editor with no
+    // rows has nowhere to type and no obvious way to get a row.
+    expect(rowsFromData({})).toHaveLength(1);
+    expect(rowsFromData({})[0]).toMatchObject({ key: "", value: "" });
+  });
+
+  it("round-trips through the payload unchanged", () => {
+    const data = { tone: "Be concise.", safety: "Confirm first." };
+    expect(fragmentsToData(rowsFromData(data))).toEqual(data);
+  });
+});
+
+describe("fragmentIssues", () => {
+  it("passes a library with at least one distinct key", () => {
+    expect(fragmentIssues(rows(["tone", "Be concise."]))).toEqual([]);
+  });
+
+  it("rejects rows that would submit an empty map", () => {
+    // What the controller rejects too — "at least one template key is required" —
+    // so catching it here is the same rule stated before the request.
+    expect(fragmentIssues(rows())).toEqual(["Add at least one fragment key."]);
+    expect(fragmentIssues(rows(["", "orphaned text"]))).toEqual([
+      "Add at least one fragment key.",
+    ]);
+  });
+
+  it("names a duplicated key, which the payload would silently swallow", () => {
+    expect(fragmentIssues(rows(["tone", "first"], ["tone", "second"]))).toEqual([
+      'Two fragments share the key "tone".',
+    ]);
+  });
+
+  it("ignores whitespace-only differences between keys, as the payload does", () => {
+    expect(fragmentIssues(rows(["tone", "first"], [" tone ", "second"]))).toEqual([
+      'Two fragments share the key "tone".',
+    ]);
+  });
+});

--- a/ui/src/components/prompts/fragmentRows.ts
+++ b/ui/src/components/prompts/fragmentRows.ts
@@ -58,3 +58,39 @@ export function findDuplicateKey(rows: FragmentRow[]): string | undefined {
   }
   return undefined;
 }
+
+/**
+ * The rows that edit an existing library's fragments.
+ *
+ * Sorted by key, because `data` is a map: it arrives in whatever order the API server
+ * serialised it, and an editor whose rows reshuffled between reads would move a
+ * fragment out from under the cursor. The detail page reads its fragments in the same
+ * order for the same reason.
+ *
+ * Never empty — a library the API hands back with no fragments still gets somewhere
+ * to type, which is the rule the editor itself follows when the last row is removed.
+ */
+export function rowsFromData(data: Record<string, string>): FragmentRow[] {
+  const rows = Object.entries(data)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => ({ ...newFragmentRow(), key, value }));
+  return rows.length > 0 ? rows : [newFragmentRow()];
+}
+
+/**
+ * What stops a set of rows being saved, in the words a form shows.
+ *
+ * Shared by the create form and the detail page's edit mode because the controller
+ * applies one rule to both: `UpdatePromptTemplate` rejects an empty map — "at least
+ * one template key is required" — exactly as `CreatePromptTemplate` does. Two copies
+ * of that rule are two things to keep in step with it.
+ */
+export function fragmentIssues(rows: FragmentRow[]): string[] {
+  const issues: string[] = [];
+  if (Object.keys(fragmentsToData(rows)).length === 0) {
+    issues.push("Add at least one fragment key.");
+  }
+  const duplicate = findDuplicateKey(rows);
+  if (duplicate) issues.push(`Two fragments share the key "${duplicate}".`);
+  return issues;
+}

--- a/ui/src/components/prompts/promptDraft.test.ts
+++ b/ui/src/components/prompts/promptDraft.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  type PromptDraft,
+  emptyPromptDraft,
+  promptDraftFrom,
+  promptDraftIssues,
+  promptPayloadFrom,
+} from "./promptDraft";
+import { newFragmentRow } from "./fragmentRows";
+
+/** A draft that would be accepted, plus any overrides. */
+const draft = (overrides: Partial<PromptDraft> = {}): PromptDraft => ({
+  namespace: "kagent",
+  name: "team-prompts",
+  rows: [{ ...newFragmentRow(), key: "tone", value: "Be concise." }],
+  ...overrides,
+});
+
+describe("promptDraftFrom", () => {
+  it("carries the library's identity and its fragments", () => {
+    const seeded = promptDraftFrom({
+      namespace: "platform",
+      name: "incident-playbooks",
+      data: { triage: "Blast radius first.", postmortem: "Timeline." },
+    });
+    expect(seeded.namespace).toBe("platform");
+    expect(seeded.name).toBe("incident-playbooks");
+    expect(seeded.rows.map((row) => row.key)).toEqual(["postmortem", "triage"]);
+  });
+});
+
+describe("promptDraftIssues", () => {
+  it("accepts a complete draft", () => {
+    expect(promptDraftIssues(draft())).toEqual([]);
+  });
+
+  it("requires a namespace and a name that Kubernetes would accept", () => {
+    expect(promptDraftIssues(draft({ namespace: "" }))).toContain(
+      "A namespace is required.",
+    );
+    expect(promptDraftIssues(draft({ name: "" }))).toContain(
+      "A library name is required.",
+    );
+    expect(promptDraftIssues(draft({ name: "Team Prompts" }))).toEqual([
+      "The name must use lowercase letters, numbers and hyphens, starting and ending with a letter or number.",
+    ]);
+  });
+
+  it("skips the identity rules when the identity is locked", () => {
+    // An edit addresses a library that already exists: its name and namespace are
+    // the resource's own, shown but not editable, so they cannot be wrong. Marking
+    // them would be complaining about a field the reader cannot change.
+    const locked = draft({ namespace: "", name: "" });
+    expect(promptDraftIssues(locked, { identityLocked: true })).toEqual([]);
+  });
+
+  it("applies the fragment rules either way, because the controller does", () => {
+    const empty = draft({ rows: [newFragmentRow()] });
+    for (const options of [{}, { identityLocked: true }]) {
+      expect(promptDraftIssues(empty, options)).toContain(
+        "Add at least one fragment key.",
+      );
+    }
+  });
+});
+
+describe("promptPayloadFrom", () => {
+  it("trims the identity and folds the rows into the data map", () => {
+    const payload = promptPayloadFrom(
+      draft({
+        namespace: " kagent ",
+        name: " team-prompts ",
+        rows: [
+          { ...newFragmentRow(), key: " tone ", value: "Be concise." },
+          // A blank trailing row is how the editor normally looks, not something to
+          // send an empty key for.
+          newFragmentRow(),
+        ],
+      }),
+    );
+    expect(payload).toEqual({
+      namespace: "kagent",
+      name: "team-prompts",
+      data: { tone: "Be concise." },
+    });
+  });
+});
+
+describe("emptyPromptDraft", () => {
+  it("starts in the default namespace with one row to type into", () => {
+    const fresh = emptyPromptDraft();
+    expect(fresh.namespace).toBe("kagent");
+    expect(fresh.name).toBe("");
+    expect(fresh.rows).toHaveLength(1);
+  });
+});

--- a/ui/src/components/prompts/promptDraft.ts
+++ b/ui/src/components/prompts/promptDraft.ts
@@ -1,0 +1,91 @@
+/**
+ * What a prompt library looks like while somebody is writing it.
+ *
+ * Split from the form for the reason `modelDraft` is: the shape and the rules that
+ * decide whether it can be sent are worth reading — and unit-testing — without a
+ * component around them, and a component file that exports functions cannot
+ * hot-reload.
+ */
+
+import type { CreatePromptTemplateRequest, PromptTemplateDetail } from "@/api";
+import { DEFAULT_NAMESPACE, RFC1123_SUBDOMAIN } from "@/components/common/resourceName";
+import {
+  type FragmentRow,
+  fragmentIssues,
+  fragmentsToData,
+  newFragmentRow,
+  rowsFromData,
+} from "./fragmentRows";
+
+/**
+ * A library being authored: where it lives, what it is called, what is in it.
+ *
+ * The rows rather than the `data` map the API takes, because a map cannot hold what
+ * the editor has to — a half-typed key, two rows briefly sharing one, a blank row
+ * waiting to be filled in.
+ */
+export interface PromptDraft {
+  namespace: string;
+  name: string;
+  rows: FragmentRow[];
+}
+
+/** A new library: the default namespace, no name, and one row to type into. */
+export function emptyPromptDraft(): PromptDraft {
+  return { namespace: DEFAULT_NAMESPACE, name: "", rows: [newFragmentRow()] };
+}
+
+/** An existing library, as the form edits it. */
+export function promptDraftFrom(detail: PromptTemplateDetail): PromptDraft {
+  return {
+    namespace: detail.namespace,
+    name: detail.name,
+    rows: rowsFromData(detail.data),
+  };
+}
+
+/**
+ * What stops this draft being sent, in the words the form shows.
+ *
+ * `identityLocked` drops the name and namespace rules rather than the fields: an edit
+ * addresses a library that already exists, so those two are the resource's own and
+ * cannot be wrong. Everything else applies to both, because the controller applies it
+ * to both — `UpdatePromptTemplate` refuses an empty map exactly as `Create` does.
+ */
+export function promptDraftIssues(
+  draft: PromptDraft,
+  { identityLocked = false }: { identityLocked?: boolean } = {},
+): string[] {
+  const issues: string[] = [];
+
+  if (!identityLocked) {
+    if (!draft.namespace.trim()) issues.push("A namespace is required.");
+    else if (!RFC1123_SUBDOMAIN.test(draft.namespace.trim())) {
+      issues.push("The namespace must be a valid Kubernetes name.");
+    }
+    if (!draft.name.trim()) issues.push("A library name is required.");
+    else if (!RFC1123_SUBDOMAIN.test(draft.name.trim())) {
+      issues.push(
+        "The name must use lowercase letters, numbers and hyphens, starting and ending with a letter or number.",
+      );
+    }
+  }
+
+  issues.push(...fragmentIssues(draft.rows));
+  return issues;
+}
+
+/**
+ * The request body, in the create shape.
+ *
+ * One shape for both callers, as the model form does: an update carries only `data` —
+ * the ref addresses the library — so the edit caller takes the map out of this and
+ * ignores the identity it already knows.
+ */
+export function promptPayloadFrom(draft: PromptDraft): CreatePromptTemplateRequest {
+  return {
+    namespace: draft.namespace.trim(),
+    name: draft.name.trim(),
+    data: fragmentsToData(draft.rows),
+  };
+}

--- a/ui/src/mocks/state.ts
+++ b/ui/src/mocks/state.ts
@@ -265,7 +265,11 @@ const promptSummary = (detail: PromptTemplateDetail): PromptTemplateSummary => (
   namespace: detail.namespace,
   name: detail.name,
   keyCount: Object.keys(detail.data).length,
-  keys: Object.keys(detail.data),
+  // Sorted, because `summarize` in the prompt template service sorts before
+  // answering. Left in insertion order, a library edited through the app came back
+  // with its new key last while the same library re-read from a cluster came back
+  // with it in place — a difference in the fixture, not in the app.
+  keys: Object.keys(detail.data).sort((left, right) => left.localeCompare(right)),
 });
 
 export function savePrompt(detail: PromptTemplateDetail): PromptTemplateDetail {

--- a/ui/src/pages/PromptDetailPage.tsx
+++ b/ui/src/pages/PromptDetailPage.tsx
@@ -1,14 +1,24 @@
+import { useMemo } from "react";
 import { Alert, Button, Empty, Skeleton, Space, Tag, Typography } from "antd";
 import { useTheme } from "@emotion/react";
+import { Pencil } from "lucide-react";
 import { Link, useParams } from "react-router-dom";
 import { PageFrame } from "@/components/Structure/PageFrame";
 import { PromptFragment } from "@/components/prompts/PromptFragment";
-import { paths } from "@/router/routes";
+import { buildPath, paths } from "@/router/routes";
 import { isNotFound, usePrompt } from "@/api";
 import { RefreshButton } from "@/components/table/RefreshButton";
 
 const { Text } = Typography;
 
+/**
+ * One prompt library: what is in it, and how to include each fragment.
+ *
+ * A reading page. Editing is `PromptEditPage`, which renders the same `PromptForm`
+ * the create page does — reached from the Edit action here and from the list's, so
+ * clicking a row to *look* at a library does not land in a page of inputs with Save
+ * waiting.
+ */
 export function PromptDetailPage() {
   const theme = useTheme();
   const { namespace, name } = useParams<{ namespace: string; name: string }>();
@@ -19,7 +29,16 @@ export function PromptDetailPage() {
   // way back to the list instead of a "Try again".
   const missing = error !== undefined && isNotFound(error);
 
-  const fragments = Object.entries(data?.data ?? {});
+  // Sorted, because `data` is a map: it arrives in whatever order the API server
+  // serialised it, and the edit form sorts too — so a reader who opens Edit sees the
+  // fragments in the order they were just reading them in.
+  const fragments = useMemo(
+    () =>
+      Object.entries(data?.data ?? {}).sort(([left], [right]) =>
+        left.localeCompare(right),
+      ),
+    [data],
+  );
 
   return (
     <PageFrame
@@ -33,6 +52,13 @@ export function PromptDetailPage() {
       }
       actions={
         <Space size={8}>
+          {data && namespace && name ? (
+            <Link to={buildPath(paths.promptEdit, { namespace, name })}>
+              <Button icon={<Pencil size={14} />} data-testid="prompt-edit">
+                Edit
+              </Button>
+            </Link>
+          ) : null}
           <Link to={paths.prompts}>
             <Button>Back to libraries</Button>
           </Link>

--- a/ui/src/pages/PromptEditPage.tsx
+++ b/ui/src/pages/PromptEditPage.tsx
@@ -1,0 +1,133 @@
+import { Alert, Button, Skeleton, Space } from "antd";
+import toast from "react-hot-toast";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { PageFrame } from "@/components/Structure/PageFrame";
+import { PromptForm } from "@/components/prompts/PromptForm";
+import { promptDraftFrom } from "@/components/prompts/promptDraft";
+import { buildPath, paths } from "@/router/routes";
+import {
+  apiClient,
+  isNotFound,
+  useInvalidatePrompts,
+  usePrompt,
+  type CreatePromptTemplateRequest,
+} from "@/api";
+
+/**
+ * Change a prompt library's fragments.
+ *
+ * The edit half of the pair `PromptForm` serves: the form owns the fields and the
+ * rules, this page owns the request and what happens afterwards.
+ *
+ * The library is read before the form is shown rather than the form appearing empty
+ * and filling in: a form that renders blank invites somebody to type into a field
+ * about to be overwritten, and on a slow read an empty fragment is indistinguishable
+ * from one nobody has written yet.
+ *
+ * `UpdatePromptTemplate` carries only the fragment map — the ref addresses the
+ * ConfigMap, which is why the form's identity fields are locked — so the identity in
+ * the payload the form hands over is dropped here rather than sent.
+ */
+export function PromptEditPage() {
+  const navigate = useNavigate();
+  const { namespace, name } = useParams<{ namespace: string; name: string }>();
+  const library = usePrompt(namespace, name);
+  const invalidatePrompts = useInvalidatePrompts();
+
+  // A 404 is a different answer from a failed request: the cluster says there is
+  // nothing here to edit, so that branch offers a way back rather than a retry.
+  const missing = library.error !== undefined && isNotFound(library.error);
+
+  /** Where a save or a cancel lands: the library itself, which is what changed. */
+  const detail =
+    namespace && name
+      ? buildPath(paths.promptDetail, { namespace, name })
+      : paths.prompts;
+
+  async function saveLibrary(payload: CreatePromptTemplateRequest): Promise<void> {
+    if (!namespace || !name) return;
+
+    await apiClient.prompts.update(namespace, name, { data: payload.data });
+    /*
+     * Re-read before navigating, so the page that opens shows the saved fragments
+     * rather than the ones just replaced — which would read as a save that did not
+     * take.
+     *
+     * A key sweep rather than this library's own read: the list's key count and
+     * fragment tags change with an edit too, and its key carries the namespace
+     * filter, so refreshing one read would leave whichever list is behind this
+     * stale.
+     */
+    await invalidatePrompts();
+    toast.success(`Prompt library ${name} saved`);
+    await navigate(detail);
+  }
+
+  return (
+    <PageFrame
+      title={name ? `Edit ${name}` : "Edit prompt library"}
+      description={
+        missing ? undefined : "Replaces this library's fragments with what you save."
+      }
+      actions={
+        <Link to={detail}>
+          <Button>Back to library</Button>
+        </Link>
+      }
+    >
+      <Space
+        orientation="vertical"
+        size="middle"
+        css={{ display: "flex", maxWidth: 720 }}
+      >
+        {missing ? (
+          <Alert
+            type="warning"
+            showIcon
+            title="This prompt library does not exist"
+            description={`No library named ${namespace}/${name} was found in the cluster. It may have been deleted.`}
+            data-testid="prompt-edit-not-found"
+            action={
+              <Link to={paths.prompts}>
+                <Button size="small">Back to libraries</Button>
+              </Link>
+            }
+          />
+        ) : library.error ? (
+          <Alert
+            type="error"
+            showIcon
+            title="Could not load this prompt library"
+            description={library.error.message}
+            data-testid="prompt-edit-load-error"
+            action={
+              <Button size="small" onClick={() => void library.refresh()}>
+                Try again
+              </Button>
+            }
+          />
+        ) : null}
+
+        {library.isLoading ? (
+          <Skeleton active paragraph={{ rows: 6 }} data-testid="prompt-edit-loading" />
+        ) : null}
+
+        {library.data ? (
+          <PromptForm
+            initial={promptDraftFrom(library.data)}
+            outcome="saved"
+            submitLabel="Save changes"
+            // The ref is how the controller addresses the library, so an edit cannot
+            // rename one or move it to another namespace.
+            identityLocked
+            onSubmit={saveLibrary}
+            // Handed a callback rather than left to the form's own link back to the
+            // list, so Cancel returns to the library being edited — and so the form
+            // can ask first when there is a draft to lose.
+            onCancel={() => void navigate(detail)}
+          />
+        ) : null}
+      </Space>
+    </PageFrame>
+  );
+}

--- a/ui/src/pages/PromptEditPage.tsx
+++ b/ui/src/pages/PromptEditPage.tsx
@@ -45,7 +45,15 @@ export function PromptEditPage() {
       : paths.prompts;
 
   async function saveLibrary(payload: CreatePromptTemplateRequest): Promise<void> {
-    if (!namespace || !name) return;
+    /*
+     * Thrown rather than returned. The route cannot match without both, so this is
+     * unreachable — but returning would hand the form a save that wrote nothing and
+     * said nothing: no toast, no navigation, no error, and a draft it has already
+     * stopped guarding. A throw reaches the form's own failure path.
+     */
+    if (!namespace || !name) {
+      throw new Error("A prompt library is addressed by both a namespace and a name.");
+    }
 
     await apiClient.prompts.update(namespace, name, { data: payload.data });
     /*

--- a/ui/src/pages/PromptNewPage.tsx
+++ b/ui/src/pages/PromptNewPage.tsx
@@ -1,78 +1,29 @@
-import { useMemo, useState } from "react";
-import { Alert, Button, Form, Input, Space, Typography } from "antd";
-import { useTheme } from "@emotion/react";
+import { Button, Space } from "antd";
 import { Link, useNavigate } from "react-router-dom";
 import { PageFrame } from "@/components/Structure/PageFrame";
-import { SubmitError } from "@/components/common/SubmitError";
-import { FragmentEditor } from "@/components/prompts/FragmentEditor";
-import {
-  type FragmentRow,
-  findDuplicateKey,
-  fragmentsToData,
-  newFragmentRow,
-} from "@/components/prompts/fragmentRows";
-import { DEFAULT_NAMESPACE, RFC1123_SUBDOMAIN } from "@/components/common/resourceName";
+import { PromptForm } from "@/components/prompts/PromptForm";
 import { paths } from "@/router/routes";
-import { apiClient } from "@/api";
+import { apiClient, useInvalidatePrompts, type CreatePromptTemplateRequest } from "@/api";
 
-const { Text } = Typography;
-
+/**
+ * Create a prompt library.
+ *
+ * The fields are `PromptForm`, which the detail page's edit mode renders too; this
+ * page owns only the request and where the reader lands afterwards.
+ */
 export function PromptNewPage() {
-  const theme = useTheme();
   const navigate = useNavigate();
-  const [namespace, setNamespace] = useState(DEFAULT_NAMESPACE);
-  const [name, setName] = useState("");
-  const [rows, setRows] = useState<FragmentRow[]>(() => [newFragmentRow()]);
-  const [submitted, setSubmitted] = useState(false);
-  const [saving, setSaving] = useState(false);
-  const [failure, setFailure] = useState<unknown>();
+  const invalidatePrompts = useInvalidatePrompts();
 
-  const data = useMemo(() => fragmentsToData(rows), [rows]);
-  const duplicate = useMemo(() => findDuplicateKey(rows), [rows]);
-
-  const issues = useMemo(() => {
-    const found: string[] = [];
-    if (!namespace.trim()) found.push("A namespace is required.");
-    else if (!RFC1123_SUBDOMAIN.test(namespace.trim())) {
-      found.push("The namespace must be a valid Kubernetes name.");
-    }
-    if (!name.trim()) found.push("A library name is required.");
-    else if (!RFC1123_SUBDOMAIN.test(name.trim())) {
-      found.push(
-        "The name must use lowercase letters, numbers and hyphens, starting and ending with a letter or number.",
-      );
-    }
-    if (Object.keys(data).length === 0) found.push("Add at least one fragment key.");
-    // A duplicate would silently overwrite: the map has one slot per key, so the
-    // second value wins and the first fragment vanishes without a word.
-    if (duplicate) found.push(`Two fragments share the key "${duplicate}".`);
-    return found;
-  }, [namespace, name, data, duplicate]);
-
-  const invalidName = submitted && !RFC1123_SUBDOMAIN.test(name.trim());
-
-  const submit = async () => {
-    setSubmitted(true);
-    setFailure(undefined);
-    if (issues.length > 0) return;
-
-    setSaving(true);
-    try {
-      await apiClient.prompts.create({
-        namespace: namespace.trim(),
-        name: name.trim(),
-        data,
-      });
-      // Straight to the list, where the new library can actually be seen — a
-      // success message on a form the user is still looking at proves less than
-      // the row itself.
-      await navigate(paths.prompts);
-    } catch (error) {
-      setFailure(error);
-    } finally {
-      setSaving(false);
-    }
-  };
+  async function createLibrary(payload: CreatePromptTemplateRequest): Promise<void> {
+    await apiClient.prompts.create(payload);
+    // Re-read before navigating, so the list lands showing the new library rather
+    // than the set that was cached without it.
+    await invalidatePrompts();
+    // Straight to the list, where the new library can actually be seen — a success
+    // message on a form the user is still looking at proves less than the row itself.
+    await navigate(paths.prompts);
+  }
 
   return (
     <PageFrame
@@ -84,112 +35,8 @@ export function PromptNewPage() {
         </Link>
       }
     >
-      <Space
-        orientation="vertical"
-        size="middle"
-        css={{ display: "flex", maxWidth: 720 }}
-      >
-        <Form layout="vertical" component="div">
-          <Form.Item
-            label="Namespace"
-            required
-            validateStatus={submitted && !namespace.trim() ? "error" : undefined}
-            help={submitted && !namespace.trim() ? "A namespace is required." : undefined}
-          >
-            <Input
-              data-testid="prompt-namespace"
-              placeholder="kagent"
-              value={namespace}
-              onChange={(event) => {
-                setNamespace(event.target.value);
-                setFailure(undefined);
-              }}
-            />
-          </Form.Item>
-
-          <Form.Item
-            label="Name"
-            required
-            validateStatus={submitted && (!name.trim() || invalidName) ? "error" : undefined}
-            help={
-              submitted && !name.trim()
-                ? "A library name is required."
-                : invalidName
-                  ? "Lowercase letters, numbers and hyphens only."
-                  : undefined
-            }
-          >
-            <Input
-              data-testid="prompt-name"
-              placeholder="team-prompts"
-              value={name}
-              onChange={(event) => {
-                setName(event.target.value);
-                setFailure(undefined);
-              }}
-              css={{ fontFamily: theme.font.mono }}
-            />
-          </Form.Item>
-        </Form>
-
-        <div>
-          <Text strong css={{ display: "block", marginBottom: theme.space(1) }}>
-            Fragments
-          </Text>
-          <Text
-            css={{ display: "block", marginBottom: theme.space(3), color: theme.color.textMuted }}
-          >
-            Each key becomes an include target. An agent pulls one in with the tag shown
-            beside it.
-          </Text>
-          <FragmentEditor
-            rows={rows}
-            onChange={(next) => {
-              setRows(next);
-              setFailure(undefined);
-            }}
-            library={name.trim() || undefined}
-          />
-        </div>
-
-        {submitted && issues.length > 0 ? (
-          <Alert
-            type="error"
-            showIcon
-            title="This library cannot be created yet"
-            data-testid="prompt-form-errors"
-            description={
-              <ul css={{ margin: 0, paddingLeft: theme.space(5) }}>
-                {issues.map((issue) => (
-                  <li key={issue}>{issue}</li>
-                ))}
-              </ul>
-            }
-          />
-        ) : null}
-
-        {failure !== undefined ? (
-          <SubmitError
-            error={failure}
-            what="prompt library"
-            onRetry={() => void submit()}
-            data-testid="prompt-submit-error"
-          />
-        ) : null}
-
-        <Space size={8}>
-          <Button
-            type="primary"
-            data-testid="prompt-submit"
-            loading={saving}
-            onClick={() => void submit()}
-          >
-            Create library
-          </Button>
-          <Link to={paths.prompts}>
-            <Button>Cancel</Button>
-          </Link>
-        </Space>
+      <Space orientation="vertical" size="middle" css={{ display: "flex" }}>
+        <PromptForm onSubmit={createLibrary} />
       </Space>
     </PageFrame>
   );

--- a/ui/src/pages/PromptsPage.tsx
+++ b/ui/src/pages/PromptsPage.tsx
@@ -117,9 +117,26 @@ export function PromptsPage() {
         render: (_, row) => `${row.keyCount} ${row.keyCount === 1 ? "key" : "keys"}`,
       },
       {
-        // Editing and deleting were both in the client, both unit-tested, and
-        // unreachable from anywhere in the app — so a library could be created and
-        // read and then never changed or removed.
+        title: "Fragments",
+        key: "keys",
+        render: (_, row) =>
+          row.keys?.length ? (
+            <Space size={4} wrap>
+              {row.keys.map((key) => (
+                <Tag key={key} css={{ fontFamily: theme.font.mono, marginInlineEnd: 0 }}>
+                  {key}
+                </Tag>
+              ))}
+            </Space>
+          ) : (
+            "—"
+          ),
+      },
+      {
+        // Last and untitled, as on every other list: a row's actions belong at the
+        // end of it, past the data they act on. This column sat before the fragment
+        // keys, which put two buttons through the middle of the row and left its
+        // widest, most ragged column hanging off the end.
         title: "",
         key: "actions",
         width: 76,
@@ -147,22 +164,6 @@ export function PromptsPage() {
             />
           </Space>
         ),
-      },
-      {
-        title: "Fragments",
-        key: "keys",
-        render: (_, row) =>
-          row.keys?.length ? (
-            <Space size={4} wrap>
-              {row.keys.map((key) => (
-                <Tag key={key} css={{ fontFamily: theme.font.mono, marginInlineEnd: 0 }}>
-                  {key}
-                </Tag>
-              ))}
-            </Space>
-          ) : (
-            "—"
-          ),
       },
     ],
     [theme, refresh, view],

--- a/ui/src/pages/PromptsPage.tsx
+++ b/ui/src/pages/PromptsPage.tsx
@@ -126,7 +126,7 @@ export function PromptsPage() {
         render: (_, row) => (
           <Space size={0}>
             <Link
-              to={buildPath(paths.promptDetail, {
+              to={buildPath(paths.promptEdit, {
                 namespace: row.namespace,
                 name: row.name,
               })}

--- a/ui/src/router/router.tsx
+++ b/ui/src/router/router.tsx
@@ -31,6 +31,7 @@ import { McpServerNewPage } from "@/pages/McpServerNewPage";
 import { PromptsPage } from "@/pages/PromptsPage";
 import { PromptNewPage } from "@/pages/PromptNewPage";
 import { PromptDetailPage } from "@/pages/PromptDetailPage";
+import { PromptEditPage } from "@/pages/PromptEditPage";
 import { SubstratePage } from "@/pages/SubstratePage";
 import { AppDetailPage } from "@/pages/AppDetailPage";
 import { SharedAgentPage } from "@/pages/SharedAgentPage";
@@ -80,6 +81,7 @@ const coreLayoutRoutes: (RouteObject & { key: string })[] = [
   { key: "prompts", path: paths.prompts, element: <PromptsPage /> },
   { key: "promptNew", path: paths.promptNew, element: <PromptNewPage /> },
   { key: "promptDetail", path: paths.promptDetail, element: <PromptDetailPage /> },
+  { key: "promptEdit", path: paths.promptEdit, element: <PromptEditPage /> },
   { key: "substrate", path: paths.substrate, element: <SubstratePage /> },
   { key: "appDetail", path: paths.appDetail, element: <AppDetailPage /> },
   { key: "sharedAgent", path: paths.sharedAgent, element: <SharedAgentPage /> },

--- a/ui/src/router/routes.ts
+++ b/ui/src/router/routes.ts
@@ -109,6 +109,7 @@ export const paths = {
   prompts: "/prompts",
   promptNew: "/prompts/new",
   promptDetail: "/prompts/:namespace/:name",
+  promptEdit: "/prompts/:namespace/:name/edit",
 
   substrate: "/substrate",
 


### PR DESCRIPTION
- The edit button on prompts table now brings you to the edit form as expected
- When creating/editing a prompt, clicking the cancel button now properly confirms if you want to throw away changes if any were made
- Moved the name input above namespace, to be more consistent with other forms
- Fragment delete button is now red
- Delete button is now disabled when only 1 fragment with empty content (since otherwise clicking the button doesn't have any effect so UI makes sure there ia always at least 1)

<img width="633" height="574" alt="image" src="https://github.com/user-attachments/assets/2da5d75c-7b6c-4987-a9f0-a95a30f3fa5a" />

delete disabled when only 1 empty fragment:

<img width="604" height="232" alt="image" src="https://github.com/user-attachments/assets/69115963-c5aa-4344-a44f-494f074f78d4" />

