### PR TITLE
fix(adk): return a retryable error from ask_user instead of raising

### DIFF
--- a/python/packages/kagent-adk/src/kagent/adk/tools/ask_user_tool.py
+++ b/python/packages/kagent-adk/src/kagent/adk/tools/ask_user_tool.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any
+from typing import Any, Final
 
 from google.adk.tools.base_tool import BaseTool
 from google.adk.tools.tool_context import ToolContext
@@ -39,6 +39,37 @@ _QUESTION_SCHEMA = types.Schema(
     },
     required=["question"],
 )
+
+
+_RETRY_HINT = (
+    ". Call ask_user again with a 'questions' array holding at least one object whose "
+    "'question' field is non-empty text, or answer the user directly without calling ask_user."
+)
+
+
+def _question_text(question: Any) -> str:
+    """The question's trimmed text, or "" when the entry cannot supply one."""
+    match question:
+        case {"question": str() as text}:
+            return text.strip()
+        case _:
+            return ""
+
+
+def _validation_error(questions: Any) -> str | None:
+    """Why `questions` is unusable, or None when every entry carries real text."""
+    match questions:
+        case list() if questions:
+            return next(
+                (
+                    f"ask_user: question {index} must contain non-whitespace text"
+                    for index, question in enumerate(questions, start=1)
+                    if not _question_text(question)
+                ),
+                None,
+            )
+        case _:
+            return "ask_user: at least one question is required"
 
 
 class AskUserTool(BaseTool):
@@ -73,7 +104,8 @@ class AskUserTool(BaseTool):
                     "questions": types.Schema(
                         type=types.Type.ARRAY,
                         items=_QUESTION_SCHEMA,
-                        description="List of questions to ask the user.",
+                        min_items=1,
+                        description="List of questions to ask the user. Must contain at least one question.",
                     ),
                 },
                 required=["questions"],
@@ -86,18 +118,19 @@ class AskUserTool(BaseTool):
         args: dict[str, Any],
         tool_context: ToolContext,
     ) -> Any:
-        questions: list[dict] = args.get("questions", [])
+        questions: Final = args.get("questions")
+        error: Final = _validation_error(questions)
 
-        if not questions:
-            raise ValueError("ask_user: at least one question is required")
-        for index, question in enumerate(questions, start=1):
-            question_text = question.get("question")
-            if not isinstance(question_text, str) or not question_text.strip():
-                raise ValueError(f"ask_user: question {index} must contain non-whitespace text")
+        # Raising here aborts the whole request: ADK re-raises tool exceptions, so the caller
+        # gets a failed task and the user is shown nothing at all. The call is still rejected,
+        # but as a response the model can act on and retry.
+        if error is not None:
+            logger.warning("%s (received %r)", error, questions)
+            return {"error": error + _RETRY_HINT}
 
         if tool_context.tool_confirmation is None:
             # First invocation — pause execution and ask the user.
-            summary = "; ".join(q["question"] for q in questions)
+            summary = "; ".join(question["question"] for question in questions)
             tool_context.request_confirmation(hint=summary)
             logger.debug("ask_user: requesting confirmation with %d question(s)", len(questions))
             return {"status": "pending", "questions": questions}

--- a/python/packages/kagent-adk/tests/unittests/test_ask_user_tool.py
+++ b/python/packages/kagent-adk/tests/unittests/test_ask_user_tool.py
@@ -37,16 +37,31 @@ from kagent.adk.tools.ask_user_tool import AskUserTool
             },
             "ask_user: question 2 must contain non-whitespace text",
         ),
+        # Previously AttributeError: the validation loop assumed every entry was a dict.
+        (
+            {"questions": ["show me active alarms"]},
+            "ask_user: question 1 must contain non-whitespace text",
+        ),
+        ({"questions": [{"choices": ["a", "b"]}]}, "ask_user: question 1 must contain non-whitespace text"),
+        ({"questions": [{"question": 42}]}, "ask_user: question 1 must contain non-whitespace text"),
+        # Previously ValueError; `questions` absent or not a list at all.
+        ({}, "ask_user: at least one question is required"),
+        ({"questions": None}, "ask_user: at least one question is required"),
+        ({"questions": "not-a-list"}, "ask_user: at least one question is required"),
     ],
 )
 async def test_rejects_invalid_questions_without_requesting_confirmation(args, expected_error):
+    """Rejected calls come back as a tool error, never as a raise.
+
+    Raising propagates out of ADK's function-call handling and fails the whole request,
+    so the caller receives an empty response instead of a retryable error.
+    """
     context = Mock(spec=ToolContext)
     context.tool_confirmation = None
 
-    with pytest.raises(ValueError) as exc_info:
-        await AskUserTool().run_async(args=args, tool_context=context)
+    result = await AskUserTool().run_async(args=args, tool_context=context)
 
