### PR TITLE
fix: flush buffered OTEL logs

### DIFF
--- a/go/adk/pkg/a2a/server/server.go
+++ b/go/adk/pkg/a2a/server/server.go
@@ -96,7 +96,7 @@ func NewA2AServer(agentCard a2atype.AgentCard, executor a2asrv.AgentExecutor, lo
 		}),
 		otelhttp.WithFilter(isA2ARequest),
 	)
-	// Pre-response span flushing is opt-in via KAGENT_PRE_RESPONSE_TRACE_FLUSH
+	// Pre-response telemetry flushing is opt-in via KAGENT_PRE_RESPONSE_TRACE_FLUSH
 	// (the controller sets it on Agent Substrate actors): a checkpoint/suspend
 	// runtime freezes as soon as the response body closes, making this the only
 	// reliable export window. Everywhere else the batch exporter's timer

--- a/go/adk/pkg/telemetry/tracing.go
+++ b/go/adk/pkg/telemetry/tracing.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	logglobal "go.opentelemetry.io/otel/log/global"
 	"go.opentelemetry.io/otel/propagation"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -39,24 +40,36 @@ func StartInvocationSpan(ctx context.Context) (context.Context, trace.Span) {
 	return otel.Tracer("gcp.vertex.agent").Start(ctx, "invocation")
 }
 
-// ForceFlush exports any spans still buffered in the tracer provider's batch
-// processor. Call it before an A2A response completes when the process may be
-// suspended right afterwards: Agent Substrate checkpoints the actor as soon as
-// the response body closes, so unexported spans stay frozen in the snapshot
-// until the session's next resume (or forever, for a session's last message).
+// ForceFlush exports any telemetry still buffered in the tracer and logger
+// providers' batch processors. Call it before an A2A response completes when
+// the process may be suspended right afterwards: Agent Substrate checkpoints
+// the actor as soon as the response body closes, so unexported telemetry stays
+// frozen in the snapshot until the session's next resume (or forever, for a
+// session's last message).
 // Uses its own detached timeout because the request context is typically
 // already canceled by the time deferred cleanup runs. The timeout defaults to
 // 3s and is configurable via KAGENT_TRACE_FLUSH_TIMEOUT_MS.
 func ForceFlush(ctx context.Context) {
 	type flusher interface{ ForceFlush(context.Context) error }
-	fp, ok := otel.GetTracerProvider().(flusher)
-	if !ok {
+
+	tracerProvider, tracerOK := otel.GetTracerProvider().(flusher)
+	loggerProvider, loggerOK := logglobal.GetLoggerProvider().(flusher)
+	if !tracerOK && !loggerOK {
 		return
 	}
+
 	flushCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), flushTimeout())
 	defer cancel()
-	if err := fp.ForceFlush(flushCtx); err != nil {
-		otel.Handle(err)
+
+	if tracerOK {
+		if err := tracerProvider.ForceFlush(flushCtx); err != nil {
+			otel.Handle(err)
+		}
+	}
+	if loggerOK {
+		if err := loggerProvider.ForceFlush(flushCtx); err != nil {
+			otel.Handle(err)
+		}
 	}
 }
 

--- a/go/adk/pkg/telemetry/tracing.go
+++ b/go/adk/pkg/telemetry/tracing.go
@@ -48,35 +48,35 @@ func StartInvocationSpan(ctx context.Context) (context.Context, trace.Span) {
 // session's last message).
 // Uses its own detached timeout because the request context is typically
 // already canceled by the time deferred cleanup runs. The timeout defaults to
-// 3s and is configurable via KAGENT_TRACE_FLUSH_TIMEOUT_MS.
+// 3s and is configurable via KAGENT_TELEMETRY_FLUSH_TIMEOUT_MS.
 func ForceFlush(ctx context.Context) {
-	type flusher interface{ ForceFlush(context.Context) error }
+        type flusher interface{ ForceFlush(context.Context) error }
 
-	tracerProvider, tracerOK := otel.GetTracerProvider().(flusher)
-	loggerProvider, loggerOK := logglobal.GetLoggerProvider().(flusher)
-	if !tracerOK && !loggerOK {
-		return
-	}
+        tracerProvider, tracerOK := otel.GetTracerProvider().(flusher)
+        loggerProvider, loggerOK := logglobal.GetLoggerProvider().(flusher)
+        if !tracerOK && !loggerOK {
+                return
+        }
 
-	flushCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), flushTimeout())
-	defer cancel()
+        flushCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), flushTimeout())
+        defer cancel()
 
