### PR TITLE
fix(substrate): render BYO extraContainers in the SandboxAgent ActorTemplate

### DIFF
--- a/go/core/pkg/sandboxbackend/substrate/agent_lifecycle.go
+++ b/go/core/pkg/sandboxbackend/substrate/agent_lifecycle.go
@@ -106,6 +106,11 @@ func (p *Lifecycle) buildSandboxAgentActorTemplate(
 			OnCommit: atev1alpha1.SnapshotScopeFull,
 		},
 	}
+	extraContainers, err := actorTemplateExtraContainers(podTemplate.Spec.Containers, kagentContainer)
+	if err != nil {
+		return nil, err
+	}
+	spec.Containers = append(spec.Containers, extraContainers...)
 	applyDurableDirSessionStore(&spec)
 
 	actorTemplateHash, err := actorTemplateShapeHash(spec)
@@ -186,6 +191,56 @@ func findKagentContainer(containers []corev1.Container) *corev1.Container {
 		return &containers[0]
 	}
 	return nil
+}
+
+// actorTemplateExtraContainers converts the pod template's extra containers —
+// every container except the agent's own, which buildSandboxAgentActorTemplate
+// renders explicitly — into ActorTemplate containers, preserving order. The
+// agent pointer must come from findKagentContainer on the same slice, so it
+// can be identified by identity.
+//
+// An ActorTemplate container is a restricted pod container: the image must be
+// digest-pinned (snapshots key on it), the command is copied verbatim into the
+// OCI Process.Args with no shell and no image-entrypoint fallback, env supports
+// literal values and secretKeyRef only, and there are no ports, resources,
+// envFrom, probes, or volume sources. Constructs the ActorTemplate cannot
+// express fail the build loudly instead of being silently dropped — a sidecar
+// whose credential source or mount vanished mid-flight is worse than a
+// rejected apply.
+func actorTemplateExtraContainers(containers []corev1.Container, agent *corev1.Container) ([]atev1alpha1.Container, error) {
+	var out []atev1alpha1.Container
+	for i := range containers {
+		c := &containers[i]
+		if c == agent {
+			continue
+		}
+		image, err := pinImageRef(c.Image)
+		if err != nil {
+			return nil, fmt.Errorf("extra container %q: %w", c.Name, err)
+		}
+		command := append(append([]string{}, c.Command...), c.Args...)
+		if len(command) == 0 {
+			return nil, fmt.Errorf("extra container %q must set command and/or args: substrate runs the command verbatim with no image entrypoint fallback", c.Name)
+		}
+		if len(c.EnvFrom) > 0 {
+			return nil, fmt.Errorf("extra container %q uses envFrom, which ActorTemplates do not support", c.Name)
+		}
+		for _, e := range c.Env {
+			if e.Value == "" && e.ValueFrom != nil && e.ValueFrom.SecretKeyRef == nil {
+				return nil, fmt.Errorf("extra container %q env %q: ActorTemplates support literal values and secretKeyRef only", c.Name, e.Name)
+			}
+		}
+		if len(c.VolumeMounts) > 0 {
+			return nil, fmt.Errorf("extra container %q mounts volumes, which ActorTemplates do not support (the only mount is the agent's durableDir session store)", c.Name)
+		}
+		out = append(out, atev1alpha1.Container{
+			Name:    c.Name,
+			Image:   image,
+			Command: command,
+			Env:     actorTemplateEnvFromPodEnv(c.Env),
+		})
+	}
+	return out, nil
 }
 
 // buildSubstrateKagentContainerCommand returns the ActorTemplate command and the prepended

--- a/go/core/pkg/sandboxbackend/substrate/agent_lifecycle_test.go
+++ b/go/core/pkg/sandboxbackend/substrate/agent_lifecycle_test.go
@@ -326,3 +326,118 @@ func TestBuildSandboxAgentActorTemplateDurableDirSessions(t *testing.T) {
 		})
 	}
 }
