### PR TITLE
helm: derive the substrate endpoints when substrate is a subchart

### DIFF
--- a/helm/kagent/templates/_helpers.tpl
+++ b/helm/kagent/templates/_helpers.tpl
@@ -261,3 +261,36 @@ imagePullSecrets:
 {{- toYaml $global | nindent 2 }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Endpoint the controller dials to reach ateapi.
+
+An explicit controller.substrate.ateApiEndpoint always wins. Otherwise, when
+substrate is installed as a subchart of this release, its own helper is asked
+for the endpoint: the chart prefixes resource names with the release name for
+any release not called "substrate", so the Service is not at the canonical
+api.ate-system.svc and only the subchart knows what it rendered.
+
+Empty when substrate is not a subchart, which leaves the controller on its
+compiled-in default — correct for the topology where substrate is installed as
+its own release and the endpoint is passed explicitly.
+*/}}
+{{- define "kagent.substrate.ateApiEndpoint" -}}
+{{- if .Values.controller.substrate.ateApiEndpoint -}}
+{{- .Values.controller.substrate.ateApiEndpoint -}}
+{{- else if and .Values.substrate .Values.substrate.enabled -}}
+{{- include "substrate.ateApi.endpoint" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+URL the controller uses to reach atenet-router, resolved the same way as
+kagent.substrate.ateApiEndpoint.
+*/}}
+{{- define "kagent.substrate.atenetRouterURL" -}}
+{{- if .Values.controller.substrate.atenetRouterURL -}}
+{{- .Values.controller.substrate.atenetRouterURL -}}
+{{- else if and .Values.substrate .Values.substrate.enabled -}}
+{{- include "substrate.atenetRouter.url" . -}}
+{{- end -}}
+{{- end -}}

--- a/helm/kagent/templates/controller-deployment.yaml
+++ b/helm/kagent/templates/controller-deployment.yaml
@@ -143,12 +143,12 @@ spec:
             {{- end }}
             {{- if and .Values.controller.substrate .Values.controller.substrate.enabled }}
             - name: SUBSTRATE_ATE_API_ENDPOINT
-              value: {{ .Values.controller.substrate.ateApiEndpoint | quote }}
+              value: {{ include "kagent.substrate.ateApiEndpoint" . | quote }}
             - name: SUBSTRATE_ATE_API_CA_FILE
               value: /run/substrate-servicedns/trust-bundle.pem
             - name: SUBSTRATE_ATE_API_CLIENT_CERT_FILE
               value: /run/substrate-podidentity/credential-bundle.pem
-            {{- with .Values.controller.substrate.atenetRouterURL }}
+            {{- with include "kagent.substrate.atenetRouterURL" . }}
             - name: SUBSTRATE_ATENET_ROUTER_URL
               value: {{ . | quote }}
             {{- end }}


### PR DESCRIPTION
## What

`controller.substrate.ateApiEndpoint` and `atenetRouterURL` fall back to the
controller's compiled-in defaults, which name `api.ate-system.svc` and
`atenet-router.ate-system.svc`. Both now fall back to substrate's own chart
helpers when substrate is enabled as a subchart of this release.

## Why

The current defaults are right for the topology
`scripts/setup-cluster/setup-cluster.sh` sets up, where substrate is installed
as its own release named `substrate` in `ate-system` and both endpoints are
passed explicitly.

They are wrong when substrate is enabled as a subchart. A subchart inherits the
parent's release name, and substrate's chart prefixes every resource name for a
release not called `substrate`, so the Service is at
`<release>-api.<namespace>.svc`. The controller dialled `api.ate-system.svc`
and never reached ateapi:

```
substrate: dial ate-api "dns:///api.ate-system.svc:443": context deadline exceeded
```

Substrate's chart already exposes `substrate.ateApi.endpoint` and
`substrate.atenetRouter.url` for this, with a comment inviting parent charts to
use them rather than hardcode a name. Asking the subchart what it rendered is
better than keeping a second copy of its naming convention in step.

## Behaviour

| Case | Result |
|---|---|
| Explicit `ateApiEndpoint` / `atenetRouterURL` | wins, unchanged |
| substrate enabled as a subchart, nothing explicit | derived from the subchart's helpers |
| substrate not a subchart | empty, so the controller keeps its default — unchanged |

The helper reference is guarded on `.Values.substrate.enabled`, so it is only
evaluated when the subchart is actually present.

## Testing

Rendered against the released substrate chart at the version this repo pins
(v0.0.24), confirming both helpers exist there:

- subchart enabled, nothing explicit → `dns:///kagent-api.kagent.svc:443` and
  `http://kagent-atenet-router.kagent.svc:80`
- explicit values → unchanged
- subchart disabled with the values `setup-cluster.sh` passes → unchanged

Also verified on a kind cluster: with the endpoints cleared so they had to be
derived, the controller rolled out and reached ateapi with no dial errors, and
this repo's e2e suite ran against that install.

## Worth deciding separately

Whether kagent should ship with the substrate subchart enabled. It is gated in
two charts today — `kagent-crds` and `kagent`, both defaulting to false — so
enabling only the workload chart installs no substrate CRDs and silently does
nothing. Flipping the default would need to cover both, or the CRD chart would
need to follow the workload chart.
