### PR TITLE
feat(adk): surface prompt-cache hit metrics via genai cached content token count

### DIFF
--- a/go/adk/pkg/models/anthropic_adk.go
+++ b/go/adk/pkg/models/anthropic_adk.go
@@ -264,7 +264,7 @@ func runAnthropicStreaming(ctx context.Context, m *AnthropicModel, params anthro
 		inputJSON string
 	})
 	var stopReason anthropic.StopReason
-	var inputTokens, outputTokens int64
+	var inputTokens, outputTokens, cacheReadInputTokens int64
 
 	for stream.Next() {
 		event := stream.Current()
@@ -272,6 +272,7 @@ func runAnthropicStreaming(ctx context.Context, m *AnthropicModel, params anthro
 		switch e := event.AsAny().(type) {
 		case anthropic.MessageStartEvent:
 			inputTokens = e.Message.Usage.InputTokens
+			cacheReadInputTokens = e.Message.Usage.CacheReadInputTokens
 		case anthropic.ContentBlockStartEvent:
 			idx := int(e.Index)
 			if e.ContentBlock.Type == "tool_use" {
@@ -341,8 +342,9 @@ func runAnthropicStreaming(ctx context.Context, m *AnthropicModel, params anthro
 	var usage *genai.GenerateContentResponseUsageMetadata
 	if inputTokens > 0 || outputTokens > 0 {
 		usage = &genai.GenerateContentResponseUsageMetadata{
-			PromptTokenCount:     int32(inputTokens),
-			CandidatesTokenCount: int32(outputTokens),
+			PromptTokenCount:        int32(inputTokens),
+			CandidatesTokenCount:    int32(outputTokens),
+			CachedContentTokenCount: int32(cacheReadInputTokens),
 		}
 	}
 	resp := &model.LLMResponse{
@@ -388,8 +390,9 @@ func runAnthropicNonStreaming(ctx context.Context, m *AnthropicModel, params ant
 	var usage *genai.GenerateContentResponseUsageMetadata
 	if message.Usage.InputTokens > 0 || message.Usage.OutputTokens > 0 {
 		usage = &genai.GenerateContentResponseUsageMetadata{
-			PromptTokenCount:     int32(message.Usage.InputTokens),
-			CandidatesTokenCount: int32(message.Usage.OutputTokens),
+			PromptTokenCount:        int32(message.Usage.InputTokens),
+			CandidatesTokenCount:    int32(message.Usage.OutputTokens),
+			CachedContentTokenCount: int32(message.Usage.CacheReadInputTokens),
 		}
 	}
 

--- a/go/adk/pkg/models/anthropic_adk.go
+++ b/go/adk/pkg/models/anthropic_adk.go
@@ -310,6 +310,9 @@ func runAnthropicStreaming(ctx context.Context, m *AnthropicModel, params anthro
 		case anthropic.MessageDeltaEvent:
 			stopReason = e.Delta.StopReason
 			outputTokens = e.Usage.OutputTokens
+			if e.Usage.JSON.CacheReadInputTokens.Valid() {
+				cacheReadInputTokens = e.Usage.CacheReadInputTokens
+			}
 		}
 	}
 
@@ -340,11 +343,11 @@ func runAnthropicStreaming(ctx context.Context, m *AnthropicModel, params anthro
 	}
 
 	var usage *genai.GenerateContentResponseUsageMetadata
-	if inputTokens > 0 || outputTokens > 0 {
+	if inputTokens > 0 || outputTokens > 0 || cacheReadInputTokens > 0 {
 		usage = &genai.GenerateContentResponseUsageMetadata{
 			PromptTokenCount:        int32(inputTokens),
 			CandidatesTokenCount:    int32(outputTokens),
-			CachedContentTokenCount: int32(cacheReadInputTokens),
+			CachedContentTokenCount: cachedTokenCount(cacheReadInputTokens),
 		}
 	}
 	resp := &model.LLMResponse{
@@ -388,11 +391,11 @@ func runAnthropicNonStreaming(ctx context.Context, m *AnthropicModel, params ant
 
 	// Build usage metadata
 	var usage *genai.GenerateContentResponseUsageMetadata
-	if message.Usage.InputTokens > 0 || message.Usage.OutputTokens > 0 {
+	if message.Usage.InputTokens > 0 || message.Usage.OutputTokens > 0 || message.Usage.CacheReadInputTokens > 0 {
 		usage = &genai.GenerateContentResponseUsageMetadata{
 			PromptTokenCount:        int32(message.Usage.InputTokens),
 			CandidatesTokenCount:    int32(message.Usage.OutputTokens),
-			CachedContentTokenCount: int32(message.Usage.CacheReadInputTokens),
+			CachedContentTokenCount: cachedTokenCount(message.Usage.CacheReadInputTokens),
 		}
 	}
 

--- a/go/adk/pkg/models/anthropic_adk_test.go
+++ b/go/adk/pkg/models/anthropic_adk_test.go
@@ -1,0 +1,62 @@
+package models
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/option"
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/genai"
+)
+
+// messageResponse is the anthropic Messages API payload served by the mock server.
+const anthropicMessageResponse = `{
+	"id":"msg_01","type":"message","role":"assistant","model":"claude-sonnet-4-20250514",
+	"content":[{"type":"text","text":"pong"}],
+	"stop_reason":"end_turn","stop_sequence":null,
+	"usage":{"input_tokens":10,"output_tokens":5,"cache_read_input_tokens":8,"cache_creation_input_tokens":0}
+}`
+
+// TestAnthropicNonStreamingCachedTokens verifies CacheReadInputTokens flows into
+// GenerateContentResponseUsageMetadata.CachedContentTokenCount for non-streaming calls.
+func TestAnthropicNonStreamingCachedTokens(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, anthropicMessageResponse)
+	}))
+	defer srv.Close()
+
+	client := anthropic.NewClient(
+		option.WithAPIKey("test"),
+		option.WithBaseURL(srv.URL),
+	)
+	m := &AnthropicModel{
+		Config: &AnthropicConfig{Model: "claude-sonnet-4-20250514"},
+		Client: client,
+		Logger: slog.New(slog.DiscardHandler),
+	}
+
+	var got *model.LLMResponse
+	for resp, err := range m.GenerateContent(context.Background(), &model.LLMRequest{
+		Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "ping"}}}},
+	}, false) {
+		if err != nil {
+			t.Fatalf("GenerateContent error: %v", err)
+		}
+		got = resp
+	}
+	if got == nil || got.UsageMetadata == nil {
+		t.Fatalf("usage metadata = %#v", got)
+	}
+	if got.UsageMetadata.PromptTokenCount != 10 {
+		t.Fatalf("PromptTokenCount = %d, want 10", got.UsageMetadata.PromptTokenCount)
+	}
+	if got.UsageMetadata.CachedContentTokenCount != 8 {
+		t.Fatalf("CachedContentTokenCount = %d, want 8", got.UsageMetadata.CachedContentTokenCount)
+	}
+}

--- a/go/adk/pkg/models/bedrock.go
+++ b/go/adk/pkg/models/bedrock.go
@@ -409,9 +409,10 @@ func (m *BedrockModel) generateStreaming(ctx context.Context, modelId string, me
 		if meta, ok := event.(*types.ConverseStreamOutputMemberMetadata); ok {
 			if meta.Value.Usage != nil {
 				usageMetadata = &genai.GenerateContentResponseUsageMetadata{
-					PromptTokenCount:     aws.ToInt32(meta.Value.Usage.InputTokens),
-					CandidatesTokenCount: aws.ToInt32(meta.Value.Usage.OutputTokens),
-					TotalTokenCount:      aws.ToInt32(meta.Value.Usage.TotalTokens),
+					PromptTokenCount:        aws.ToInt32(meta.Value.Usage.InputTokens),
+					CandidatesTokenCount:    aws.ToInt32(meta.Value.Usage.OutputTokens),
+					TotalTokenCount:         aws.ToInt32(meta.Value.Usage.TotalTokens),
+					CachedContentTokenCount: aws.ToInt32(meta.Value.Usage.CacheReadInputTokens),
 				}
 			}
 		}
@@ -537,9 +538,10 @@ func (m *BedrockModel) generateNonStreaming(ctx context.Context, modelId string,
 	var usageMetadata *genai.GenerateContentResponseUsageMetadata
 	if output.Usage != nil {
 		usageMetadata = &genai.GenerateContentResponseUsageMetadata{
-			PromptTokenCount:     aws.ToInt32(output.Usage.InputTokens),
-			CandidatesTokenCount: aws.ToInt32(output.Usage.OutputTokens),
-			TotalTokenCount:      aws.ToInt32(output.Usage.TotalTokens),
+			PromptTokenCount:        aws.ToInt32(output.Usage.InputTokens),
+			CandidatesTokenCount:    aws.ToInt32(output.Usage.OutputTokens),
+			TotalTokenCount:         aws.ToInt32(output.Usage.TotalTokens),
+			CachedContentTokenCount: aws.ToInt32(output.Usage.CacheReadInputTokens),
 		}
 	}
 

--- a/go/adk/pkg/models/bedrock.go
+++ b/go/adk/pkg/models/bedrock.go
@@ -412,7 +412,7 @@ func (m *BedrockModel) generateStreaming(ctx context.Context, modelId string, me
 					PromptTokenCount:        aws.ToInt32(meta.Value.Usage.InputTokens),
 					CandidatesTokenCount:    aws.ToInt32(meta.Value.Usage.OutputTokens),
 					TotalTokenCount:         aws.ToInt32(meta.Value.Usage.TotalTokens),
-					CachedContentTokenCount: aws.ToInt32(meta.Value.Usage.CacheReadInputTokens),
+					CachedContentTokenCount: cachedTokenCount(int64(aws.ToInt32(meta.Value.Usage.CacheReadInputTokens))),
 				}
 			}
 		}
@@ -541,7 +541,7 @@ func (m *BedrockModel) generateNonStreaming(ctx context.Context, modelId string,
 			PromptTokenCount:        aws.ToInt32(output.Usage.InputTokens),
 			CandidatesTokenCount:    aws.ToInt32(output.Usage.OutputTokens),
 			TotalTokenCount:         aws.ToInt32(output.Usage.TotalTokens),
-			CachedContentTokenCount: aws.ToInt32(output.Usage.CacheReadInputTokens),
+			CachedContentTokenCount: cachedTokenCount(int64(aws.ToInt32(output.Usage.CacheReadInputTokens))),
 		}
 	}
 

