### PR TITLE
fix: discover Kubernetes issuer for kubectl-ate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,7 +101,8 @@ jobs:
           ./kubectl-ate --context kind-kagent admin make-ca-pool --ca-id=1 --name=actor-id-ca-pool --secret-namespace=ate-system
           actor_id_ca_root="$(kubectl get secret actor-id-ca-pool -n ate-system -o jsonpath='{.data.pool}' | base64 --decode | jq -r '.CAs[0].RootCertificateDER' | base64 --decode | openssl x509 -inform der -outform pem)"
           kubectl create secret generic actor-id-ca-certs -n ate-system --from-literal=ca.crt="${actor_id_ca_root}"
-          kubectl create configmap ate-api-authentication -n ate-system --from-literal=authentication.yaml=$'actorIdentityJWTProvider: kubernetes\njwtProviders:\n- name: kubernetes\n  issuer: https://kubernetes.default.svc\n  audiences: [api.ate-system.svc]\n  certificateAuthorityFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt\n  discoveryTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token\n'
+          k8s_issuer="$(kubectl get --raw /.well-known/openid-configuration | jq -r '.issuer')"
+          kubectl create configmap ate-api-authentication -n ate-system --from-literal=authentication.yaml=$'actorIdentityJWTProvider: kubernetes\njwtProviders:\n- name: kubernetes\n  issuer: '"${k8s_issuer}"$'\n  audiences: [api.ate-system.svc]\n  certificateAuthorityFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt\n  discoveryTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token\n'
           helm upgrade substrate oci://ghcr.io/kagent-dev/substrate/helm/substrate --version "${SUBSTRATE_VERSION}" --namespace ate-system --reuse-values --wait --timeout 5m
 
       - name: Install Kagent

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,7 +102,16 @@ jobs:
           actor_id_ca_root="$(kubectl get secret actor-id-ca-pool -n ate-system -o jsonpath='{.data.pool}' | base64 --decode | jq -r '.CAs[0].RootCertificateDER' | base64 --decode | openssl x509 -inform der -outform pem)"
           kubectl create secret generic actor-id-ca-certs -n ate-system --from-literal=ca.crt="${actor_id_ca_root}"
           k8s_issuer="$(kubectl get --raw /.well-known/openid-configuration | jq -r '.issuer')"
-          kubectl create configmap ate-api-authentication -n ate-system --from-literal=authentication.yaml=$'actorIdentityJWTProvider: kubernetes\njwtProviders:\n- name: kubernetes\n  issuer: '"${k8s_issuer}"$'\n  audiences: [api.ate-system.svc]\n  certificateAuthorityFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt\n  discoveryTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token\n'
+          kubectl create configmap ate-api-authentication -n ate-system --from-literal=authentication.yaml="$(cat <<EOF
+actorIdentityJWTProvider: kubernetes
+jwtProviders:
+- name: kubernetes
+  issuer: ${k8s_issuer}
+  audiences: [api.ate-system.svc]
+  certificateAuthorityFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  discoveryTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+EOF
+)"
           helm upgrade substrate oci://ghcr.io/kagent-dev/substrate/helm/substrate --version "${SUBSTRATE_VERSION}" --namespace ate-system --reuse-values --wait --timeout 5m
 
       - name: Install Kagent

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,17 +101,7 @@ jobs:
           ./kubectl-ate --context kind-kagent admin make-ca-pool --ca-id=1 --name=actor-id-ca-pool --secret-namespace=ate-system
           actor_id_ca_root="$(kubectl get secret actor-id-ca-pool -n ate-system -o jsonpath='{.data.pool}' | base64 --decode | jq -r '.CAs[0].RootCertificateDER' | base64 --decode | openssl x509 -inform der -outform pem)"
           kubectl create secret generic actor-id-ca-certs -n ate-system --from-literal=ca.crt="${actor_id_ca_root}"
