### PR TITLE
chore: update substrate to v0.0.23

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
       - setup
     env:
       VERSION: v0.0.1-test
-      SUBSTRATE_VERSION: 0.0.22
+      SUBSTRATE_VERSION: 0.0.23
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     steps:

--- a/examples/substrate-openclaw/README.md
+++ b/examples/substrate-openclaw/README.md
@@ -40,7 +40,7 @@ on the kagent chart), prefix these keys with `substrate.` — e.g.
 Then install the Substrate platform and kagent:
 
 ```bash
-export SUBSTRATE_VERSION=0.0.20
+export SUBSTRATE_VERSION=0.0.23
 
 helm upgrade --install substrate-crds \
   oci://ghcr.io/kagent-dev/substrate/helm/substrate-crds \

--- a/go/core/v2/substrate/client.go
+++ b/go/core/v2/substrate/client.go
@@ -144,7 +144,7 @@ func (c *Client) CreateActorTemplate(ctx context.Context, template *ateapipb.Act
 }
 
 // DeleteActorTemplate also removes the template's golden Actor. Substrate
-// v0.0.22 documents that behavior but does not implement it yet.
+// documents that behavior but does not implement it yet.
 func (c *Client) DeleteActorTemplate(ctx context.Context, atespace, name, uid string) error {
 	ctx, cancel := c.callCtx(ctx)
 	defer cancel()

--- a/go/core/v2/substrate/client_test.go
+++ b/go/core/v2/substrate/client_test.go
@@ -139,8 +139,6 @@ func TestCreateActorUsesStableTemplateRef(t *testing.T) {
 	_, err := client.CreateActor(t.Context(), "team-a", "actor", "team-a", "template")
 	require.NoError(t, err)
 	require.Equal(t, &ateapipb.ObjectRef{Atespace: "team-a", Name: "template"}, fake.actor.GetActorTemplate())
-	require.Empty(t, fake.actor.GetActorTemplateNamespace())
-	require.Empty(t, fake.actor.GetActorTemplateName())
 }
 
 func (f *listActorTemplatesFake) ListActorTemplates(_ context.Context, in *ateapipb.ListActorTemplatesRequest, _ ...grpc.CallOption) (*ateapipb.ListActorTemplatesResponse, error) {

--- a/go/go.mod
+++ b/go/go.mod
@@ -68,7 +68,7 @@ require (
 	golang.org/x/text v0.41.0
 	google.golang.org/adk/v2 v2.2.0
 	google.golang.org/genai v1.69.0
-	google.golang.org/grpc v1.83.1
+	google.golang.org/grpc v1.83.2
 	google.golang.org/protobuf v1.36.12
 	gopkg.in/yaml.v3 v3.0.1
 	istio.io/istio v0.0.0-20260820015531-47320ba1a73b
@@ -486,4 +486,4 @@ require (
 
 tool sigs.k8s.io/kube-api-linter/cmd/golangci-lint-kube-api-linter
 
-replace github.com/agent-substrate/substrate => github.com/kagent-dev/substrate v0.0.22
+replace github.com/agent-substrate/substrate => github.com/kagent-dev/substrate v0.0.23

--- a/go/go.sum
+++ b/go/go.sum
@@ -707,8 +707,8 @@ github.com/kagent-dev/mockllm v0.0.7 h1:ofucOQKKqarRICBjxJFKIpxD7NQOjVuA0Frujh96
 github.com/kagent-dev/mockllm v0.0.7/go.mod h1:tDLemRsTZa1NdHaDbg3sgFk9cT1QWvMPlBtLVD6I2mA=
 github.com/kagent-dev/mockmcp v0.0.0-20260520211643-dcd475b74085 h1:5bYxRc6K6+JiFMYGSJpQ7y18PzTGXUmUtVXY7Fqh0Ew=
 github.com/kagent-dev/mockmcp v0.0.0-20260520211643-dcd475b74085/go.mod h1:vTMste7c+XiDOQyhe6iGPKLbMy3chY/h2fL3Dox5fAE=
-github.com/kagent-dev/substrate v0.0.22 h1:wA9W/VESYcbhZ/G44Thz+Alees5yqyBtC4o6hCASwhs=
-github.com/kagent-dev/substrate v0.0.22/go.mod h1:K+R6RzFtX5tl3hoix8/OlNGOGqgDiHBytu66U4PAPcg=
+github.com/kagent-dev/substrate v0.0.23 h1:pdFpwYos7ALg8+HdQspJbgfr6JpQqYLY1WN6kRq3Zb8=
+github.com/kagent-dev/substrate v0.0.23/go.mod h1:6mRISVlnhE/lEgzOScqBmKh/fgzPgfEE/Nq2YFG40c4=
 github.com/karamaru-alpha/copyloopvar v1.2.2 h1:yfNQvP9YaGQR7VaWLYcfZUlRP2eo2vhExWKxD/fP6q0=
 github.com/karamaru-alpha/copyloopvar v1.2.2/go.mod h1:oY4rGZqZ879JkJMtX3RRkcXRkmUvH0x35ykgaKgsgJY=
 github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRtuthU=
@@ -1508,8 +1508,8 @@ google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/grpc v1.32.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
-google.golang.org/grpc v1.83.1 h1:HIO0+BEtBP6soyqvqC8sNUjZ7bTs+0hFQuFF+RAy++Y=
-google.golang.org/grpc v1.83.1/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
+google.golang.org/grpc v1.83.2 h1:EManeRomTObA0BU7I8vXgg/78uE5MJ9M8B39EX2WscU=
+google.golang.org/grpc v1.83.2/go.mod h1:YPI1hK3kDked6iHvgX3tR0y+nX/qpMFKhPgFsokw1S8=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/scripts/setup-cluster/setup-cluster.sh
+++ b/scripts/setup-cluster/setup-cluster.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 
 # The repo this script lives in, so it works from any checkout and any directory.
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-SUBSTRATE_VERSION=0.0.22
+SUBSTRATE_VERSION=0.0.23
 cd "$REPO"
 
 step() { printf '\n\033[1;36m==> %s\033[0m\n' "$1"; }


### PR DESCRIPTION
## Summary

- update the Substrate Go dependency, CI, cluster setup, and example to v0.0.23
- adapt client tests to the released API and keep the delete workaround comment version-neutral

## Testing

- `go test ./core/...`
- clean Substrate v0.0.23 deployment on Kind; all workloads Ready and WorkerPool using `ghcr.io/kagent-dev/substrate/ateom-gvisor:v0.0.23`
- full real-cluster E2E suite passed (`ok github.com/kagent-dev/kagent/go/core/test/e2e 132.687s`)