--- a/go/adk/pkg/models/openai_adk.go
+++ b/go/adk/pkg/models/openai_adk.go
@@ -378,7 +378,7 @@ func runStreaming(ctx context.Context, m *OpenAIModel, params openai.ChatComplet
 	var aggregatedText strings.Builder
 	toolCallsAcc := make(map[int64]map[string]any)
 	var finishReason string
-	var promptTokens, completionTokens, totalTokens int64
+	var promptTokens, completionTokens, totalTokens, cachedTokens int64
 
 	for stream.Next() {
 		chunk := stream.Current()
@@ -386,6 +386,7 @@ func runStreaming(ctx context.Context, m *OpenAIModel, params openai.ChatComplet
 			promptTokens = chunk.Usage.PromptTokens
 			completionTokens = chunk.Usage.CompletionTokens
 			totalTokens = chunk.Usage.TotalTokens
+			cachedTokens = chunk.Usage.PromptTokensDetails.CachedTokens
 		}
 		if len(chunk.Choices) == 0 {
 			continue
@@ -465,9 +466,10 @@ func runStreaming(ctx context.Context, m *OpenAIModel, params openai.ChatComplet
 	var usage *genai.GenerateContentResponseUsageMetadata
 	if promptTokens > 0 || completionTokens > 0 {
 		usage = &genai.GenerateContentResponseUsageMetadata{
-			PromptTokenCount:     int32(promptTokens),
-			CandidatesTokenCount: int32(completionTokens),
-			TotalTokenCount:      int32(totalTokens),
+			PromptTokenCount:        int32(promptTokens),
+			CandidatesTokenCount:    int32(completionTokens),
+			TotalTokenCount:         int32(totalTokens),
+			CachedContentTokenCount: int32(cachedTokens),
 		}
 	}
 	resp := &model.LLMResponse{
@@ -527,9 +529,10 @@ func chatCompletionToLLMResponse(completion *openai.ChatCompletion) *model.LLMRe
 	var usage *genai.GenerateContentResponseUsageMetadata
 	if completion.Usage.PromptTokens > 0 || completion.Usage.CompletionTokens > 0 {
 		usage = &genai.GenerateContentResponseUsageMetadata{
-			PromptTokenCount:     int32(completion.Usage.PromptTokens),
-			CandidatesTokenCount: int32(completion.Usage.CompletionTokens),
-			TotalTokenCount:      int32(completion.Usage.TotalTokens),
+			PromptTokenCount:        int32(completion.Usage.PromptTokens),
+			CandidatesTokenCount:    int32(completion.Usage.CompletionTokens),
+			TotalTokenCount:         int32(completion.Usage.TotalTokens),
+			CachedContentTokenCount: int32(completion.Usage.PromptTokensDetails.CachedTokens),
 		}
 	}
 	return &model.LLMResponse{

--- a/go/adk/pkg/models/openai_adk.go
+++ b/go/adk/pkg/models/openai_adk.go
@@ -469,7 +469,7 @@ func runStreaming(ctx context.Context, m *OpenAIModel, params openai.ChatComplet
 			PromptTokenCount:        int32(promptTokens),
 			CandidatesTokenCount:    int32(completionTokens),
 			TotalTokenCount:         int32(totalTokens),
-			CachedContentTokenCount: int32(cachedTokens),
+			CachedContentTokenCount: cachedTokenCount(cachedTokens),
 		}
 	}
 	resp := &model.LLMResponse{
@@ -532,7 +532,7 @@ func chatCompletionToLLMResponse(completion *openai.ChatCompletion) *model.LLMRe
 			PromptTokenCount:        int32(completion.Usage.PromptTokens),
 			CandidatesTokenCount:    int32(completion.Usage.CompletionTokens),
 			TotalTokenCount:         int32(completion.Usage.TotalTokens),
-			CachedContentTokenCount: int32(completion.Usage.PromptTokensDetails.CachedTokens),
+			CachedContentTokenCount: cachedTokenCount(completion.Usage.PromptTokensDetails.CachedTokens),
 		}
 	}
 	return &model.LLMResponse{

--- a/go/adk/pkg/models/openai_adk_test.go
+++ b/go/adk/pkg/models/openai_adk_test.go
@@ -387,7 +387,8 @@ func TestChatCompletionToLLMResponse_PreservesThoughtSignature(t *testing.T) {
 		"usage":{
 			"prompt_tokens":3,
 			"completion_tokens":4,
-			"total_tokens":7
+			"total_tokens":7,
+			"prompt_tokens_details":{"cached_tokens":11}
 		}
 	}`)
 
@@ -413,6 +414,9 @@ func TestChatCompletionToLLMResponse_PreservesThoughtSignature(t *testing.T) {
 	}
 	if resp.UsageMetadata == nil || resp.UsageMetadata.PromptTokenCount != 3 || resp.UsageMetadata.CandidatesTokenCount != 4 {
 		t.Fatalf("usage metadata = %#v, want prompt=3 completion=4", resp.UsageMetadata)
+	}
+	if resp.UsageMetadata.CachedContentTokenCount != 11 {
+		t.Fatalf("cachedContentTokenCount = %d, want 11", resp.UsageMetadata.CachedContentTokenCount)
 	}
 }
 

--- a/go/adk/pkg/models/openai_adk_test.go
+++ b/go/adk/pkg/models/openai_adk_test.go
@@ -388,7 +388,7 @@ func TestChatCompletionToLLMResponse_PreservesThoughtSignature(t *testing.T) {
 			"prompt_tokens":3,
 			"completion_tokens":4,
 			"total_tokens":7,
-			"prompt_tokens_details":{"cached_tokens":11}
+			"prompt_tokens_details":{"cached_tokens":2}
 		}
 	}`)
 
@@ -415,8 +415,8 @@ func TestChatCompletionToLLMResponse_PreservesThoughtSignature(t *testing.T) {
 	if resp.UsageMetadata == nil || resp.UsageMetadata.PromptTokenCount != 3 || resp.UsageMetadata.CandidatesTokenCount != 4 {
 		t.Fatalf("usage metadata = %#v, want prompt=3 completion=4", resp.UsageMetadata)
 	}
-	if resp.UsageMetadata.CachedContentTokenCount != 11 {
-		t.Fatalf("cachedContentTokenCount = %d, want 11", resp.UsageMetadata.CachedContentTokenCount)
+	if resp.UsageMetadata.CachedContentTokenCount != 2 {
+		t.Fatalf("cachedContentTokenCount = %d, want 2", resp.UsageMetadata.CachedContentTokenCount)
 	}
 }
 

--- a/go/adk/pkg/models/openai_responses.go
+++ b/go/adk/pkg/models/openai_responses.go
@@ -349,7 +349,7 @@ func responsesUsageToGenai(u responses.ResponseUsage) *genai.GenerateContentResp
 	return &genai.GenerateContentResponseUsageMetadata{
 		PromptTokenCount:        int32(u.InputTokens),
 		CandidatesTokenCount:    int32(u.OutputTokens),
-		CachedContentTokenCount: int32(u.InputTokensDetails.CachedTokens),
+		CachedContentTokenCount: cachedTokenCount(u.InputTokensDetails.CachedTokens),
 		ThoughtsTokenCount:      int32(u.OutputTokensDetails.ReasoningTokens),
 	}
 }

--- a/go/adk/pkg/models/openai_responses.go
+++ b/go/adk/pkg/models/openai_responses.go
@@ -342,6 +342,10 @@ func responsesUsageToGenai(u responses.ResponseUsage) *genai.GenerateContentResp
 	if u.InputTokens == 0 && u.OutputTokens == 0 {
 		return nil
 	}
+	// CachedContentTokenCount flows into A2A task usage and the llm_response trace
+	// attribute via GenerateContentResponseUsageMetadata. Emitting a dedicated
+	// gen_ai.client.token.usage observation (gen_ai.token.type="cached") is a
+	// follow-up; see #2669.
 	return &genai.GenerateContentResponseUsageMetadata{
 		PromptTokenCount:        int32(u.InputTokens),
 		CandidatesTokenCount:    int32(u.OutputTokens),

--- a/go/adk/pkg/models/openai_responses_test.go
+++ b/go/adk/pkg/models/openai_responses_test.go
@@ -128,7 +128,7 @@ func TestResponseToLLMResponse(t *testing.T) {
 				"status":"completed"
 			}
 		],
-		"usage":{"input_tokens":10,"output_tokens":5,"total_tokens":15,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}
+		"usage":{"input_tokens":10,"output_tokens":5,"total_tokens":15,"input_tokens_details":{"cached_tokens":42},"output_tokens_details":{"reasoning_tokens":0}}
 	}`)
 	var resp responses.Response
 	if err := json.Unmarshal(raw, &resp); err != nil {
@@ -147,6 +147,9 @@ func TestResponseToLLMResponse(t *testing.T) {
 	if out.UsageMetadata == nil || out.UsageMetadata.PromptTokenCount != 10 {
 		t.Fatalf("usage = %#v", out.UsageMetadata)
 	}
+	if out.UsageMetadata.CachedContentTokenCount != 42 {
+		t.Fatalf("cachedContentTokenCount = %d, want 42", out.UsageMetadata.CachedContentTokenCount)
+	}
 }
 
 func TestOpenAIModel_GenerateContent_Responses(t *testing.T) {
@@ -161,7 +164,7 @@ func TestOpenAIModel_GenerateContent_Responses(t *testing.T) {
 			"id":"resp_1","object":"response","created_at":1,"status":"completed","model":"gpt-4o",
 			"output":[{"type":"message","id":"msg_1","role":"assistant","status":"completed",
 				"content":[{"type":"output_text","text":"pong","annotations":[]}]}],
-			"usage":{"input_tokens":3,"output_tokens":1,"total_tokens":4,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}
+			"usage":{"input_tokens":3,"output_tokens":1,"total_tokens":4,"input_tokens_details":{"cached_tokens":7},"output_tokens_details":{"reasoning_tokens":0}}
 		}`))
 	}))
 	defer srv.Close()