-	if tracerOK {
-		if err := tracerProvider.ForceFlush(flushCtx); err != nil {
-			otel.Handle(err)
-		}
-	}
-	if loggerOK {
-		if err := loggerProvider.ForceFlush(flushCtx); err != nil {
-			otel.Handle(err)
-		}
-	}
+        if loggerOK {
+                if err := loggerProvider.ForceFlush(flushCtx); err != nil {
+                        otel.Handle(err)
+                }
+        }
+        if tracerOK {
+                if err := tracerProvider.ForceFlush(flushCtx); err != nil {
+                        otel.Handle(err)
+                }
+        }
 }
 
-// flushTimeout returns KAGENT_TRACE_FLUSH_TIMEOUT_MS as a duration, or 3s
+// flushTimeout returns KAGENT_TELEMETRY_FLUSH_TIMEOUT_MS as a duration, or 3s
 // when unset or invalid.
 func flushTimeout() time.Duration {
-	if v := strings.TrimSpace(os.Getenv("KAGENT_TRACE_FLUSH_TIMEOUT_MS")); v != "" {
+	if v := strings.TrimSpace(os.Getenv("KAGENT_TELEMETRY_FLUSH_TIMEOUT_MS")); v != "" {
 		if ms, err := strconv.Atoi(v); err == nil && ms > 0 {
 			return time.Duration(ms) * time.Millisecond
 		}

--- a/go/adk/pkg/telemetry/tracing_test.go
+++ b/go/adk/pkg/telemetry/tracing_test.go
@@ -99,7 +99,7 @@ func (e *testLogExporter) count() int {
 	return len(e.records)
 }
 
-// flushTimeout reads KAGENT_TRACE_FLUSH_TIMEOUT_MS and falls back to 3s on
+// flushTimeout reads KAGENT_TELEMETRY_FLUSH_TIMEOUT_MS and falls back to 3s on
 // unset, non-numeric, or non-positive values.
 func TestFlushTimeout(t *testing.T) {
 	tests := []struct {
@@ -115,7 +115,7 @@ func TestFlushTimeout(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("KAGENT_TRACE_FLUSH_TIMEOUT_MS", tt.env)
+			t.Setenv("KAGENT_TELEMETRY_FLUSH_TIMEOUT_MS", tt.env)
 			if got := flushTimeout(); got != tt.want {
 				t.Errorf("flushTimeout() = %v, want %v", got, tt.want)
 			}

--- a/go/adk/pkg/telemetry/tracing_test.go
+++ b/go/adk/pkg/telemetry/tracing_test.go
@@ -6,6 +6,9 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel"
+	logapi "go.opentelemetry.io/otel/log"
+	logglobal "go.opentelemetry.io/otel/log/global"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace/noop"
@@ -40,6 +43,60 @@ func TestForceFlush(t *testing.T) {
 
 	otel.SetTracerProvider(noop.NewTracerProvider())
 	ForceFlush(context.Background()) // must not panic
+}
+
+// TestForceFlushFlushesLogs verifies that ForceFlush drains records queued by
+// the batch log processor even when the tracer provider is not flushable.
+func TestForceFlushFlushesLogs(t *testing.T) {
+	exporter := &testLogExporter{}
+	lp := sdklog.NewLoggerProvider(
+		sdklog.WithProcessor(sdklog.NewBatchProcessor(exporter)),
+	)
+	prev := logglobal.GetLoggerProvider()
+	logglobal.SetLoggerProvider(lp)
+	t.Cleanup(func() {
+		logglobal.SetLoggerProvider(prev)
+		_ = lp.Shutdown(context.Background())
+	})
+
+	logger := logglobal.GetLoggerProvider().Logger("test")
+	var record logapi.Record
+	record.SetEventName("buffered")
+	logger.Emit(context.Background(), record)
+
+	if got := exporter.count(); got != 0 {
+		t.Fatalf("log exported before flush: %d", got)
+	}
+
+	// A canceled request context must not prevent the flush.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	ForceFlush(ctx)
+
+	if got := exporter.count(); got != 1 {
+		t.Fatalf("expected 1 log after flush, got %d", got)
+	}
+}
+
+type testLogExporter struct {
+	records []sdklog.Record
+}
+
+func (e *testLogExporter) Export(_ context.Context, records []sdklog.Record) error {
+	e.records = append(e.records, records...)
+	return nil
+}
+
+func (e *testLogExporter) Shutdown(context.Context) error {
+	return nil
+}
+
+func (e *testLogExporter) ForceFlush(context.Context) error {
+	return nil
+}
+
+func (e *testLogExporter) count() int {
+	return len(e.records)
 }
 
 // flushTimeout reads KAGENT_TRACE_FLUSH_TIMEOUT_MS and falls back to 3s on

--- a/python/packages/kagent-core/src/kagent/core/tracing/_utils.py
+++ b/python/packages/kagent-core/src/kagent/core/tracing/_utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+import time
 
 from fastapi import FastAPI
 from opentelemetry import _logs, trace
@@ -110,8 +111,8 @@ def _instrument_google_generativeai(logger_provider=None):
 
 
 def _resolve_flush_timeout_millis() -> int:
-    """Resolve KAGENT_TRACE_FLUSH_TIMEOUT_MS, falling back to 3000ms when unset or invalid."""
-    raw = os.getenv("KAGENT_TRACE_FLUSH_TIMEOUT_MS")
+    """Resolve KAGENT_TELEMETRY_FLUSH_TIMEOUT_MS, falling back to 3000ms when unset or invalid."""
+    raw = os.getenv("KAGENT_TELEMETRY_FLUSH_TIMEOUT_MS")
     if raw is None:
         return 3000
     try:
@@ -119,32 +120,49 @@ def _resolve_flush_timeout_millis() -> int:
     except ValueError:
         timeout_millis = -1
     if timeout_millis <= 0:
-        logging.warning("Invalid KAGENT_TRACE_FLUSH_TIMEOUT_MS value %r; falling back to 3000ms", raw)
+        logging.warning("Invalid KAGENT_TELEMETRY_FLUSH_TIMEOUT_MS value %r; falling back to 3000ms", raw)
         return 3000
     return timeout_millis
 
 
 def force_flush(timeout_millis: int | None = None) -> None:
-    """Export any spans still buffered in the tracer provider's batch processor.
+    """Export telemetry still buffered in the tracer and logger providers.
 
     Call before a response completes when the process may be suspended right
     afterwards: Agent Substrate checkpoints the actor as soon as the A2A
-    response body closes, so unexported spans stay frozen in the snapshot
+    response body closes, so unexported telemetry stays frozen in the snapshot
     until the session's next resume (or forever, for a session's last
-    message). No-op when the provider has no force_flush (tracing disabled).
-    The timeout defaults to 3000ms, configurable via
-    KAGENT_TRACE_FLUSH_TIMEOUT_MS.
+    message). No-op for providers without force_flush support. The timeout
+    defaults to 3000ms, configurable via KAGENT_TELEMETRY_FLUSH_TIMEOUT_MS.
+
+    Logs are flushed first because GenAI audit events are the telemetry most
+    likely to be lost when the actor is checkpointed immediately after the
+    response closes.
     """
     if timeout_millis is None:
         timeout_millis = _resolve_flush_timeout_millis()
-    provider = trace.get_tracer_provider()
-    flush = getattr(provider, "force_flush", None)
-    if flush is None:
-        return
-    try:
-        flush(timeout_millis)
-    except Exception:
-        logging.warning("Failed to flush pending spans", exc_info=True)
+
+    logger_provider = _logs.get_logger_provider()
+    tracer_provider = trace.get_tracer_provider()
+    deadline = time.monotonic() + timeout_millis / 1000
+
+    for name, provider in (
+        ("logs", logger_provider),
+        ("traces", tracer_provider),
+    ):
+        flush = getattr(provider, "force_flush", None)
+        if flush is None:
+            continue
+
+        remaining_millis = max(0, int((deadline - time.monotonic()) * 1000))
+        if remaining_millis == 0:
+            logging.warning("Skipping pending %s flush because the telemetry flush budget expired", name)
+            continue
+
+        try:
+            flush(remaining_millis)
+        except Exception:
+            logging.warning("Failed to flush pending %s", name, exc_info=True)
 
 
 # High-frequency probe endpoints with nothing worth flushing.

--- a/python/packages/kagent-core/tests/test_tracing_configure.py
+++ b/python/packages/kagent-core/tests/test_tracing_configure.py
@@ -224,14 +224,65 @@ def test_resolve_otlp_timeout_seconds_uses_milliseconds(monkeypatch, signal, env
     assert _utils._resolve_otlp_timeout_seconds(signal) == expected
 
 
-def test_force_flush_calls_provider_force_flush(monkeypatch):
-    calls = []
-    provider = SimpleNamespace(force_flush=lambda timeout: calls.append(timeout))
-    monkeypatch.setattr(_utils.trace, "get_tracer_provider", lambda: provider)
+def test_force_flush_flushes_logs_and_traces(monkeypatch):
+    from opentelemetry.sdk._logs import LoggerProvider
+    from opentelemetry.sdk._logs.export import (
+        BatchLogRecordProcessor,
+        InMemoryLogRecordExporter,
+    )
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    log_exporter = InMemoryLogRecordExporter()
+    logger_provider = LoggerProvider()
+    logger_provider.add_log_record_processor(BatchLogRecordProcessor(log_exporter))
+
+    span_exporter = InMemorySpanExporter()
+    tracer_provider = TracerProvider()
+    tracer_provider.add_span_processor(BatchSpanProcessor(span_exporter))
+
+    monkeypatch.setattr(_utils._logs, "get_logger_provider", lambda: logger_provider)
+    monkeypatch.setattr(_utils.trace, "get_tracer_provider", lambda: tracer_provider)
+
+    logger = logger_provider.get_logger("test")
+    logger.emit(body="buffered log")
+
+    tracer = tracer_provider.get_tracer("test")
+    span = tracer.start_span("buffered span")
+    span.end()
+
+    assert log_exporter.get_finished_logs() == ()
+    assert span_exporter.get_finished_spans() == ()
 
     _utils.force_flush()
 
-    assert calls == [3000]
+    assert len(log_exporter.get_finished_logs()) == 1
+    assert len(span_exporter.get_finished_spans()) == 1
+
+    logger_provider.shutdown()
+    tracer_provider.shutdown()
+
+
+def test_force_flush_continues_when_log_flush_fails(monkeypatch):
+    calls = []
+
+    def fail_logs(timeout):
+        calls.append(("logs", timeout))
+        raise RuntimeError("collector down")
+
+    def flush_traces(timeout):
+        calls.append(("traces", timeout))
+
+    logger_provider = SimpleNamespace(force_flush=fail_logs)
+    tracer_provider = SimpleNamespace(force_flush=flush_traces)
+
+    monkeypatch.setattr(_utils._logs, "get_logger_provider", lambda: logger_provider)
+    monkeypatch.setattr(_utils.trace, "get_tracer_provider", lambda: tracer_provider)
+
+    _utils.force_flush()
+
+    assert [name for name, _ in calls] == ["logs", "traces"]
 
 
 @pytest.mark.parametrize(
@@ -245,28 +296,28 @@ def test_force_flush_calls_provider_force_flush(monkeypatch):
 )
 def test_force_flush_timeout_env_override(monkeypatch, raw, expected):
     calls = []
-    provider = SimpleNamespace(force_flush=lambda timeout: calls.append(timeout))
-    monkeypatch.setattr(_utils.trace, "get_tracer_provider", lambda: provider)
-    monkeypatch.setenv("KAGENT_TRACE_FLUSH_TIMEOUT_MS", raw)
+
+    logger_provider = SimpleNamespace(
+        force_flush=lambda timeout: calls.append(("logs", timeout))
+    )
+    tracer_provider = SimpleNamespace(
+        force_flush=lambda timeout: calls.append(("traces", timeout))
+    )
+
+    monkeypatch.setattr(_utils._logs, "get_logger_provider", lambda: logger_provider)
+    monkeypatch.setattr(_utils.trace, "get_tracer_provider", lambda: tracer_provider)
+    monkeypatch.setenv("KAGENT_TELEMETRY_FLUSH_TIMEOUT_MS", raw)
 
     _utils.force_flush()
 
-    assert calls == [expected]
+    assert [name for name, _ in calls] == ["logs", "traces"]
+    assert all(0 < timeout <= expected for _, timeout in calls)
 
 
 def test_force_flush_noop_without_provider_support(monkeypatch):
-    # The default (no-op) provider has no force_flush; must not raise.
+    # Providers without force_flush support must not raise.
+    monkeypatch.setattr(_utils._logs, "get_logger_provider", lambda: SimpleNamespace())
     monkeypatch.setattr(_utils.trace, "get_tracer_provider", lambda: SimpleNamespace())
-
-    _utils.force_flush()
-
-
-def test_force_flush_swallows_exporter_errors(monkeypatch):
-    def boom(timeout):
-        raise RuntimeError("collector down")
-
-    provider = SimpleNamespace(force_flush=boom)
-    monkeypatch.setattr(_utils.trace, "get_tracer_provider", lambda: provider)
 
     _utils.force_flush()
 


### PR DESCRIPTION
## What

Fix `ForceFlush()` so it flushes both the tracer and logger providers.

## Why

GenAI audit logs are buffered by the OTEL batch log processor. When an Agent Substrate actor checkpoints right after the A2A response closes, those buffered logs can be left behind and never exported.

## Changes

* Flush the global `LoggerProvider` in `ForceFlush()`.
* Keep tracer flushing working as before.
* Use the same timeout for both providers.
* Added a regression test to make sure buffered logs are exported, even when the request context is already cancelled.
* Updated the related comment from spans to telemetry.

## Validation

* `go test ./adk/pkg/telemetry ./adk/pkg/a2a/server `
* `go build ./adk/pkg/telemetry ./adk/pkg/a2a/server`

All passed.

Fixes #2759