### PR TITLE
chore: update substrate to v0.0.24

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
       - setup
     env:
       VERSION: v0.0.1-test
-      SUBSTRATE_VERSION: 0.0.23
+      SUBSTRATE_VERSION: 0.0.24
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     steps:

--- a/examples/substrate-openclaw/README.md
+++ b/examples/substrate-openclaw/README.md
@@ -40,7 +40,7 @@ on the kagent chart), prefix these keys with `substrate.` — e.g.
 Then install the Substrate platform and kagent:
 
 ```bash
-export SUBSTRATE_VERSION=0.0.23
+export SUBSTRATE_VERSION=0.0.24
 
 helm upgrade --install substrate-crds \
   oci://ghcr.io/kagent-dev/substrate/helm/substrate-crds \

--- a/go/go.mod
+++ b/go/go.mod
@@ -439,7 +439,7 @@ require (
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.6 // indirect
-	golang.org/x/crypto v0.55.0 // indirect
+	golang.org/x/crypto v0.56.0 // indirect
 	golang.org/x/exp v0.0.0-20260813180055-c1d0aacb2297 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20260209203927-2842357ff358 // indirect
 	golang.org/x/mod v0.40.0 // indirect
@@ -486,4 +486,4 @@ require (
 
 tool sigs.k8s.io/kube-api-linter/cmd/golangci-lint-kube-api-linter
 
-replace github.com/agent-substrate/substrate => github.com/kagent-dev/substrate v0.0.23
+replace github.com/agent-substrate/substrate => github.com/kagent-dev/substrate v0.0.24

--- a/go/go.sum
+++ b/go/go.sum
@@ -707,8 +707,8 @@ github.com/kagent-dev/mockllm v0.0.7 h1:ofucOQKKqarRICBjxJFKIpxD7NQOjVuA0Frujh96
 github.com/kagent-dev/mockllm v0.0.7/go.mod h1:tDLemRsTZa1NdHaDbg3sgFk9cT1QWvMPlBtLVD6I2mA=
 github.com/kagent-dev/mockmcp v0.0.0-20260520211643-dcd475b74085 h1:5bYxRc6K6+JiFMYGSJpQ7y18PzTGXUmUtVXY7Fqh0Ew=
 github.com/kagent-dev/mockmcp v0.0.0-20260520211643-dcd475b74085/go.mod h1:vTMste7c+XiDOQyhe6iGPKLbMy3chY/h2fL3Dox5fAE=
-github.com/kagent-dev/substrate v0.0.23 h1:pdFpwYos7ALg8+HdQspJbgfr6JpQqYLY1WN6kRq3Zb8=
-github.com/kagent-dev/substrate v0.0.23/go.mod h1:6mRISVlnhE/lEgzOScqBmKh/fgzPgfEE/Nq2YFG40c4=
+github.com/kagent-dev/substrate v0.0.24 h1:eOVjFZBOqgJrVZwk48sWAhzra3MR8F8Trqnhg6qJvsk=
+github.com/kagent-dev/substrate v0.0.24/go.mod h1:EMlL/eOwu0RTnh0kgRQYwd+YkWZ0HmDM2pf5f/OCKAo=
 github.com/karamaru-alpha/copyloopvar v1.2.2 h1:yfNQvP9YaGQR7VaWLYcfZUlRP2eo2vhExWKxD/fP6q0=
 github.com/karamaru-alpha/copyloopvar v1.2.2/go.mod h1:oY4rGZqZ879JkJMtX3RRkcXRkmUvH0x35ykgaKgsgJY=
 github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRtuthU=
@@ -1303,8 +1303,8 @@ golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
-golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
+golang.org/x/crypto v0.56.0 h1:GUh5Ii4J5jtcseSMiRqr1jXCNHoxjeV9Fmekc2oLy6Y=
+golang.org/x/crypto v0.56.0/go.mod h1:OMW5y6CY9l38uPLmxU6l6pwcXp1obtLo3e6gT7gQR2I=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20200331195152-e8c3332aa8e5/go.mod h1:4M0jN8W1tt0AVLNr8HDosyJCDCDuyL9N9+3m7wDWgKw=

--- a/scripts/setup-cluster/setup-cluster.sh
+++ b/scripts/setup-cluster/setup-cluster.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 
 # The repo this script lives in, so it works from any checkout and any directory.
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-SUBSTRATE_VERSION=0.0.23
+SUBSTRATE_VERSION=0.0.24
 cd "$REPO"
 
 step() { printf '\n\033[1;36m==> %s\033[0m\n' "$1"; }


### PR DESCRIPTION
## Summary

- update the Substrate Go dependency, CI, cluster setup, and example to v0.0.24
- accept the transitive `golang.org/x/crypto` update required by the release

## Testing

- `go test ./core/...`
- clean Kind install from scratch with Substrate and CRDs v0.0.24; all workloads Ready and eight workers using `ghcr.io/kagent-dev/substrate/ateom-gvisor:v0.0.24`
- full real-cluster E2E suite passed (`ok github.com/kagent-dev/kagent/go/core/test/e2e 316.142s`)