@@ -195,6 +198,9 @@ func TestOpenAIModel_GenerateContent_Responses(t *testing.T) {
 	if got == nil || got.Content == nil || len(got.Content.Parts) != 1 || got.Content.Parts[0].Text != "pong" {
 		t.Fatalf("response = %#v", got)
 	}
+	if got == nil || got.UsageMetadata == nil || got.UsageMetadata.CachedContentTokenCount != 7 {
+		t.Fatalf("cachedContentTokenCount = %#v, want 7", got.UsageMetadata)
+	}
 }
 
 func TestOpenAIModel_GenerateContent_ResponsesStreaming(t *testing.T) {
@@ -209,7 +215,7 @@ func TestOpenAIModel_GenerateContent_ResponsesStreaming(t *testing.T) {
 		}
 		write(`{"type":"response.output_text.delta","content_index":0,"delta":"hel","item_id":"msg_1","output_index":0,"sequence_number":1,"logprobs":[]}`)
 		write(`{"type":"response.output_text.delta","content_index":0,"delta":"lo","item_id":"msg_1","output_index":0,"sequence_number":2,"logprobs":[]}`)
-		write(`{"type":"response.completed","sequence_number":3,"response":{"id":"resp_1","object":"response","created_at":1,"status":"completed","model":"gpt-4o","output":[],"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}}}`)
+		write(`{"type":"response.completed","sequence_number":3,"response":{"id":"resp_1","object":"response","created_at":1,"status":"completed","model":"gpt-4o","output":[],"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3,"input_tokens_details":{"cached_tokens":5},"output_tokens_details":{"reasoning_tokens":0}}}}`)
 		_, _ = io.WriteString(w, "data: [DONE]\n\n")
 	}))
 	defer srv.Close()
