### PR TITLE
fix(adk): map cached and reasoning tokens in Responses usage

### DIFF
--- a/go/adk/pkg/models/openai_responses.go
+++ b/go/adk/pkg/models/openai_responses.go
@@ -343,8 +343,10 @@ func responsesUsageToGenai(u responses.ResponseUsage) *genai.GenerateContentResp
 		return nil
 	}
 	return &genai.GenerateContentResponseUsageMetadata{
-		PromptTokenCount:     int32(u.InputTokens),
-		CandidatesTokenCount: int32(u.OutputTokens),
+		PromptTokenCount:        int32(u.InputTokens),
+		CandidatesTokenCount:    int32(u.OutputTokens),
+		CachedContentTokenCount: int32(u.InputTokensDetails.CachedTokens),
+		ThoughtsTokenCount:      int32(u.OutputTokensDetails.ReasoningTokens),
 	}
 }
 

--- a/go/adk/pkg/models/openai_responses_test.go
+++ b/go/adk/pkg/models/openai_responses_test.go
@@ -267,3 +267,41 @@ func TestGenaiContentsToResponsesInput_Image(t *testing.T) {
 		t.Fatalf("marshaled message missing image: %s", b)
 	}
 }
+
+func TestResponsesUsageToGenai(t *testing.T) {
+	t.Run("nil when no tokens", func(t *testing.T) {
+		if got := responsesUsageToGenai(responses.ResponseUsage{}); got != nil {
+			t.Fatalf("expected nil for empty usage, got %+v", got)
+		}
+	})
+
+	t.Run("maps input, output, cached and reasoning tokens", func(t *testing.T) {
+		usage := responses.ResponseUsage{
+			InputTokens:  100,
+			OutputTokens: 50,
+			InputTokensDetails: responses.ResponseUsageInputTokensDetails{
+				CachedTokens: 80,
+			},
+			OutputTokensDetails: responses.ResponseUsageOutputTokensDetails{
+				ReasoningTokens: 30,
+			},
+		}
+
+		got := responsesUsageToGenai(usage)
+		if got == nil {
+			t.Fatal("expected non-nil usage metadata")
+		}
+		if got.PromptTokenCount != 100 {
+			t.Errorf("PromptTokenCount = %d, want 100", got.PromptTokenCount)
+		}
+		if got.CandidatesTokenCount != 50 {
+			t.Errorf("CandidatesTokenCount = %d, want 50", got.CandidatesTokenCount)
+		}
+		if got.CachedContentTokenCount != 80 {
+			t.Errorf("CachedContentTokenCount = %d, want 80", got.CachedContentTokenCount)
+		}
+		if got.ThoughtsTokenCount != 30 {
+			t.Errorf("ThoughtsTokenCount = %d, want 30", got.ThoughtsTokenCount)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

`responsesUsageToGenai` in `go/adk/pkg/models/openai_responses.go` only mapped input and output tokens, silently dropping `InputTokensDetails.CachedTokens` and `OutputTokensDetails.ReasoningTokens` from the OpenAI Responses API usage.

As a result, **cached-prompt and reasoning token counts were always reported as zero** in the emitted GenAI usage metadata and in downstream OTel/Langfuse telemetry — overstating cost and hiding prompt-cache savings.

Notably, the ADK telemetry layer already emits `gen_ai.usage.cache_read.input_tokens` and `gen_ai.usage.reasoning.output_tokens` from `CachedContentTokenCount` / `ThoughtsTokenCount`, so those attributes were being exported as `0` purely because this mapping never populated the fields.

This function is used by both the streaming and non-streaming Responses paths.

## Fix

Map the two detail fields into `CachedContentTokenCount` and `ThoughtsTokenCount`, mirroring the upstream `google.golang.org/adk` `openaimodel.convertUsage` behavior:

```go
CachedContentTokenCount: int32(u.InputTokensDetails.CachedTokens),
ThoughtsTokenCount:      int32(u.OutputTokensDetails.ReasoningTokens),
```

## Evidence

Verified against an OpenAI-Responses-compatible gateway that the API returns non-zero details:
- Repeated prompt → `usage.input_tokens_details.cached_tokens` > 0 (prompt caching active).
- `reasoning: { effort: high }` → `usage.output_tokens_details.reasoning_tokens` > 0.

Before this fix both surfaced as `0` in usage metadata / Langfuse; after, they flow through correctly.

## Testing

Added `TestResponsesUsageToGenai` covering the nil-usage case and the input/output/cached/reasoning mapping.

```
go test ./adk/pkg/models/ -run TestResponsesUsageToGenai -v
--- PASS: TestResponsesUsageToGenai
```
