### PR TITLE
chore: update substrate to v0.0.25

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
       - setup
     env:
       VERSION: v0.0.1-test
-      SUBSTRATE_VERSION: 0.0.24
+      SUBSTRATE_VERSION: 0.0.25
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     steps:

--- a/go/core/internal/service/system/service.go
+++ b/go/core/internal/service/system/service.go
@@ -441,14 +441,10 @@ func actorFromProto(actor *ateapipb.Actor) SubstrateActor {
 }
 
 func workerFromProto(worker *ateapipb.Worker) SubstrateWorker {
-	assignment := worker.GetStatus().GetAssignment()
 	return SubstrateWorker{
 		WorkerNamespace: worker.GetWorkerNamespace(),
 		WorkerPool:      worker.GetWorkerPool(),
 		WorkerPod:       worker.GetWorkerPod(),
-		ActorNamespace:  assignment.GetActorTemplateRef().GetAtespace(),
-		ActorTemplate:   assignment.GetActorTemplateRef().GetName(),
-		ActorID:         assignment.GetActor().GetName(),
 		IP:              worker.GetIp(),
 		Version:         worker.GetMetadata().GetVersion(),
 	}

--- a/go/core/internal/service/system/service_test.go
+++ b/go/core/internal/service/system/service_test.go
@@ -157,10 +157,6 @@ func TestGetSubstrateStatus(t *testing.T) {
 				WorkerNamespace: "team",
 				WorkerPool:      "pool",
 				WorkerPod:       "worker-0",
-				Status: &ateapipb.WorkerStatus{Assignment: &ateapipb.ActorAssignment{
-					ActorTemplateRef: &ateapipb.ObjectRef{Atespace: "team", Name: "template"},
-					Actor:            &ateapipb.ObjectRef{Name: "actor-1"},
-				}},
 			}},
 		}
 		revisions := &fakeRuntimeRevisionStore{harnesses: []dbpkg.ActorTemplateHarness{{
@@ -186,8 +182,7 @@ func TestGetSubstrateStatus(t *testing.T) {
 		require.Len(t, result.Actors, 1)
 		assert.Equal(t, "Running", result.Actors[0].Status)
 		require.Len(t, result.Workers, 1)
-		assert.Equal(t, "template", result.Workers[0].ActorTemplate)
-		assert.Equal(t, "actor-1", result.Workers[0].ActorID)
+		assert.Equal(t, "worker-0", result.Workers[0].WorkerPod)
 		assert.Equal(t, int64(3), result.Workers[0].Version)
 	})
 

--- a/go/go.mod
+++ b/go/go.mod
@@ -44,7 +44,6 @@ require (
 	github.com/pgvector/pgvector-go v0.4.1
 	github.com/pgvector/pgvector-go/pgx v0.4.1
 	github.com/prometheus/client_golang v1.24.1
-	github.com/spf13/afero v1.15.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stoewer/go-strcase v1.3.1
@@ -384,6 +383,7 @@ require (
 	github.com/sivchari/containedctx v1.0.3 // indirect
 	github.com/sonatard/noctx v0.5.1 // indirect
 	github.com/sourcegraph/go-diff v0.8.0 // indirect
+	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/viper v1.21.0 // indirect
 	github.com/ssgreg/nlreturn/v2 v2.2.1 // indirect
@@ -486,4 +486,4 @@ require (
 
 tool sigs.k8s.io/kube-api-linter/cmd/golangci-lint-kube-api-linter
 
-replace github.com/agent-substrate/substrate => github.com/kagent-dev/substrate v0.0.24
+replace github.com/agent-substrate/substrate => github.com/kagent-dev/substrate v0.0.25

--- a/go/go.sum
+++ b/go/go.sum
@@ -707,8 +707,8 @@ github.com/kagent-dev/mockllm v0.0.7 h1:ofucOQKKqarRICBjxJFKIpxD7NQOjVuA0Frujh96
 github.com/kagent-dev/mockllm v0.0.7/go.mod h1:tDLemRsTZa1NdHaDbg3sgFk9cT1QWvMPlBtLVD6I2mA=
 github.com/kagent-dev/mockmcp v0.0.0-20260520211643-dcd475b74085 h1:5bYxRc6K6+JiFMYGSJpQ7y18PzTGXUmUtVXY7Fqh0Ew=
 github.com/kagent-dev/mockmcp v0.0.0-20260520211643-dcd475b74085/go.mod h1:vTMste7c+XiDOQyhe6iGPKLbMy3chY/h2fL3Dox5fAE=
-github.com/kagent-dev/substrate v0.0.24 h1:eOVjFZBOqgJrVZwk48sWAhzra3MR8F8Trqnhg6qJvsk=
-github.com/kagent-dev/substrate v0.0.24/go.mod h1:EMlL/eOwu0RTnh0kgRQYwd+YkWZ0HmDM2pf5f/OCKAo=
+github.com/kagent-dev/substrate v0.0.25 h1:YEJYF3h1njiQGw7vxi0F35fW3YslTUlB8A6Jes3MP8g=
+github.com/kagent-dev/substrate v0.0.25/go.mod h1:EMlL/eOwu0RTnh0kgRQYwd+YkWZ0HmDM2pf5f/OCKAo=
 github.com/karamaru-alpha/copyloopvar v1.2.2 h1:yfNQvP9YaGQR7VaWLYcfZUlRP2eo2vhExWKxD/fP6q0=
 github.com/karamaru-alpha/copyloopvar v1.2.2/go.mod h1:oY4rGZqZ879JkJMtX3RRkcXRkmUvH0x35ykgaKgsgJY=
 github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRtuthU=

--- a/scripts/setup-cluster/setup-cluster.sh
+++ b/scripts/setup-cluster/setup-cluster.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 
 # The repo this script lives in, so it works from any checkout and any directory.
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-SUBSTRATE_VERSION=0.0.24
+SUBSTRATE_VERSION=0.0.25
 cd "$REPO"
 
 step() { printf '\n\033[1;36m==> %s\033[0m\n' "$1"; }


### PR DESCRIPTION
## Summary

- update the Substrate Go dependency, CI, and cluster setup to v0.0.25
- adapt worker inventory to the v0.0.25 multi-actor worker API, which no longer exposes a singular assignment on WorkerStatus
- refresh Go module metadata

## Testing

- go test ./core/...
- verified the substrate and substrate-crds 0.0.25 Helm charts are published