@@ -244,6 +250,9 @@ func TestOpenAIModel_GenerateContent_ResponsesStreaming(t *testing.T) {
 	}
 	if final == nil || final.Content.Parts[0].Text != "hello" {
 		t.Fatalf("final = %#v", final)
+	}
+	if final == nil || final.UsageMetadata == nil || final.UsageMetadata.CachedContentTokenCount != 5 {
+		t.Fatalf("cachedContentTokenCount = %#v, want 5", final.UsageMetadata)
 	}
 }
 

--- a/go/adk/pkg/models/openai_responses_test.go
+++ b/go/adk/pkg/models/openai_responses_test.go
@@ -128,7 +128,7 @@ func TestResponseToLLMResponse(t *testing.T) {
 				"status":"completed"
 			}
 		],
-		"usage":{"input_tokens":10,"output_tokens":5,"total_tokens":15,"input_tokens_details":{"cached_tokens":42},"output_tokens_details":{"reasoning_tokens":0}}
+		"usage":{"input_tokens":10,"output_tokens":5,"total_tokens":15,"input_tokens_details":{"cached_tokens":8},"output_tokens_details":{"reasoning_tokens":0}}
 	}`)
 	var resp responses.Response
 	if err := json.Unmarshal(raw, &resp); err != nil {
@@ -147,8 +147,8 @@ func TestResponseToLLMResponse(t *testing.T) {
 	if out.UsageMetadata == nil || out.UsageMetadata.PromptTokenCount != 10 {
 		t.Fatalf("usage = %#v", out.UsageMetadata)
 	}
-	if out.UsageMetadata.CachedContentTokenCount != 42 {
-		t.Fatalf("cachedContentTokenCount = %d, want 42", out.UsageMetadata.CachedContentTokenCount)
+	if out.UsageMetadata.CachedContentTokenCount != 8 {
+		t.Fatalf("cachedContentTokenCount = %d, want 8", out.UsageMetadata.CachedContentTokenCount)
 	}
 }
 
@@ -164,7 +164,7 @@ func TestOpenAIModel_GenerateContent_Responses(t *testing.T) {
 			"id":"resp_1","object":"response","created_at":1,"status":"completed","model":"gpt-4o",
 			"output":[{"type":"message","id":"msg_1","role":"assistant","status":"completed",
 				"content":[{"type":"output_text","text":"pong","annotations":[]}]}],
-			"usage":{"input_tokens":3,"output_tokens":1,"total_tokens":4,"input_tokens_details":{"cached_tokens":7},"output_tokens_details":{"reasoning_tokens":0}}
+			"usage":{"input_tokens":3,"output_tokens":1,"total_tokens":4,"input_tokens_details":{"cached_tokens":2},"output_tokens_details":{"reasoning_tokens":0}}
 		}`))
 	}))
 	defer srv.Close()
@@ -198,8 +198,8 @@ func TestOpenAIModel_GenerateContent_Responses(t *testing.T) {
 	if got == nil || got.Content == nil || len(got.Content.Parts) != 1 || got.Content.Parts[0].Text != "pong" {
 		t.Fatalf("response = %#v", got)
 	}
-	if got == nil || got.UsageMetadata == nil || got.UsageMetadata.CachedContentTokenCount != 7 {
-		t.Fatalf("cachedContentTokenCount = %#v, want 7", got.UsageMetadata)
+	if got.UsageMetadata == nil || got.UsageMetadata.CachedContentTokenCount != 2 {
+		t.Fatalf("cachedContentTokenCount = %#v, want 2", got.UsageMetadata)
 	}
 }
 
@@ -215,7 +215,7 @@ func TestOpenAIModel_GenerateContent_ResponsesStreaming(t *testing.T) {
 		}
 		write(`{"type":"response.output_text.delta","content_index":0,"delta":"hel","item_id":"msg_1","output_index":0,"sequence_number":1,"logprobs":[]}`)
 		write(`{"type":"response.output_text.delta","content_index":0,"delta":"lo","item_id":"msg_1","output_index":0,"sequence_number":2,"logprobs":[]}`)
-		write(`{"type":"response.completed","sequence_number":3,"response":{"id":"resp_1","object":"response","created_at":1,"status":"completed","model":"gpt-4o","output":[],"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3,"input_tokens_details":{"cached_tokens":5},"output_tokens_details":{"reasoning_tokens":0}}}}`)
+		write(`{"type":"response.completed","sequence_number":3,"response":{"id":"resp_1","object":"response","created_at":1,"status":"completed","model":"gpt-4o","output":[],"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3,"input_tokens_details":{"cached_tokens":1},"output_tokens_details":{"reasoning_tokens":0}}}}`)
 		_, _ = io.WriteString(w, "data: [DONE]\n\n")
 	}))
 	defer srv.Close()
