### PR TITLE
ci: run workflows on Blacksmith runners (backport to release/v0.10.x)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
         run: |
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
       - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v1
+        uses: useblacksmith/setup-docker-builder@v2
 
       - name: Set up Helm
         uses: azure/setup-helm@v5.0.1
@@ -376,7 +376,7 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
       - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v1
+        uses: useblacksmith/setup-docker-builder@v2
       - name: Run make build
         env:
           BUILDX_BUILDER_NAME: ${{ env.BUILDX_BUILDER_NAME }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
       - setup
     env:
       VERSION: v0.0.1-test
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -53,14 +53,8 @@ jobs:
         # See https://github.com/openai/codex/issues/14919
         run: |
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-        with:
-          name: ${{ env.BUILDX_BUILDER_NAME }}
-          version: ${{ env.BUILDX_VERSION }}
-          platforms: linux/amd64
-          use: "true"
-          driver-opts: network=host
+      - name: Setup Blacksmith Builder
+        uses: useblacksmith/setup-docker-builder@v1
 
       - name: Set up Helm
         uses: azure/setup-helm@v5.0.1
@@ -174,7 +168,7 @@ jobs:
       - setup
     env:
       VERSION: v0.0.1-test
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       fail-fast: false
       matrix:
@@ -222,7 +216,7 @@ jobs:
       - setup
     env:
       VERSION: v0.0.1-test
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       fail-fast: false
       matrix:
@@ -310,7 +304,7 @@ jobs:
           helm unittest helm/tools/grafana-mcp
 
   ui-tests:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
       pull-requests: write
@@ -368,7 +362,7 @@ jobs:
           - acp-sandbox-hermes
           - acp-sandbox-openclaw
           - acp-sandbox-claude
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     services:
       registry:
         image: registry:2
@@ -381,14 +375,8 @@ jobs:
         uses: docker/setup-qemu-action@v4
         with:
           platforms: linux/amd64,linux/arm64
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-        with:
-          name: ${{ env.BUILDX_BUILDER_NAME }}
-          platforms: linux/amd64,linux/arm64
-          version: ${{ env.BUILDX_VERSION }}
-          use: "true"
-          driver-opts: network=host
+      - name: Setup Blacksmith Builder
+        uses: useblacksmith/setup-docker-builder@v1
       - name: Run make build
         env:
           BUILDX_BUILDER_NAME: ${{ env.BUILDX_BUILDER_NAME }}

--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
       - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v1
+        uses: useblacksmith/setup-docker-builder@v2
       - name: Set version
         id: vars
         run: echo "version=v0.0.0-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT

--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -48,7 +48,7 @@ jobs:
           - build_target: golang-adk-full
             image_name: golang-adk
             tag_suffix: "-full"
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     services:
       registry:
         image: registry:2
@@ -59,14 +59,8 @@ jobs:
         uses: actions/checkout@v6
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-        with:
-          name: ${{ env.BUILDX_BUILDER_NAME }}
-          version: ${{ env.BUILDX_VERSION }}
-          platforms: linux/amd64,linux/arm64
-          use: 'true'
-          driver-opts: network=host
+      - name: Setup Blacksmith Builder
+        uses: useblacksmith/setup-docker-builder@v1
       - name: Set version
         id: vars
         run: echo "version=v0.0.0-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -26,7 +26,7 @@ jobs:
           - acp-sandbox-hermes
           - acp-sandbox-openclaw
           - acp-sandbox-claude
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
---
*🤖 written by Claude (start)*

## Release note

```release-note
NONE
```

## Changes

Backport of #2659 and #2723: CI, image scan and tag builds run on Blacksmith runners with its Docker builder.

---
*🤖 written by Claude (end)*
