### PR TITLE
fix: wire runtime revisions into substrate inventory

### DIFF
--- a/go/core/internal/grpcserver/agenttemplate_harness_test.go
+++ b/go/core/internal/grpcserver/agenttemplate_harness_test.go
@@ -39,6 +39,7 @@ func newTemplateAndHarnessConnection(t *testing.T, objects ...ctrlclient.Object)
 		Listener:             listener,
 		Registerer:           prometheus.NewRegistry(),
 		Authenticator:        &authimpl.UnsecureAuthenticator{},
+		SystemService:        testSystemService(),
 		AgentTemplateService: kubecrud.NewService(kubeClient, &authimpl.NoopAuthorizer{}, &v1alpha3.AgentTemplate{}, &v1alpha3.AgentTemplateList{}, "AgentTemplate"),
 		HarnessService:       kubecrud.NewService(kubeClient, &authimpl.NoopAuthorizer{}, &v1alpha3.Harness{}, &v1alpha3.HarnessList{}, "Harness"),
 	})

--- a/go/core/internal/grpcserver/model_test.go
+++ b/go/core/internal/grpcserver/model_test.go
@@ -62,6 +62,7 @@ func TestModelServiceCRUD(t *testing.T) {
 		Listener:      listener,
 		Registerer:    prometheus.NewRegistry(),
 		Authenticator: &authimpl.UnsecureAuthenticator{},
+		SystemService: testSystemService(),
 		ModelService:  service,
 	})
 	if err != nil {

--- a/go/core/internal/grpcserver/prompttemplate_test.go
+++ b/go/core/internal/grpcserver/prompttemplate_test.go
@@ -42,6 +42,7 @@ func TestPromptTemplateServiceGeneratedClient(t *testing.T) {
 		Listener:              listener,
 		Registerer:            prometheus.NewRegistry(),
 		Authenticator:         &authimpl.UnsecureAuthenticator{},
+		SystemService:         testSystemService(),
 		PromptTemplateService: service,
 	})
 	if err != nil {

--- a/go/core/internal/grpcserver/server.go
+++ b/go/core/internal/grpcserver/server.go
@@ -80,7 +80,7 @@ func New(config Config) (*Server, error) {
 		config.MaxMessageBytes = DefaultMaxMessageSize
 	}
 	if config.SystemService == nil {
-		config.SystemService = systemservice.NewService()
+		return nil, fmt.Errorf("system service is required")
 	}
 	if config.MethodPolicies == nil {
 		config.MethodPolicies = DefaultMethodPolicies()

--- a/go/core/internal/grpcserver/server_test.go
+++ b/go/core/internal/grpcserver/server_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	apiv1alpha1 "github.com/kagent-dev/kagent/go/api/gen/kagent/api/v1alpha1"
+	systemservice "github.com/kagent-dev/kagent/go/core/internal/service/system"
 	"github.com/kagent-dev/kagent/go/core/internal/version"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
@@ -14,6 +15,10 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/test/bufconn"
 )
+
+func testSystemService() *systemservice.Service {
+	return systemservice.NewService(nil, nil, nil, nil, nil)
+}
 
 func TestServerGetVersionAndHealth(t *testing.T) {
 	oldVersion, oldCommit, oldDate := version.Version, version.GitCommit, version.BuildDate
@@ -24,8 +29,9 @@ func TestServerGetVersionAndHealth(t *testing.T) {
 
 	listener := bufconn.Listen(1024 * 1024)
 	server, err := New(Config{
-		Listener:   listener,
-		Registerer: prometheus.NewRegistry(),
+		Listener:      listener,
+		Registerer:    prometheus.NewRegistry(),
+		SystemService: testSystemService(),
 	})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
@@ -76,8 +82,15 @@ func TestServerGetVersionAndHealth(t *testing.T) {
 }
 
 func TestNewRejectsPartialTLSConfiguration(t *testing.T) {
-	_, err := New(Config{TLSCertFile: "cert.pem"})
+	_, err := New(Config{TLSCertFile: "cert.pem", SystemService: testSystemService()})
 	if err == nil {
 		t.Fatal("New() error = nil, want partial TLS configuration error")
+	}
+}
+
+func TestNewRejectsMissingSystemService(t *testing.T) {
+	_, err := New(Config{})
+	if err == nil {
+		t.Fatal("New() error = nil, want missing system service error")
 	}
 }

--- a/go/core/internal/grpcserver/system_feedback_test.go
+++ b/go/core/internal/grpcserver/system_feedback_test.go
@@ -33,7 +33,7 @@ func TestSystemGeneratedClient(t *testing.T) {
 		Listener:      listener,
 		Registerer:    prometheus.NewRegistry(),
 		Authenticator: &authimpl.UnsecureAuthenticator{},
-		SystemService: systemservice.NewService(systemservice.WithInventory(kubeClient, nil, &authimpl.NoopAuthorizer{}, nil)),
+		SystemService: systemservice.NewService(systemservice.WithInventory(kubeClient, nil, &authimpl.NoopAuthorizer{}, nil, nil)),
 	})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)

--- a/go/core/internal/grpcserver/system_feedback_test.go
+++ b/go/core/internal/grpcserver/system_feedback_test.go
@@ -33,7 +33,7 @@ func TestSystemGeneratedClient(t *testing.T) {
 		Listener:      listener,
 		Registerer:    prometheus.NewRegistry(),
 		Authenticator: &authimpl.UnsecureAuthenticator{},
-		SystemService: systemservice.NewService(systemservice.WithInventory(kubeClient, nil, &authimpl.NoopAuthorizer{}, nil, nil)),
+		SystemService: systemservice.NewService(kubeClient, nil, &authimpl.NoopAuthorizer{}, nil, nil),
 	})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)

