### PR TITLE
feat(substrate): Resume from golden snapshot with durable data instead of cold booting from OCI images

### DIFF
--- a/go/core/internal/substrate/actor_template.go
+++ b/go/core/internal/substrate/actor_template.go
@@ -67,7 +67,7 @@ func ActorTemplateForRevision(spec *translator.Revision, revisionID translator.R
 			StorageLocation: spec.SnapshotLocation,
 			OnPause:         ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_FULL,
 			OnCommit:        ateapipb.SnapshotContentScope_SNAPSHOT_CONTENT_SCOPE_DATA,
-			OnResume:        &ateapipb.OnResumeConfig{FromData: ateapipb.ResumeSource_RESUME_SOURCE_COLD_BOOT},
+			OnResume:        &ateapipb.OnResumeConfig{FromData: ateapipb.ResumeSource_RESUME_SOURCE_GOLDEN},
 		},
 		Volumes: []*ateapipb.Volume{{Name: durableDataVolume, DurableDir: &ateapipb.DurableDirVolumeSource{}}},
 	}

--- a/go/core/internal/substrate/actor_template_test.go
+++ b/go/core/internal/substrate/actor_template_test.go
@@ -38,7 +38,7 @@ func TestActorTemplateForRevision(t *testing.T) {
 	if template.GetSandboxConfig().GetSandboxClass() != ateapipb.SandboxClass_SANDBOX_CLASS_GVISOR || template.GetSandboxConfig().GetConfigName() != "gvisor-default" || container.GetReadyz().GetHttpGet().GetPath() != "/readyz" || container.GetReadyz().GetHttpGet().GetPort() != 8081 || container.GetReadyz().GetTimeoutSeconds() != 30 {
 		t.Fatalf("unexpected runtime contract: %+v", template)
 	}
-	if template.GetSnapshotsConfig().GetOnResume().GetFromData() != ateapipb.ResumeSource_RESUME_SOURCE_COLD_BOOT {
+	if template.GetSnapshotsConfig().GetOnResume().GetFromData() != ateapipb.ResumeSource_RESUME_SOURCE_GOLDEN {
 		t.Fatalf("unexpected snapshot resume default: %+v", template.GetSnapshotsConfig().GetOnResume())
 	}
 	environment := map[string]*ateapipb.EnvVar{}


### PR DESCRIPTION
Upstream Substrate added the capability to resume from golden snapshot (FULL snapshots) with durable data (DATA snapshots) for `gVisor` sandbox class.

## Snapshot selection

| Actor State | Selected source |
| --- | --- |
| No actor snapshot | Template golden |
| PAUSED with local checkpoint | Node-local FULL snapshot |
| SUSPENDED with latest actor snapshot | Latest DATA snapshot + golden FULL |

## Benchmark

I ran Codex and Claude harness each with 25 turns comparing cold boot vs golden latency for the following metrics:

| Metric | Codex: cold / golden | Claude: cold / golden |
| --- | ---: | ---: |
| Median first output | 725 / 695 ms | 1,282 / 1,068 ms |
| Median turn completion | 971 / 957 ms | 2,007 / 1,731 ms |
| Mean Substrate restore | 235 / 234 ms | 294 / 196 ms |
| Mean checkpoint | 232 / 232 ms | 243 / 212 ms |

## Compatibility boundary

A Substrate upgrade does not inherently invalidate FULL snapshots. The snapshot manifest records the sandbox class, exact runtime asset URL and hash, and pause image. Restore uses those pinned assets rather than the current `SandboxConfig`. Consequently, rolling out a new worker image or changing the default `runsc` version does not by itself prevent an old golden from restoring.

Compatibility can break when an upgrade changes one of the contracts around the snapshot:

- the snapshot manifest or file format;
- atelet/ateom's bundle reconstruction, mount layout, or restore flags;
- host support for the pinned runtime, such as architecture or kernel support

An old golden also continues to use its old pinned runtime. We will need to regenerate it when the runtime must move forward for a security fix or when Substrate intentionally drops the old restore contract.