@@ -251,8 +251,8 @@ func TestOpenAIModel_GenerateContent_ResponsesStreaming(t *testing.T) {
 	if final == nil || final.Content.Parts[0].Text != "hello" {
 		t.Fatalf("final = %#v", final)
 	}
-	if final == nil || final.UsageMetadata == nil || final.UsageMetadata.CachedContentTokenCount != 5 {
-		t.Fatalf("cachedContentTokenCount = %#v, want 5", final.UsageMetadata)
+	if final.UsageMetadata == nil || final.UsageMetadata.CachedContentTokenCount != 1 {
+		t.Fatalf("cachedContentTokenCount = %#v, want 1", final.UsageMetadata)
 	}
 }
 

--- a/go/adk/pkg/models/usage.go
+++ b/go/adk/pkg/models/usage.go
@@ -1,0 +1,7 @@
+package models
+
+import "math"
+
+func cachedTokenCount(tokens int64) int32 {
+	return int32(min(max(tokens, 0), math.MaxInt32))
+}

--- a/go/adk/pkg/models/usage_test.go
+++ b/go/adk/pkg/models/usage_test.go
@@ -1,0 +1,207 @@
+package models
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	anthropicoption "github.com/anthropics/anthropic-sdk-go/option"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+	"github.com/openai/openai-go/v3"
+	openaioption "github.com/openai/openai-go/v3/option"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/genai"
+)
+
+func TestModelCachedTokens(t *testing.T) {
+	tests := []struct {
+		name   string
+		cached string
+		want   int32
+	}{
+		{name: "cache hit", cached: "8", want: 8},
+		{name: "omitted"},
+		{name: "null", cached: "null"},
+		{name: "zero", cached: "0"},
+		{name: "negative", cached: "-1"},
+		{name: "int32 limit", cached: "2147483647", want: math.MaxInt32},
+		{name: "int32 overflow", cached: "2147483648", want: math.MaxInt32},
+		{name: "int64 limit", cached: "9223372036854775807", want: math.MaxInt32},
+		{name: "int64 minimum", cached: "-9223372036854775808"},
+	}
+	for _, provider := range []string{"openai_chat", "openai_responses", "anthropic", "bedrock"} {
+		for _, stream := range []bool{false, true} {
+			for _, test := range tests {
+				if provider == "bedrock" && (test.name == "int32 overflow" || test.name == "int64 limit" || test.name == "int64 minimum") {
+					continue
+				}
+				t.Run(fmt.Sprintf("%s/stream=%t/%s", provider, stream, test.name), func(t *testing.T) {
+					contentType, payload := cachedTokensPayload(t, provider, test.cached, stream)
+					server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+						writer.Header().Set("Content-Type", contentType)
+						_, _ = writer.Write(payload)
+					}))
+					t.Cleanup(server.Close)
+					logger := slog.New(slog.DiscardHandler)
+					var llm model.LLM
+					switch provider {
+					case "openai_chat", "openai_responses":
+						config := &OpenAIConfig{Model: "gpt-4o"}
+						if provider == "openai_responses" {
+							config.APIFormat = OpenAIAPIFormatResponses
+						}
+						llm = &OpenAIModel{
+							Config: config,
+							Client: openai.NewClient(openaioption.WithAPIKey("test"), openaioption.WithBaseURL(server.URL)),
+							Logger: logger,
+						}
+					case "anthropic":
+						llm = &AnthropicModel{
+							Config: &AnthropicConfig{Model: "claude-sonnet-4-20250514"},
+							Client: anthropic.NewClient(anthropicoption.WithAPIKey("test"), anthropicoption.WithBaseURL(server.URL)),
+							Logger: logger,
+						}
+					case "bedrock":
+						llm = &BedrockModel{
+							Config: &BedrockConfig{Model: "anthropic.claude-v2"},
+							Client: bedrockruntime.New(bedrockruntime.Options{
+								Region: "us-east-1", BaseEndpoint: aws.String(server.URL),
+								Credentials: aws.CredentialsProviderFunc(func(context.Context) (aws.Credentials, error) {
+									return aws.Credentials{AccessKeyID: "test", SecretAccessKey: "test"}, nil
+								}),
+							}),
+							Logger: logger,
+						}
+					}
+					var final *model.LLMResponse
+					for response, err := range llm.GenerateContent(context.Background(), &model.LLMRequest{
+						Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "ping"}}}},
+					}, stream) {
+						require.NoError(t, err)
+						require.Empty(t, response.ErrorCode, response.ErrorMessage)
+						if !response.Partial {
+							final = response
+						}
+					}
+					require.NotNil(t, final)
+					require.NotNil(t, final.UsageMetadata)
+					require.Equal(t, test.want, final.UsageMetadata.CachedContentTokenCount)
+					require.Equal(t, int32(10), final.UsageMetadata.PromptTokenCount)
+					require.Equal(t, int32(5), final.UsageMetadata.CandidatesTokenCount)
+				})
+			}
+		}
+	}
+}
+
+func cachedTokensPayload(t *testing.T, provider, cached string, stream bool) (string, []byte) {
+	t.Helper()
+	contentType := "application/json"
+	if stream {
+		contentType = "text/event-stream"
+	}
+	field := ""
+	if cached != "" {
+		switch provider {
+		case "openai_chat":
+			field = fmt.Sprintf(`,"prompt_tokens_details":{"cached_tokens":%s}`, cached)
+		case "openai_responses":
+			field = fmt.Sprintf(`,"input_tokens_details":{"cached_tokens":%s}`, cached)
+		case "anthropic":
+			field = fmt.Sprintf(`,"cache_read_input_tokens":%s`, cached)
+		case "bedrock":
+			field = fmt.Sprintf(`,"cacheReadInputTokens":%s`, cached)
+		}
+	}
+	var payload string
+	switch provider {
+	case "openai_chat":
+		usage := fmt.Sprintf(`{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15%s}`, field)
+		payload = fmt.Sprintf(`{"id":"chat_1","choices":[{"index":0,"message":{"role":"assistant","content":"pong"},"finish_reason":"stop"}],"usage":%s}`, usage)
+		if stream {
+			payload = "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"pong\"},\"finish_reason\":\"stop\"}]}\n\n"
+			payload += fmt.Sprintf("data: {\"choices\":[],\"usage\":%s}\n\ndata: [DONE]\n\n", usage)
+		}
+	case "openai_responses":
+		payload = fmt.Sprintf(`{"id":"resp_1","status":"completed","output":[],"usage":{"input_tokens":10,"output_tokens":5,"total_tokens":15%s}}`, field)
+		if stream {
+			payload = fmt.Sprintf("data: {\"type\":\"response.completed\",\"response\":%s}\n\n", payload)
+		}
+	case "anthropic":
+		payload = fmt.Sprintf(`{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"text","text":"pong"}],"stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":5,"cache_creation_input_tokens":3%s}}`, field)
+		if stream {
+			payload = fmt.Sprintf("event: message_start\ndata: {\"type\":\"message_start\",\"message\":%s}\n\n", payload)
+			payload += "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":5}}\n\n"
+			payload += "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
+		}
+	case "bedrock":
+		usage := fmt.Sprintf(`{"inputTokens":10,"outputTokens":5,"totalTokens":15,"cacheWriteInputTokens":3%s}`, field)
+		payload = fmt.Sprintf(`{"output":{"message":{"role":"assistant","content":[{"text":"pong"}]}},"stopReason":"end_turn","usage":%s}`, usage)
+		if stream {
+			var buffer bytes.Buffer
+			require.NoError(t, eventstream.NewEncoder().Encode(&buffer, eventstream.Message{
+				Headers: eventstream.Headers{
+					{Name: ":message-type", Value: eventstream.StringValue("event")},
+					{Name: ":event-type", Value: eventstream.StringValue("metadata")},
+					{Name: ":content-type", Value: eventstream.StringValue("application/json")},
+				},
+				Payload: []byte(fmt.Sprintf(`{"usage":%s}`, usage)),
+			}))
+			return "application/vnd.amazon.eventstream", buffer.Bytes()
+		}
+	}
+	return contentType, []byte(payload)
+}
+
+func TestAnthropicStreamingCachedTokenDeltas(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		delta string
+		want  int32
+	}{
+		{name: "omitted", want: 8},
+		{name: "null", delta: `,"cache_read_input_tokens":null`, want: 8},
+		{name: "cumulative update", delta: `,"cache_read_input_tokens":12`, want: 12},
+		{name: "explicit zero", delta: `,"cache_read_input_tokens":0`},
+		{name: "negative", delta: `,"cache_read_input_tokens":-1`},
+		{name: "overflow", delta: `,"cache_read_input_tokens":2147483648`, want: math.MaxInt32},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				writer.Header().Set("Content-Type", "text/event-stream")
+				_, _ = io.WriteString(writer, "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":0,\"output_tokens\":0,\"cache_read_input_tokens\":8}}}\n\n")
+				_, _ = fmt.Fprintf(writer, "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":0%s}}\n\n", test.delta)
+				_, _ = io.WriteString(writer, "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n")
+			}))
+			t.Cleanup(server.Close)
+			llm := &AnthropicModel{
+				Config: &AnthropicConfig{Model: "claude-sonnet-4-20250514"},
+				Client: anthropic.NewClient(anthropicoption.WithAPIKey("test"), anthropicoption.WithBaseURL(server.URL)),
+				Logger: slog.New(slog.DiscardHandler),
+			}
+			var final *model.LLMResponse
+			for response, err := range llm.GenerateContent(context.Background(), &model.LLMRequest{}, true) {
+				require.NoError(t, err)
+				require.Empty(t, response.ErrorCode, response.ErrorMessage)
+				final = response
+			}
+			require.NotNil(t, final)
+			if test.want == 0 {
+				require.Nil(t, final.UsageMetadata)
+			} else {
+				require.NotNil(t, final.UsageMetadata)
+				require.Equal(t, test.want, final.UsageMetadata.CachedContentTokenCount)
+			}
+		})
+	}
+}