--- a/go/core/internal/grpcserver/tool_test.go
+++ b/go/core/internal/grpcserver/tool_test.go
@@ -297,6 +297,7 @@ func newToolGRPCClient(t *testing.T, service *toolservice.Service) (apiv1alpha1.
 		Listener:      listener,
 		Registerer:    prometheus.NewRegistry(),
 		Authenticator: &authimpl.UnsecureAuthenticator{},
+		SystemService: testSystemService(),
 		ToolService:   service,
 	})
 	if err != nil {

--- a/go/core/internal/service/system/service.go
+++ b/go/core/internal/service/system/service.go
@@ -120,17 +120,13 @@ func WithInventory(
 	observedNamespaces []string,
 	authorizer auth.Authorizer,
 	ateClient ATEClient,
+	revisions runtimeRevisionStore,
 ) Option {
 	return func(service *Service) {
 		service.kubeClient = kubeClient
 		service.observedNamespaces = slices.Clone(observedNamespaces)
 		service.authorizer = authorizer
 		service.ateClient = ateClient
-	}
-}
-
-func WithRuntimeRevisions(revisions runtimeRevisionStore) Option {
-	return func(service *Service) {
 		service.revisions = revisions
 	}
 }

--- a/go/core/internal/service/system/service.go
+++ b/go/core/internal/service/system/service.go
@@ -46,8 +46,6 @@ type Service struct {
 	revisions          runtimeRevisionStore
 }
 
-type Option func(*Service)
-
 type Namespace struct {
 	Name   string
 	Status string
@@ -107,27 +105,19 @@ type SubstrateWorker struct {
 	Version         int64
 }
 
-func NewService(options ...Option) *Service {
-	service := &Service{}
-	for _, option := range options {
-		option(service)
-	}
-	return service
-}
-
-func WithInventory(
+func NewService(
 	kubeClient client.Client,
 	observedNamespaces []string,
 	authorizer auth.Authorizer,
 	ateClient ATEClient,
 	revisions runtimeRevisionStore,
-) Option {
-	return func(service *Service) {
-		service.kubeClient = kubeClient
-		service.observedNamespaces = slices.Clone(observedNamespaces)
-		service.authorizer = authorizer
-		service.ateClient = ateClient
-		service.revisions = revisions
+) *Service {
+	return &Service{
+		kubeClient:         kubeClient,
+		observedNamespaces: slices.Clone(observedNamespaces),
+		authorizer:         authorizer,
+		ateClient:          ateClient,
+		revisions:          revisions,
 	}
 }
 

--- a/go/core/internal/service/system/service_test.go
+++ b/go/core/internal/service/system/service_test.go
@@ -61,7 +61,7 @@ func (client *fakeATEClient) ListActorTemplates(context.Context, string) ([]*ate
 }
 
 func TestCurrentUser(t *testing.T) {
-	service := system.NewService()
+	service := system.NewService(nil, nil, nil, nil, nil)
 	claims := map[string]any{"sub": "user-1", "groups": []any{"admins"}}
 	ctx := pkgAuth.AuthSessionTo(t.Context(), &authimpl.SimpleSession{P: pkgAuth.Principal{
 		User:   pkgAuth.User{ID: "user-1"},
@@ -92,7 +92,7 @@ func TestListNamespaces(t *testing.T) {
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "Zoo"}, Status: corev1.NamespaceStatus{Phase: corev1.NamespaceActive}},
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "alpha"}, Status: corev1.NamespaceStatus{Phase: corev1.NamespaceTerminating}},
 		).Build()
-		service := system.NewService(system.WithInventory(kubeClient, nil, nil, nil, nil))
+		service := system.NewService(kubeClient, nil, nil, nil, nil)
 
 		result, err := service.ListNamespaces(t.Context())
 		require.NoError(t, err)
@@ -108,7 +108,7 @@ func TestListNamespaces(t *testing.T) {
 				return apierrors.NewForbidden(schema.GroupResource{Resource: "namespaces"}, "", nil)
 			},
 		}).Build()
-		service := system.NewService(system.WithInventory(kubeClient, []string{"team-b", "team-a"}, nil, nil, nil))
+		service := system.NewService(kubeClient, []string{"team-b", "team-a"}, nil, nil, nil)
 
 		result, err := service.ListNamespaces(t.Context())
 		require.NoError(t, err)
@@ -123,7 +123,7 @@ func TestGetSubstrateStatus(t *testing.T) {
 	ctx := pkgAuth.AuthSessionTo(t.Context(), &authimpl.SimpleSession{P: pkgAuth.Principal{User: pkgAuth.User{ID: "user"}}})
 
 	t.Run("disabled does not read Kubernetes", func(t *testing.T) {
-		service := system.NewService(system.WithInventory(nil, nil, &authimpl.NoopAuthorizer{}, nil, nil))
+		service := system.NewService(nil, nil, &authimpl.NoopAuthorizer{}, nil, nil)
 		result, err := service.GetSubstrateStatus(ctx, "team")
 		require.NoError(t, err)
 		assert.False(t, result.Enabled)
@@ -162,9 +162,7 @@ func TestGetSubstrateStatus(t *testing.T) {
 		revisions := &fakeRuntimeRevisionStore{harnesses: []dbpkg.ActorTemplateHarness{{
 			Atespace: "team", Name: "template", UID: "template-uid", HarnessName: "kagent",
 		}}}
-		service := system.NewService(
-			system.WithInventory(kubeClient, nil, &authimpl.NoopAuthorizer{}, ateClient, revisions),
-		)
+		service := system.NewService(kubeClient, nil, &authimpl.NoopAuthorizer{}, ateClient, revisions)
 
 		result, err := service.GetSubstrateStatus(ctx, "team")
 		require.NoError(t, err)
@@ -186,11 +184,11 @@ func TestGetSubstrateStatus(t *testing.T) {
 	})
 
 	t.Run("validates and authorizes", func(t *testing.T) {
-		service := system.NewService(system.WithInventory(nil, nil, &authimpl.NoopAuthorizer{}, nil, nil))
+		service := system.NewService(nil, nil, &authimpl.NoopAuthorizer{}, nil, nil)
 		_, err := service.GetSubstrateStatus(ctx, "INVALID_NAMESPACE")
 		assert.True(t, serviceerrors.IsCode(err, serviceerrors.CodeInvalidArgument), err)
 
-		service = system.NewService(system.WithInventory(nil, nil, systemDenyAuthorizer{}, nil, nil))
+		service = system.NewService(nil, nil, systemDenyAuthorizer{}, nil, nil)
 		_, err = service.GetSubstrateStatus(ctx, "")
 		assert.True(t, serviceerrors.IsCode(err, serviceerrors.CodePermissionDenied), err)
 	})

--- a/go/core/internal/service/system/service_test.go
+++ b/go/core/internal/service/system/service_test.go
@@ -92,7 +92,7 @@ func TestListNamespaces(t *testing.T) {
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "Zoo"}, Status: corev1.NamespaceStatus{Phase: corev1.NamespaceActive}},
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "alpha"}, Status: corev1.NamespaceStatus{Phase: corev1.NamespaceTerminating}},
 		).Build()
-		service := system.NewService(system.WithInventory(kubeClient, nil, nil, nil))
+		service := system.NewService(system.WithInventory(kubeClient, nil, nil, nil, nil))
 
 		result, err := service.ListNamespaces(t.Context())
 		require.NoError(t, err)
@@ -108,7 +108,7 @@ func TestListNamespaces(t *testing.T) {
 				return apierrors.NewForbidden(schema.GroupResource{Resource: "namespaces"}, "", nil)
 			},
 		}).Build()