-    assert str(exc_info.value) == expected_error
+    assert result["error"].startswith(expected_error)
     context.request_confirmation.assert_not_called()
 
 


### PR DESCRIPTION
## What

`ask_user` aborts the entire A2A request when the model calls it with an unusable `questions` list. The rejection is right; killing the request is not.

ADK re-raises tool exceptions (`google/adk/flows/llm_flows/functions.py:546`, when no `on_tool_error` callback returns a response), so the `ValueError` propagates out through `handle_function_call_list_async` and `_agent_executor` publishes the task as **failed**. The caller receives a well-formed `200` with no content: the user sees an empty reply, and nothing downstream logs an error.

Observed in production on `kagent/app:0.10.0` from an ordinary underspecified prompt ("show me active alarms"). The agent decided to ask a clarifying question, called `ask_user` with `questions: []`, and the turn died silently:

```
kagent_adk.kagent.adk._agent_executor - ERROR - Error handling A2A request: ask_user: at least one question is required
  File ".../google/adk/flows/llm_flows/functions.py", line 1152, in __call_tool_async
    return await tool.run_async(args=args, tool_context=tool_context)
  File ".../kagent/adk/tools/ask_user_tool.py", line 92, in run_async
    raise ValueError("ask_user: at least one question is required")
ValueError: ask_user: at least one question is required
```

That call was **schema-legal**. `_get_declaration` declared `questions` as an unconstrained array, so only the prose description forbade an empty list — `required: ["questions"]` merely forces the key to exist. Confirmed by running the OpenAI converter against the live tool; the model receives no `minItems`.

There is a second, undocumented crash mode on the same path: the per-question loop called `.get()` on every entry, so `{"questions": ["some text"]}` raised `AttributeError` and killed the request identically.

## How

- **Return instead of raise.** `run_async` now returns `{"error": ...}` — the same shape `McpTool.run_async` uses — so the model can correct itself and ask a real question. **The rejection criteria are unchanged**; only the delivery differs. `AskUserTool.is_long_running` is `False`, so an early plain-dict return is an ordinary function response.
- **Fix the `AttributeError`.** `_question_text` pattern-matches the entry shape rather than assuming a dict, so malformed entries are rejected with the existing per-question message instead of crashing.
- **Constrain the declaration.** `min_items=1` so the empty call is not expressible in the first place.

The confirmation hint still passes the model's text through **verbatim** — `test_valid_question_requests_confirmation_without_rewriting_text` covers this, and an earlier draft that trimmed via the helper broke it.

## Tests

`tests/unittests/test_ask_user_tool.py` — the existing parametrized rejection test now asserts the returned error rather than `pytest.raises`, and gains the shapes that previously crashed differently:

| Args | Before | After |
|---|---|---|
| `{"questions": []}` | `ValueError`, request dies | `{"error": ...}` |
| `{}` | `ValueError`, request dies | `{"error": ...}` |
| `{"questions": ["text"]}` | **`AttributeError`**, request dies | `{"error": ...}` |
| `{"questions": None}` / `"not-a-list"` | `AttributeError`/`ValueError` | `{"error": ...}` |
| `{"questions": [{"question": "Which subscription?"}]}` | pending | pending (unchanged) |

```
$ uv run pytest tests/unittests/test_ask_user_tool.py tests/unittests/test_hitl.py -q
36 passed

$ uv run pytest tests/unittests/ -q
418 passed, 9 failed
```

The 9 failures are all `tests/unittests/models/test_tls_e2e.py` (`FileNotFoundError` on cert fixtures) and reproduce identically on a clean checkout of this branch's base — unrelated to this change.

## Notes for reviewers

**Branch targeting.** This targets `release/v0.10.x` because that is where the validation lives. #2486 merged into this branch only — `git log -S "at least one question is required"` on `main` has no hits, and `main` still carries the tolerant original. So the branches have diverged into opposite bugs: `v0.10.x` crashes the request, `main` still pauses the UI with zero questions (#2468). A separate PR is needed for `main`; the patch there is different.

**`min_items` does not currently reach OpenAI/Ollama models.** `kagent/adk/models/_openai.py:301` and `_ollama.py:113` serialize schemas with `prop_schema.model_dump(exclude_none=True)` and no `by_alias=True`, so it emits `"min_items"` rather than the JSON Schema keyword `"minItems"` and is silently ignored. `_bedrock.py:230` already passes `by_alias=True`. Fixing that converter also corrects other aliased keys (`any_of` -> `anyOf`) across every tool schema on those adapters, and looks adjacent to #1683 — so it deserves its own PR and regression run rather than being folded in here. The graceful return in this PR is what actually stops the outage; `min_items` is belt-and-braces for adapters that honour it.

**The Go runtime** (`go/adk/pkg/tools/ask_user.go`) has the same validation but returns `(nil, error)` rather than raising. I have not verified whether its runner degrades gracefully.

Refs #2468, #2486
