### PR TITLE
ci: run workflows on Blacksmith runners (backport to release/v0.9.x)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
       - setup
     env:
       VERSION: v0.0.1-test
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -54,14 +54,8 @@ jobs:
         uses: docker/setup-qemu-action@v4
         with:
           platforms: linux/amd64,linux/arm64
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-        with:
-          name: ${{ env.BUILDX_BUILDER_NAME }}
-          version: ${{ env.BUILDX_VERSION }}
-          platforms: linux/amd64,linux/arm64
-          use: "true"
-          driver-opts: network=host
+      - name: Setup Blacksmith Builder
+        uses: useblacksmith/setup-docker-builder@v1
 
       - name: Set up Helm
         uses: azure/setup-helm@v5.0.0
@@ -206,7 +200,7 @@ jobs:
           helm unittest helm/tools/grafana-mcp
 
   ui-tests:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
       pull-requests: write
@@ -258,7 +252,7 @@ jobs:
           - golang-adk
           - golang-adk-full
           - skills-init
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     services:
       registry:
         image: registry:2
@@ -271,14 +265,8 @@ jobs:
         uses: docker/setup-qemu-action@v4
         with:
           platforms: linux/amd64,linux/arm64
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-        with:
-          name: ${{ env.BUILDX_BUILDER_NAME }}
-          platforms: linux/amd64,linux/arm64
-          version: ${{ env.BUILDX_VERSION }}
-          use: "true"
-          driver-opts: network=host
+      - name: Setup Blacksmith Builder
+        uses: useblacksmith/setup-docker-builder@v1
       - name: Run make build
         env:
           BUILDX_BUILDER_NAME: ${{ env.BUILDX_BUILDER_NAME }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
       - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v1
+        uses: useblacksmith/setup-docker-builder@v2
 
       - name: Set up Helm
         uses: azure/setup-helm@v5.0.0
@@ -266,7 +266,7 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
       - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v1
+        uses: useblacksmith/setup-docker-builder@v2
       - name: Run make build
         env:
           BUILDX_BUILDER_NAME: ${{ env.BUILDX_BUILDER_NAME }}

--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -44,7 +44,7 @@ jobs:
           - build_target: golang-adk-full
             image_name: golang-adk
             tag_suffix: "-full"
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     services:
       registry:
         image: registry:2
@@ -55,14 +55,8 @@ jobs:
         uses: actions/checkout@v6
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-        with:
-          name: ${{ env.BUILDX_BUILDER_NAME }}
-          version: ${{ env.BUILDX_VERSION }}
-          platforms: linux/amd64,linux/arm64
-          use: 'true'
-          driver-opts: network=host
+      - name: Setup Blacksmith Builder
+        uses: useblacksmith/setup-docker-builder@v1
       - name: Set version
         id: vars
         run: echo "version=v0.0.0-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT

--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
       - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v1
+        uses: useblacksmith/setup-docker-builder@v2
       - name: Set version
         id: vars
         run: echo "version=v0.0.0-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -23,7 +23,7 @@ jobs:
           - golang-adk
           - golang-adk-full
           - skills-init
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
---
*🤖 written by Claude (start)*

## Release note

```release-note
NONE
```

## Changes

Backport of #2659 and #2723: CI, image scan and tag builds run on Blacksmith runners with its Docker builder.

---
*🤖 written by Claude (end)*