-		service := system.NewService(system.WithInventory(kubeClient, []string{"team-b", "team-a"}, nil, nil))
+		service := system.NewService(system.WithInventory(kubeClient, []string{"team-b", "team-a"}, nil, nil, nil))
 
 		result, err := service.ListNamespaces(t.Context())
 		require.NoError(t, err)
@@ -123,7 +123,7 @@ func TestGetSubstrateStatus(t *testing.T) {
 	ctx := pkgAuth.AuthSessionTo(t.Context(), &authimpl.SimpleSession{P: pkgAuth.Principal{User: pkgAuth.User{ID: "user"}}})
 
 	t.Run("disabled does not read Kubernetes", func(t *testing.T) {
-		service := system.NewService(system.WithInventory(nil, nil, &authimpl.NoopAuthorizer{}, nil))
+		service := system.NewService(system.WithInventory(nil, nil, &authimpl.NoopAuthorizer{}, nil, nil))
 		result, err := service.GetSubstrateStatus(ctx, "team")
 		require.NoError(t, err)
 		assert.False(t, result.Enabled)
@@ -163,8 +163,7 @@ func TestGetSubstrateStatus(t *testing.T) {
 			Atespace: "team", Name: "template", UID: "template-uid", HarnessName: "kagent",
 		}}}
 		service := system.NewService(
-			system.WithInventory(kubeClient, nil, &authimpl.NoopAuthorizer{}, ateClient),
-			system.WithRuntimeRevisions(revisions),
+			system.WithInventory(kubeClient, nil, &authimpl.NoopAuthorizer{}, ateClient, revisions),
 		)
 
 		result, err := service.GetSubstrateStatus(ctx, "team")
@@ -187,11 +186,11 @@ func TestGetSubstrateStatus(t *testing.T) {
 	})
 
 	t.Run("validates and authorizes", func(t *testing.T) {
-		service := system.NewService(system.WithInventory(nil, nil, &authimpl.NoopAuthorizer{}, nil))
+		service := system.NewService(system.WithInventory(nil, nil, &authimpl.NoopAuthorizer{}, nil, nil))
 		_, err := service.GetSubstrateStatus(ctx, "INVALID_NAMESPACE")
 		assert.True(t, serviceerrors.IsCode(err, serviceerrors.CodeInvalidArgument), err)
 
-		service = system.NewService(system.WithInventory(nil, nil, systemDenyAuthorizer{}, nil))
+		service = system.NewService(system.WithInventory(nil, nil, systemDenyAuthorizer{}, nil, nil))
 		_, err = service.GetSubstrateStatus(ctx, "")
 		assert.True(t, serviceerrors.IsCode(err, serviceerrors.CodePermissionDenied), err)
 	})