-          k8s_issuer="$(kubectl get --raw /.well-known/openid-configuration | jq -r '.issuer')"
-          kubectl create configmap ate-api-authentication -n ate-system --from-literal=authentication.yaml="$(cat <<EOF
-actorIdentityJWTProvider: kubernetes
-jwtProviders:
-- name: kubernetes
-  issuer: ${k8s_issuer}
-  audiences: [api.ate-system.svc]
-  certificateAuthorityFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-  discoveryTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-EOF
-)"
+          kubectl create configmap ate-api-authentication -n ate-system --from-literal=authentication.yaml=$'actorIdentityJWTProvider: kubernetes\njwtProviders:\n- name: kubernetes\n  issuer: https://kubernetes.default.svc\n  audiences: [api.ate-system.svc]\n  certificateAuthorityFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt\n  discoveryTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token\n'
           helm upgrade substrate oci://ghcr.io/kagent-dev/substrate/helm/substrate --version "${SUBSTRATE_VERSION}" --namespace ate-system --reuse-values --wait --timeout 5m
 
       - name: Install Kagent

--- a/scripts/setup-cluster/setup-cluster.sh
+++ b/scripts/setup-cluster/setup-cluster.sh
@@ -61,7 +61,16 @@ kubectl create secret generic actor-id-ca-certs -n ate-system \
 
 k8s_issuer="$(kubectl get --raw /.well-known/openid-configuration | jq -r '.issuer')"
 kubectl create configmap ate-api-authentication -n ate-system \
-  --from-literal=authentication.yaml=$'actorIdentityJWTProvider: kubernetes\njwtProviders:\n- name: kubernetes\n  issuer: '"${k8s_issuer}"$'\n  audiences: [api.ate-system.svc]\n  certificateAuthorityFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt\n  discoveryTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token\n' \
+  --from-literal=authentication.yaml="$(cat <<EOF
+actorIdentityJWTProvider: kubernetes
+jwtProviders:
+- name: kubernetes
+  issuer: ${k8s_issuer}
+  audiences: [api.ate-system.svc]
+  certificateAuthorityFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  discoveryTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+EOF
+)" \
   --dry-run=client -o yaml | kubectl apply -f -
 
 helm upgrade substrate "oci://ghcr.io/kagent-dev/substrate/helm/substrate" \

--- a/scripts/setup-cluster/setup-cluster.sh
+++ b/scripts/setup-cluster/setup-cluster.sh
@@ -58,8 +58,10 @@ actor_id_ca_root="$(kubectl get secret actor-id-ca-pool -n ate-system -o jsonpat
   | openssl x509 -inform der -outform pem)"
 kubectl create secret generic actor-id-ca-certs -n ate-system \
   --from-literal=ca.crt="${actor_id_ca_root}" --dry-run=client -o yaml | kubectl apply -f -
+
+k8s_issuer="$(kubectl get --raw /.well-known/openid-configuration | jq -r '.issuer')"
 kubectl create configmap ate-api-authentication -n ate-system \
-  --from-literal=authentication.yaml=$'actorIdentityJWTProvider: kubernetes\njwtProviders:\n- name: kubernetes\n  issuer: https://kubernetes.default.svc\n  audiences: [api.ate-system.svc]\n  certificateAuthorityFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt\n  discoveryTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token\n' \
+  --from-literal=authentication.yaml=$'actorIdentityJWTProvider: kubernetes\njwtProviders:\n- name: kubernetes\n  issuer: '"${k8s_issuer}"$'\n  audiences: [api.ate-system.svc]\n  certificateAuthorityFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt\n  discoveryTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token\n' \
   --dry-run=client -o yaml | kubectl apply -f -
 
 helm upgrade substrate "oci://ghcr.io/kagent-dev/substrate/helm/substrate" \


### PR DESCRIPTION
Fixes the hardcoded Kubernetes issuer in setup/CI by discovering the issuer from the cluster’s OIDC config. 
This fixes kubectl-ate auth on kind.

Fixes https://github.com/kagent-dev/kagent/issues/2763
