### PR TITLE
fix(adk): Python agents HITL resume and align memory API

### DIFF
--- a/python/packages/kagent-adk/src/kagent/adk/_agent_executor.py
+++ b/python/packages/kagent-adk/src/kagent/adk/_agent_executor.py
@@ -600,8 +600,17 @@ class A2aAgentExecutor(UpstreamA2aAgentExecutor):
                 subagent_session_ids[tool.name] = tool.subagent_session_id
 
         task_result_aggregator = TaskResultAggregator()
+        awaiting_confirmation_response = False
         async with Aclosing(runner.run_async(**run_args)) as agen:
             async for adk_event in agen:
+                # ADK yields the confirmation prompt before the tool response
+                # carrying requested_tool_confirmations. The runner persists
+                # that response before yielding it; ADK needs it to validate a
+                # dynamic confirmation on resume. Stop here, before another
+                # model call, and keep the prompt as the A2A input_required message.
+                if awaiting_confirmation_response and adk_event.actions.requested_tool_confirmations:
+                    break
+
                 # Capture the real invocation_id from the first ADK event that has one
                 event_inv_id = getattr(adk_event, "invocation_id", None)
                 if event_inv_id and not real_invocation_id:
@@ -627,9 +636,14 @@ class A2aAgentExecutor(UpstreamA2aAgentExecutor):
                         task_result_aggregator.process_event(a2a_event)
                     await event_queue.enqueue_event(a2a_event)
 
-                # Break on confirmation events that use long running tools
+                # Confirmation requests must drain their following tool response.
+                # Other long-running tools retain the immediate pause behavior.
                 if getattr(adk_event, "long_running_tool_ids", None):
-                    break
+                    awaiting_confirmation_response = any(
+                        fc.name == REQUEST_CONFIRMATION_FUNCTION_CALL_NAME for fc in adk_event.get_function_calls()
+                    )
+                    if not awaiting_confirmation_response:
+                        break
 
         # Attach the last LLM usage to run_metadata so the A2A task_manager
         # merges it into task.metadata on the completed Task object.

--- a/python/packages/kagent-adk/src/kagent/adk/_memory_service.py
+++ b/python/packages/kagent-adk/src/kagent/adk/_memory_service.py
@@ -3,7 +3,7 @@
 import asyncio
 import json
 import logging
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Union, cast
 
 import httpx
 from google.adk.memory import BaseMemoryService
@@ -135,50 +135,55 @@ class KagentMemoryService(BaseMemoryService):
         *,
         app_name: str,
         user_id: str,
-        content: str,
-        metadata: Optional[Dict[str, Any]] = None,
+        memories: Sequence[MemoryEntry],
+        custom_metadata: Optional[Mapping[str, object]] = None,
     ) -> None:
-        """Add a specific text content to memory.
+        """Add explicit memory entries to Kagent's text memory store.
 
         Args:
             app_name: The application name
             user_id: The user ID