--- a/go/core/pkg/app/app.go
+++ b/go/core/pkg/app/app.go
@@ -262,7 +262,10 @@ func Run(ctx context.Context, opts Options) error {
 	models := modelservice.NewService(manager.GetClient(), authorizer, resourceNamespace)
 	tools := toolservice.NewService(manager.GetClient(), store, authorizer, resourceNamespace, mcpClient)
 	prompts := prompttemplateservice.NewService(manager.GetClient(), authorizer)
-	system := systemservice.NewService(systemservice.WithInventory(manager.GetClient(), watchNamespaces, authorizer, actors))
+	system := systemservice.NewService(
+		systemservice.WithInventory(manager.GetClient(), watchNamespaces, authorizer, actors),
+		systemservice.WithRuntimeRevisions(store),
+	)
 	memory := memoryservice.NewService(store)
 	instanceWorkflow := agentinstance.NewActorWorkflow(store, actors)
 	instances := agentinstance.NewService(store, authorizer, instanceWorkflow)

--- a/go/core/pkg/app/app.go
+++ b/go/core/pkg/app/app.go
@@ -262,9 +262,7 @@ func Run(ctx context.Context, opts Options) error {
 	models := modelservice.NewService(manager.GetClient(), authorizer, resourceNamespace)
 	tools := toolservice.NewService(manager.GetClient(), store, authorizer, resourceNamespace, mcpClient)
 	prompts := prompttemplateservice.NewService(manager.GetClient(), authorizer)
-	system := systemservice.NewService(
-		systemservice.WithInventory(manager.GetClient(), watchNamespaces, authorizer, actors, store),
-	)
+	system := systemservice.NewService(manager.GetClient(), watchNamespaces, authorizer, actors, store)
 	memory := memoryservice.NewService(store)
 	instanceWorkflow := agentinstance.NewActorWorkflow(store, actors)
 	instances := agentinstance.NewService(store, authorizer, instanceWorkflow)

--- a/go/core/pkg/app/app.go
+++ b/go/core/pkg/app/app.go
@@ -263,8 +263,7 @@ func Run(ctx context.Context, opts Options) error {
 	tools := toolservice.NewService(manager.GetClient(), store, authorizer, resourceNamespace, mcpClient)
 	prompts := prompttemplateservice.NewService(manager.GetClient(), authorizer)
 	system := systemservice.NewService(
-		systemservice.WithInventory(manager.GetClient(), watchNamespaces, authorizer, actors),
-		systemservice.WithRuntimeRevisions(store),
+		systemservice.WithInventory(manager.GetClient(), watchNamespaces, authorizer, actors, store),
 	)
 	memory := memoryservice.NewService(store)
 	instanceWorkflow := agentinstance.NewActorWorkflow(store, actors)


### PR DESCRIPTION
## Summary

- provide the database-backed runtime revision store to the system service
- restore Substrate inventory, actor, and worker reads

## Testing

- `go test ./core/pkg/app ./core/internal/service/system`
- deployed locally and verified `SystemService/GetSubstrateStatus` returns `OK`