--- a/python/packages/kagent-adk/src/kagent/adk/models/_bedrock.py
+++ b/python/packages/kagent-adk/src/kagent/adk/models/_bedrock.py
@@ -23,6 +23,7 @@ from google.genai import types
 from pydantic import Field
 
 from ._ssl import KAgentTLSMixin
+from ._usage import cached_token_count
 from ._utils import function_declaration_schema
 
 if TYPE_CHECKING:
@@ -428,6 +429,7 @@ class KAgentBedrockLlm(KAgentTLSMixin, BaseLlm):
                                 prompt_token_count=usage.get("inputTokens"),
                                 candidates_token_count=usage.get("outputTokens"),
                                 total_token_count=usage.get("totalTokens"),
+                                cached_content_token_count=cached_token_count(usage.get("cacheReadInputTokens")),
                             )
 
                 final_parts = []
@@ -471,6 +473,7 @@ class KAgentBedrockLlm(KAgentTLSMixin, BaseLlm):
                     prompt_token_count=usage.get("inputTokens"),
                     candidates_token_count=usage.get("outputTokens"),
                     total_token_count=usage.get("totalTokens"),
+                    cached_content_token_count=cached_token_count(usage.get("cacheReadInputTokens")),
                 )
 
                 yield LlmResponse(

--- a/python/packages/kagent-adk/src/kagent/adk/models/_openai.py
+++ b/python/packages/kagent-adk/src/kagent/adk/models/_openai.py
@@ -51,6 +51,7 @@ from pydantic import Field, model_validator
 
 from ._ssl import KAgentTLSMixin
 from ._token_source import GDCHTokenSource
+from ._usage import cached_token_count
 from ._utils import function_declaration_schema
 
 if TYPE_CHECKING:
@@ -336,7 +337,7 @@ def _cached_prompt_tokens(usage: Any) -> int:
     details = getattr(usage, "prompt_tokens_details", None)
     if details is None:
         return 0
-    return getattr(details, "cached_tokens", 0) or 0
+    return cached_token_count(getattr(details, "cached_tokens", None))
 
 
 def _convert_openai_response_to_llm_response(response: ChatCompletion) -> LlmResponse:
@@ -497,6 +498,9 @@ def _responses_usage_to_genai(
         prompt_token_count=usage.input_tokens,
         candidates_token_count=usage.output_tokens,
         total_token_count=usage.total_tokens,
+        cached_content_token_count=cached_token_count(
+            getattr(getattr(usage, "input_tokens_details", None), "cached_tokens", None)
+        ),
     )
 
 

--- a/python/packages/kagent-adk/src/kagent/adk/models/_openai.py
+++ b/python/packages/kagent-adk/src/kagent/adk/models/_openai.py
@@ -328,6 +328,17 @@ def _convert_tools_to_openai(tools: list[types.Tool]) -> list[ChatCompletionTool
     return openai_tools
 
 
+def _cached_prompt_tokens(usage: Any) -> int:
+    """Return OpenAI cached prompt-token count (0 when absent).
+
+    OpenAI reports prompt-cache hits via usage.prompt_tokens_details.cached_tokens.
+    """
+    details = getattr(usage, "prompt_tokens_details", None)
+    if details is None:
+        return 0
+    return getattr(details, "cached_tokens", 0) or 0
+
+
 def _convert_openai_response_to_llm_response(response: ChatCompletion) -> LlmResponse:
     """Convert OpenAI response to LlmResponse."""
     choice = response.choices[0]
@@ -367,6 +378,7 @@ def _convert_openai_response_to_llm_response(response: ChatCompletion) -> LlmRes
             prompt_token_count=response.usage.prompt_tokens,
             candidates_token_count=response.usage.completion_tokens,
             total_token_count=response.usage.total_tokens,
+            cached_content_token_count=_cached_prompt_tokens(response.usage),
         )
 
     # Handle finish reason
@@ -755,6 +767,7 @@ class BaseOpenAI(KAgentTLSMixin, BaseLlm):
                             prompt_token_count=chunk.usage.prompt_tokens,
                             candidates_token_count=chunk.usage.completion_tokens,
                             total_token_count=chunk.usage.total_tokens,
+                            cached_content_token_count=_cached_prompt_tokens(chunk.usage),
                         )
 
                 # Yield final aggregated response with partial=False

--- a/python/packages/kagent-adk/src/kagent/adk/models/_usage.py
+++ b/python/packages/kagent-adk/src/kagent/adk/models/_usage.py
@@ -1,0 +1,3 @@
+def cached_token_count(tokens: int | None) -> int:
+    """Normalize cached tokens to the nonnegative int32 range used by Go genai."""
+    return min(max(tokens or 0, 0), (1 << 31) - 1)

--- a/python/packages/kagent-adk/tests/unittests/models/test_bedrock.py
+++ b/python/packages/kagent-adk/tests/unittests/models/test_bedrock.py
@@ -235,12 +235,15 @@ class TestKAgentBedrockLlm:
             KAgentBedrockLlm(model="meta.llama3-8b-instruct-v1:0", **{field: value})
 
     @pytest.mark.asyncio
