### PR TITLE
feat: per-request pass-through headers on ModelConfig

### DIFF
--- a/go/adk/pkg/agent/agent.go
+++ b/go/adk/pkg/agent/agent.go
@@ -270,6 +270,10 @@ func CreateLLM(ctx context.Context, m adk.Model) (adkmodel.LLM, error) {
 		})
 
 	case *adk.GeminiVertexAI:
+		// The Vertex AI client has no custom HTTP transport (same gap as defaultHeaders/TLS).
+		if len(m.PassthroughHeaders) > 0 {
+			logging.FromContext(ctx).WarnContext(ctx, "passthroughHeaders are not supported for GeminiVertexAI models and will be ignored")
+		}
 		project := os.Getenv("GOOGLE_CLOUD_PROJECT")
 		location := os.Getenv("GOOGLE_CLOUD_LOCATION")
 		if location == "" {
@@ -377,6 +381,10 @@ func CreateLLM(ctx context.Context, m adk.Model) (adkmodel.LLM, error) {
 		return models.NewAnthropicVertexAIModel(ctx, cfg, region, project)
 
 	case *adk.SAPAICore:
+		// SAP AI Core builds its own HTTP client without the shared transport.
+		if len(m.PassthroughHeaders) > 0 {
+			logging.FromContext(ctx).WarnContext(ctx, "passthroughHeaders are not supported for SAPAICore models and will be ignored")
+		}
 		cfg := models.SAPAICoreConfig{
 			Model:         m.Model,
 			BaseUrl:       m.BaseUrl,
@@ -416,6 +424,7 @@ func CreateLLM(ctx context.Context, m adk.Model) (adkmodel.LLM, error) {
 func transportConfigFromBase(b adk.BaseModel, timeout *int) models.TransportConfig {
 	return models.TransportConfig{
 		Headers:               extractHeaders(b.Headers),
+		PassthroughHeaders:    b.PassthroughHeaders,
 		TLSInsecureSkipVerify: b.TLSInsecureSkipVerify,
 		TLSCACertPath:         b.TLSCACertPath,
 		TLSDisableSystemCAs:   b.TLSDisableSystemCAs,

--- a/go/adk/pkg/headers/headers.go
+++ b/go/adk/pkg/headers/headers.go
@@ -1,0 +1,92 @@
+// Package headers resolves per-request HTTP headers from the incoming A2A
+// call context. It is shared by the MCP tool transport (allowedHeaders) and
+// the model transport (passthroughHeaders) so both forward caller-supplied
+// headers with identical semantics.
+package headers
+
+import (
+	"context"
+	"strings"
+
+	"github.com/a2aproject/a2a-go/v2/a2asrv"
+)
+
+// restrictedPassthroughHeaders are names that must never be forwarded from a
+// caller onto another hop:
+//   - credential headers (Authorization, Proxy-Authorization, Cookie) would
+//     forward a caller credential onward or clobber the credential the
+//     receiving hop manages itself; apiKeyPassthrough is the supported
+//     mechanism for credential forwarding;
+//   - the rest are hop-by-hop or message-framing headers per RFC 9110, plus
+//     the non-standard Proxy-Connection.
+//
+// Must stay in sync with RESTRICTED_PASSTHROUGH_HEADERS in
+// python/packages/kagent-adk/src/kagent/adk/_llm_header_passthrough_plugin.py.
+var restrictedPassthroughHeaders = map[string]struct{}{
+	"authorization":       {},
+	"connection":          {},
+	"content-length":      {},
+	"cookie":              {},
+	"host":                {},
+	"keep-alive":          {},
+	"proxy-authenticate":  {},
+	"proxy-authorization": {},
+	"proxy-connection":    {},
+	"te":                  {},
+	"trailer":             {},
+	"transfer-encoding":   {},
+	"upgrade":             {},
+}
+
+// IsRestricted reports whether a header name (case-insensitively) must never
+// be forwarded from a caller onto another hop.
+func IsRestricted(name string) bool {
+	_, restricted := restrictedPassthroughHeaders[strings.ToLower(name)]
+	return restricted
+}
+
+// FilterRestricted drops restricted names (case-insensitively) from a
+// configured pass-through header list.
+func FilterRestricted(names []string) []string {
+	var out []string
+	for _, n := range names {
+		if !IsRestricted(n) {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+// AllowedRequestHeaders reads the incoming A2A request metadata from ctx and
+// returns only the header key/value pairs whose names appear in allowed.
+// It reads directly from the A2A CallContext that is already present in the Go
+// context, avoiding a redundant copy.
+//
+// Lookup relies on ServiceParams.Get, which does a case-insensitive lookup
+// (NewServiceParams lowercases keys at construction). Keys in the result
+// preserve the casing from the allowed list so the receiving server sees the
+// header names the operator configured. When a header has multiple values only
+// the first one is forwarded; additional values are intentionally dropped.
+func AllowedRequestHeaders(ctx context.Context, allowed []string) map[string]string {
+	if len(allowed) == 0 {
+		return nil
+	}
+	callCtx, ok := a2asrv.CallContextFrom(ctx)
+	if !ok {
+		return nil
+	}
+	meta := callCtx.ServiceParams()
+	if meta == nil {
+		return nil
+	}
+	result := make(map[string]string)
+	for _, name := range allowed {
+		if vals, ok := meta.Get(name); ok && len(vals) > 0 && vals[0] != "" {
+			result[name] = vals[0]
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}

--- a/go/adk/pkg/headers/headers.go
+++ b/go/adk/pkg/headers/headers.go
@@ -6,6 +6,7 @@ package headers
 
 import (
 	"context"
+	"sort"
 	"strings"
 
 	"github.com/a2aproject/a2a-go/v2/a2asrv"
@@ -43,6 +44,19 @@ var restrictedPassthroughHeaders = map[string]struct{}{
 func IsRestricted(name string) bool {
 	_, restricted := restrictedPassthroughHeaders[strings.ToLower(name)]
 	return restricted
+}
+
+// RestrictedNames returns the restricted header names in sorted order. The
+// passthroughHeaders CEL validation on the ModelConfig CRD enumerates the same
+// set; TestPassthroughHeadersValidation iterates this list so the two cannot
+// drift silently.
+func RestrictedNames() []string {
+	names := make([]string, 0, len(restrictedPassthroughHeaders))
+	for name := range restrictedPassthroughHeaders {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 // FilterRestricted drops restricted names (case-insensitively) from a

--- a/go/adk/pkg/mcp/registry.go
+++ b/go/adk/pkg/mcp/registry.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/a2aproject/a2a-go/v2/a2asrv"
 	"github.com/kagent-dev/kagent/go/adk/pkg/constants"
+	"github.com/kagent-dev/kagent/go/adk/pkg/headers"
 	"github.com/kagent-dev/kagent/go/api/adk"
 	"github.com/kagent-dev/kagent/go/pkg/logging"
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
@@ -30,40 +31,6 @@ const (
 	// Default timeout matching Python KAGENT_REMOTE_AGENT_TIMEOUT
 	defaultTimeout = 30 * time.Minute
 )
-
-// allowedRequestHeaders reads the incoming A2A request metadata from ctx and
-// returns only the header key/value pairs whose names appear in allowed.
-// It reads directly from the A2A CallContext that is already present in the Go
-// context, avoiding a redundant copy.
-//
-// Lookup relies on RequestMeta.Get which already does a case-insensitive O(1)
-// lookup (NewRequestMeta lowercases keys at construction). Keys in the result
-// preserve the casing from the allowed list so the MCP server sees the header
-// names the operator configured. When a header has multiple values only the
-// first one is forwarded; additional values are intentionally dropped.
-func allowedRequestHeaders(ctx context.Context, allowed []string) map[string]string {
-	if len(allowed) == 0 {
-		return nil
-	}
-	callCtx, ok := a2asrv.CallContextFrom(ctx)
-	if !ok {
-		return nil
-	}
-	meta := callCtx.ServiceParams()
-	if meta == nil {
-		return nil
-	}
-	result := make(map[string]string)
-	for _, name := range allowed {
-		if vals, ok := meta.Get(name); ok && len(vals) > 0 && vals[0] != "" {
-			result[name] = vals[0]
-		}
-	}
-	if len(result) == 0 {
-		return nil
-	}
-	return result
-}
 
 // mcpServerParams groups connection parameters for an MCP server,
 // reducing parameter sprawl across createTransport / initializeToolSet.
@@ -322,7 +289,7 @@ func (rt *headerRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 	}
 
 	// Forward explicitly allowed headers from the incoming A2A request.
-	for k, v := range allowedRequestHeaders(req.Context(), rt.allowedHeaders) {
+	for k, v := range headers.AllowedRequestHeaders(req.Context(), rt.allowedHeaders) {
 		req.Header.Set(k, v)
 	}
 

--- a/go/adk/pkg/mcp/registry_test.go
+++ b/go/adk/pkg/mcp/registry_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/a2aproject/a2a-go/v2/a2asrv"
+	"github.com/kagent-dev/kagent/go/adk/pkg/headers"
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 	adkagent "google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/session"
@@ -197,12 +198,12 @@ func TestAllowedRequestHeaders_EmptyAllowedList(t *testing.T) {
 		"Authorization": {"Bearer token"},
 	})
 
-	got := allowedRequestHeaders(ctx, nil)
+	got := headers.AllowedRequestHeaders(ctx, nil)
 	if got != nil {
 		t.Errorf("expected nil for empty allowed list, got %v", got)
 	}
 
-	got = allowedRequestHeaders(ctx, []string{})
+	got = headers.AllowedRequestHeaders(ctx, []string{})
 	if got != nil {
 		t.Errorf("expected nil for empty allowed list, got %v", got)
 	}
@@ -401,7 +402,7 @@ func TestAllowedRequestHeaders_CaseInsensitiveLookup(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := a2aCtx(tc.incoming)
-			got := allowedRequestHeaders(ctx, tc.allowed)
+			got := headers.AllowedRequestHeaders(ctx, tc.allowed)
 			if got[tc.wantKey] != tc.wantVal {
 				t.Errorf("got[%q] = %q, want %q (full map: %v)", tc.wantKey, got[tc.wantKey], tc.wantVal, got)
 			}
@@ -417,7 +418,7 @@ func TestAllowedRequestHeaders_MultiValueFirstWins(t *testing.T) {
 	ctx := a2aCtx(map[string][]string{
 		"X-Forwarded-For": {"1.2.3.4", "5.6.7.8", "9.10.11.12"},
 	})
-	got := allowedRequestHeaders(ctx, []string{"X-Forwarded-For"})
+	got := headers.AllowedRequestHeaders(ctx, []string{"X-Forwarded-For"})
 	if got["X-Forwarded-For"] != "1.2.3.4" {
 		t.Errorf("expected first value 1.2.3.4, got %q", got["X-Forwarded-For"])
 	}
@@ -498,7 +499,7 @@ func TestAllowedRequestHeaders_ReturnsNilWhenNoMatches(t *testing.T) {
 	ctx := a2aCtx(map[string][]string{
 		"X-Something-Else": {"value"},
 	})
-	got := allowedRequestHeaders(ctx, []string{"Authorization", "X-Trace-Id"})
+	got := headers.AllowedRequestHeaders(ctx, []string{"Authorization", "X-Trace-Id"})
 	if got != nil {
 		t.Errorf("expected nil when no allowed headers are present, got %v", got)
 	}

--- a/go/adk/pkg/models/base.go
+++ b/go/adk/pkg/models/base.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"google.golang.org/genai"
+
+	"github.com/kagent-dev/kagent/go/adk/pkg/headers"
 )
 
 // defaultTimeout is the default execution timeout used by model implementations.
@@ -18,6 +20,7 @@ const defaultTimeout = 30 * time.Minute
 // TransportConfig holds TLS, passthrough, and header settings shared by all model providers.
 type TransportConfig struct {
 	Headers               map[string]string
+	PassthroughHeaders    []string // header names forwarded per request from the incoming A2A call context
 	TLSInsecureSkipVerify *bool
 	TLSCACertPath         *string
 	TLSDisableSystemCAs   *bool
@@ -49,8 +52,9 @@ func BuildHTTPClient(tc TransportConfig) (*http.Client, error) {
 		}
 	}
 
-	if len(tc.Headers) > 0 {
-		transport = &headerTransport{base: transport, headers: tc.Headers}
+	passthrough := headers.FilterRestricted(tc.PassthroughHeaders)
+	if len(tc.Headers) > 0 || len(passthrough) > 0 {
+		transport = &headerTransport{base: transport, headers: tc.Headers, passthrough: passthrough}
 	}
 
 	timeout := defaultTimeout
@@ -96,15 +100,23 @@ func PassthroughToken(ctx context.Context, apiKeyPassthrough bool) (token string
 
 type contextKey struct{}
 
-// headerTransport wraps an http.RoundTripper and adds custom headers to all requests
+// headerTransport wraps an http.RoundTripper and adds custom headers to all
+// requests: static headers first, then pass-through headers resolved per
+// request from the incoming A2A call context, which therefore win on
+// collision. Provider credentials are never affected — restricted names are
+// stripped from the pass-through list at construction (headers.FilterRestricted).
 type headerTransport struct {
-	base    http.RoundTripper
-	headers map[string]string
+	base        http.RoundTripper
+	headers     map[string]string
+	passthrough []string
 }
 
 func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req = req.Clone(req.Context())
 	for k, v := range t.headers {
+		req.Header.Set(k, v)
+	}
+	for k, v := range headers.AllowedRequestHeaders(req.Context(), t.passthrough) {
 		req.Header.Set(k, v)
 	}
 	return t.base.RoundTrip(req)

--- a/go/adk/pkg/models/header_transport_test.go
+++ b/go/adk/pkg/models/header_transport_test.go
@@ -1,0 +1,166 @@
+package models
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/a2aproject/a2a-go/v2/a2asrv"
+	"github.com/kagent-dev/kagent/go/adk/pkg/headers"
+)
+
+// a2aCtx builds a context that carries an A2A CallContext with the given
+// headers, matching what the A2A server puts in the context for real requests.
+func a2aCtx(headers map[string][]string) context.Context {
+	ctx, _ := a2asrv.NewCallContext(context.Background(), a2asrv.NewServiceParams(headers))
+	return ctx
+}
+
+// doRequest sends a GET through the client built from tc and returns the
+// headers the server received.
+func doRequest(t *testing.T, tc TransportConfig, ctx context.Context, mutate func(*http.Request)) http.Header {
+	t.Helper()
+
+	var captured http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client, err := BuildHTTPClient(tc)
+	if err != nil {
+		t.Fatalf("BuildHTTPClient() error = %v", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequestWithContext() error = %v", err)
+	}
+	if mutate != nil {
+		mutate(req)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do() error = %v", err)
+	}
+	resp.Body.Close()
+	return captured
+}
+
+// TestHeaderTransport_Passthrough verifies that configured pass-through
+// headers are resolved from the incoming A2A call context per request, that
+// unconfigured headers are not forwarded, and that a pass-through value
+// overrides a static defaultHeaders entry of the same name.
+func TestHeaderTransport_Passthrough(t *testing.T) {
+	t.Parallel()
+
+	tc := TransportConfig{
+		Headers:            map[string]string{"x-static": "static-value", "x-tenant": "config-tenant"},
+		PassthroughHeaders: []string{"x-guardrail-token", "x-tenant", "x-missing"},
+	}
+	ctx := a2aCtx(map[string][]string{
+		"X-Guardrail-Token": {"caller-token"},
+		"X-Tenant":          {"caller-tenant"},
+		"X-Ignored":         {"should-not-appear"},
+	})
+
+	got := doRequest(t, tc, ctx, nil)
+
+	if v := got.Get("x-guardrail-token"); v != "caller-token" {
+		t.Errorf("x-guardrail-token = %q, want %q", v, "caller-token")
+	}
+	if v := got.Get("x-static"); v != "static-value" {
+		t.Errorf("x-static = %q, want %q", v, "static-value")
+	}
+	if v := got.Get("x-tenant"); v != "caller-tenant" {
+		t.Errorf("x-tenant = %q, want pass-through value %q to override the static one", v, "caller-tenant")
+	}
+	if v := got.Get("x-ignored"); v != "" {
+		t.Errorf("x-ignored should not be forwarded, got %q", v)
+	}
+	if got.Values("x-missing") != nil {
+		t.Errorf("x-missing absent from the request should be omitted, got %q", got.Values("x-missing"))
+	}
+}
+
+// TestHeaderTransport_PassthroughNeverClobbersCredentials verifies that
+// restricted names (Authorization, hop-by-hop headers) are stripped from the
+// pass-through list, so a caller can never override the provider credential
+// the SDK set on the request.
+func TestHeaderTransport_PassthroughNeverClobbersCredentials(t *testing.T) {
+	t.Parallel()
+
+	tc := TransportConfig{
+		PassthroughHeaders: []string{"Authorization", "Connection", "x-allowed"},
+	}
+	ctx := a2aCtx(map[string][]string{
+		"Authorization": {"Bearer caller-token"},
+		"Connection":    {"close"},
+		"X-Allowed":     {"ok"},
+	})
+
+	got := doRequest(t, tc, ctx, func(req *http.Request) {
+		req.Header.Set("Authorization", "Bearer provider-credential")
+	})
+
+	if v := got.Get("Authorization"); v != "Bearer provider-credential" {
+		t.Errorf("Authorization = %q, want the provider credential to be preserved", v)
+	}
+	if v := got.Get("x-allowed"); v != "ok" {
+		t.Errorf("x-allowed = %q, want %q", v, "ok")
+	}
+}
+
+// TestHeaderTransport_NoCallContext verifies that requests without an A2A
+// call context still go out with the static headers and nothing else.
+func TestHeaderTransport_NoCallContext(t *testing.T) {
+	t.Parallel()
+
+	tc := TransportConfig{
+		Headers:            map[string]string{"x-static": "static-value"},
+		PassthroughHeaders: []string{"x-guardrail-token"},
+	}
+
+	got := doRequest(t, tc, context.Background(), nil)
+
+	if v := got.Get("x-static"); v != "static-value" {
+		t.Errorf("x-static = %q, want %q", v, "static-value")
+	}
+	if v := got.Get("x-guardrail-token"); v != "" {
+		t.Errorf("x-guardrail-token should be absent without a call context, got %q", v)
+	}
+}
+
+func TestFilterRestricted(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		names []string
+		want  []string
+	}{
+		{name: "nil list", names: nil, want: nil},
+		{name: "plain names pass", names: []string{"x-a", "X-B"}, want: []string{"x-a", "X-B"}},
+		{name: "authorization dropped case-insensitively", names: []string{"Authorization", "authorization", "AUTHORIZATION", "x-ok"}, want: []string{"x-ok"}},
+		{name: "credential headers dropped", names: []string{"Proxy-Authorization", "Cookie", "x-ok"}, want: []string{"x-ok"}},
+		{name: "hop-by-hop dropped", names: []string{"Connection", "Transfer-Encoding", "Host", "Content-Length", "Proxy-Authenticate", "x-ok"}, want: []string{"x-ok"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := headers.FilterRestricted(tt.names)
+			if len(got) != len(tt.want) {
+				t.Fatalf("headers.FilterRestricted() = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("headers.FilterRestricted()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/go/api/adk/types.go
+++ b/go/api/adk/types.go
@@ -63,6 +63,10 @@ type BaseModel struct {
 	Model   string            `json:"model"`
 	Headers map[string]string `json:"headers,omitempty"`
 
+	// PassthroughHeaders lists header names whose values are forwarded from the
+	// incoming A2A request onto the outbound LLM call, resolved per request.
+	PassthroughHeaders []string `json:"passthrough_headers,omitempty"`
+
 	// TLS/SSL configuration (applies to all model types)
 	TLSInsecureSkipVerify *bool   `json:"tls_insecure_skip_verify,omitempty"`
 	TLSCACertPath         *string `json:"tls_ca_cert_path,omitempty"`

--- a/go/api/adk/types_test.go
+++ b/go/api/adk/types_test.go
@@ -125,6 +125,7 @@ func TestMarshalJSON_BaseModelFields(t *testing.T) {
 	base := BaseModel{
 		Model:                 "test-model",
 		Headers:               map[string]string{"X-Custom": "value"},
+		PassthroughHeaders:    []string{"x-guardrail-token"},
 		TLSInsecureSkipVerify: new(true),
 		TLSCACertPath:         new("/etc/ssl/ca.crt"),
 		TLSDisableSystemCAs:   new(false),
@@ -167,6 +168,14 @@ func TestMarshalJSON_BaseModelFields(t *testing.T) {
 			}
 			if headers["X-Custom"] != "value" {
 				t.Errorf("headers[X-Custom] = %v, want %q", headers["X-Custom"], "value")
+			}
+
+			passthrough, ok := raw["passthrough_headers"].([]any)
+			if !ok {
+				t.Fatal("passthrough_headers field missing or wrong type")
+			}
+			if len(passthrough) != 1 || passthrough[0] != "x-guardrail-token" {
+				t.Errorf("passthrough_headers = %v, want [x-guardrail-token]", passthrough)
 			}
 
 			if raw["tls_insecure_skip_verify"] != true {

--- a/go/api/config/crd/bases/kagent.dev_modelconfigs.yaml
+++ b/go/api/config/crd/bases/kagent.dev_modelconfigs.yaml
@@ -484,8 +484,12 @@ spec:
                   Unlike defaultHeaders, which carries static values fixed at configuration
                   time, the value of a pass-through header is read from each incoming request;
                   headers absent from the request are omitted. A pass-through value overrides
-                  a defaultHeaders entry of the same name. The Authorization header cannot be
-                  passed through — use apiKeyPassthrough to forward the caller's credential.
+                  a defaultHeaders entry of the same name.
+                  Credential and hop-by-hop headers are rejected at admission and are never
+                  forwarded: Authorization (use apiKeyPassthrough to forward the caller's
+                  credential), Proxy-Authorization, Proxy-Authenticate, Cookie, Connection,
+                  Content-Length, Host, Keep-Alive, Proxy-Connection, TE, Trailer,
+                  Transfer-Encoding, and Upgrade.
                   Not supported for the GeminiVertexAI and SAPAICore providers; on the Python
                   runtime additionally unsupported for Bedrock, Ollama, and AnthropicVertexAI
                   (a warning is logged and the field is ignored).
@@ -499,6 +503,13 @@ spec:
                 - message: the Authorization header cannot be passed through; use
                     apiKeyPassthrough to forward the caller's credential
                   rule: self.all(h, h.lowerAscii() != 'authorization')
+                - message: passthroughHeaders must not contain credential or hop-by-hop
+                    headers (proxy-authorization, proxy-authenticate, cookie, connection,
+                    content-length, host, keep-alive, proxy-connection, te, trailer,
+                    transfer-encoding, upgrade)
+                  rule: self.all(h, !(h.lowerAscii() in ['proxy-authorization', 'proxy-authenticate',
+                    'cookie', 'connection', 'content-length', 'host', 'keep-alive',
+                    'proxy-connection', 'te', 'trailer', 'transfer-encoding', 'upgrade']))
               provider:
                 default: OpenAI
                 description: The provider of the model

--- a/go/api/config/crd/bases/kagent.dev_modelconfigs.yaml
+++ b/go/api/config/crd/bases/kagent.dev_modelconfigs.yaml
@@ -477,6 +477,28 @@ spec:
                 x-kubernetes-validations:
                 - message: maxTokens and maxCompletionTokens are mutually exclusive
                   rule: '!(has(self.maxTokens) && has(self.maxCompletionTokens))'
+              passthroughHeaders:
+                description: |-
+                  PassthroughHeaders lists HTTP header names (case-insensitive) whose values
+                  are forwarded from the incoming A2A request onto the outbound LLM call.
+                  Unlike defaultHeaders, which carries static values fixed at configuration
+                  time, the value of a pass-through header is read from each incoming request;
+                  headers absent from the request are omitted. A pass-through value overrides
+                  a defaultHeaders entry of the same name. The Authorization header cannot be
+                  passed through — use apiKeyPassthrough to forward the caller's credential.
+                  Not supported for the GeminiVertexAI and SAPAICore providers; on the Python
+                  runtime additionally unsupported for Bedrock, Ollama, and AnthropicVertexAI
+                  (a warning is logged and the field is ignored).
+                items:
+                  maxLength: 256
+                  minLength: 1
+                  type: string
+                maxItems: 32
+                type: array
+                x-kubernetes-validations:
+                - message: the Authorization header cannot be passed through; use
+                    apiKeyPassthrough to forward the caller's credential
+                  rule: self.all(h, h.lowerAscii() != 'authorization')
               provider:
                 default: OpenAI
                 description: The provider of the model

--- a/go/api/v1alpha3/modelconfig_cel_test.go
+++ b/go/api/v1alpha3/modelconfig_cel_test.go
@@ -18,6 +18,7 @@ package v1alpha3
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -189,6 +190,61 @@ func TestOpenAIConfigValidation(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			err := cl.Create(ctx, c.build())
+			if c.wantReject == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.Contains(t, err.Error(), c.wantReject)
+		})
+	}
+}
+
+// TestPassthroughHeadersValidation pins the passthroughHeaders admission rules:
+// the Authorization header is rejected case-insensitively (credential
+// forwarding goes through apiKeyPassthrough instead), while ordinary custom
+// header names are accepted.
+func TestPassthroughHeadersValidation(t *testing.T) {
+	testEnv := &envtest.Environment{
+		BinaryAssetsDirectory: envtestAssetsDir(t),
+		CRDDirectoryPaths:     []string{crdBasesDir(t)},
+		ErrorIfCRDPathMissing: true,
+	}
+	cfg, err := testEnv.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = testEnv.Stop() })
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, AddToScheme(scheme))
+	cl, err := ctrl_client.New(cfg, ctrl_client.Options{Scheme: scheme})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	const ns = "passthrough-cel"
+	require.NoError(t, cl.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}))
+
+	cases := []struct {
+		name       string
+		headers    []string
+		wantReject string // substring in admission error; empty means accept
+	}{
+		{name: "custom header names accepted", headers: []string{"x-guardrail-token", "X-Request-Id"}},
+		{name: "authorization rejected lowercase", headers: []string{"authorization"}, wantReject: "apiKeyPassthrough"},
+		{name: "authorization rejected mixed case", headers: []string{"Authorization"}, wantReject: "apiKeyPassthrough"},
+		{name: "empty header name rejected", headers: []string{""}, wantReject: "passthroughHeaders"},
+	}
+
+	for i, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := cl.Create(ctx, &ModelConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("mc-passthrough-%d", i), Namespace: ns},
+				Spec: ModelConfigSpec{
+					Model:              "gpt-4",
+					Provider:           ModelProviderOpenAI,
+					PassthroughHeaders: c.headers,
+				},
+			})
 			if c.wantReject == "" {
 				require.NoError(t, err)
 				return

--- a/go/api/v1alpha3/modelconfig_cel_test.go
+++ b/go/api/v1alpha3/modelconfig_cel_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/kagent-dev/kagent/go/adk/pkg/headers"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -232,6 +233,7 @@ func TestPassthroughHeadersValidation(t *testing.T) {
 		{name: "custom header names accepted", headers: []string{"x-guardrail-token", "X-Request-Id"}},
 		{name: "authorization rejected lowercase", headers: []string{"authorization"}, wantReject: "apiKeyPassthrough"},
 		{name: "authorization rejected mixed case", headers: []string{"Authorization"}, wantReject: "apiKeyPassthrough"},
+		{name: "cookie rejected mixed case", headers: []string{"Cookie"}, wantReject: "passthroughHeaders"},
 		{name: "empty header name rejected", headers: []string{""}, wantReject: "passthroughHeaders"},
 	}
 
@@ -251,6 +253,24 @@ func TestPassthroughHeadersValidation(t *testing.T) {
 			}
 			require.Error(t, err)
 			require.Contains(t, err.Error(), c.wantReject)
+		})
+	}
+
+	// Every name the runtimes refuse to forward must also be rejected at
+	// admission, so the CEL rule cannot silently drift from the Go list in
+	// adk/pkg/headers.
+	for i, name := range headers.RestrictedNames() {
+		t.Run("restricted name rejected: "+name, func(t *testing.T) {
+			err := cl.Create(ctx, &ModelConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("mc-restricted-%d", i), Namespace: ns},
+				Spec: ModelConfigSpec{
+					Model:              "gpt-4",
+					Provider:           ModelProviderOpenAI,
+					PassthroughHeaders: []string{name},
+				},
+			})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "passthroughHeaders")
 		})
 	}
 }

--- a/go/api/v1alpha3/modelconfig_types.go
+++ b/go/api/v1alpha3/modelconfig_types.go
@@ -551,6 +551,23 @@ type ModelConfigSpec struct {
 	// +optional
 	DefaultHeaders map[string]string `json:"defaultHeaders,omitempty"`
 
+	// PassthroughHeaders lists HTTP header names (case-insensitive) whose values
+	// are forwarded from the incoming A2A request onto the outbound LLM call.
+	// Unlike defaultHeaders, which carries static values fixed at configuration
+	// time, the value of a pass-through header is read from each incoming request;
+	// headers absent from the request are omitted. A pass-through value overrides
+	// a defaultHeaders entry of the same name. The Authorization header cannot be
+	// passed through — use apiKeyPassthrough to forward the caller's credential.
+	// Not supported for the GeminiVertexAI and SAPAICore providers; on the Python
+	// runtime additionally unsupported for Bedrock, Ollama, and AnthropicVertexAI
+	// (a warning is logged and the field is ignored).
+	// +optional
+	// +kubebuilder:validation:MaxItems=32
+	// +kubebuilder:validation:items:MinLength=1
+	// +kubebuilder:validation:items:MaxLength=256
+	// +kubebuilder:validation:XValidation:message="the Authorization header cannot be passed through; use apiKeyPassthrough to forward the caller's credential",rule="self.all(h, h.lowerAscii() != 'authorization')"
+	PassthroughHeaders []string `json:"passthroughHeaders,omitempty"`
+
 	// The provider of the model
 	// +kubebuilder:default=OpenAI
 	// +optional

--- a/go/api/v1alpha3/modelconfig_types.go
+++ b/go/api/v1alpha3/modelconfig_types.go
@@ -556,8 +556,12 @@ type ModelConfigSpec struct {
 	// Unlike defaultHeaders, which carries static values fixed at configuration
 	// time, the value of a pass-through header is read from each incoming request;
 	// headers absent from the request are omitted. A pass-through value overrides
-	// a defaultHeaders entry of the same name. The Authorization header cannot be
-	// passed through — use apiKeyPassthrough to forward the caller's credential.
+	// a defaultHeaders entry of the same name.
+	// Credential and hop-by-hop headers are rejected at admission and are never
+	// forwarded: Authorization (use apiKeyPassthrough to forward the caller's
+	// credential), Proxy-Authorization, Proxy-Authenticate, Cookie, Connection,
+	// Content-Length, Host, Keep-Alive, Proxy-Connection, TE, Trailer,
+	// Transfer-Encoding, and Upgrade.
 	// Not supported for the GeminiVertexAI and SAPAICore providers; on the Python
 	// runtime additionally unsupported for Bedrock, Ollama, and AnthropicVertexAI
 	// (a warning is logged and the field is ignored).
@@ -566,6 +570,7 @@ type ModelConfigSpec struct {
 	// +kubebuilder:validation:items:MinLength=1
 	// +kubebuilder:validation:items:MaxLength=256
 	// +kubebuilder:validation:XValidation:message="the Authorization header cannot be passed through; use apiKeyPassthrough to forward the caller's credential",rule="self.all(h, h.lowerAscii() != 'authorization')"
+	// +kubebuilder:validation:XValidation:message="passthroughHeaders must not contain credential or hop-by-hop headers (proxy-authorization, proxy-authenticate, cookie, connection, content-length, host, keep-alive, proxy-connection, te, trailer, transfer-encoding, upgrade)",rule="self.all(h, !(h.lowerAscii() in ['proxy-authorization', 'proxy-authenticate', 'cookie', 'connection', 'content-length', 'host', 'keep-alive', 'proxy-connection', 'te', 'trailer', 'transfer-encoding', 'upgrade']))"
 	PassthroughHeaders []string `json:"passthroughHeaders,omitempty"`
 
 	// The provider of the model

--- a/go/api/v1alpha3/zz_generated.deepcopy.go
+++ b/go/api/v1alpha3/zz_generated.deepcopy.go
@@ -975,6 +975,11 @@ func (in *ModelConfigSpec) DeepCopyInto(out *ModelConfigSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.PassthroughHeaders != nil {
+		in, out := &in.PassthroughHeaders, &out.PassthroughHeaders
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.OpenAI != nil {
 		in, out := &in.OpenAI, &out.OpenAI
 		*out = new(OpenAIConfig)

--- a/go/core/internal/a2agateway/runtime.go
+++ b/go/core/internal/a2agateway/runtime.go
@@ -6,11 +6,14 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	a2atype "github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/a2aproject/a2a-go/v2/a2aclient"
 	"github.com/a2aproject/a2a-go/v2/a2aext"
 	a2agrpc "github.com/a2aproject/a2a-go/v2/a2agrpc/v1"
+	"github.com/a2aproject/a2a-go/v2/a2asrv"
+	"github.com/kagent-dev/kagent/go/adk/pkg/headers"
 	apiv1alpha1 "github.com/kagent-dev/kagent/go/api/gen/kagent/api/v1alpha1"
 	"github.com/kagent-dev/kagent/go/core/internal/substrate"
 	"github.com/kagent-dev/kagent/go/core/pkg/auth"
@@ -75,6 +78,7 @@ func (d *RuntimeDialer) Dial(ctx context.Context, instance *apiv1alpha1.AgentIns
 		a2aclient.WithCallInterceptors(
 			a2aext.NewClientPropagator(nil),
 			&upstreamAuthInterceptor{authenticator: d.authenticator, instance: instance, targetActor: targetActor},
+			&callerHeadersInterceptor{},
 		),
 	)
 }
@@ -108,4 +112,50 @@ func (u *upstreamAuthInterceptor) Before(ctx context.Context, req *a2aclient.Req
 	}
 	req.ServiceParams["ate-target-actor"] = []string{u.targetActor}
 	return ctx, nil, nil
+}
+
+// callerHeadersInterceptor forwards caller-supplied custom headers from the
+// public gateway request onto the private runtime call, where the per-feature
+// allowlists (ModelConfig passthroughHeaders, MCP tool allowedHeaders) decide
+// what is actually used. Credential and hop-by-hop names (headers.IsRestricted)
+// and transport/system metadata are dropped; Authorization on this hop belongs
+// to upstreamAuthInterceptor and trace context to its propagation injector.
+type callerHeadersInterceptor struct {
+	a2aclient.PassthroughInterceptor
+}
+
+func (c *callerHeadersInterceptor) Before(ctx context.Context, req *a2aclient.Request) (context.Context, any, error) {
+	callCtx, ok := a2asrv.CallContextFrom(ctx)
+	if !ok {
+		return ctx, nil, nil
+	}
+	params := callCtx.ServiceParams()
+	if params == nil {
+		return ctx, nil, nil
+	}
+	for key, values := range params.List() {
+		if !forwardableCallerHeader(key) || len(values) == 0 || values[0] == "" {
+			continue
+		}
+		req.ServiceParams.Append(key, values[0])
+	}
+	return ctx, nil, nil
+}
+
+// forwardableCallerHeader reports whether a public-request metadata key is a
+// caller-supplied custom header safe to relay to the runtime. gRPC pseudo and
+// grpc-* keys never leave their hop; the named transport headers describe the
+// public request rather than the caller's intent; traceparent/tracestate and
+// x-a2a-extensions are owned by the other interceptors on this client.
+func forwardableCallerHeader(name string) bool {
+	lowered := strings.ToLower(name)
+	if headers.IsRestricted(lowered) || strings.HasPrefix(lowered, ":") || strings.HasPrefix(lowered, "grpc-") {
+		return false
+	}
+	switch lowered {
+	case "accept", "accept-encoding", "content-type", "user-agent",
+		"traceparent", "tracestate", "x-a2a-extensions":
+		return false
+	}
+	return true
 }

--- a/go/core/internal/a2agateway/runtime_test.go
+++ b/go/core/internal/a2agateway/runtime_test.go
@@ -8,7 +8,9 @@ import (
 	"time"
 
 	a2atype "github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2aclient"
 	a2apb "github.com/a2aproject/a2a-go/v2/a2apb/v1"
+	"github.com/a2aproject/a2a-go/v2/a2asrv"
 	apiv1alpha1 "github.com/kagent-dev/kagent/go/api/gen/kagent/api/v1alpha1"
 	"github.com/kagent-dev/kagent/go/core/internal/substrate"
 	"github.com/kagent-dev/kagent/go/core/pkg/auth"
@@ -74,5 +76,55 @@ func TestRuntimeDialerRoutesUnaryAndStreamingCalls(t *testing.T) {
 		case <-ctx.Done():
 			t.Fatal("runtime did not receive both calls")
 		}
+	}
+}
+
+// TestCallerHeadersInterceptor verifies that caller-supplied custom headers on
+// the public gateway request are relayed to the runtime call, while
+// credential, hop-by-hop, transport, and gRPC system metadata are not.
+func TestCallerHeadersInterceptor(t *testing.T) {
+	ctx, _ := a2asrv.NewCallContext(context.Background(), a2asrv.NewServiceParams(map[string][]string{
+		"x-guardrail-token": {"caller-token"},
+		"X-User-Email":      {"user@example.com"},
+		"Authorization":     {"Bearer caller"},
+		"Cookie":            {"session=abc"},
+		"content-type":      {"application/grpc"},
+		"grpc-timeout":      {"5S"},
+		":authority":        {"gateway"},
+		"traceparent":       {"00-abc-def-01"},
+		"x-empty":           {""},
+	}))
+	req := &a2aclient.Request{ServiceParams: a2aclient.ServiceParams{}}
+
+	if _, _, err := (&callerHeadersInterceptor{}).Before(ctx, req); err != nil {
+		t.Fatalf("Before() error = %v", err)
+	}
+
+	for key, want := range map[string]string{
+		"x-guardrail-token": "caller-token",
+		"x-user-email":      "user@example.com",
+	} {
+		if got := req.ServiceParams.Get(key); len(got) != 1 || got[0] != want {
+			t.Errorf("%s = %v, want [%s]", key, got, want)
+		}
+	}
+	for _, key := range []string{
+		"Authorization", "Cookie", "content-type", "grpc-timeout", ":authority", "traceparent", "x-empty",
+	} {
+		if got := req.ServiceParams.Get(key); len(got) != 0 {
+			t.Errorf("%s must not be forwarded, got %v", key, got)
+		}
+	}
+}
+
+// TestCallerHeadersInterceptor_NoCallContext verifies the interceptor is a
+// no-op for calls without a public call context (e.g. internal invocations).
+func TestCallerHeadersInterceptor_NoCallContext(t *testing.T) {
+	req := &a2aclient.Request{ServiceParams: a2aclient.ServiceParams{}}
+	if _, _, err := (&callerHeadersInterceptor{}).Before(context.Background(), req); err != nil {
+		t.Fatalf("Before() error = %v", err)
+	}
+	if got := req.ServiceParams.Get("x-guardrail-token"); len(got) != 0 {
+		t.Errorf("expected no forwarded params, got %v", got)
 	}
 }

--- a/go/core/internal/translator/adkconfig/model.go
+++ b/go/core/internal/translator/adkconfig/model.go
@@ -121,6 +121,14 @@ func populateTLSFields(baseModel *adk.BaseModel, tlsConfig *v1alpha3.TLSConfig) 
 	baseModel.TLSInsecureSkipVerify, baseModel.TLSCACertPath, baseModel.TLSDisableSystemCAs = deriveTLSFields(tlsConfig)
 }
 
+// populateHeaderFields writes the header-related spec fields onto an adk.BaseModel.
+// Like populateTLSFields, it is called by every provider branch in
+// translateModel, so a new header field only needs to be wired here.
+func populateHeaderFields(baseModel *adk.BaseModel, spec *v1alpha3.ModelConfigSpec) {
+	baseModel.Headers = spec.DefaultHeaders
+	baseModel.PassthroughHeaders = spec.PassthroughHeaders
+}
+
 // addTLSConfiguration mounts a CA Secret as a per-Secret read-only volume on
 // modelDeploymentData. Safe to call multiple times for the same agent with
 // the same OR different TLSConfigs:
@@ -264,12 +272,12 @@ func (c *Builder) translateModel(ctx context.Context, resolved *v2translator.Res
 		}
 		openai := &adk.OpenAI{
 			BaseModel: adk.BaseModel{
-				Model:   model.Spec.Model,
-				Headers: model.Spec.DefaultHeaders,
+				Model: model.Spec.Model,
 			},
 		}
 		// Populate TLS fields in BaseModel
 		populateTLSFields(&openai.BaseModel, model.Spec.TLS)
+		populateHeaderFields(&openai.BaseModel, &model.Spec)
 		// Populate TokenExchange fields (OpenAI-specific)
 		addTokenExchangeConfiguration(openai, modelDeploymentData, &model.Spec)
 		openai.APIKeyPassthrough = model.Spec.APIKeyPassthrough
@@ -328,12 +336,12 @@ func (c *Builder) translateModel(ctx context.Context, resolved *v2translator.Res
 		}
 		anthropic := &adk.Anthropic{
 			BaseModel: adk.BaseModel{
-				Model:   model.Spec.Model,
-				Headers: model.Spec.DefaultHeaders,
+				Model: model.Spec.Model,
 			},
 		}
 		// Populate TLS fields in BaseModel
 		populateTLSFields(&anthropic.BaseModel, model.Spec.TLS)
+		populateHeaderFields(&anthropic.BaseModel, &model.Spec)
 		anthropic.APIKeyPassthrough = model.Spec.APIKeyPassthrough
 
 		if model.Spec.Anthropic != nil {
@@ -386,8 +394,7 @@ func (c *Builder) translateModel(ctx context.Context, resolved *v2translator.Res
 		}
 		azureOpenAI := &adk.AzureOpenAI{
 			BaseModel: adk.BaseModel{
-				Model:   model.Spec.AzureOpenAI.DeploymentName,
-				Headers: model.Spec.DefaultHeaders,
+				Model: model.Spec.AzureOpenAI.DeploymentName,
 			},
 			Endpoint:    model.Spec.AzureOpenAI.Endpoint,
 			Deployment:  model.Spec.AzureOpenAI.DeploymentName,
@@ -398,6 +405,7 @@ func (c *Builder) translateModel(ctx context.Context, resolved *v2translator.Res
 		}
 		// Populate TLS fields in BaseModel
 		populateTLSFields(&azureOpenAI.BaseModel, model.Spec.TLS)
+		populateHeaderFields(&azureOpenAI.BaseModel, &model.Spec)
 		azureOpenAI.APIKeyPassthrough = model.Spec.APIKeyPassthrough
 
 		return azureOpenAI, modelDeploymentData, nil
@@ -437,12 +445,12 @@ func (c *Builder) translateModel(ctx context.Context, resolved *v2translator.Res
 		}
 		gemini := &adk.GeminiVertexAI{
 			BaseModel: adk.BaseModel{
-				Model:   model.Spec.Model,
-				Headers: model.Spec.DefaultHeaders,
+				Model: model.Spec.Model,
 			},
 		}
 		// Populate TLS fields in BaseModel
 		populateTLSFields(&gemini.BaseModel, model.Spec.TLS)
+		populateHeaderFields(&gemini.BaseModel, &model.Spec)
 		gemini.APIKeyPassthrough = model.Spec.APIKeyPassthrough
 
 		if model.Spec.GeminiVertexAI.MaxOutputTokens > 0 {
@@ -482,12 +490,12 @@ func (c *Builder) translateModel(ctx context.Context, resolved *v2translator.Res
 		}
 		anthropic := &adk.GeminiAnthropic{
 			BaseModel: adk.BaseModel{
-				Model:   model.Spec.Model,
-				Headers: model.Spec.DefaultHeaders,
+				Model: model.Spec.Model,
 			},
 		}
 		// Populate TLS fields in BaseModel
 		populateTLSFields(&anthropic.BaseModel, model.Spec.TLS)
+		populateHeaderFields(&anthropic.BaseModel, &model.Spec)
 		anthropic.APIKeyPassthrough = model.Spec.APIKeyPassthrough
 
 		return anthropic, modelDeploymentData, nil
@@ -505,13 +513,13 @@ func (c *Builder) translateModel(ctx context.Context, resolved *v2translator.Res
 		})
 		ollama := &adk.Ollama{
 			BaseModel: adk.BaseModel{
-				Model:   model.Spec.Model,
-				Headers: model.Spec.DefaultHeaders,
+				Model: model.Spec.Model,
 			},
 			Options: model.Spec.Ollama.Options,
 		}
 		// Populate TLS fields in BaseModel
 		populateTLSFields(&ollama.BaseModel, model.Spec.TLS)
+		populateHeaderFields(&ollama.BaseModel, &model.Spec)
 		ollama.APIKeyPassthrough = model.Spec.APIKeyPassthrough
 
 		return ollama, modelDeploymentData, nil
@@ -529,12 +537,12 @@ func (c *Builder) translateModel(ctx context.Context, resolved *v2translator.Res
 		})
 		gemini := &adk.Gemini{
 			BaseModel: adk.BaseModel{
-				Model:   model.Spec.Model,
-				Headers: model.Spec.DefaultHeaders,
+				Model: model.Spec.Model,
 			},
 		}
 		// Populate TLS fields in BaseModel
 		populateTLSFields(&gemini.BaseModel, model.Spec.TLS)
+		populateHeaderFields(&gemini.BaseModel, &model.Spec)
 		if model.Spec.Gemini != nil && model.Spec.Gemini.MaxOutputTokens > 0 {
 			gemini.MaxOutputTokens = &model.Spec.Gemini.MaxOutputTokens
 		}
@@ -618,8 +626,7 @@ func (c *Builder) translateModel(ctx context.Context, resolved *v2translator.Res
 		}
 		bedrock := &adk.Bedrock{
 			BaseModel: adk.BaseModel{
-				Model:   model.Spec.Model,
-				Headers: model.Spec.DefaultHeaders,
+				Model: model.Spec.Model,
 			},
 			Region:                       model.Spec.Bedrock.Region,
 			AdditionalModelRequestFields: additionalFields,
@@ -638,6 +645,7 @@ func (c *Builder) translateModel(ctx context.Context, resolved *v2translator.Res
 
 		// Populate TLS fields in BaseModel
 		populateTLSFields(&bedrock.BaseModel, model.Spec.TLS)
+		populateHeaderFields(&bedrock.BaseModel, &model.Spec)
 		bedrock.APIKeyPassthrough = model.Spec.APIKeyPassthrough
 
 		return bedrock, modelDeploymentData, nil
@@ -673,8 +681,7 @@ func (c *Builder) translateModel(ctx context.Context, resolved *v2translator.Res
 
 		sapAICore := &adk.SAPAICore{
 			BaseModel: adk.BaseModel{
-				Model:   model.Spec.Model,
-				Headers: model.Spec.DefaultHeaders,
+				Model: model.Spec.Model,
 			},
 			BaseUrl:       model.Spec.SAPAICore.BaseURL,
 			ResourceGroup: model.Spec.SAPAICore.ResourceGroup,
@@ -682,6 +689,7 @@ func (c *Builder) translateModel(ctx context.Context, resolved *v2translator.Res
 		}
 
 		populateTLSFields(&sapAICore.BaseModel, model.Spec.TLS)
+		populateHeaderFields(&sapAICore.BaseModel, &model.Spec)
 		sapAICore.APIKeyPassthrough = model.Spec.APIKeyPassthrough
 
 		return sapAICore, modelDeploymentData, nil
@@ -745,8 +753,7 @@ func (c *Builder) translateModel(ctx context.Context, resolved *v2translator.Res
 
 		foundry := &adk.Foundry{
 			BaseModel: adk.BaseModel{
-				Model:   model.Spec.Model,
-				Headers: model.Spec.DefaultHeaders,
+				Model: model.Spec.Model,
 			},
 			Endpoint:   endpoint,
 			Deployment: cfg.Deployment,
@@ -754,6 +761,7 @@ func (c *Builder) translateModel(ctx context.Context, resolved *v2translator.Res
 			APIFormat:  apiFormat,
 		}
 		populateTLSFields(&foundry.BaseModel, model.Spec.TLS)
+		populateHeaderFields(&foundry.BaseModel, &model.Spec)
 		foundry.APIKeyPassthrough = model.Spec.APIKeyPassthrough
 
 		return foundry, modelDeploymentData, nil

--- a/helm/kagent-crds/templates/kagent.dev_modelconfigs.yaml
+++ b/helm/kagent-crds/templates/kagent.dev_modelconfigs.yaml
@@ -484,8 +484,12 @@ spec:
                   Unlike defaultHeaders, which carries static values fixed at configuration
                   time, the value of a pass-through header is read from each incoming request;
                   headers absent from the request are omitted. A pass-through value overrides
-                  a defaultHeaders entry of the same name. The Authorization header cannot be
-                  passed through — use apiKeyPassthrough to forward the caller's credential.
+                  a defaultHeaders entry of the same name.
+                  Credential and hop-by-hop headers are rejected at admission and are never
+                  forwarded: Authorization (use apiKeyPassthrough to forward the caller's
+                  credential), Proxy-Authorization, Proxy-Authenticate, Cookie, Connection,
+                  Content-Length, Host, Keep-Alive, Proxy-Connection, TE, Trailer,
+                  Transfer-Encoding, and Upgrade.
                   Not supported for the GeminiVertexAI and SAPAICore providers; on the Python
                   runtime additionally unsupported for Bedrock, Ollama, and AnthropicVertexAI
                   (a warning is logged and the field is ignored).
@@ -499,6 +503,13 @@ spec:
                 - message: the Authorization header cannot be passed through; use
                     apiKeyPassthrough to forward the caller's credential
                   rule: self.all(h, h.lowerAscii() != 'authorization')
+                - message: passthroughHeaders must not contain credential or hop-by-hop
+                    headers (proxy-authorization, proxy-authenticate, cookie, connection,
+                    content-length, host, keep-alive, proxy-connection, te, trailer,
+                    transfer-encoding, upgrade)
+                  rule: self.all(h, !(h.lowerAscii() in ['proxy-authorization', 'proxy-authenticate',
+                    'cookie', 'connection', 'content-length', 'host', 'keep-alive',
+                    'proxy-connection', 'te', 'trailer', 'transfer-encoding', 'upgrade']))
               provider:
                 default: OpenAI
                 description: The provider of the model

--- a/helm/kagent-crds/templates/kagent.dev_modelconfigs.yaml
+++ b/helm/kagent-crds/templates/kagent.dev_modelconfigs.yaml
@@ -477,6 +477,28 @@ spec:
                 x-kubernetes-validations:
                 - message: maxTokens and maxCompletionTokens are mutually exclusive
                   rule: '!(has(self.maxTokens) && has(self.maxCompletionTokens))'
+              passthroughHeaders:
+                description: |-
+                  PassthroughHeaders lists HTTP header names (case-insensitive) whose values
+                  are forwarded from the incoming A2A request onto the outbound LLM call.
+                  Unlike defaultHeaders, which carries static values fixed at configuration
+                  time, the value of a pass-through header is read from each incoming request;
+                  headers absent from the request are omitted. A pass-through value overrides
+                  a defaultHeaders entry of the same name. The Authorization header cannot be
+                  passed through — use apiKeyPassthrough to forward the caller's credential.
+                  Not supported for the GeminiVertexAI and SAPAICore providers; on the Python
+                  runtime additionally unsupported for Bedrock, Ollama, and AnthropicVertexAI
+                  (a warning is logged and the field is ignored).
+                items:
+                  maxLength: 256
+                  minLength: 1
+                  type: string
+                maxItems: 32
+                type: array
+                x-kubernetes-validations:
+                - message: the Authorization header cannot be passed through; use
+                    apiKeyPassthrough to forward the caller's credential
+                  rule: self.all(h, h.lowerAscii() != 'authorization')
               provider:
                 default: OpenAI
                 description: The provider of the model

--- a/python/packages/kagent-adk/src/kagent/adk/_llm_header_passthrough_plugin.py
+++ b/python/packages/kagent-adk/src/kagent/adk/_llm_header_passthrough_plugin.py
@@ -1,0 +1,109 @@
+"""LLM pass-through header plugin.
+
+Forwards caller-supplied headers from the incoming A2A request onto the
+outbound LLM call, for the header names listed in the model's
+``passthrough_headers`` config. Incoming request headers are read from
+``callback_context.state["headers"]`` (set by ``_agent_executor.py``), the
+same pattern as ``create_header_provider()`` and ``LLMPassthroughPlugin``.
+
+Delivery is provider-specific: models exposing ``set_passthrough_headers``
+(Anthropic) receive the resolved headers directly, because their SDK call
+happens inside the ADK base class where the outbound request cannot be
+modified per call; all other models receive them on the per-request
+``llm_request.config.http_options.headers``.
+"""
+
+import logging
+from typing import Optional
+
+from google.adk.agents.callback_context import CallbackContext
+from google.adk.models.llm_request import LlmRequest
+from google.adk.models.llm_response import LlmResponse
+from google.adk.plugins.base_plugin import BasePlugin
+from google.genai import types as genai_types
+
+logger = logging.getLogger(__name__)
+
+# Credential headers (Authorization, Proxy-Authorization, Cookie) plus the
+# RFC 9110 hop-by-hop / message-framing set. Must stay in sync with
+# restrictedPassthroughHeaders in go/adk/pkg/headers/headers.go, which explains
+# each group.
+RESTRICTED_PASSTHROUGH_HEADERS = frozenset(
+    {
+        "authorization",
+        "connection",
+        "content-length",
+        "cookie",
+        "host",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "proxy-connection",
+        "te",
+        "trailer",
+        "transfer-encoding",
+        "upgrade",
+    }
+)
+
+
+def _resolve_passthrough_headers(allowed: list[str], request_headers: dict[str, str]) -> dict[str, str]:
+    """Return the allowed subset of the incoming request headers.
+
+    Matching is case-insensitive on both sides; keys in the result preserve
+    the casing from the configured list. Headers absent from the request, or
+    present with an empty value, are omitted rather than sent empty.
+    """
+    lookup = {k.lower(): v for k, v in request_headers.items()}
+    resolved: dict[str, str] = {}
+    for name in allowed:
+        lname = name.lower()
+        if lname in RESTRICTED_PASSTHROUGH_HEADERS:
+            continue
+        value = lookup.get(lname)
+        if value:
+            resolved[name] = value
+    return resolved
+
+
+class LLMHeaderPassthroughPlugin(BasePlugin):
+    """Forwards configured pass-through headers from the incoming request to the LLM call."""
+
+    def __init__(self):
+        super().__init__(name="llm_header_passthrough")
+
+    async def before_model_callback(
+        self, *, callback_context: CallbackContext, llm_request: LlmRequest
+    ) -> Optional[LlmResponse]:
+        model = callback_context._invocation_context.agent.model
+        allowed = getattr(model, "passthrough_headers", None)
+        if not allowed:
+            return None
+
+        request_headers = callback_context.state.get("headers", {})
+        resolved = _resolve_passthrough_headers(allowed, request_headers)
+
+        setter = getattr(model, "set_passthrough_headers", None)
+        if callable(setter):
+            # resolved may be empty and must still reach the setter: the model is
+            # shared across requests, so an empty result must clear the previous
+            # caller's values rather than inherit them.
+            setter(resolved)
+            return None
+
+        if not resolved:
+            return None
+
+        config = llm_request.config
+        if config is None:
+            config = genai_types.GenerateContentConfig()
+            llm_request.config = config
+        http_options = config.http_options
+        if http_options is None:
+            http_options = genai_types.HttpOptions()
+            config.http_options = http_options
+        merged = dict(http_options.headers or {})
+        merged.update(resolved)
+        http_options.headers = merged
+        logger.debug("Forwarding %d pass-through header(s) to the LLM call", len(resolved))
+        return None

--- a/python/packages/kagent-adk/src/kagent/adk/cli.py
+++ b/python/packages/kagent-adk/src/kagent/adk/cli.py
@@ -103,6 +103,13 @@ def static(
             plugins = []
         plugins.append(LLMPassthroughPlugin())
 
+    if agent_config.model.passthrough_headers:
+        from ._llm_header_passthrough_plugin import LLMHeaderPassthroughPlugin
+
+        if plugins is None:
+            plugins = []
+        plugins.append(LLMHeaderPassthroughPlugin())
+
     def root_agent_factory() -> BaseAgent:
         root_agent = agent_config.to_agent(app_cfg.name, sts_integration, propagate_token)
 

--- a/python/packages/kagent-adk/src/kagent/adk/models/_anthropic.py
+++ b/python/packages/kagent-adk/src/kagent/adk/models/_anthropic.py
@@ -19,8 +19,10 @@ class KAgentAnthropicLlm(KAgentTLSMixin, AnthropicLlm):
     """Anthropic model with api_key_passthrough, custom base_url, header, and TLS support."""
 
     api_key_passthrough: Optional[bool] = None
+    passthrough_headers: Optional[list[str]] = None
 
     _api_key: Optional[str] = None
+    _passthrough_header_values: Optional[dict[str, str]] = None
     base_url: Optional[str] = None
     extra_headers: Optional[dict[str, str]] = None
 
@@ -32,6 +34,23 @@ class KAgentAnthropicLlm(KAgentTLSMixin, AnthropicLlm):
         # Invalidate cached clients so they're recreated with the new key
         self.__dict__.pop("_anthropic_client", None)
         self.__dict__.pop("_http_client", None)
+
+    def set_passthrough_headers(self, headers: dict[str, str]) -> None:
+        """Forward caller-supplied pass-through headers on the outbound call.
+
+        The messages.create call happens inside the ADK base class where the
+        request cannot be modified per call, so headers are applied by
+        rebuilding the cached client — the same mechanism set_passthrough_key
+        uses for the credential. Delivery is therefore model-level, not
+        per-call: this mutates state shared by every request in the pod, so it
+        must be called on every request (an empty dict clears the previous
+        caller's values), and two concurrent requests race on the shared
+        client exactly as set_passthrough_key does.
+        """
+        if self._passthrough_header_values != headers:
+            self._passthrough_header_values = headers
+            self.__dict__.pop("_anthropic_client", None)
+            self.__dict__.pop("_http_client", None)
 
     def _create_http_client(self):
         """Create HTTP client with custom SSL context using Anthropic SDK defaults.
@@ -49,8 +68,10 @@ class KAgentAnthropicLlm(KAgentTLSMixin, AnthropicLlm):
             kwargs["api_key"] = api_key
         if self.base_url:
             kwargs["base_url"] = self.base_url
-        if self.extra_headers:
-            kwargs["default_headers"] = self.extra_headers
+        # Pass-through header values override static extra_headers on collision.
+        merged_headers = {**(self.extra_headers or {}), **(self._passthrough_header_values or {})}
+        if merged_headers:
+            kwargs["default_headers"] = merged_headers
 
         # Use the httpx.AsyncClient with SSL configuration if present
         http_client = self._create_http_client()

--- a/python/packages/kagent-adk/src/kagent/adk/models/_gemini.py
+++ b/python/packages/kagent-adk/src/kagent/adk/models/_gemini.py
@@ -47,6 +47,9 @@ class KAgentGeminiLlm(KAgentTLSMixin, _GeminiGenerationConfigMixin, GeminiLLM):
 
     extra_headers: Optional[dict[str, str]] = None
     api_key_passthrough: Optional[bool] = None
+    # Header names forwarded per request via llm_request.config.http_options
+    # (see LLMHeaderPassthroughPlugin); honoured natively by the genai client.
+    passthrough_headers: Optional[list[str]] = None
     max_output_tokens: Optional[int] = None
 
     model_config = {"arbitrary_types_allowed": True}

--- a/python/packages/kagent-adk/src/kagent/adk/models/_openai.py
+++ b/python/packages/kagent-adk/src/kagent/adk/models/_openai.py
@@ -573,6 +573,10 @@ class BaseOpenAI(KAgentTLSMixin, BaseLlm):
     # API key passthrough: forward the Bearer token from incoming requests as the LLM API key
     api_key_passthrough: Optional[bool] = None
 
+    # Header names forwarded per request from the incoming A2A request (see
+    # LLMHeaderPassthroughPlugin, which resolves them onto llm_request.config.http_options).
+    passthrough_headers: Optional[list[str]] = None
+
     # GDCH token exchange: refreshes a short-lived bearer token before each model call.
     token_exchange: Optional[GDCHTokenSource] = Field(default=None, exclude=True)
 
@@ -682,6 +686,12 @@ class BaseOpenAI(KAgentTLSMixin, BaseLlm):
             kwargs["temperature"] = self.temperature
         if self.top_p is not None:
             kwargs["top_p"] = self.top_p
+
+        # Per-request headers resolved by LLMHeaderPassthroughPlugin ride on
+        # llm_request.config.http_options; the OpenAI SDK applies extra_headers
+        # on top of the client-level default_headers.
+        if llm_request.config and llm_request.config.http_options and llm_request.config.http_options.headers:
+            kwargs["extra_headers"] = dict(llm_request.config.http_options.headers)
 
         # Handle tools
         if llm_request.config and llm_request.config.tools:

--- a/python/packages/kagent-adk/src/kagent/adk/types.py
+++ b/python/packages/kagent-adk/src/kagent/adk/types.py
@@ -246,6 +246,9 @@ class RemoteAgentConfig(BaseModel):
 class BaseLLM(BaseModel):
     model: str
     headers: dict[str, str] | None = None
+    # Header names forwarded per request from the incoming A2A request onto the
+    # outbound LLM call (see LLMHeaderPassthroughPlugin).
+    passthrough_headers: list[str] | None = None
 
     # TLS/SSL configuration (applies to all model types)
     tls_disable_verify: bool | None = Field(
@@ -643,7 +646,15 @@ def _transport_kwargs(model_config: BaseLLM) -> dict[str, Any]:
 
 def _create_llm_from_model_config(model_config: ModelUnion):
     extra_headers = model_config.headers or {}
+    passthrough_headers = model_config.passthrough_headers or None
     base_url = getattr(model_config, "base_url", None)
+
+    def _warn_passthrough_unsupported() -> None:
+        if passthrough_headers:
+            logger.warning(
+                "passthrough_headers are not supported for %s models and will be ignored.",
+                model_config.type,
+            )
 
     if model_config.type == "openai":
         from .models._token_source import GDCHTokenSource
@@ -671,6 +682,7 @@ def _create_llm_from_model_config(model_config: ModelUnion):
             type="openai",
             base_url=base_url,
             default_headers=extra_headers,
+            passthrough_headers=passthrough_headers,
             frequency_penalty=model_config.frequency_penalty,
             max_tokens=model_config.max_tokens,
             max_completion_tokens=model_config.max_completion_tokens,
@@ -691,16 +703,20 @@ def _create_llm_from_model_config(model_config: ModelUnion):
             model=model_config.model,
             base_url=base_url,
             extra_headers=extra_headers,
+            passthrough_headers=passthrough_headers,
             **_transport_kwargs(model_config),
         )
     if model_config.type == "gemini_vertex_ai":
+        _warn_passthrough_unsupported()
         return KAgentGeminiVertexAILlm(
             model=model_config.model,
             max_output_tokens=model_config.max_output_tokens,
         )
     if model_config.type == "gemini_anthropic":
+        _warn_passthrough_unsupported()
         return ClaudeLLM(model=model_config.model)
     if model_config.type == "ollama":
+        _warn_passthrough_unsupported()
         ollama_options = _convert_ollama_options(getattr(model_config, "options", None))
         # api key passthrough is not applicable for ollama
         return create_ollama_llm(
@@ -714,16 +730,19 @@ def _create_llm_from_model_config(model_config: ModelUnion):
             model=model_config.model,
             type="azure_openai",
             default_headers=extra_headers,
+            passthrough_headers=passthrough_headers,
             **_transport_kwargs(model_config),
         )
     if model_config.type == "gemini":
         return KAgentGeminiLlm(
             model=model_config.model,
             extra_headers=extra_headers,
+            passthrough_headers=passthrough_headers,
             max_output_tokens=model_config.max_output_tokens,
             **_transport_kwargs(model_config),
         )
     if model_config.type == "bedrock":
+        _warn_passthrough_unsupported()
         return KAgentBedrockLlm(
             model=model_config.model,
             extra_headers=extra_headers,
@@ -735,6 +754,7 @@ def _create_llm_from_model_config(model_config: ModelUnion):
             **_transport_kwargs(model_config),
         )
     if model_config.type == "sap_ai_core":
+        _warn_passthrough_unsupported()
         from .models._sap_ai_core import KAgentSAPAICoreLlm
 
         return KAgentSAPAICoreLlm(

--- a/python/packages/kagent-adk/tests/unittests/models/test_anthropic.py
+++ b/python/packages/kagent-adk/tests/unittests/models/test_anthropic.py
@@ -2,6 +2,7 @@
 
 from unittest import mock
 
+import pytest
 from anthropic import AsyncAnthropic
 from anthropic.types import ThinkingBlock
 from google.adk.models.anthropic_llm import content_block_to_part
@@ -52,6 +53,36 @@ class TestKAgentAnthropicLlm:
             _ = llm._anthropic_client
             assert mock_anthropic.call_args.kwargs["api_key"] == "sk-test-key"
 
+    def test_set_passthrough_headers_invalidates_cached_client(self):
+        llm = KAgentAnthropicLlm(model="claude-3-sonnet-20240229", passthrough_headers=["x-guardrail-token"])
+        with mock.patch("kagent.adk.models._anthropic.AsyncAnthropic"):
+            _ = llm._anthropic_client
+            assert "_anthropic_client" in llm.__dict__
+        llm.set_passthrough_headers({"x-guardrail-token": "caller-token"})
+        assert "_anthropic_client" not in llm.__dict__
+
+    def test_set_passthrough_headers_same_value_keeps_cached_client(self):
+        llm = KAgentAnthropicLlm(model="claude-3-sonnet-20240229")
+        llm.set_passthrough_headers({"x-guardrail-token": "caller-token"})
+        with mock.patch("kagent.adk.models._anthropic.AsyncAnthropic"):
+            _ = llm._anthropic_client
+        llm.set_passthrough_headers({"x-guardrail-token": "caller-token"})
+        assert "_anthropic_client" in llm.__dict__
+
+    def test_client_merges_passthrough_headers_over_extra_headers(self):
+        llm = KAgentAnthropicLlm(
+            model="claude-3-sonnet-20240229",
+            extra_headers={"x-tenant": "config-tenant", "x-static": "static-value"},
+        )
+        llm.set_passthrough_headers({"x-tenant": "caller-tenant"})
+        with mock.patch("kagent.adk.models._anthropic.AsyncAnthropic") as mock_anthropic:
+            mock_anthropic.return_value = mock.MagicMock(spec=AsyncAnthropic)
+            _ = llm._anthropic_client
+            assert mock_anthropic.call_args.kwargs["default_headers"] == {
+                "x-tenant": "caller-tenant",
+                "x-static": "static-value",
+            }
+
     def test_create_llm_from_anthropic_model_config(self):
         """Integration: _create_llm_from_model_config returns KAgentAnthropicLlm for anthropic type."""
         from kagent.adk.types import Anthropic, _create_llm_from_model_config
@@ -65,6 +96,48 @@ class TestKAgentAnthropicLlm:
         assert isinstance(result, KAgentAnthropicLlm)
         assert result.model == "claude-3-sonnet-20240229"
         assert result.base_url == "https://api.anthropic.com"
+
+    def test_create_llm_from_anthropic_model_config_with_passthrough_headers(self):
+        from kagent.adk.types import Anthropic, _create_llm_from_model_config
+
+        config = Anthropic(
+            type="anthropic",
+            model="claude-3-sonnet-20240229",
+            passthrough_headers=["x-guardrail-token"],
+        )
+        result = _create_llm_from_model_config(config)
+        assert isinstance(result, KAgentAnthropicLlm)
+        assert result.passthrough_headers == ["x-guardrail-token"]
+
+    @pytest.mark.asyncio
+    async def test_second_caller_without_headers_does_not_inherit_previous_token(self):
+        """Regression: the shared cached client must not leak caller A's pass-through header to caller B."""
+        from kagent.adk._llm_header_passthrough_plugin import LLMHeaderPassthroughPlugin
+
+        llm = KAgentAnthropicLlm(model="claude-3-sonnet-20240229", passthrough_headers=["x-guardrail-token"])
+        plugin = LLMHeaderPassthroughPlugin()
+
+        def callback_context(headers):
+            ctx = mock.MagicMock()
+            ctx.state = {"headers": headers}
+            ctx._invocation_context.agent.model = llm
+            return ctx
+
+        llm_request = mock.MagicMock()
+
+        with mock.patch("kagent.adk.models._anthropic.AsyncAnthropic") as mock_anthropic:
+            mock_anthropic.return_value = mock.MagicMock(spec=AsyncAnthropic)
+
+            await plugin.before_model_callback(
+                callback_context=callback_context({"x-guardrail-token": "CALLER-A-TOKEN"}),
+                llm_request=llm_request,
+            )
+            _ = llm._anthropic_client
+            assert mock_anthropic.call_args.kwargs["default_headers"] == {"x-guardrail-token": "CALLER-A-TOKEN"}
+
+            await plugin.before_model_callback(callback_context=callback_context({}), llm_request=llm_request)
+            _ = llm._anthropic_client
+            assert "default_headers" not in mock_anthropic.call_args.kwargs
 
 
 class TestAnthropicThinkingBlock:

--- a/python/packages/kagent-adk/tests/unittests/models/test_openai.py
+++ b/python/packages/kagent-adk/tests/unittests/models/test_openai.py
@@ -414,6 +414,42 @@ async def test_generate_content_async_with_max_tokens(llm_request, generate_cont
 
 
 @pytest.mark.asyncio
+async def test_generate_content_async_forwards_passthrough_headers(llm_request, generate_content_response):
+    """Headers resolved onto llm_request.config.http_options are sent as per-call extra_headers."""
+    openai_llm = OpenAI(model="gpt-3.5-turbo", type="openai", api_key="fake")
+    llm_request.config.http_options = types.HttpOptions(headers={"x-guardrail-token": "caller-token"})
+    with mock.patch.object(openai_llm, "_client") as mock_client:
+
+        async def mock_coro(*args, **kwargs):
+            return generate_content_response
+
+        mock_client.chat.completions.create.return_value = mock_coro()
+
+        _ = [resp async for resp in openai_llm.generate_content_async(llm_request, stream=False)]
+        mock_client.chat.completions.create.assert_called_once()
+        _, kwargs = mock_client.chat.completions.create.call_args
+        assert kwargs["extra_headers"] == {"x-guardrail-token": "caller-token"}
+
+
+@pytest.mark.asyncio
+async def test_generate_content_async_without_passthrough_headers_sends_no_extra_headers(
+    openai_llm, llm_request, generate_content_response
+):
+    """Regression: a config with only static default_headers produces an unchanged request."""
+    with mock.patch.object(openai_llm, "_client") as mock_client:
+
+        async def mock_coro(*args, **kwargs):
+            return generate_content_response
+
+        mock_client.chat.completions.create.return_value = mock_coro()
+
+        _ = [resp async for resp in openai_llm.generate_content_async(llm_request, stream=False)]
+        mock_client.chat.completions.create.assert_called_once()
+        _, kwargs = mock_client.chat.completions.create.call_args
+        assert "extra_headers" not in kwargs
+
+
+@pytest.mark.asyncio
 async def test_generate_content_async_with_max_completion_tokens(
     llm_request, generate_content_response, generate_llm_response
 ):

--- a/python/packages/kagent-adk/tests/unittests/test_llm_header_passthrough_plugin.py
+++ b/python/packages/kagent-adk/tests/unittests/test_llm_header_passthrough_plugin.py
@@ -1,0 +1,135 @@
+"""Tests for LLMHeaderPassthroughPlugin."""
+
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+from google.adk.models.llm_request import LlmRequest
+from google.genai import types as genai_types
+
+from kagent.adk._llm_header_passthrough_plugin import (
+    LLMHeaderPassthroughPlugin,
+    _resolve_passthrough_headers,
+)
+
+
+def _callback_context(model, headers):
+    ctx = mock.MagicMock()
+    ctx.state = {"headers": headers}
+    ctx._invocation_context.agent.model = model
+    return ctx
+
+
+class TestResolvePassthroughHeaders:
+    def test_case_insensitive_match_preserves_configured_casing(self):
+        resolved = _resolve_passthrough_headers(
+            ["X-Guardrail-Token"], {"x-guardrail-token": "caller-token", "x-ignored": "nope"}
+        )
+        assert resolved == {"X-Guardrail-Token": "caller-token"}
+
+    def test_restricted_names_are_dropped(self):
+        resolved = _resolve_passthrough_headers(
+            ["Authorization", "Proxy-Authorization", "Cookie", "Connection", "x-ok"],
+            {
+                "authorization": "Bearer caller",
+                "proxy-authorization": "Basic caller",
+                "cookie": "session=abc",
+                "connection": "close",
+                "x-ok": "yes",
+            },
+        )
+        assert resolved == {"x-ok": "yes"}
+
+    def test_missing_or_empty_values_are_omitted(self):
+        resolved = _resolve_passthrough_headers(["x-missing", "x-empty"], {"x-empty": ""})
+        assert resolved == {}
+
+
+class TestLLMHeaderPassthroughPlugin:
+    @pytest.mark.asyncio
+    async def test_noop_when_model_has_no_passthrough_headers(self):
+        model = SimpleNamespace(passthrough_headers=None)
+        llm_request = LlmRequest(model="gpt-4o", contents=[])
+        llm_request.config = None
+        ctx = _callback_context(model, {"x-guardrail-token": "caller-token"})
+
+        result = await LLMHeaderPassthroughPlugin().before_model_callback(callback_context=ctx, llm_request=llm_request)
+
+        assert result is None
+        assert llm_request.config is None
+
+    @pytest.mark.asyncio
+    async def test_noop_when_no_configured_header_in_request(self):
+        model = SimpleNamespace(passthrough_headers=["x-guardrail-token"])
+        llm_request = LlmRequest(model="gpt-4o", contents=[])
+        llm_request.config = None
+        ctx = _callback_context(model, {"x-other": "value"})
+
+        await LLMHeaderPassthroughPlugin().before_model_callback(callback_context=ctx, llm_request=llm_request)
+
+        assert llm_request.config is None
+
+    @pytest.mark.asyncio
+    async def test_resolved_headers_merge_into_http_options(self):
+        model = SimpleNamespace(passthrough_headers=["x-guardrail-token"])
+        llm_request = LlmRequest(model="gpt-4o", contents=[])
+        llm_request.config = genai_types.GenerateContentConfig(
+            http_options=genai_types.HttpOptions(headers={"x-existing": "keep"})
+        )
+        ctx = _callback_context(model, {"x-guardrail-token": "caller-token"})
+
+        await LLMHeaderPassthroughPlugin().before_model_callback(callback_context=ctx, llm_request=llm_request)
+
+        assert llm_request.config.http_options.headers == {
+            "x-existing": "keep",
+            "x-guardrail-token": "caller-token",
+        }
+
+    @pytest.mark.asyncio
+    async def test_creates_config_and_http_options_when_absent(self):
+        model = SimpleNamespace(passthrough_headers=["x-guardrail-token"])
+        llm_request = LlmRequest(model="gpt-4o", contents=[])
+        llm_request.config = None
+        ctx = _callback_context(model, {"x-guardrail-token": "caller-token"})
+
+        await LLMHeaderPassthroughPlugin().before_model_callback(callback_context=ctx, llm_request=llm_request)
+
+        assert llm_request.config.http_options.headers == {"x-guardrail-token": "caller-token"}
+
+    @pytest.mark.asyncio
+    async def test_model_with_setter_receives_headers_directly(self):
+        received: dict[str, str] = {}
+
+        class SetterModel:
+            passthrough_headers = ["x-guardrail-token"]
+
+            def set_passthrough_headers(self, headers):
+                received.update(headers)
+
+        llm_request = LlmRequest(model="claude-sonnet-4-5", contents=[])
+        llm_request.config = None
+        ctx = _callback_context(SetterModel(), {"x-guardrail-token": "caller-token"})
+
+        await LLMHeaderPassthroughPlugin().before_model_callback(callback_context=ctx, llm_request=llm_request)
+
+        assert received == {"x-guardrail-token": "caller-token"}
+        assert llm_request.config is None
+
+    @pytest.mark.asyncio
+    async def test_setter_model_receives_empty_dict_to_clear_previous_caller(self):
+        """A caller sending no configured headers must clear, not inherit, the previous caller's values."""
+        calls: list[dict[str, str]] = []
+
+        class SetterModel:
+            passthrough_headers = ["x-guardrail-token"]
+
+            def set_passthrough_headers(self, headers):
+                calls.append(dict(headers))
+
+        llm_request = LlmRequest(model="claude-sonnet-4-5", contents=[])
+        llm_request.config = None
+        ctx = _callback_context(SetterModel(), {"x-other": "value"})
+
+        await LLMHeaderPassthroughPlugin().before_model_callback(callback_context=ctx, llm_request=llm_request)
+
+        assert calls == [{}]


### PR DESCRIPTION
## Motivation

kagent supports static `defaultHeaders` on outbound LLM calls, and `apiKeyPassthrough` for forwarding the caller's Bearer credential. There is no way to forward an arbitrary **caller-supplied** header per request — e.g. a guardrail token, tenant token, or request id that a proxy in front of the LLM provider needs. Organizations running LLM traffic through policy gateways need the caller's own token on each outbound call, which static configuration cannot express.

## What this adds

```yaml
apiVersion: kagent.dev/v1alpha3
kind: ModelConfig
spec:
  defaultHeaders:            # unchanged: static values
    x-tenant: acme
  passthroughHeaders:        # NEW: names resolved from each incoming A2A request
    - x-guardrail-token
```

Header names are case-insensitive; values are read per request from the incoming A2A call context. A pass-through value overrides a `defaultHeaders` entry of the same name; headers absent from the request are omitted. `Authorization` is rejected at admission (CEL) — credential forwarding stays on `apiKeyPassthrough` — and both runtimes additionally drop credential carriers (`Proxy-Authorization`, `Cookie`) and RFC 9110 hop-by-hop names at runtime.

## Changes by layer

- **CRD (v1alpha3)**: `passthroughHeaders []string` with bounds and CEL validation; envtest CEL test; manifests + Helm CRDs regenerated.
- **Wire**: `passthrough_headers` on `adk.BaseModel`; `populateHeaderFields` helper (mirrors `populateTLSFields`) in the adkconfig translator, covering all 10 provider branches.
- **Go runtime**: `allowedRequestHeaders` lifted from `pkg/mcp` into a shared `pkg/headers` package (a2a-go v2); `headerTransport` overlays per-request headers from the call context after static ones. 8/10 providers get this via `BuildHTTPClient`; GeminiVertexAI and SAPAICore log a warning — they build clients without the shared transport and already drop `defaultHeaders`/TLS today (pre-existing gap, left as-is here).
- **A2A gateway**: a `callerHeadersInterceptor` on the runtime dialer relays caller-supplied custom headers from the public request onto the private runtime call, excluding credential, hop-by-hop, gRPC pseudo/system, and interceptor-owned (`traceparent`, `x-a2a-extensions`) metadata. Without this hop, neither `passthroughHeaders` nor the existing MCP `allowedHeaders` can see caller headers through the gateway; the runtime-side allowlists remain the actual gate.
- **Python runtime**: `LLMHeaderPassthroughPlugin` resolves session-state headers (case-insensitive, restricted names filtered, empty values omitted) onto `llm_request.config.http_options` for OpenAI/Azure (per-call `extra_headers`) and Gemini (honoured natively); Anthropic uses a cache-invalidating `set_passthrough_headers`, the same mechanism as `set_passthrough_key` (same shared-client concurrency caveat, documented). Bedrock, Ollama, VertexAI, and SAP AI Core log a warning and ignore the field.

## Design points for reviewers

1. **Gateway forwarding scope** — the interceptor forwards *all* non-restricted custom caller headers rather than resolving the instance's configured allowlist at the gateway (the dialer has no ModelConfig access, and the runtime filters by allowlist anyway). If you'd rather plumb the configured names into the resolved bundle instead, happy to rework.
2. **Anthropic delivery** — per-call headers can't reach `messages.create` inside the ADK Claude base class, hence the cache-invalidation setter. A per-request carrier in google-adk would allow removing it.

## Testing

Unit tests at every layer (transport overlay + credential protection, restricted-name filter, wire round-trip, gateway interceptor, CEL admission via envtest, Python plugin + provider behavior), plus a regression asserting a `defaultHeaders`-only config produces byte-identical requests.