+
+// TestBuildSandboxAgentActorTemplateExtraContainers covers the BYO extraContainers
+// translation: the pod template's non-agent containers ride along as ActorTemplate
+// containers (credential-brokering sidecars etc.), with the ActorTemplate's
+// restricted container surface enforced loudly instead of silently dropped.
+func TestBuildSandboxAgentActorTemplateExtraContainers(t *testing.T) {
+	t.Parallel()
+
+	const (
+		pinnedImage  = "registry.example/kagent-dev/kagent/app@sha256:1111111111111111111111111111111111111111111111111111111111111111"
+		sidecarImage = "registry.example/example/credential-proxy@sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	)
+	cmd := "/serve"
+	wpKey := types.NamespacedName{Namespace: "kagent", Name: "kagent-default"}
+	sa := &v1alpha2.SandboxAgent{
+		ObjectMeta: metav1.ObjectMeta{Name: "byo-agent", Namespace: "kagent"},
+		Spec: v1alpha2.SandboxAgentSpec{
+			AgentSpec: v1alpha2.AgentSpec{Type: v1alpha2.AgentType_BYO, BYO: &v1alpha2.BYOAgentSpec{Deployment: &v1alpha2.ByoDeploymentSpec{Image: pinnedImage, Cmd: &cmd}}},
+		},
+	}
+	sidecar := corev1.Container{
+		Name:    "credential-proxy",
+		Image:   sidecarImage,
+		Command: []string{"/sidecar"},
+		Args:    []string{"--listen", "127.0.0.1:14322"},
+		Env: []corev1.EnvVar{
+			{Name: "PROXY_LISTEN_ADDR", Value: "127.0.0.1:14322"},
+			{
+				Name: "PROXY_SECRET_TOKEN",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "creds"},
+						Key:                  "token",
+					},
+				},
+			},
+		},
+	}
+	agent := corev1.Container{Name: defaultKagentContainer, Image: pinnedImage, Command: []string{"/serve"}}
+	podTemplate := corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: []corev1.Container{agent, sidecar}}}
+
+	t.Run("converted", func(t *testing.T) {
+		p := newTestLifecycle(t)
+		tmpl, err := p.buildSandboxAgentActorTemplate(sa, wpKey, podTemplate)
+		require.NoError(t, err)
+		require.Len(t, tmpl.Spec.Containers, 2)
+
+		// The agent container stays first: applyDurableDirSessionStore targets it.
+		require.Equal(t, defaultKagentContainer, tmpl.Spec.Containers[0].Name)
+		require.Equal(t, durableDataVolume, tmpl.Spec.Containers[0].VolumeMounts[0].Name)
+
+		extra := tmpl.Spec.Containers[1]
+		require.Equal(t, "credential-proxy", extra.Name)
+		require.Equal(t, sidecarImage, extra.Image)
+		require.Equal(t, []string{"/sidecar", "--listen", "127.0.0.1:14322"}, extra.Command)
+		require.Len(t, extra.Env, 2)
+		require.Equal(t, "PROXY_LISTEN_ADDR", extra.Env[0].Name)
+		require.NotNil(t, extra.Env[0].Value)
+		require.Equal(t, "PROXY_SECRET_TOKEN", extra.Env[1].Name)
+		require.NotNil(t, extra.Env[1].ValueFrom.SecretKeyRef)
+		require.Equal(t, "creds", extra.Env[1].ValueFrom.SecretKeyRef.Name)
+		require.Empty(t, extra.VolumeMounts, "the durableDir session store is the agent container's alone")
+	})
+
+	for _, tc := range []struct {
+		name    string
+		mutate  func(*corev1.Container)
+		errText string
+	}{
+		{
+			name:    "unpinned image",
+			mutate:  func(c *corev1.Container) { c.Image = "registry.example/example/credential-proxy:latest" },
+			errText: "must be pinned",
+		},
+		{
+			name:    "no command and no args",
+			mutate:  func(c *corev1.Container) { c.Command, c.Args = nil, nil },
+			errText: "no image entrypoint fallback",
+		},
+		{
+			name: "envFrom",
+			mutate: func(c *corev1.Container) {
+				c.EnvFrom = []corev1.EnvFromSource{{SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "creds"}}}}
+			},
+			errText: "envFrom",
+		},
+		{
+			name: "fieldRef env",
+			mutate: func(c *corev1.Container) {
+				c.Env = append(c.Env, corev1.EnvVar{
+					Name:      "POD_NAME",
+					ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"}},
+				})
+			},
+			errText: "secretKeyRef only",
+		},
+		{
+			name: "volumeMounts",
+			mutate: func(c *corev1.Container) {
+				c.VolumeMounts = []corev1.VolumeMount{{Name: "config", MountPath: "/config"}}
+			},
+			errText: "mounts volumes",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bad := sidecar
+			tc.mutate(&bad)
+			pod := corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: []corev1.Container{agent, bad}}}
+			p := newTestLifecycle(t)
+			_, err := p.buildSandboxAgentActorTemplate(sa, wpKey, pod)
+			require.Error(t, err)
+			require.ErrorContains(t, err, tc.errText)
+		})
+	}
+}