-    async def test_generate_calls_converse(self):
+    @pytest.mark.parametrize(
+        "cached,want", [({}, 0), ({"cacheReadInputTokens": 8}, 8), ({"cacheReadInputTokens": -1}, 0)]
+    )
+    async def test_generate_calls_converse(self, cached, want):
         llm = KAgentBedrockLlm(model="us.anthropic.claude-sonnet-4-20250514-v1:0")
         converse_response = {
             "output": {"message": {"role": "assistant", "content": [{"text": "hello"}]}},
             "stopReason": "end_turn",
-            "usage": {"inputTokens": 10, "outputTokens": 5, "totalTokens": 15},
+            "usage": {"inputTokens": 10, "outputTokens": 5, "totalTokens": 15, "cacheWriteInputTokens": 3, **cached},
         }
         mock_client = mock.MagicMock()
         mock_client.converse.return_value = converse_response
@@ -261,16 +264,30 @@ class TestKAgentBedrockLlm:
 
         assert len(responses) == 1
         assert responses[0].content.parts[0].text == "hello"
+        assert responses[0].usage_metadata.cached_content_token_count == want
 
     @pytest.mark.asyncio
-    async def test_streaming_captures_usage_metadata(self):
+    @pytest.mark.parametrize(
+        "cached,want", [({}, 0), ({"cacheReadInputTokens": 8}, 8), ({"cacheReadInputTokens": -1}, 0)]
+    )
+    async def test_streaming_captures_usage_metadata(self, cached, want):
         llm = KAgentBedrockLlm(model="us.anthropic.claude-sonnet-4-20250514-v1:0")
 
         stream_events = [
             {"contentBlockStart": {"start": {}}},
             {"contentBlockDelta": {"delta": {"text": "hello"}}},
             {"messageStop": {"stopReason": "end_turn"}},
-            {"metadata": {"usage": {"inputTokens": 10, "outputTokens": 5, "totalTokens": 15}}},
+            {
+                "metadata": {
+                    "usage": {
+                        "inputTokens": 10,
+                        "outputTokens": 5,
+                        "totalTokens": 15,
+                        "cacheWriteInputTokens": 3,
+                        **cached,
+                    }
+                }
+            },
         ]
         mock_client = mock.MagicMock()
         mock_client.converse_stream.return_value = {"stream": stream_events}
@@ -294,6 +311,7 @@ class TestKAgentBedrockLlm:
         assert final.usage_metadata.prompt_token_count == 10
         assert final.usage_metadata.candidates_token_count == 5
         assert final.usage_metadata.total_token_count == 15
+        assert final.usage_metadata.cached_content_token_count == want
 
     @pytest.mark.asyncio
     async def test_dot_tool_name_sanitized_to_bedrock_and_remapped_in_response(self):

--- a/python/packages/kagent-adk/tests/unittests/models/test_openai.py
+++ b/python/packages/kagent-adk/tests/unittests/models/test_openai.py
@@ -1061,3 +1061,31 @@ class TestConvertOpenAIResponseToLlmResponse:
         tool_messages = [m for m in messages if m["role"] == "tool"]
         assert len(tool_messages) == 1
         assert tool_messages[0]["extra_content"] == {"google": {"thought_signature": "YWJj"}}
+
+
+    def test_usage_metadata_populates_cached_content_token_count(self):
+        # Openai reports prompt-cache hits via usage.prompt_tokens_details.cached_tokens.
+        class _MockPromptTokensDetails:
+            cached_tokens = 12
+
+        response = self._MockResponse(self._MockMessage(content="hi"))
+        response.usage.prompt_tokens_details = _MockPromptTokensDetails()
+
+        llm_response = _convert_openai_response_to_llm_response(response)
+
+        assert llm_response.usage_metadata is not None, "usage metadata should be populated"
+        assert llm_response.usage_metadata.cached_content_token_count == 12, (
+            "cached_content_token_count should equal cached prompt tokens",
+            llm_response.usage_metadata
+        )
+
+    def test_opens_metadata_cached_content_token_zero_when_absent(self):
+        response = self._MockResponse(self._MockMessage("hi"))
+
+        llm_response = _convert_openai_response_to_llm_response(response)
+
+        assert llm_response.usage_metadata is not None
+        assert llm_response.usage_metadata.cached_content_token_count == 0, (
+            "cached_content_token_count should default to 0 when provider omits it",
+            llm_response.usage_metadata.cached_content_token_count,
+        )

--- a/python/packages/kagent-adk/tests/unittests/models/test_openai.py
+++ b/python/packages/kagent-adk/tests/unittests/models/test_openai.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
 from unittest import mock
 
 import pytest