-            content: The text content to save
-            metadata: Optional additional metadata
+            memories: Memory entries to save
+            custom_metadata: Metadata shared by every memory entry
         """
-        if not content:
+        entries_with_text = [
+            (memory, "\n".join(part.text for part in memory.content.parts or [] if part.text)) for memory in memories
+        ]
+        entries_with_text = [(memory, text) for memory, text in entries_with_text if text]
+        if not entries_with_text:
             return
 
-        logger.debug("Adding specific content to memory for user %s", user_id)
+        logger.debug("Adding %d explicit memory items for user %s", len(entries_with_text), user_id)
 
-        # Generate embedding
         if not self._embedding_client:
             logger.warning("No embedding client available")
             return
-        vector = await self._embedding_client.generate(content)
-        if not vector:
-            logger.warning("Failed to generate embedding for memory content")
+
+        contents = [text for _, text in entries_with_text]
+        generated_vectors = await self._embedding_client.generate(contents)
+        vectors = cast(List[List[float]], generated_vectors)
+        if not vectors or len(vectors) != len(entries_with_text):
+            logger.warning("Failed to generate embeddings for explicit memories")
             return
 
-        # Send to Kagent API
-        payload: Dict[str, Any] = {
-            "agent_name": self.agent_name,
-            "user_id": user_id,
-            "content": content,
-            "vector": vector,
-        }
-        if self.ttl_days > 0:
-            payload["ttl_days"] = self.ttl_days
+        for (memory, content), vector in zip(entries_with_text, vectors, strict=True):
+            metadata = dict(custom_metadata or {})
+            metadata.update(memory.custom_metadata)
+            payload: Dict[str, Any] = {
+                "agent_name": self.agent_name,
+                "user_id": user_id,
+                "content": content,
+                "vector": vector,
+                "metadata": metadata,
+            }
+            if self.ttl_days > 0:
+                payload["ttl_days"] = self.ttl_days
 
-        try:
             response = await self.client.post("/api/memories/sessions", json=payload)
             if response.status_code >= 400:
                 logger.error("Response body: %s", response.text)
             response.raise_for_status()
-            memory_id = response.json().get("id")
-            logger.info("Successfully saved memory item (id=%s)", memory_id)
-        except Exception as e:
-            logger.error("Failed to save memory: %s", e)
+            logger.info("Successfully saved memory item (id=%s)", response.json().get("id"))
 
     async def search_memory(
         self,

--- a/python/packages/kagent-adk/src/kagent/adk/models/_bedrock.py
+++ b/python/packages/kagent-adk/src/kagent/adk/models/_bedrock.py
@@ -18,9 +18,9 @@ from typing import TYPE_CHECKING, Any, AsyncGenerator, Optional
 import boto3
 from botocore.config import Config as BotocoreConfig
 from google.adk.models import BaseLlm
-from pydantic import Field
 from google.adk.models.llm_response import LlmResponse
 from google.genai import types
+from pydantic import Field
 
 from ._ssl import KAgentTLSMixin
 

--- a/python/packages/kagent-adk/src/kagent/adk/tools/memory_tools.py
+++ b/python/packages/kagent-adk/src/kagent/adk/tools/memory_tools.py
@@ -6,6 +6,7 @@ import json
 import logging
 from typing import Any, Dict, List, Optional
 
+from google.adk.memory.memory_entry import MemoryEntry
 from google.adk.tools import BaseTool, ToolContext
 from google.genai import types
 
@@ -77,8 +78,12 @@ class SaveMemoryTool(BaseTool):
             await memory_service.add_memory(
                 app_name=tool_context.session.app_name,
                 user_id=tool_context.session.user_id,
-                content=content,
-                metadata={"session_id": tool_context.session.id, "source": "explicit_save"},
+                memories=[
+                    MemoryEntry(
+                        content=types.Content(role="user", parts=[types.Part(text=content)]),
+                        custom_metadata={"session_id": tool_context.session.id, "source": "explicit_save"},
+                    )
+                ],
             )
             return "Successfully saved information to long-term memory."
 

--- a/python/packages/kagent-adk/tests/unittests/test_hitl_resume.py
+++ b/python/packages/kagent-adk/tests/unittests/test_hitl_resume.py
@@ -1,0 +1,184 @@
+"""Exercise HITL pause/resume through the real ADK runner and serialized sessions."""
+
+import json
+from collections.abc import AsyncGenerator
+
+import httpx
+import pytest
+from a2a.server.agent_execution.context import RequestContext
+from a2a.server.context import ServerCallContext
+from a2a.server.events.event_queue import EventQueue
+from a2a.types import DataPart, Message, MessageSendParams, Part, Role, TaskState, TaskStatusUpdateEvent, TextPart
+from google.adk.agents import Agent
+from google.adk.agents.run_config import RunConfig, StreamingMode
+from google.adk.models.base_llm import BaseLlm
+from google.adk.models.llm_request import LlmRequest
+from google.adk.models.llm_response import LlmResponse
+from google.adk.runners import Runner
+from google.adk.tools.function_tool import FunctionTool
+from google.adk.tools.long_running_tool import LongRunningFunctionTool
+from google.genai import types
+from kagent.core.a2a import (
+    KAGENT_ASK_USER_ANSWERS_KEY,
+    KAGENT_HITL_DECISION_TYPE_APPROVE,
+    KAGENT_HITL_DECISION_TYPE_KEY,
+    KAGENT_HITL_DECISION_TYPE_REJECT,
+)
+from pydantic import Field
+
+from kagent.adk._agent_executor import A2aAgentExecutor
+from kagent.adk._approval import make_approval_callback
+from kagent.adk._session_service import KAgentSessionService
+from kagent.adk.tools.ask_user_tool import AskUserTool
+
+
+class ToolCallingModel(BaseLlm):
+    model: str = "test-model"
+    calls: list[types.FunctionCall]
+    requests: list[LlmRequest] = Field(default_factory=list)
+
+    async def generate_content_async(
+        self, llm_request: LlmRequest, stream: bool = False
+    ) -> AsyncGenerator[LlmResponse, None]:
+        self.requests.append(llm_request.model_copy(deep=True))
+        parts = (
+            [types.Part(function_call=call) for call in self.calls]
+            if len(self.requests) == 1
+            else [types.Part(text="Finished")]
+        )
+        yield LlmResponse(content=types.Content(role="model", parts=parts))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.parametrize("case", ["ask_user", "approve", "reject", "parallel", "long_running"])
+async def test_confirmation_survives_pause_and_session_reload(case, stream):
+    # Mock the controller HTTP boundary, retaining only JSON between requests.
+    # Every get_session therefore reconstructs ADK events just as production does.
+    saved_events: list[dict] = []
+    session_data = {"id": "session", "user_id": "user"}
+
+    def controller(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path.endswith("/events"):
+            saved_events.append(json.loads(request.content))
+            return httpx.Response(200, json={"data": {}})
+        assert request.method == "GET"
+        return httpx.Response(200, json={"data": {"session": session_data, "events": saved_events}})
+
+    executed: list[str] = []
+
+    def delete_file(path: str) -> str:
+        """Delete a file after user approval."""
+        executed.append(path)
+        return "Deleted " + path
+
+    if case == "ask_user":
+        calls = [types.FunctionCall(id="ask", name="ask_user", args={"questions": [{"question": "Which database?"}]})]
+    else:
+        calls = [types.FunctionCall(id="delete-1", name="delete_file", args={"path": "one"})]
+        if case == "parallel":
+            calls.append(types.FunctionCall(id="delete-2", name="delete_file", args={"path": "two"}))
+    model = ToolCallingModel(calls=calls)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(controller), base_url="http://controller") as client:
+
+        def make_runner():
+            return Runner(
+                app_name="test-app",
+                agent=Agent(
+                    name="agent",
+                    model=model,
+                    tools=[
+                        AskUserTool(),
+                        LongRunningFunctionTool(delete_file) if case == "long_running" else FunctionTool(delete_file),
+                    ],
+                    before_tool_callback=None if case == "long_running" else make_approval_callback({"delete_file"}),
+                ),
+                session_service=KAgentSessionService(client),
+            )
+
+        executor = A2aAgentExecutor(runner=make_runner)
+
+        async def invoke(part: Part):
+            message = Message(role=Role.user, message_id="message", parts=[part])
+            context = RequestContext(
+                request=MessageSendParams(message=message),
+                task_id="task",
+                context_id="session",
+                call_context=ServerCallContext(state={}),
+            )
+            queue = EventQueue()
+            runner = make_runner()
+            try:
+                await executor._handle_request(
+                    context,
+                    queue,
+                    runner,
+                    {
+                        "user_id": "user",
+                        "session_id": "session",
+                        "new_message": types.Content(role="user", parts=[types.Part(text="Run the tool")]),
+                        "run_config": RunConfig(streaming_mode=StreamingMode.SSE if stream else StreamingMode.NONE),
+                    },
+                )
+            finally:
+                await runner.close()
+            events = []
+            while not queue.queue.empty():
+                events.append(await queue.dequeue_event())
+            return events
+
+        paused = await invoke(Part(TextPart(text="Run the tool")))
+        assert isinstance(paused[-1], TaskStatusUpdateEvent)
+        assert paused[-1].final
+        assert paused[-1].status.state == TaskState.input_required
+        assert paused[-1].status.message is not None
+        assert executed == []
+        assert len(model.requests) == 1, "The model must not run again before the user responds"
+
+        session = await KAgentSessionService(client).get_session(
+            app_name="test-app", user_id="user", session_id="session"
+        )
+        assert session is not None
+        requested_ids = {
+            response.id
+            for event in session.events
+            for response in event.get_function_responses()
+            if response.id in event.actions.requested_tool_confirmations
+        }
+        if case == "long_running":
+            # Ordinary long-running calls still pause immediately, without
+            # executing the tool or waiting for a confirmation response.
+            assert requested_ids == set()
+            return
+        assert requested_ids == {call.id for call in calls}
+
+        decision = {
+            KAGENT_HITL_DECISION_TYPE_KEY: (
+                KAGENT_HITL_DECISION_TYPE_REJECT if case == "reject" else KAGENT_HITL_DECISION_TYPE_APPROVE
+            )
+        }
+        if case == "ask_user":
+            decision[KAGENT_ASK_USER_ANSWERS_KEY] = [{"answer": ["PostgreSQL"]}]
+        resumed = await invoke(Part(DataPart(data=decision)))
+        assert isinstance(resumed[-1], TaskStatusUpdateEvent)
+        assert resumed[-1].final
+        assert resumed[-1].status.state == TaskState.completed
+        assert len(model.requests) == 2
+        assert executed == ([] if case in ("ask_user", "reject") else [call.args["path"] for call in calls])
+        responses = [
+            part.function_response
+            for content in model.requests[-1].contents
+            for part in content.parts or []
+            if part.function_response and part.function_response.name == calls[0].name
+        ]
+        if case == "ask_user":
+            assert json.loads(responses[-1].response["result"]) == [
+                {"question": "Which database?", "answer": ["PostgreSQL"]}
+            ]
+        elif case == "reject":
+            assert responses[-1].response == {"result": "Tool call was rejected by user."}
+        else:
+            assert {response.response["result"] for response in responses} >= {
+                "Deleted " + call.args["path"] for call in calls
+            }

--- a/python/packages/kagent-adk/tests/unittests/test_memory_tools.py
+++ b/python/packages/kagent-adk/tests/unittests/test_memory_tools.py
@@ -1,0 +1,107 @@
+import json
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from google.adk.memory.memory_entry import MemoryEntry
+from google.adk.tools import ToolContext
+from google.genai import types
+
+from kagent.adk._memory_service import KagentMemoryService
+from kagent.adk.tools.memory_tools import SaveMemoryTool
+
+
+@pytest.mark.asyncio
+async def test_add_memory_stores_adk_memory_entries_with_metadata():
+    requests: list[dict] = []
+
+    def controller(request: httpx.Request) -> httpx.Response:
+        requests.append(json.loads(request.content))
+        return httpx.Response(201, json={"id": f"memory-{len(requests)}"})
+
+    embedding_client = SimpleNamespace(
+        generate=AsyncMock(return_value=[[0.1, 0.2], [0.3, 0.4]]),
+    )
+    memories = [
+        MemoryEntry(
+            content=types.Content(role="user", parts=[types.Part(text="first memory")]),
+            custom_metadata={"scope": "entry", "shared": "entry wins"},
+        ),
+        MemoryEntry(
+            content=types.Content(role="user", parts=[types.Part(text="second"), types.Part(text="memory")]),
+        ),
+    ]
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(controller), base_url="http://controller") as client:
+        service = KagentMemoryService(agent_name="agent", http_client=client, ttl_days=7)
+        service._embedding_client = embedding_client
+        await service.add_memory(
+            app_name="app",
+            user_id="user",
+            memories=memories,
+            custom_metadata={"shared": "default"},
+        )
+
+    embedding_client.generate.assert_awaited_once_with(["first memory", "second\nmemory"])
+    assert requests == [
+        {
+            "agent_name": "agent",
+            "user_id": "user",
+            "content": "first memory",
+            "vector": [0.1, 0.2],
+            "metadata": {"shared": "entry wins", "scope": "entry"},
+            "ttl_days": 7,
+        },
+        {
+            "agent_name": "agent",
+            "user_id": "user",
+            "content": "second\nmemory",
+            "vector": [0.3, 0.4],
+            "metadata": {"shared": "default"},
+            "ttl_days": 7,
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_add_memory_propagates_storage_errors():
+    def controller(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="storage unavailable")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(controller), base_url="http://controller") as client:
+        service = KagentMemoryService(agent_name="agent", http_client=client)
+        service._embedding_client = SimpleNamespace(generate=AsyncMock(return_value=[[0.1, 0.2]]))
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await service.add_memory(
+                app_name="app",
+                user_id="user",
+                memories=[MemoryEntry(content=types.Content(role="user", parts=[types.Part(text="remember")]))],
+            )
+
+
+@pytest.mark.asyncio
+async def test_save_memory_tool_uses_adk_memory_service_interface():
+    memory_service = SimpleNamespace(add_memory=AsyncMock())
+    context = cast(
+        ToolContext,
+        SimpleNamespace(
+            _invocation_context=SimpleNamespace(memory_service=memory_service),
+            session=SimpleNamespace(id="session", app_name="app", user_id="user"),
+        ),
+    )
+
+    result = await SaveMemoryTool().run_async(args={"content": "remember this"}, tool_context=context)
+
+    assert result == "Successfully saved information to long-term memory."
+    memory_service.add_memory.assert_awaited_once()
+    call = memory_service.add_memory.await_args
+    assert call.kwargs["app_name"] == "app"
+    assert call.kwargs["user_id"] == "user"
+    assert "custom_metadata" not in call.kwargs
+    memories = call.kwargs["memories"]
+    assert len(memories) == 1
+    assert memories[0].content.parts[0].text == "remember this"
+    assert memories[0].custom_metadata == {"session_id": "session", "source": "explicit_save"}


### PR DESCRIPTION
Fixes #2731 

Google ADK 1.38 (bumped in #2558) validates that dynamically confirmed tools recorded their confirmation request in session history. The Python executor stopped before that event was persisted, causing every `ask_user` response and tool approval to fail on resume.

This change preserves the confirmation response before pausing, and also updates the memory service to the current Google ADK interface.

**This change is only applicable to `release/v0.10.x` branch. `main` already uses upstream executor which handles HITL pause properly.** This also does not affect Go agents, since go-adk does not have the above validation