### PR TITLE
fix(helm): merge podLabels into bundled Postgres pod template

### DIFF
--- a/helm/kagent/templates/postgresql.yaml
+++ b/helm/kagent/templates/postgresql.yaml
@@ -48,8 +48,10 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "kagent.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: database
+        {{- /* extra pod labels: component merged over global, selector labels
+             applied last so they can never be overridden */}}
+        {{- $podLabels := mergeOverwrite (dict) (.Values.podLabels | default dict) ($pg.podLabels | default dict) (include "kagent.selectorLabels" . | fromYaml) (dict "app.kubernetes.io/component" "database") }}
+        {{- toYaml $podLabels | nindent 8 }}
     spec:
       {{- include "kagent.imagePullSecrets" $ | nindent 6 }}
       serviceAccountName: {{ $fullname }}

--- a/helm/kagent/tests/pod-labels_test.yaml
+++ b/helm/kagent/tests/pod-labels_test.yaml
@@ -1,7 +1,8 @@
-suite: test controller and UI pod labels
+suite: test controller, UI, and bundled Postgres pod labels
 templates:
   - controller-deployment.yaml
   - controller-configmap.yaml
+  - postgresql.yaml
   - postgresql-secret.yaml
   - ui-deployment.yaml
   - ui-nginx-configmap.yaml
@@ -92,3 +93,71 @@ tests:
       - equal:
           path: spec.template.metadata.labels["app.kubernetes.io/name"]
           value: kagent
+
+  - it: should not add extra pod labels by default (bundled postgres)
+    template: postgresql.yaml
+    asserts:
+      - documentIndex: 2
+        notExists:
+          path: spec.template.metadata.labels.team
+
+  - it: should merge global podLabels into the bundled postgres pod template
+    template: postgresql.yaml
+    set:
+      podLabels:
+        team: platform
+        cost-center: ai
+    asserts:
+      - documentIndex: 2
+        equal:
+          path: spec.template.metadata.labels.team
+          value: platform
+      - documentIndex: 2
+        equal:
+          path: spec.template.metadata.labels["cost-center"]
+          value: ai
+      # selector labels and component label must remain intact
+      - documentIndex: 2
+        equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: kagent
+      - documentIndex: 2
+        equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: database
+
+  - it: should let database.postgres.bundled.podLabels override the global podLabels
+    template: postgresql.yaml
+    set:
+      podLabels:
+        team: platform
+      database:
+        postgres:
+          bundled:
+            podLabels:
+              team: postgres-team
+    asserts:
+      - documentIndex: 2
+        equal:
+          path: spec.template.metadata.labels.team
+          value: postgres-team
+
+  - it: should not allow podLabels to override bundled postgres selector or component labels
+    template: postgresql.yaml
+    set:
+      podLabels:
+        app.kubernetes.io/name: hijacked
+      database:
+        postgres:
+          bundled:
+            podLabels:
+              app.kubernetes.io/component: hijacked
+    asserts:
+      - documentIndex: 2
+        equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: kagent
+      - documentIndex: 2
+        equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: database

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -149,6 +149,11 @@ database:
           drop:
             - ALL
 
+      # -- Additional labels for the bundled PostgreSQL pod template, merged over the
+      # global `podLabels` (per-key; component keys win). Selector labels can
+      # never be overridden.
+      podLabels: {}
+
 # ==============================================================================
 # RBAC CONFIGURATION
 # ==============================================================================


### PR DESCRIPTION
## Summary
- The bundled Postgres Deployment (`templates/postgresql.yaml`) hardcoded its pod template labels with no values hook, unlike the controller/UI Deployments which already merge `.Values.podLabels` and a per-component override.
- Adds `database.postgres.bundled.podLabels`, merged with the same precedence used for the controller/UI: global `podLabels` < component `podLabels` < selector/component labels (which can never be overridden).

## Why
Admission policies requiring specific labels on all Pods (e.g. OPA Gatekeeper's `required-labels` constraint) could never allow the bundled Postgres Deployment, even when `podLabels` satisfied the policy for every other kagent resource.

Fixes #2748

## Test plan
- [x] `helm unittest` — extended `tests/pod-labels_test.yaml` with cases mirroring the existing controller/UI coverage (default, global merge, component override, selector/component-label protection)
- [x] Verified rendered output via `helm template` for the bundled Postgres Deployment with/without `podLabels` set