### PR TITLE
fix(ui): keep chat sidebars below header

### DIFF
--- a/ui/src/components/ui/__tests__/sidebar.test.tsx
+++ b/ui/src/components/ui/__tests__/sidebar.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react"
+
+import { Sidebar, SidebarProvider } from "@/components/ui/sidebar"
+
+describe("Sidebar", () => {
+  it("positions the desktop panel within its provider", () => {
+    render(
+      <SidebarProvider data-testid="sidebar-provider">
+        <Sidebar data-testid="sidebar-panel">Sidebar content</Sidebar>
+      </SidebarProvider>
+    )
+
+    expect(screen.getByTestId("sidebar-provider")).toHaveClass("relative")
+    expect(screen.getByTestId("sidebar-panel")).toHaveClass("absolute", "h-full")
+    expect(screen.getByTestId("sidebar-panel")).not.toHaveClass("fixed", "h-svh")
+  })
+})

--- a/ui/src/components/ui/__tests__/sidebar.test.tsx
+++ b/ui/src/components/ui/__tests__/sidebar.test.tsx
@@ -10,7 +10,10 @@ describe("Sidebar", () => {
       </SidebarProvider>
     )
 
-    expect(screen.getByTestId("sidebar-provider")).toHaveClass("relative")
+    expect(screen.getByTestId("sidebar-provider")).toHaveClass(
+      "relative",
+      "overflow-hidden",
+    )
     expect(screen.getByTestId("sidebar-panel")).toHaveClass("absolute", "h-full")
     expect(screen.getByTestId("sidebar-panel")).not.toHaveClass("fixed", "h-svh")
   })

--- a/ui/src/components/ui/sidebar.tsx
+++ b/ui/src/components/ui/sidebar.tsx
@@ -147,7 +147,7 @@ const SidebarProvider = React.forwardRef<
               } as React.CSSProperties
             }
             className={cn(
-              "group/sidebar-wrapper relative flex min-h-svh w-full has-[[data-variant=inset]]:bg-sidebar",
+              "group/sidebar-wrapper relative flex min-h-svh w-full overflow-hidden has-[[data-variant=inset]]:bg-sidebar",
               className
             )}
             ref={ref}

--- a/ui/src/components/ui/sidebar.tsx
+++ b/ui/src/components/ui/sidebar.tsx
@@ -147,7 +147,7 @@ const SidebarProvider = React.forwardRef<
               } as React.CSSProperties
             }
             className={cn(
-              "group/sidebar-wrapper flex min-h-svh w-full has-[[data-variant=inset]]:bg-sidebar",
+              "group/sidebar-wrapper relative flex min-h-svh w-full has-[[data-variant=inset]]:bg-sidebar",
               className
             )}
             ref={ref}
@@ -244,7 +244,7 @@ const Sidebar = React.forwardRef<
         />
         <div
           className={cn(
-            "fixed inset-y-0 z-10 hidden h-svh w-[--sidebar-width] transition-[left,right,width] duration-200 ease-linear md:flex",
+            "absolute inset-y-0 z-10 hidden h-full w-[--sidebar-width] transition-[left,right,width] duration-200 ease-linear md:flex",
             side === "left"
               ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
               : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",


### PR DESCRIPTION
## Summary

- keep desktop chat sidebars within the chat layout instead of positioning them against the viewport
- prevent both chat sidebars from covering the global header on the 0.9.x UI
- add a regression test for the provider and desktop panel positioning contract

## Root cause

The desktop sidebar panel used `fixed inset-y-0 h-svh`, so it started at the top of the viewport while the chat layout itself starts below the global header. Its opaque background and higher stacking order covered the left side of the header, clipping the kagent wordmark.

The provider now establishes the positioning context and the panel uses `absolute inset-y-0 h-full`, keeping it within the available chat area without hard-coding the header height.

## Testing

- `npm test -- --runInBand` (25 suites, 276 tests)
- `npm run lint` (0 errors; 3 pre-existing warnings)
- `npm run build`
- `npm run test:vitest` (33 files, 134 tests)