### PR DESCRIPTION
## Problem

A BYO SandboxAgent that sets `spec.byo.deployment.extraContainers` gets them rendered into its pod template (the translator appends them after the kagent container, `manifest_builder.go`), and they work fine on the plain Deployment path. On substrate, however, `buildSandboxAgentActorTemplate` picks out only the kagent container via `findKagentContainer` and constructs a **one-element** `Containers` slice — every extra container is silently dropped. The SandboxAgent CRD accepts them, the ActorTemplate CRD supports up to ten containers with per-container env, so nothing fails; the sidecars are just gone at runtime.

Concrete case we hit: an agent plus a credential-brokering proxy sidecar (loopback forward proxy injecting a `secretKeyRef`-sourced bearer). On substrate the proxy never starts, and since the agent is configured to route egress through `127.0.0.1` it loses all outbound API access.

## Fix

Render the pod template's remaining containers as additional ActorTemplate containers (`actorTemplateExtraContainers`), preserving order after the agent container:

- The ActorTemplate container surface is restricted, so unsupported constructs **fail the build loudly** instead of being silently dropped:
  - image must be digest-pinned (reuses `pinImageRef`; snapshots key on the image)
  - command must be explicit — command + args are concatenated, since atelet copies `Command` verbatim into the OCI Process.Args with no shell and no image-entrypoint fallback
  - env supports literal values and `secretKeyRef` only; `envFrom`, `fieldRef`/`configMapKeyRef` env sources, and `volumeMounts` are rejected with a named-container error
  - resources, ports, and probes have no ActorTemplate equivalent and are ignored (documented on the helper)
- The agent container stays `Containers[0]`, so the durableDir session-store mount (`applyDurableDirSessionStore`) remains agent-private.
- The extra containers feed `actorTemplateShapeHash`, so changes to them fan out blue-green to a new template + actors, same as any other spec change.

## Testing

- `TestBuildSandboxAgentActorTemplateExtraContainers`: happy-path conversion (command/args concat, literal + secretKeyRef env, agent stays first with the durableDir mount, sidecar gets no mounts) plus rejection cases for unpinned image, missing command, `envFrom`, `fieldRef` env, and `volumeMounts`.
- Full `go test ./core/pkg/sandboxbackend/...` green; `go vet` clean.

Scoped to the SandboxAgent path; the AgentHarness substrate path has no extra-container field today, so it is untouched. Targeting `release/v0.10.x` since that is the line that carries the substrate backend; happy to rebase onto `main` if preferred (the sandbox backend was restructured there).