@@ -536,7 +537,8 @@ async def test_streaming_includes_stream_options_for_usage(
 
 
 @pytest.mark.asyncio
-async def test_streaming_usage_metadata_propagation(openai_llm, llm_request):
+@pytest.mark.parametrize("cached,want", [(8, 8), (None, 0), (-1, 0), (1 << 31, (1 << 31) - 1)])
+async def test_streaming_usage_metadata_propagation(openai_llm, llm_request, cached, want):
     """Test that usage metadata from streaming response is properly propagated."""
 
     class MockDelta:
@@ -554,6 +556,7 @@ async def test_streaming_usage_metadata_propagation(openai_llm, llm_request):
         prompt_tokens = 10
         completion_tokens = 5
         total_tokens = 15
+        prompt_tokens_details = SimpleNamespace(cached_tokens=cached)
 
     class MockChunk:
         id = "chatcmpl-test"
@@ -590,6 +593,7 @@ async def test_streaming_usage_metadata_propagation(openai_llm, llm_request):
         assert final_response.usage_metadata.prompt_token_count == 10
         assert final_response.usage_metadata.candidates_token_count == 5
         assert final_response.usage_metadata.total_token_count == 15
+        assert final_response.usage_metadata.cached_content_token_count == want
 
 
 # ============================================================================
@@ -1062,25 +1066,29 @@ class TestConvertOpenAIResponseToLlmResponse:
         assert len(tool_messages) == 1
         assert tool_messages[0]["extra_content"] == {"google": {"thought_signature": "YWJj"}}
 
-
-    def test_usage_metadata_populates_cached_content_token_count(self):
-        # Openai reports prompt-cache hits via usage.prompt_tokens_details.cached_tokens.
-        class _MockPromptTokensDetails:
-            cached_tokens = 12
-
+    @pytest.mark.parametrize(
+        "details,want",
+        [
+            (None, 0),
+            (SimpleNamespace(), 0),
+            (SimpleNamespace(cached_tokens=None), 0),
+            (SimpleNamespace(cached_tokens=2), 2),
+            (SimpleNamespace(cached_tokens=-1), 0),
+            (SimpleNamespace(cached_tokens=(1 << 31) - 1), (1 << 31) - 1),
+            (SimpleNamespace(cached_tokens=1 << 31), (1 << 31) - 1),
+        ],
+    )
+    def test_usage_metadata_populates_cached_content_token_count(self, details, want):
         response = self._MockResponse(self._MockMessage(content="hi"))
-        response.usage.prompt_tokens_details = _MockPromptTokensDetails()
+        response.usage.prompt_tokens_details = details
 
         llm_response = _convert_openai_response_to_llm_response(response)
 
         assert llm_response.usage_metadata is not None, "usage metadata should be populated"
-        assert llm_response.usage_metadata.cached_content_token_count == 12, (
-            "cached_content_token_count should equal cached prompt tokens",
-            llm_response.usage_metadata
-        )
+        assert llm_response.usage_metadata.cached_content_token_count == want
 
-    def test_opens_metadata_cached_content_token_zero_when_absent(self):
-        response = self._MockResponse(self._MockMessage("hi"))
+    def test_usage_metadata_cached_content_token_zero_when_absent(self):
+        response = self._MockResponse(self._MockMessage(content="hi"))
 
         llm_response = _convert_openai_response_to_llm_response(response)
 

--- a/python/packages/kagent-adk/tests/unittests/models/test_openai_responses.py
+++ b/python/packages/kagent-adk/tests/unittests/models/test_openai_responses.py
@@ -1,4 +1,5 @@
 import logging
+from types import SimpleNamespace
 from unittest import mock
 
 import pytest
@@ -28,6 +29,7 @@ from kagent.adk.models._openai import (
     _convert_content_to_responses_input,
     _convert_responses_output_to_llm_response,
     _convert_tools_to_responses,
+    _responses_usage_to_genai,
 )
 from kagent.adk.types import OpenAI as OpenAIModelConfig
 from kagent.adk.types import _create_llm_from_model_config
@@ -220,7 +222,7 @@ def test_convert_responses_output_to_llm_response_text():
         ],
         usage=ResponseUsage(
             input_tokens=10,
-            input_tokens_details={"cache_write_tokens": 0, "cached_tokens": 0},
+            input_tokens_details={"cache_write_tokens": 3, "cached_tokens": 8},
             output_tokens=5,
             output_tokens_details={"reasoning_tokens": 0},
             total_tokens=15,
@@ -233,6 +235,28 @@ def test_convert_responses_output_to_llm_response_text():
     assert llm_response.finish_reason == types.FinishReason.STOP
     assert llm_response.usage_metadata.prompt_token_count == 10
     assert llm_response.usage_metadata.candidates_token_count == 5
+    assert llm_response.usage_metadata.cached_content_token_count == 8
+
+
+@pytest.mark.parametrize(
+    "details,want",
+    [
+        (None, 0),
+        (SimpleNamespace(), 0),
+        (SimpleNamespace(cached_tokens=None), 0),
+        (SimpleNamespace(cached_tokens=8), 8),
+        (SimpleNamespace(cached_tokens=-1), 0),
+        (SimpleNamespace(cached_tokens=1 << 31), (1 << 31) - 1),
+    ],
+)
+def test_responses_cached_tokens(details, want):
+    usage = ResponseUsage.model_construct(input_tokens=10, output_tokens=5, total_tokens=15)
+    usage.input_tokens_details = details
+    assert _responses_usage_to_genai(usage).cached_content_token_count == want
+
+
+def test_responses_cached_tokens_without_usage():
+    assert _responses_usage_to_genai(None) is None
 
 
 def test_convert_responses_output_to_llm_response_function_call():
@@ -442,7 +466,7 @@ async def test_generate_content_async_responses_streaming(responses_llm, llm_req
                 output=[],
                 usage=ResponseUsage(
                     input_tokens=1,
-                    input_tokens_details={"cache_write_tokens": 0, "cached_tokens": 0},
+                    input_tokens_details={"cache_write_tokens": 3, "cached_tokens": 1},
                     output_tokens=2,
                     output_tokens_details={"reasoning_tokens": 0},
                     total_tokens=3,
@@ -477,6 +501,7 @@ async def test_generate_content_async_responses_streaming(responses_llm, llm_req
     assert fc.args == {"location": "NYC"}
     assert final.usage_metadata.prompt_token_count == 1
     assert final.usage_metadata.candidates_token_count == 2
+    assert final.usage_metadata.cached_content_token_count == 1
 
 
 async def _stream_results(llm, llm_request, events):


### PR DESCRIPTION
## Summary

Closes #2669 — surfaces provider-reported **prompt-cache hit / cached-token** counts from the kagent model adapters into `genai.GenerateContentResponseUsageMetadata.CachedContentTokenCount`, so cached prompt-token spend and prompt-cache hit rate are observable via A2A task usage and the `llm_response` trace attributes instead of being silently dropped.

### Adapter changes

Populate `CachedContentTokenCount` (int32) at each adapter, mapping the provider's cached-prompt-token counter; defaults to 0 when the provider omits the field (nil-safe):

- **OpenAI Responses** — `go/adk/pkg/models/openai_responses.go`: `ResponseUsage.InputTokensDetails.CachedTokens`
- **OpenAI Chat** (streaming + non-streaming) — `go/adk/pkg/models/openai_adk.go`: `PromptTokensDetails.CachedTokens`
- **Anthropic** (streaming + non-streaming) — `go/adk/pkg/models/anthropic_adk.go`: `Usage.CacheReadInputTokens`
- **Amazon Bedrock Converse** (streaming + non-streaming) — `go/adk/pkg/models/bedrock.go`: `Usage.CacheReadInputTokens`
- **Python OpenAI runtime** — `python/packages/kagent-adk/src/kagent/adk/models/_openai.py`: `prompt_tokens_details.cached_tokens`

This is gap 1 ("populate the cached-token counts in the adapters") from #2669. Emitting a dedicated `gen_ai.token.type=cached` metric remains the separately-tracked follow-up surfaced in #2148/#2149, and upstream ADK already records `gen_ai.usage.cache_read.input_tokens` once `CachedContentTokenCount` is non-zero.

## Tests

- **Go** unit tests added/updated for the cached-token mapping:
  - `anthropic_adk_test.go` — new `TestAnthropicNonStreamingCachedTokens`
  - `openai_responses_test.go` — responses non-streaming, `GenerateContent`, and streaming cached-token assertions
  - `openai_adk_test.go` — chat completion cached-token assertion
- **Python** `tests/unittests/models/test_openai.py` — asserts `cached_content_token_count` is populated and defaults to 0 when absent.

## Validation

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./adk/pkg/...` ✅ (note: `go/adk/pkg/session` shows a pre-existing Windows-only TempDir lockfile cleanup failure unrelated to this change; all models package tests pass)
- `gofmt -l` on changed Go files: empty ✅
- Python unit tests for the changed file could not be executed in this workspace because dependency installation failed on repeated `files.pythonhosted.org` TLS (`HandshakeFailure`) downloads — an environment/network issue, not a code defect (recorded in notes; CI will exercise them).

This branch is DCO-signed (`git commit -s`). Not a draft.
