### PR TITLE
refactor: simplify database client operations

### DIFF
--- a/go/core/internal/a2agateway/gateway.go
+++ b/go/core/internal/a2agateway/gateway.go
@@ -43,8 +43,8 @@ type instanceStore interface {
 	GetActiveAgentInstanceTask(context.Context, string) (*a2atype.Task, error)
 	InterruptActiveAgentInstanceTask(context.Context, string, string) (bool, error)
 	StoreAgentInstanceTaskEvent(context.Context, string, *a2atype.Task, a2atype.Event, *database.AgentInstanceTaskSnapshot) error
-	GetAgentInstanceTask(context.Context, string, string) (*a2atype.Task, error)
-	ListAgentInstanceTasks(context.Context, string, string, a2atype.TaskState, *time.Time, int) ([]*a2atype.Task, int, error)
+	GetAgentInstanceTask(context.Context, string, string, *int) (*a2atype.Task, error)
+	ListAgentInstanceTasks(context.Context, string, string, a2atype.TaskState, *time.Time, int, *int) ([]*a2atype.Task, int, error)
 }
 
 type runtimeDialer interface {
@@ -208,7 +208,7 @@ func (g *Gateway) GetTask(ctx context.Context, req *a2atype.GetTaskRequest) (*a2
 	if req == nil || req.ID == "" {
 		return nil, a2atype.NewError(a2atype.ErrInvalidRequest, "task ID is required")
 	}
-	task, err := g.store.GetAgentInstanceTask(ctx, instance.GetId(), string(req.ID))
+	task, err := g.store.GetAgentInstanceTask(ctx, instance.GetId(), string(req.ID), req.HistoryLength)
 	if errors.Is(err, database.ErrNotFound) {
 		return nil, a2atype.ErrTaskNotFound
 	}
@@ -241,7 +241,7 @@ func (g *Gateway) ListTasks(ctx context.Context, req *a2atype.ListTasksRequest) 
 	if err != nil {
 		return nil, a2atype.NewError(a2atype.ErrInvalidRequest, "invalid page token")
 	}
-	tasks, total, err := g.store.ListAgentInstanceTasks(ctx, instance.GetId(), afterID, req.Status, req.StatusTimestampAfter, pageSize+1)
+	tasks, total, err := g.store.ListAgentInstanceTasks(ctx, instance.GetId(), afterID, req.Status, req.StatusTimestampAfter, pageSize+1, req.HistoryLength)
 	if err != nil {
 		logging.FromContext(ctx).ErrorContext(ctx, "failed to list agent instance tasks", "error", err, "instance_id", instance.GetId())
 		return nil, a2atype.NewError(a2atype.ErrInternalError, "failed to list tasks")
@@ -265,7 +265,7 @@ func (g *Gateway) CancelTask(ctx context.Context, req *a2atype.CancelTaskRequest
 	if req == nil || req.ID == "" {
 		return nil, a2atype.NewError(a2atype.ErrInvalidRequest, "task ID is required")
 	}
-	task, err := g.store.GetAgentInstanceTask(ctx, instance.GetId(), string(req.ID))
+	task, err := g.store.GetAgentInstanceTask(ctx, instance.GetId(), string(req.ID), nil)
 	if errors.Is(err, database.ErrNotFound) {
 		return nil, a2atype.ErrTaskNotFound
 	}
@@ -307,7 +307,7 @@ func (g *Gateway) CancelTask(ctx context.Context, req *a2atype.CancelTaskRequest
 		}
 		select {
 		case <-run.done:
-			latest, err := g.store.GetAgentInstanceTask(ctx, instance.GetId(), string(req.ID))
+			latest, err := g.store.GetAgentInstanceTask(ctx, instance.GetId(), string(req.ID), nil)
 			if err != nil {
 				return nil, g.storeError(ctx, err)
 			}
@@ -320,7 +320,7 @@ func (g *Gateway) CancelTask(ctx context.Context, req *a2atype.CancelTaskRequest
 	}
 	release := g.coordinator.Quiesce(instance.GetId())
 	defer release()
-	task, err = g.store.GetAgentInstanceTask(ctx, instance.GetId(), string(req.ID))
+	task, err = g.store.GetAgentInstanceTask(ctx, instance.GetId(), string(req.ID), nil)
 	if err != nil {
 		return nil, g.storeError(ctx, err)
 	}
@@ -386,7 +386,7 @@ func (g *Gateway) SubscribeToTask(ctx context.Context, req *a2atype.SubscribeToT
 	if req == nil || req.ID == "" {
 		return errorEvents(a2atype.NewError(a2atype.ErrInvalidRequest, "task ID is required"))
 	}
-	task, err := g.store.GetAgentInstanceTask(ctx, instance.GetId(), string(req.ID))
+	task, err := g.store.GetAgentInstanceTask(ctx, instance.GetId(), string(req.ID), nil)
 	if errors.Is(err, database.ErrNotFound) {
 		return errorEvents(a2atype.ErrTaskNotFound)
 	}
@@ -548,7 +548,7 @@ func (g *Gateway) prepareSend(ctx context.Context, req *a2atype.SendMessageReque
 
 func (g *Gateway) prepareReply(ctx context.Context, instance *apiv1alpha1.AgentInstance, req *a2atype.SendMessageRequest) (*preparedSend, error) {
 	message := req.Message
-	stored, err := g.store.GetAgentInstanceTask(ctx, instance.GetId(), string(message.TaskID))
+	stored, err := g.store.GetAgentInstanceTask(ctx, instance.GetId(), string(message.TaskID), nil)
 	if errors.Is(err, database.ErrNotFound) {
 		return nil, a2atype.ErrTaskNotFound
 	}

--- a/go/core/internal/a2agateway/gateway_test.go
+++ b/go/core/internal/a2agateway/gateway_test.go
@@ -50,6 +50,7 @@ type gatewayTestStore struct {
 	created         *a2atype.Task
 	tasks           []*a2atype.Task
 	total           int
+	historyLength   *int
 	taskErr         error
 	replay          *a2atype.Task
 	active          *a2atype.Task
@@ -128,7 +129,8 @@ func (s *gatewayTestStore) InterruptActiveAgentInstanceTask(_ context.Context, _
 	return true, nil
 }
 
-func (s *gatewayTestStore) GetAgentInstanceTask(_ context.Context, _ string, taskID string) (*a2atype.Task, error) {
+func (s *gatewayTestStore) GetAgentInstanceTask(_ context.Context, _ string, taskID string, historyLength *int) (*a2atype.Task, error) {
+	s.historyLength = historyLength
 	if s.taskErr != nil {
 		return nil, s.taskErr
 	}
@@ -138,7 +140,8 @@ func (s *gatewayTestStore) GetAgentInstanceTask(_ context.Context, _ string, tas
 	return s.task, nil
 }
 
-func (s *gatewayTestStore) ListAgentInstanceTasks(context.Context, string, string, a2atype.TaskState, *time.Time, int) ([]*a2atype.Task, int, error) {
+func (s *gatewayTestStore) ListAgentInstanceTasks(_ context.Context, _, _ string, _ a2atype.TaskState, _ *time.Time, _ int, historyLength *int) ([]*a2atype.Task, int, error) {
+	s.historyLength = historyLength
 	return s.tasks, s.total, s.taskErr
 }
 
@@ -617,9 +620,16 @@ func TestGatewayReadsTasksWithoutDialingRuntime(t *testing.T) {
 			if err != nil || len(got.History) != 1 || len(got.Artifacts) != 1 {
 				t.Fatalf("GetTask() = %#v, %v", got, err)
 			}
+			if store.historyLength == nil || *store.historyLength != historyLength {
+				t.Fatal("GetTask did not pass the history limit to persistence")
+			}
+			store.historyLength = nil
 			listed, err := gateway.ListTasks(gatewayTestContext(), &a2atype.ListTasksRequest{HistoryLength: &historyLength})
 			if err != nil || len(listed.Tasks) != 1 || len(listed.Tasks[0].History) != 1 || listed.Tasks[0].Artifacts != nil {
 				t.Fatalf("ListTasks() = %#v, %v", listed, err)
+			}
+			if store.historyLength == nil || *store.historyLength != historyLength {
+				t.Fatal("ListTasks did not pass the history limit to persistence")
 			}
 			if dialer.instance != nil {
 				t.Fatal("task reads dialed the private runtime")

--- a/go/core/internal/a2agateway/invocation.go
+++ b/go/core/internal/a2agateway/invocation.go
@@ -33,7 +33,7 @@ func (g *Gateway) recordResult(ctx context.Context, instance *apiv1alpha1.AgentI
 	defer release()
 	// A cancellation or another observer may have finished while the RPC was
 	// in flight. The stream ingester, when present, owns task persistence.
-	latest, err := g.store.GetAgentInstanceTask(ctx, instance.GetId(), string(task.ID))
+	latest, err := g.store.GetAgentInstanceTask(ctx, instance.GetId(), string(task.ID), nil)
 	if err != nil {
 		return nil, g.storeError(ctx, err)
 	}

--- a/go/core/internal/controller/mcpserver/reconciler.go
+++ b/go/core/internal/controller/mcpserver/reconciler.go
@@ -55,9 +55,7 @@ type ToolDiscoverer interface {
 
 // CatalogStore persists the ToolService projection of an MCPServer.
 type CatalogStore interface {
-	StoreToolServer(context.Context, *database.ToolServer) (*database.ToolServer, error)
-	RefreshToolsForServer(context.Context, string, string, ...*v1alpha3.MCPTool) error
-	DeleteToolsForServer(context.Context, string, string) error
+	RefreshToolServer(context.Context, *database.ToolServer, ...*v1alpha3.MCPTool) error
 	DeleteToolServer(context.Context, string, string) error
 }
 
@@ -107,7 +105,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		if !apierrors.IsNotFound(err) {
 			return reconcile.Result{}, fmt.Errorf("get MCPServer %s: %w", request.String(), err)
 		}
-		return reconcile.Result{}, r.deleteCatalog(ctx, request.String())
+		return reconcile.Result{}, r.catalog.DeleteToolServer(ctx, request.String(), mcpServerGroupKind)
 	}
 
 	if !isReady(server) {
@@ -154,22 +152,9 @@ func (r *Reconciler) updateCatalog(ctx context.Context, server *kmcp.MCPServer, 
 		now := time.Now().UTC()
 		lastConnected = &now
 	}
-	if _, err := r.catalog.StoreToolServer(ctx, &database.ToolServer{
+	return r.catalog.RefreshToolServer(ctx, &database.ToolServer{
 		Name: name, GroupKind: mcpServerGroupKind, Description: "N/A", LastConnected: lastConnected,
-	}); err != nil {
-		return fmt.Errorf("store server: %w", err)
-	}
-	if err := r.catalog.RefreshToolsForServer(ctx, name, mcpServerGroupKind, tools...); err != nil {
-		return fmt.Errorf("refresh tools: %w", err)
-	}
-	return nil
-}
-
-func (r *Reconciler) deleteCatalog(ctx context.Context, name string) error {
-	return errors.Join(
-		wrapError("delete tools", r.catalog.DeleteToolsForServer(ctx, name, mcpServerGroupKind)),
-		wrapError("delete server", r.catalog.DeleteToolServer(ctx, name, mcpServerGroupKind)),
-	)
+	}, tools...)
 }
 
 func wrapError(action string, err error) error {

--- a/go/core/internal/controller/mcpserver/reconciler_test.go
+++ b/go/core/internal/controller/mcpserver/reconciler_test.go
@@ -50,24 +50,14 @@ func (f *fakeDiscoverer) ListTools(_ context.Context, ref toolservice.MCPServerR
 }
 
 type fakeCatalog struct {
-	server       *database.ToolServer
-	tools        []*v1alpha3.MCPTool
-	deletedTools string
-	deleted      string
+	server  *database.ToolServer
+	tools   []*v1alpha3.MCPTool
+	deleted string
 }
 
-func (f *fakeCatalog) StoreToolServer(_ context.Context, server *database.ToolServer) (*database.ToolServer, error) {
+func (f *fakeCatalog) RefreshToolServer(_ context.Context, server *database.ToolServer, tools ...*v1alpha3.MCPTool) error {
 	f.server = server
-	return server, nil
-}
-
-func (f *fakeCatalog) RefreshToolsForServer(_ context.Context, _, _ string, tools ...*v1alpha3.MCPTool) error {
 	f.tools = tools
-	return nil
-}
-
-func (f *fakeCatalog) DeleteToolsForServer(_ context.Context, name, groupKind string) error {
-	f.deletedTools = name + "|" + groupKind
 	return nil
 }
 
@@ -162,8 +152,8 @@ func TestReconcileDeletesCatalogProjection(t *testing.T) {
 		t.Fatalf("Reconcile() error = %v", err)
 	}
 	want := "test/gone|" + mcpServerGroupKind
-	if catalog.deletedTools != want || catalog.deleted != want {
-		t.Fatalf("catalog deletes = tools %q, server %q, want %q", catalog.deletedTools, catalog.deleted, want)
+	if catalog.deleted != want {
+		t.Fatalf("catalog delete = %q, want %q", catalog.deleted, want)
 	}
 }
 

--- a/go/core/internal/controller/reconciler.go
+++ b/go/core/internal/controller/reconciler.go
@@ -117,8 +117,7 @@ func newPairReconciliations(
 // or, later, an AgentInstance or checkpoint references them.
 type runtimeRevisionStore interface {
 	UpsertAgentTemplateHarnessPair(context.Context, database.AgentTemplateHarnessPair) error
-	UpsertRuntimeRevision(context.Context, database.RuntimeRevision) error
-	MarkRuntimeRevisionSuccessful(context.Context, database.AgentTemplateHarnessPair) error
+	RecordRuntimeRevision(context.Context, database.RuntimeRevision, bool) error
 	RetireAgentTemplateHarnessPair(context.Context, string, string, string) error
 	ListUnreferencedRuntimeRevisions(context.Context) ([]database.RuntimeRevision, error)
 	DeleteUnreferencedRuntimeRevision(context.Context, string) error
@@ -298,13 +297,11 @@ func (r *Reconciler) reconcilePair(ctx context.Context, key string) error {
 		EgressDestinations:    state.Revision.EgressDestinations,
 		ActorTemplateAtespace: observed.GetMetadata().GetAtespace(), ActorTemplateName: observed.GetMetadata().GetName(), ActorTemplateUID: observed.GetMetadata().GetUid(),
 	}
-	if err := r.store.UpsertRuntimeRevision(ctx, revision); err != nil {
+	ready := observed.GetStatus().GetGoldenSnapshotStatus().GetGoldenSnapshot() != nil
+	if err := r.store.RecordRuntimeRevision(ctx, revision, ready); err != nil {
 		return fmt.Errorf("store runtime revision %s: %w", state.RevisionID, err)
 	}
-	if observed.GetStatus().GetGoldenSnapshotStatus().GetGoldenSnapshot() != nil {
-		if err := r.store.MarkRuntimeRevisionSuccessful(ctx, pair); err != nil {
-			return fmt.Errorf("mark runtime revision %s successful: %w", state.RevisionID, err)
-		}
+	if ready {
 		return r.cleanupUnreferencedRevisions(ctx)
 	}
 	return nil

--- a/go/core/internal/controller/reconciler_test.go
+++ b/go/core/internal/controller/reconciler_test.go
@@ -138,13 +138,9 @@ func (s *fakeRuntimeRevisionStore) UpsertAgentTemplateHarnessPair(_ context.Cont
 	return nil
 }
 
-func (s *fakeRuntimeRevisionStore) UpsertRuntimeRevision(_ context.Context, revision database.RuntimeRevision) error {
+func (s *fakeRuntimeRevisionStore) RecordRuntimeRevision(_ context.Context, revision database.RuntimeRevision, ready bool) error {
 	s.revision = &revision
-	return nil
-}
-
-func (s *fakeRuntimeRevisionStore) MarkRuntimeRevisionSuccessful(context.Context, database.AgentTemplateHarnessPair) error {
-	s.markedSuccessful = true
+	s.markedSuccessful = ready
 	return nil
 }
 

--- a/go/core/internal/controller/remotemcpserver/reconciler.go
+++ b/go/core/internal/controller/remotemcpserver/reconciler.go
@@ -57,9 +57,7 @@ type ToolDiscoverer interface {
 // RemoteMCPServer status remains the source used by harness compilers, while the
 // database projection serves list RPCs without making those RPCs perform discovery.
 type CatalogStore interface {
-	StoreToolServer(context.Context, *database.ToolServer) (*database.ToolServer, error)
-	RefreshToolsForServer(context.Context, string, string, ...*v1alpha3.MCPTool) error
-	DeleteToolsForServer(context.Context, string, string) error
+	RefreshToolServer(context.Context, *database.ToolServer, ...*v1alpha3.MCPTool) error
 	DeleteToolServer(context.Context, string, string) error
 }
 
@@ -88,7 +86,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		if !apierrors.IsNotFound(err) {
 			return reconcile.Result{}, err
 		}
-		return reconcile.Result{}, r.deleteCatalog(ctx, request.String())
+		return reconcile.Result{}, r.catalog.DeleteToolServer(ctx, request.String(), remoteGroupKind)
 	}
 
 	tools, err := r.discoverer.ListTools(ctx, toolservice.MCPServerRef{
@@ -131,22 +129,9 @@ func (r *Reconciler) updateCatalog(ctx context.Context, server *v1alpha3.RemoteM
 		now := time.Now().UTC()
 		lastConnected = &now
 	}
-	if _, err := r.catalog.StoreToolServer(ctx, &database.ToolServer{
+	return r.catalog.RefreshToolServer(ctx, &database.ToolServer{
 		Name: name, GroupKind: remoteGroupKind, Description: server.Spec.Description, LastConnected: lastConnected,
-	}); err != nil {
-		return fmt.Errorf("store server: %w", err)
-	}
-	if err := r.catalog.RefreshToolsForServer(ctx, name, remoteGroupKind, tools...); err != nil {
-		return fmt.Errorf("refresh tools: %w", err)
-	}
-	return nil
-}
-
-func (r *Reconciler) deleteCatalog(ctx context.Context, name string) error {
-	return errors.Join(
-		wrapError("delete tools", r.catalog.DeleteToolsForServer(ctx, name, remoteGroupKind)),
-		wrapError("delete server", r.catalog.DeleteToolServer(ctx, name, remoteGroupKind)),
-	)
+	}, tools...)
 }
 
 func wrapError(action string, err error) error {

--- a/go/core/internal/controller/remotemcpserver/reconciler_test.go
+++ b/go/core/internal/controller/remotemcpserver/reconciler_test.go
@@ -42,24 +42,14 @@ type fakeDiscoverer struct {
 }
 
 type fakeCatalog struct {
-	server       *database.ToolServer
-	tools        []*v1alpha3.MCPTool
-	deletedTools string
-	deleted      string
+	server  *database.ToolServer
+	tools   []*v1alpha3.MCPTool
+	deleted string
 }
 
-func (f *fakeCatalog) StoreToolServer(_ context.Context, server *database.ToolServer) (*database.ToolServer, error) {
+func (f *fakeCatalog) RefreshToolServer(_ context.Context, server *database.ToolServer, tools ...*v1alpha3.MCPTool) error {
 	f.server = server
-	return server, nil
-}
-
-func (f *fakeCatalog) RefreshToolsForServer(_ context.Context, name, groupKind string, tools ...*v1alpha3.MCPTool) error {
 	f.tools = tools
-	return nil
-}
-
-func (f *fakeCatalog) DeleteToolsForServer(_ context.Context, name, groupKind string) error {
-	f.deletedTools = name + "|" + groupKind
 	return nil
 }
 
@@ -145,8 +135,8 @@ func TestReconcileDeletesCatalogProjection(t *testing.T) {
 		t.Fatalf("Reconcile() error = %v", err)
 	}
 	want := "test/gone|" + remoteGroupKind
-	if catalog.deletedTools != want || catalog.deleted != want {
-		t.Fatalf("catalog deletes = tools %q, server %q, want %q", catalog.deletedTools, catalog.deleted, want)
+	if catalog.deleted != want {
+		t.Fatalf("catalog delete = %q, want %q", catalog.deleted, want)
 	}
 }
 

--- a/go/core/internal/controller/scheduledrun/scheduler.go
+++ b/go/core/internal/controller/scheduledrun/scheduler.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"time"
 
-	apiv1alpha1 "github.com/kagent-dev/kagent/go/api/gen/kagent/api/v1alpha1"
 	"github.com/kagent-dev/kagent/go/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 type schedulerStore interface {
-	ReserveDueScheduledRuns(context.Context, int) ([]*apiv1alpha1.ScheduledRunExecution, error)
+	ReserveDueScheduledRuns(context.Context, int) error
 }
 
 // Scheduler reserves due cron firings independently of execution reconciliation.
@@ -31,7 +30,7 @@ func (s *Scheduler) Start(ctx context.Context) error {
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 	for {
-		if _, err := s.store.ReserveDueScheduledRuns(ctx, 100); err != nil && ctx.Err() == nil {
+		if err := s.store.ReserveDueScheduledRuns(ctx, 100); err != nil && ctx.Err() == nil {
 			logging.FromContext(ctx).ErrorContext(ctx, "failed to reserve scheduled executions", "error", err)
 		}
 		select {

--- a/go/core/internal/controller/scheduledrun/scheduler_test.go
+++ b/go/core/internal/controller/scheduledrun/scheduler_test.go
@@ -33,12 +33,12 @@ func (s *blockedExecutionStore) GetAgentInstance(ctx context.Context, _, _ strin
 	return nil, ctx.Err()
 }
 
-func (s *blockedExecutionStore) ReserveDueScheduledRuns(ctx context.Context, _ int) ([]*apiv1alpha1.ScheduledRunExecution, error) {
+func (s *blockedExecutionStore) ReserveDueScheduledRuns(ctx context.Context, _ int) error {
 	select {
 	case s.reservations <- struct{}{}:
 	case <-ctx.Done():
 	}
-	return nil, errors.New("temporary reservation failure")
+	return errors.New("temporary reservation failure")
 }
 
 func TestSchedulerTicksWhileExecutionIsBlocked(t *testing.T) {

--- a/go/core/internal/database/active_task_test.go
+++ b/go/core/internal/database/active_task_test.go
@@ -16,7 +16,7 @@ func TestGetActiveAgentInstanceTaskUsesInstanceHistory(t *testing.T) {
 	agentInstanceFixture(t, client, ctx, "team-a", "revision", "assistant", "kagent")
 	instance, _, err := client.CreateAgentInstance(ctx, newAgentInstanceRequest(uuid.NewString(), "assistant", "kagent", ""), uuid.NewString())
 	require.NoError(t, err)
-	_, err = client.MarkAgentInstanceReady(ctx, instance.GetId(), "agent.example")
+	_, err = markAgentInstanceReady(ctx, client, instance.GetId(), "agent.example")
 	require.NoError(t, err)
 
 	_, err = client.GetActiveAgentInstanceTask(ctx, instance.GetId())
@@ -67,7 +67,7 @@ func TestCheckpointCreationBlocksInstanceTaskWrites(t *testing.T) {
 	agentInstanceFixture(t, client, ctx, "team-a", "revision", "assistant", "kagent")
 	instance, _, err := client.CreateAgentInstance(ctx, newAgentInstanceRequest(uuid.NewString(), "assistant", "kagent", ""), uuid.NewString())
 	require.NoError(t, err)
-	_, err = client.MarkAgentInstanceReady(ctx, instance.GetId(), "agent.example")
+	_, err = markAgentInstanceReady(ctx, client, instance.GetId(), "agent.example")
 	require.NoError(t, err)
 
 	task := newAgentInstanceTask("completed", "initial-message")

--- a/go/core/internal/database/agent_instance_tasks.go
+++ b/go/core/internal/database/agent_instance_tasks.go
@@ -95,7 +95,7 @@ func (c *Client) CreateAgentInstanceTask(ctx context.Context, instanceID string,
 			if err != nil {
 				return err
 			}
-			return loadAgentInstanceTaskHistories(ctx, tx, historyID, []*a2a.Task{result})
+			return loadAgentInstanceTaskHistories(ctx, tx, historyID, []*a2a.Task{result}, nil)
 		}
 		if err != nil {
 			if isActiveTaskConflict(err) {
@@ -155,7 +155,7 @@ func (c *Client) GetActiveAgentInstanceTask(ctx context.Context, instanceID stri
 	}
 	task, err := unmarshalAgentInstanceTask(row.Data)
 	if err == nil {
-		err = loadAgentInstanceTaskHistories(ctx, c.db, row.HistoryID, []*a2a.Task{task})
+		err = loadAgentInstanceTaskHistories(ctx, c.db, row.HistoryID, []*a2a.Task{task}, nil)
 	}
 	return task, err
 }
@@ -394,20 +394,24 @@ func (c *Client) StoreAgentInstanceTaskEvent(ctx context.Context, instanceID str
 	return nil
 }
 
-// GetAgentInstanceTask returns a task with its archived message history, or ErrNotFound if
-// the instance or task is absent. Callers authorize instance access.
-func (c *Client) GetAgentInstanceTask(ctx context.Context, instanceID, taskID string) (*a2a.Task, error) {
-	instance, err := readAgentInstance(ctx, c.db, instanceID)
-	if err != nil {
-		return nil, fmt.Errorf("get AgentInstance history: %w", notFoundOr(err))
-	}
-	row, err := readAgentInstanceTask(ctx, c.db, instance.HistoryID, taskID)
+// GetAgentInstanceTask returns a task with up to historyLength latest archived messages,
+// or ErrNotFound if the instance or task is absent. Nil or negative historyLength loads
+// all history; zero skips it. Callers authorize instance access.
+func (c *Client) GetAgentInstanceTask(ctx context.Context, instanceID, taskID string, historyLength *int) (*a2a.Task, error) {
+	row, err := queryOne(ctx, c.db, `
+		SELECT t.history_id, t.id, t.state, t.status_timestamp, t.data, t.created_at, t.updated_at,
+		    t.initial_message_id, t.request_hash, t.snapshot_atespace, t.snapshot_uri,
+		    t.snapshot_content_scope, t.history_sequence, t.position
+		FROM agent_instance_task t
+		JOIN agent_instance i ON i.history_id = t.history_id
+		WHERE i.id = $1 AND t.id = $2
+	`, pgx.RowToStructByName[agentInstanceTaskRow], instanceID, taskID)
 	if err != nil {
 		return nil, fmt.Errorf("get AgentInstance task %s: %w", taskID, notFoundOr(err))
 	}
 	task, err := unmarshalAgentInstanceTask(row.Data)
 	if err == nil {
-		err = loadAgentInstanceTaskHistories(ctx, c.db, instance.HistoryID, []*a2a.Task{task})
+		err = loadAgentInstanceTaskHistories(ctx, c.db, row.HistoryID, []*a2a.Task{task}, historyLength)
 	}
 	return task, err
 }
@@ -415,8 +419,9 @@ func (c *Client) GetAgentInstanceTask(ctx context.Context, instanceID, taskID st
 // ListAgentInstanceTasks returns tasks with archived messages in immutable creation order
 // after afterID, with optional state and exclusive status-timestamp filters. The total
 // counts all matching tasks before pagination; it is read separately and can differ under
-// concurrent writes. Callers authorize instance access.
-func (c *Client) ListAgentInstanceTasks(ctx context.Context, instanceID, afterID string, state a2a.TaskState, statusTimestampAfter *time.Time, limit int) ([]*a2a.Task, int, error) {
+// concurrent writes. History limits have the same semantics as GetAgentInstanceTask.
+// Callers authorize instance access.
+func (c *Client) ListAgentInstanceTasks(ctx context.Context, instanceID, afterID string, state a2a.TaskState, statusTimestampAfter *time.Time, limit int, historyLength *int) ([]*a2a.Task, int, error) {
 	instance, err := readAgentInstance(ctx, c.db, instanceID)
 	if err != nil {
 		return nil, 0, fmt.Errorf("get AgentInstance history: %w", notFoundOr(err))
@@ -461,7 +466,7 @@ func (c *Client) ListAgentInstanceTasks(ctx context.Context, instanceID, afterID
 		}
 		tasks = append(tasks, task)
 	}
-	if err := loadAgentInstanceTaskHistories(ctx, c.db, instance.HistoryID, tasks); err != nil {
+	if err := loadAgentInstanceTaskHistories(ctx, c.db, instance.HistoryID, tasks, historyLength); err != nil {
 		return nil, 0, err
 	}
 	return tasks, int(total), nil
@@ -549,10 +554,17 @@ func storeProtoTaskMessages(ctx context.Context, db dbExecutor, historyID uuid.U
 }
 
 // loadAgentInstanceTaskHistories attaches archived messages to the supplied tasks in event
-// order. It leaves tasks with no archived messages unchanged and rejects malformed message
-// payloads.
-func loadAgentInstanceTaskHistories(ctx context.Context, db dbExecutor, historyID uuid.UUID, tasks []*a2a.Task) error {
+// order, limited to the latest historyLength per task. Zero clears history without a
+// query; nil or negative loads it all. Tasks without archived messages otherwise retain
+// their inline history, subject to the same limit. Malformed messages return errors.
+func loadAgentInstanceTaskHistories(ctx context.Context, db dbExecutor, historyID uuid.UUID, tasks []*a2a.Task, historyLength *int) error {
 	if len(tasks) == 0 {
+		return nil
+	}
+	if historyLength != nil && *historyLength == 0 {
+		for _, task := range tasks {
+			task.History = []*a2a.Message{}
+		}
 		return nil
 	}
 	ids := make([]string, len(tasks))
@@ -560,8 +572,11 @@ func loadAgentInstanceTaskHistories(ctx context.Context, db dbExecutor, historyI
 	for index, task := range tasks {
 		ids[index] = string(task.ID)
 		byID[string(task.ID)] = task
+		if historyLength != nil && *historyLength > 0 && *historyLength < len(task.History) {
+			task.History = task.History[len(task.History)-*historyLength:]
+		}
 	}
-	rows, err := readTaskMessages(ctx, db, historyID, ids)
+	rows, err := readTaskMessages(ctx, db, historyID, ids, historyLength)
 	if err != nil {
 		return fmt.Errorf("list AgentInstance task history: %w", err)
 	}
@@ -714,15 +729,23 @@ func saveTaskProjection(ctx context.Context, db dbExecutor, historyID uuid.UUID,
 	`, pgx.RowToStructByName[agentInstanceTaskRow], historyID, taskID, state, statusTimestamp, data)
 }
 
-// readTaskMessages returns archived message payloads for the requested tasks in event
-// order. Callers authorize the history and decode the returned payloads.
-func readTaskMessages(ctx context.Context, db dbExecutor, historyID uuid.UUID, taskIDs []string) ([]taskHistoryRow, error) {
+// readTaskMessages returns the latest historyLength archived messages per requested task
+// in event order. Nil or negative limits load all messages. Callers authorize the history
+// and decode the returned payloads.
+func readTaskMessages(ctx context.Context, db dbExecutor, historyID uuid.UUID, taskIDs []string, historyLength *int) ([]taskHistoryRow, error) {
+	if historyLength != nil && *historyLength < 0 {
+		historyLength = nil
+	}
 	return queryMany(ctx, db, `
-		SELECT task_id, data
-		FROM agent_instance_task_event
-		WHERE history_id = $1
-		  AND task_id = ANY($2::text[])
-		  AND message_id IS NOT NULL
-		ORDER BY sequence
-	`, pgx.RowToStructByName[taskHistoryRow], historyID, taskIDs)
+		SELECT messages.task_id, messages.data
+		FROM unnest($2::text[]) AS tasks(task_id)
+		CROSS JOIN LATERAL (
+		    SELECT task_id, data, sequence
+		    FROM agent_instance_task_event
+		    WHERE history_id = $1 AND task_id = tasks.task_id AND message_id IS NOT NULL
+		    ORDER BY sequence DESC
+		    LIMIT $3
+		) messages
+		ORDER BY messages.sequence
+	`, pgx.RowToStructByName[taskHistoryRow], historyID, taskIDs, historyLength)
 }

--- a/go/core/internal/database/agent_instances.go
+++ b/go/core/internal/database/agent_instances.go
@@ -216,60 +216,22 @@ func (c *Client) UpdateAgentInstanceName(ctx context.Context, id, userID, name s
 		if err != nil {
 			return err
 		}
-		row, err = queryOne(ctx, tx, `
+		tag, err := tx.Exec(ctx, `
 			UPDATE agent_instance
 			SET data = $1
 			WHERE id = $2 AND user_id = $3
-			RETURNING id, user_id, prepared_revision, state, data, operation, context_id,
-			    source_checkpoint_id, history_id
-		`, pgx.RowToStructByName[agentInstanceRow], data, row.ID, userID)
+		`, data, row.ID, userID)
 		if err != nil {
 			return err
 		}
-		result, err = toAgentInstance(row)
-		return err
+		if tag.RowsAffected() != 1 {
+			return ErrNotFound
+		}
+		result = instance
+		return nil
 	})
 	if err != nil {
 		return nil, fmt.Errorf("rename AgentInstance %s: %w", id, err)
-	}
-	return result, nil
-}
-
-// MarkAgentInstanceReady records the runtime authority and clears failure when an instance
-// is still CREATING/CREATE. It returns other lifecycle states unchanged, so a delayed
-// completion cannot overwrite a newer operation. Callers authorize this internal lifecycle
-// update.
-func (c *Client) MarkAgentInstanceReady(ctx context.Context, id, authority string) (*apiv1alpha1.AgentInstance, error) {
-	var result *apiv1alpha1.AgentInstance
-	err := c.withTx(ctx, func(tx pgx.Tx) error {
-		row, err := lockAgentInstance(ctx, tx, id)
-		if err != nil {
-			return notFoundOr(err)
-		}
-		result, err = toAgentInstance(row)
-		if err != nil || row.State != "AGENT_INSTANCE_STATE_CREATING" || row.Operation != "AGENT_INSTANCE_OPERATION_CREATE" {
-			return err
-		}
-		result.State = apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_READY
-		result.Operation = apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_UNSPECIFIED
-		result.A2AAuthority = authority
-		result.Failure = nil
-		result.UpdatedAt = timestamppb.Now()
-		data, err := marshalAgentInstance(result)
-		if err != nil {
-			return err
-		}
-		_, err = queryOne(ctx, tx, `
-			UPDATE agent_instance
-			SET state = 'AGENT_INSTANCE_STATE_READY', operation = 'AGENT_INSTANCE_OPERATION_UNSPECIFIED', data = $2
-			WHERE id = $1 AND state = 'AGENT_INSTANCE_STATE_CREATING' AND operation = 'AGENT_INSTANCE_OPERATION_CREATE'
-			RETURNING id, user_id, prepared_revision, state, data, operation, context_id,
-			    source_checkpoint_id, history_id
-		`, pgx.RowToStructByName[agentInstanceRow], row.ID, data)
-		return err
-	})
-	if err != nil {
-		return nil, fmt.Errorf("mark AgentInstance %s ready: %w", id, err)
 	}
 	return result, nil
 }
@@ -308,7 +270,7 @@ func (c *Client) TransitionAgentInstance(
 		if err != nil {
 			return err
 		}
-		row, err = queryOne(ctx, tx, `
+		tag, err := tx.Exec(ctx, `
 			UPDATE agent_instance
 			SET state = $1, operation = $2, data = $3
 			WHERE agent_instance.id = $4
@@ -321,21 +283,19 @@ func (c *Client) TransitionAgentInstance(
 			      WHERE c.source_instance_id = agent_instance.id AND c.state = 'CREATING'
 			    )
 			  )
-			RETURNING id, user_id, prepared_revision, state, data, operation, context_id,
-			    source_checkpoint_id, history_id
 		`,
-			pgx.RowToStructByName[agentInstanceRow], next.State.String(),
+			next.State.String(),
 			next.Operation.String(), data, row.ID, expectedState.String(),
 			expectedOperation.String(),
 		)
-		if errors.Is(err, pgx.ErrNoRows) {
-			return ErrAgentInstanceConflict
-		}
 		if err != nil {
 			return err
 		}
-		result, err = toAgentInstance(row)
-		return err
+		if tag.RowsAffected() != 1 {
+			return ErrAgentInstanceConflict
+		}
+		result = next
+		return nil
 	})
 	if err != nil {
 		return result, fmt.Errorf("transition AgentInstance %s: %w", instance.GetId(), err)

--- a/go/core/internal/database/client_agent_instance_test.go
+++ b/go/core/internal/database/client_agent_instance_test.go
@@ -35,7 +35,7 @@ func TestMalformedDatabaseIDsReturnErrors(t *testing.T) {
 			return err
 		}},
 		{"create share", func() error {
-			_, err := client.CreateAgentInstanceShare(ctx, &apiv1alpha1.AgentInstanceShare{Id: uuid.NewString(), AgentInstanceId: "invalid", Permission: apiv1alpha1.AgentInstanceSharePermission_AGENT_INSTANCE_SHARE_PERMISSION_READ_ONLY}, []byte("token"))
+			_, err := client.CreateAgentInstanceShare(ctx, &apiv1alpha1.AgentInstanceShare{Id: uuid.NewString(), AgentInstanceId: "invalid", Permission: apiv1alpha1.AgentInstanceSharePermission_AGENT_INSTANCE_SHARE_PERMISSION_READ_ONLY}, []byte("token"), "alice")
 			return err
 		}},
 		{"create task", func() error {
@@ -128,7 +128,7 @@ func TestAgentInstanceTasksAreDurableAndExclusive(t *testing.T) {
 	if err := db.QueryRow(ctx, "SELECT task_id FROM agent_instance_task_event").Scan(&eventTaskID); err != nil || eventTaskID != string(first.ID) {
 		t.Fatalf("initial event task ID = %q, want %q: %v", eventTaskID, first.ID, err)
 	}
-	got, err := client.GetAgentInstanceTask(ctx, "11111111-1111-4111-8111-111111111111", "task-1")
+	got, err := client.GetAgentInstanceTask(ctx, "11111111-1111-4111-8111-111111111111", "task-1", nil)
 	if err != nil || got.ID != first.ID || got.Status.State != first.Status.State || len(got.History) != 1 {
 		t.Fatalf("GetAgentInstanceTask() = %#v, %v", got, err)
 	}
@@ -164,7 +164,7 @@ func TestAgentInstanceTasksAreDurableAndExclusive(t *testing.T) {
 	if snapshotAtespace != snapshot.Atespace || snapshotURI != snapshot.URI || historySequence != latestSequence {
 		t.Fatalf("stored boundary = %s/%s sequence %d", snapshotAtespace, snapshotURI, historySequence)
 	}
-	got, err = client.GetAgentInstanceTask(ctx, "11111111-1111-4111-8111-111111111111", "task-1")
+	got, err = client.GetAgentInstanceTask(ctx, "11111111-1111-4111-8111-111111111111", "task-1", nil)
 	if err != nil || len(got.History) != 2 || got.History[1].Role != a2a.MessageRoleAgent {
 		t.Fatalf("reconstructed task history = %#v, error %v", got, err)
 	}
@@ -175,11 +175,11 @@ func TestAgentInstanceTasksAreDurableAndExclusive(t *testing.T) {
 		t.Fatalf("event count = %d, want 5", events)
 	}
 
-	tasks, total, err := client.ListAgentInstanceTasks(ctx, "11111111-1111-4111-8111-111111111111", "", a2a.TaskStateUnspecified, nil, 1)
+	tasks, total, err := client.ListAgentInstanceTasks(ctx, "11111111-1111-4111-8111-111111111111", "", a2a.TaskStateUnspecified, nil, 1, nil)
 	if err != nil || total != 2 || len(tasks) != 1 || tasks[0].ID != first.ID {
 		t.Fatalf("first page = %#v, total %d, error %v", tasks, total, err)
 	}
-	tasks, total, err = client.ListAgentInstanceTasks(ctx, "11111111-1111-4111-8111-111111111111", string(first.ID), a2a.TaskStateSubmitted, nil, 2)
+	tasks, total, err = client.ListAgentInstanceTasks(ctx, "11111111-1111-4111-8111-111111111111", string(first.ID), a2a.TaskStateSubmitted, nil, 2, nil)
 	if err != nil || total != 1 || len(tasks) != 1 || tasks[0].ID != second.ID {
 		t.Fatalf("filtered page = %#v, total %d, error %v", tasks, total, err)
 	}
@@ -263,7 +263,7 @@ func TestAgentInstanceReplyArchivesStatusMessageAtomically(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := client.GetAgentInstanceTask(ctx, instanceID, "task-1")
+	got, err := client.GetAgentInstanceTask(ctx, instanceID, "task-1", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -409,9 +409,6 @@ func TestForkAgentInstanceCopiesBoundedHistory(t *testing.T) {
 		ActorTemplateAtespace: "team-a", ActorTemplateName: "assistant-kagent-revision",
 		ActorTemplateUID: "actor-template-uid",
 	}
-	if err := client.UpsertRuntimeRevision(ctx, revision); err != nil {
-		t.Fatal(err)
-	}
 	pair := AgentTemplateHarnessPair{
 		Namespace: "team-a", AgentTemplateName: "assistant", AgentTemplateUID: "template-uid",
 		HarnessName: "kagent", HarnessUID: "harness-uid", DesiredRevision: revision.Revision,
@@ -419,7 +416,7 @@ func TestForkAgentInstanceCopiesBoundedHistory(t *testing.T) {
 	if err := client.UpsertAgentTemplateHarnessPair(ctx, pair); err != nil {
 		t.Fatal(err)
 	}
-	if err := client.MarkRuntimeRevisionSuccessful(ctx, pair); err != nil {
+	if err := client.RecordRuntimeRevision(ctx, revision, true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -431,7 +428,7 @@ func TestForkAgentInstanceCopiesBoundedHistory(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := client.MarkAgentInstanceReady(ctx, source.GetId(), "source.example"); err != nil {
+	if _, err := markAgentInstanceReady(ctx, client, source.GetId(), "source.example"); err != nil {
 		t.Fatal(err)
 	}
 	first := newAgentInstanceTask("task-1", "message-1")
@@ -494,7 +491,7 @@ func TestForkAgentInstanceCopiesBoundedHistory(t *testing.T) {
 	if err != nil || len(instances) != 1 || instances[0].GetId() != fork.GetId() {
 		t.Fatalf("listed forks = %+v, error %v", instances, err)
 	}
-	tasks, total, err := client.ListAgentInstanceTasks(ctx, fork.GetId(), "", a2a.TaskStateUnspecified, nil, 10)
+	tasks, total, err := client.ListAgentInstanceTasks(ctx, fork.GetId(), "", a2a.TaskStateUnspecified, nil, 10, nil)
 	if err != nil || total != 1 || len(tasks) != 1 {
 		t.Fatalf("fork tasks = %+v, total %d, error %v", tasks, total, err)
 	}
@@ -529,7 +526,7 @@ func TestForkAgentInstanceCopiesBoundedHistory(t *testing.T) {
 		t.Fatalf("delete referenced checkpoint error = %v", err)
 	}
 
-	if _, err := client.MarkAgentInstanceReady(ctx, fork.GetId(), "fork.example"); err != nil {
+	if _, err := markAgentInstanceReady(ctx, client, fork.GetId(), "fork.example"); err != nil {
 		t.Fatal(err)
 	}
 	checkpoint2, _, err := client.ReserveAgentInstanceCheckpoint(ctx, &apiv1alpha1.Checkpoint{Id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb", AgentInstanceId: fork.GetId()}, "alice", "checkpoint-request-2")
@@ -560,16 +557,6 @@ func TestAgentInstanceCreateAndTransitions(t *testing.T) {
 		ActorTemplateAtespace: "team-a", ActorTemplateName: "assistant-kagent-revision",
 		ActorTemplateUID: "actor-template-uid",
 	}
-	if err := client.UpsertRuntimeRevision(ctx, revision); err != nil {
-		t.Fatal(err)
-	}
-	storedRevision, err := client.GetRuntimeRevision(ctx, revision.Revision)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if storedRevision.AgentCard.GetName() != "assistant" {
-		t.Fatalf("GetRuntimeRevision() Agent Card = %s: %v", storedRevision.AgentCard, err)
-	}
 	pair := AgentTemplateHarnessPair{
 		Namespace: "team-a", AgentTemplateName: "assistant", AgentTemplateUID: "template-uid",
 		HarnessName: "kagent", HarnessUID: "harness-uid", DesiredRevision: revision.Revision,
@@ -577,8 +564,16 @@ func TestAgentInstanceCreateAndTransitions(t *testing.T) {
 	if err := client.UpsertAgentTemplateHarnessPair(ctx, pair); err != nil {
 		t.Fatal(err)
 	}
-	if err := client.MarkRuntimeRevisionSuccessful(ctx, pair); err != nil {
+	if err := client.RecordRuntimeRevision(ctx, revision, true); err != nil {
 		t.Fatal(err)
+	}
+
+	storedRevision, err := client.GetRuntimeRevision(ctx, revision.Revision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if storedRevision.AgentCard.GetName() != "assistant" {
+		t.Fatalf("GetRuntimeRevision() Agent Card = %s: %v", storedRevision.AgentCard, err)
 	}
 
 	request := &apiv1alpha1.AgentInstance{
@@ -604,7 +599,7 @@ func TestAgentInstanceCreateAndTransitions(t *testing.T) {
 	if err != nil || len(instances) != 1 {
 		t.Fatalf("ListAgentInstances() = %v, error %v", instances, err)
 	}
-	ready, err := client.MarkAgentInstanceReady(ctx, created.GetId(), "actor.example")
+	ready, err := markAgentInstanceReady(ctx, client, created.GetId(), "actor.example")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -684,7 +679,7 @@ func TestInterruptActiveAgentInstanceTaskRequiresMatchingTaskAndReusesSlot(t *te
 		t.Fatalf("InterruptActiveAgentInstanceTask(terminal task) = %v, %v", interruptedTask, err)
 	}
 
-	terminated, err := client.GetAgentInstanceTask(ctx, "11111111-1111-4111-8111-111111111111", "task-1")
+	terminated, err := client.GetAgentInstanceTask(ctx, "11111111-1111-4111-8111-111111111111", "task-1", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -719,9 +714,6 @@ func agentInstanceFixture(t *testing.T, client *Client, ctx context.Context, nam
 		ActorTemplateAtespace: namespace, ActorTemplateName: revisionID + "-actor-template",
 		ActorTemplateUID: revisionID + "-actor-uid",
 	}
-	if err := client.UpsertRuntimeRevision(ctx, revision); err != nil {
-		t.Fatal(err)
-	}
 	pair := AgentTemplateHarnessPair{
 		Namespace: namespace, AgentTemplateName: template, AgentTemplateUID: template + "-uid",
 		HarnessName: harness, HarnessUID: harness + "-uid", DesiredRevision: revisionID,
@@ -729,7 +721,7 @@ func agentInstanceFixture(t *testing.T, client *Client, ctx context.Context, nam
 	if err := client.UpsertAgentTemplateHarnessPair(ctx, pair); err != nil {
 		t.Fatal(err)
 	}
-	if err := client.MarkRuntimeRevisionSuccessful(ctx, pair); err != nil {
+	if err := client.RecordRuntimeRevision(ctx, revision, true); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -914,7 +906,7 @@ func TestForkTaskOrderAndAuthorityIsolation(t *testing.T) {
 	agentInstanceFixture(t, client, ctx, "team-a", "revision", "assistant", "kagent")
 	source, _, err := client.CreateAgentInstance(ctx, newAgentInstanceRequest(uuid.NewString(), "assistant", "kagent", "Source"), uuid.NewString())
 	require.NoError(t, err)
-	_, err = client.MarkAgentInstanceReady(ctx, source.GetId(), "source.example")
+	_, err = markAgentInstanceReady(ctx, client, source.GetId(), "source.example")
 	require.NoError(t, err)
 	require.NotEqual(t, source.GetId(), source.GetContextId())
 	sourceRow, err := readAgentInstance(ctx, client.db, source.GetId())
@@ -938,7 +930,7 @@ func TestForkTaskOrderAndAuthorityIsolation(t *testing.T) {
 		Id: uuid.NewString(), AgentInstanceId: source.GetId(),
 	}, "alice", uuid.NewString())
 	require.NoError(t, err)
-	waiting, err := client.GetAgentInstanceTask(ctx, source.GetId(), "z-first")
+	waiting, err := client.GetAgentInstanceTask(ctx, source.GetId(), "z-first", nil)
 	require.NoError(t, err)
 	require.ErrorIs(t, client.StoreAgentInstanceTaskEvent(ctx, source.GetId(), waiting, waiting, nil), ErrAgentInstanceConflict)
 	_, err = client.FinalizeAgentInstanceCheckpoint(ctx, checkpoint.GetId(), "tag", "tag-snapshot", "")
@@ -947,7 +939,7 @@ func TestForkTaskOrderAndAuthorityIsolation(t *testing.T) {
 	require.ErrorIs(t, err, ErrNotFound)
 	fork, _, err := client.ForkAgentInstance(ctx, checkpoint.GetId(), "alice", uuid.NewString(), uuid.NewString())
 	require.NoError(t, err)
-	_, err = client.MarkAgentInstanceReady(ctx, fork.GetId(), "fork.example")
+	_, err = markAgentInstanceReady(ctx, client, fork.GetId(), "fork.example")
 	require.NoError(t, err)
 	require.Equal(t, source.GetContextId(), fork.GetContextId())
 	forkRow, err := readAgentInstance(ctx, client.db, fork.GetId())
@@ -955,12 +947,12 @@ func TestForkTaskOrderAndAuthorityIsolation(t *testing.T) {
 	require.NotEqual(t, sourceRow.HistoryID, forkRow.HistoryID)
 
 	for _, instance := range []*apiv1alpha1.AgentInstance{source, fork} {
-		page, total, err := client.ListAgentInstanceTasks(ctx, instance.GetId(), "", a2a.TaskStateUnspecified, nil, 1)
+		page, total, err := client.ListAgentInstanceTasks(ctx, instance.GetId(), "", a2a.TaskStateUnspecified, nil, 1, nil)
 		require.NoError(t, err)
 		require.Equal(t, 2, total)
 		require.Len(t, page, 1)
 		require.Equal(t, a2a.TaskID("z-first"), page[0].ID)
-		page, _, err = client.ListAgentInstanceTasks(ctx, instance.GetId(), string(page[0].ID), a2a.TaskStateUnspecified, nil, 1)
+		page, _, err = client.ListAgentInstanceTasks(ctx, instance.GetId(), string(page[0].ID), a2a.TaskStateUnspecified, nil, 1, nil)
 		require.NoError(t, err)
 		require.Len(t, page, 1)
 		require.Equal(t, a2a.TaskID("a-second"), page[0].ID)
@@ -985,11 +977,11 @@ func TestForkTaskOrderAndAuthorityIsolation(t *testing.T) {
 	waiting.Status.State = a2a.TaskStateCanceled
 	require.NoError(t, client.StoreAgentInstanceTaskEvent(ctx, fork.GetId(), waiting, waiting,
 		&AgentInstanceTaskSnapshot{Atespace: "team-a", URI: "fork-resumed", ContentScope: "DATA"}))
-	unchanged, err := client.GetAgentInstanceTask(ctx, source.GetId(), string(waiting.ID))
+	unchanged, err := client.GetAgentInstanceTask(ctx, source.GetId(), string(waiting.ID), nil)
 	require.NoError(t, err)
 	require.Equal(t, a2a.TaskStateInputRequired, unchanged.Status.State)
 	require.Len(t, unchanged.History, 1)
-	changed, err := client.GetAgentInstanceTask(ctx, fork.GetId(), string(waiting.ID))
+	changed, err := client.GetAgentInstanceTask(ctx, fork.GetId(), string(waiting.ID), nil)
 	require.NoError(t, err)
 	require.Equal(t, a2a.TaskStateCanceled, changed.Status.State)
 	require.Len(t, changed.History, 2)
@@ -1005,7 +997,7 @@ func TestForkTaskOrderAndAuthorityIsolation(t *testing.T) {
 	require.NoError(t, err)
 	fork2, _, err := client.ForkAgentInstance(ctx, nested.GetId(), "alice", uuid.NewString(), uuid.NewString())
 	require.NoError(t, err)
-	tasks, _, err := client.ListAgentInstanceTasks(ctx, fork2.GetId(), "", a2a.TaskStateUnspecified, nil, 10)
+	tasks, _, err := client.ListAgentInstanceTasks(ctx, fork2.GetId(), "", a2a.TaskStateUnspecified, nil, 10, nil)
 	require.NoError(t, err)
 	require.Len(t, tasks, 2)
 	require.Equal(t, a2a.TaskID("z-first"), tasks[0].ID)
@@ -1014,4 +1006,41 @@ func TestForkTaskOrderAndAuthorityIsolation(t *testing.T) {
 	wrong := *waiting
 	wrong.ContextID = fork.GetId()
 	require.Error(t, client.StoreAgentInstanceTaskEvent(ctx, fork.GetId(), &wrong, &wrong, nil))
+}
+
+// markAgentInstanceReady completes creation for persistence fixtures using the lifecycle CAS.
+func markAgentInstanceReady(ctx context.Context, client *Client, id, authority string) (*apiv1alpha1.AgentInstance, error) {
+	return client.TransitionAgentInstance(ctx, &apiv1alpha1.AgentInstance{
+		Id:           id,
+		State:        apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_READY,
+		A2AAuthority: authority,
+	}, apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_CREATING,
+		apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_CREATE)
+}
+
+func TestAgentInstanceShareCreationRequiresOwner(t *testing.T) {
+	client := NewClient(setupTestDB(t))
+	ctx := t.Context()
+	agentInstanceFixture(t, client, ctx, "team-a", "revision", "assistant", "kagent")
+	instance, _, err := client.CreateAgentInstance(ctx, newAgentInstanceRequest(uuid.NewString(), "assistant", "kagent", ""), "create")
+	require.NoError(t, err)
+	share := &apiv1alpha1.AgentInstanceShare{
+		Id: uuid.NewString(), AgentInstanceId: instance.Id,
+		Permission: apiv1alpha1.AgentInstanceSharePermission_AGENT_INSTANCE_SHARE_PERMISSION_READ_ONLY,
+	}
+	_, err = client.CreateAgentInstanceShare(ctx, share, []byte("token"), "bob")
+	require.ErrorIs(t, err, ErrNotFound)
+	_, _, err = client.GetAgentInstanceShareByTokenHash(ctx, []byte("token"))
+	require.ErrorIs(t, err, ErrNotFound)
+
+	created, err := client.CreateAgentInstanceShare(ctx, share, []byte("token"), "alice")
+	require.NoError(t, err)
+	require.Equal(t, share.Id, created.Id)
+	require.NotNil(t, created.CreatedAt)
+	require.Nil(t, share.CreatedAt)
+
+	require.NoError(t, client.DeleteAgentInstance(ctx, instance.Id))
+	share.Id = uuid.NewString()
+	_, err = client.CreateAgentInstanceShare(ctx, share, []byte("missing-token"), "alice")
+	require.ErrorIs(t, err, ErrNotFound)
 }

--- a/go/core/internal/database/client_test.go
+++ b/go/core/internal/database/client_test.go
@@ -9,165 +9,10 @@ import (
 
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/kagent-dev/kagent/go/api/v1alpha3"
 	"github.com/pgvector/pgvector-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// TestConcurrentToolServerUpserts verifies that concurrent StoreToolServer calls
-// work correctly without application-level locking.
-func TestConcurrentToolServerUpserts(t *testing.T) {
-	db := setupTestDB(t)
-	client := NewClient(db)
-	ctx := context.Background()
-
-	const numGoroutines = 10
-	const numUpserts = 50
-
-	var wg sync.WaitGroup
-	wg.Add(numGoroutines)
-
-	serverName := "test-server"
-	groupKind := "RemoteMCPServer"
-
-	for i := range numGoroutines {
-		go func(goroutineID int) {
-			defer wg.Done()
-			for j := range numUpserts {
-				toolServer := &ToolServer{
-					Name:        serverName,
-					GroupKind:   groupKind,
-					Description: fmt.Sprintf("Description from goroutine %d iteration %d", goroutineID, j),
-				}
-				_, err := client.StoreToolServer(ctx, toolServer)
-				assert.NoError(t, err, "StoreToolServer should not fail")
-			}
-		}(i)
-	}
-
-	wg.Wait()
-
-	// Verify the tool server exists and has valid data
-	server, err := client.GetToolServer(ctx, serverName)
-	require.NoError(t, err)
-	assert.Equal(t, serverName, server.Name)
-	assert.NotEmpty(t, server.Description)
-}
-
-// TestConcurrentRefreshToolsForServer verifies that concurrent RefreshToolsForServer
-// calls work correctly. This is the most complex operation that previously required
-// an application-level lock.
-func TestConcurrentRefreshToolsForServer(t *testing.T) {
-	db := setupTestDB(t)
-	client := NewClient(db)
-	ctx := context.Background()
-
-	serverName := "test-server"
-	groupKind := "RemoteMCPServer"
-
-	// Create the tool server first
-	_, err := client.StoreToolServer(ctx, &ToolServer{
-		Name:        serverName,
-		GroupKind:   groupKind,
-		Description: "Test server",
-	})
-	require.NoError(t, err)
-
-	const numGoroutines = 10
-
-	var wg sync.WaitGroup
-	wg.Add(numGoroutines)
-
-	for i := range numGoroutines {
-		go func(goroutineID int) {
-			defer wg.Done()
-			// Each goroutine refreshes with a different set of tools
-			tools := []*v1alpha3.MCPTool{
-				{Name: fmt.Sprintf("tool-a-%d", goroutineID), Description: "Tool A"},
-				{Name: fmt.Sprintf("tool-b-%d", goroutineID), Description: "Tool B"},
-			}
-			err := client.RefreshToolsForServer(ctx, serverName, groupKind, tools...)
-			assert.NoError(t, err, "RefreshToolsForServer should not fail")
-		}(i)
-	}
-
-	wg.Wait()
-
-	// Verify the tools exist and no data was corrupted. With READ COMMITTED isolation,
-	// concurrent delete+insert transactions can interleave, so we don't assert on an
-	// exact count. What matters is that all calls succeeded and valid tool records exist.
-	tools, err := client.ListToolsForServer(ctx, serverName, groupKind)
-	require.NoError(t, err)
-	assert.NotEmpty(t, tools, "Should have tools after concurrent refreshes")
-	for _, tool := range tools {
-		assert.Equal(t, serverName, tool.ServerName)
-		assert.Equal(t, groupKind, tool.GroupKind)
-	}
-}
-
-func TestListToolsFiltersServerAndExcludesDeleted(t *testing.T) {
-	client := NewClient(setupTestDB(t))
-	ctx := t.Context()
-	for _, tool := range []struct{ name, server, kind string }{
-		{"target", "shared-name", "RemoteMCPServer"},
-		{"other-kind", "shared-name", "MCPServer"},
-		{"other-server", "another-name", "RemoteMCPServer"},
-		{"deleted", "deleted-server", "RemoteMCPServer"},
-	} {
-		require.NoError(t, client.RefreshToolsForServer(ctx, tool.server, tool.kind, &v1alpha3.MCPTool{Name: tool.name}))
-	}
-	require.NoError(t, client.DeleteToolsForServer(ctx, "deleted-server", "RemoteMCPServer"))
-
-	all, err := client.ListTools(ctx)
-	require.NoError(t, err)
-	ids := make([]string, len(all))
-	for i, tool := range all {
-		ids[i] = tool.ID
-	}
-	require.ElementsMatch(t, []string{"target", "other-kind", "other-server"}, ids)
-
-	filtered, err := client.ListToolsForServer(ctx, "shared-name", "RemoteMCPServer")
-	require.NoError(t, err)
-	require.Len(t, filtered, 1)
-	require.Equal(t, "target", filtered[0].ID)
-	for _, server := range []string{"deleted-server", "missing-server", ""} {
-		filtered, err := client.ListToolsForServer(ctx, server, "RemoteMCPServer")
-		require.NoError(t, err)
-		require.Empty(t, filtered)
-	}
-}
-
-// TestStoreToolServerIdempotence verifies that StoreToolServer is idempotent.
-func TestStoreToolServerIdempotence(t *testing.T) {
-	db := setupTestDB(t)
-	client := NewClient(db)
-	ctx := context.Background()
-
-	server := &ToolServer{
-		Name:        "idempotent-server",
-		GroupKind:   "RemoteMCPServer",
-		Description: "Original description",
-	}
-
-	// First store
-	_, err := client.StoreToolServer(ctx, server)
-	require.NoError(t, err, "First StoreToolServer should succeed")
-
-	// Second store with same data (idempotent)
-	_, err = client.StoreToolServer(ctx, server)
-	require.NoError(t, err, "Second StoreToolServer should succeed")
-
-	// Third store with updated data (upsert)
-	server.Description = "Updated description"
-	_, err = client.StoreToolServer(ctx, server)
-	require.NoError(t, err, "Third StoreToolServer with updated data should succeed")
-
-	// Verify final state
-	retrieved, err := client.GetToolServer(ctx, server.Name)
-	require.NoError(t, err)
-	assert.Equal(t, "Updated description", retrieved.Description)
-}
 
 // TestDirectModelScans covers database defaults, required catalog fields, and nullable
 // memory fields when rows are scanned directly into application models.
@@ -181,36 +26,33 @@ func TestDirectModelScans(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("tools", func(t *testing.T) {
-		tool, err := client.GetTool(ctx, "defaulted")
+		tools, err := client.ListTools(ctx)
 		require.NoError(t, err)
+		require.Len(t, tools, 1)
+		tool := tools[0]
 		assert.Empty(t, tool.Description)
 		assert.False(t, tool.CreatedAt.IsZero())
 		assert.Equal(t, tool.CreatedAt, tool.UpdatedAt)
 		assert.Nil(t, tool.DeletedAt)
-		all, err := client.ListTools(ctx)
-		require.NoError(t, err)
-		assert.Equal(t, []Tool{*tool}, all)
-		filtered, err := client.ListToolsForServer(ctx, "server", "kind")
-		require.NoError(t, err)
-		assert.Equal(t, []Tool{*tool}, filtered)
 	})
 
 	t.Run("servers", func(t *testing.T) {
-		server, err := client.GetToolServer(ctx, "defaulted")
+		servers, err := client.ListToolServers(ctx)
 		require.NoError(t, err)
+		require.Len(t, servers, 1)
+		server := servers[0]
 		assert.Empty(t, server.Description)
 		assert.False(t, server.CreatedAt.IsZero())
 		assert.Equal(t, server.CreatedAt, server.UpdatedAt)
 		assert.Nil(t, server.DeletedAt)
 		assert.Nil(t, server.LastConnected)
-		all, err := client.ListToolServers(ctx)
+		require.NoError(t, client.RefreshToolServer(ctx, &ToolServer{Name: "defaulted", GroupKind: "kind", Description: "updated"}))
+		updated, err := client.ListToolServers(ctx)
 		require.NoError(t, err)
-		assert.Equal(t, []ToolServer{*server}, all)
-		updated, err := client.StoreToolServer(ctx, &ToolServer{Name: "defaulted", GroupKind: "kind", Description: "updated"})
-		require.NoError(t, err)
-		assert.Equal(t, server.CreatedAt, updated.CreatedAt)
-		assert.False(t, updated.UpdatedAt.Before(server.UpdatedAt))
-		assert.Equal(t, "updated", updated.Description)
+		require.Len(t, updated, 1)
+		assert.Equal(t, server.CreatedAt, updated[0].CreatedAt)
+		assert.False(t, updated[0].UpdatedAt.Before(server.UpdatedAt))
+		assert.Equal(t, "updated", updated[0].Description)
 	})
 
 	for _, query := range []string{
@@ -235,7 +77,7 @@ func TestDirectModelScans(t *testing.T) {
 		_, err := db.Exec(ctx, `INSERT INTO memory (id, agent_name, user_id, embedding, access_count) VALUES ('nullable', 'agent', 'user', $1, NULL)`, pgvector.NewVector(embedding))
 		require.NoError(t, err)
 		memory := &Memory{AgentName: "agent", UserID: "user", Embedding: makeEmbedding(0.5), AccessCount: 1}
-		require.NoError(t, client.StoreAgentMemory(ctx, memory))
+		require.NoError(t, client.StoreAgentMemories(ctx, memory))
 		all, err := client.ListAgentMemories(ctx, "agent", "user")
 		require.NoError(t, err)
 		require.Len(t, all, 2)
@@ -323,7 +165,7 @@ func TestStoreAndSearchAgentMemory(t *testing.T) {
 	}
 
 	for _, m := range memories {
-		err := client.StoreAgentMemory(ctx, m)
+		err := client.StoreAgentMemories(ctx, m)
 		require.NoError(t, err)
 	}
 
@@ -353,7 +195,7 @@ func TestStoreAgentMemoriesBatch(t *testing.T) {
 		{ID: "b-3", AgentName: agentName, UserID: userID, Content: "batch memory 3", Embedding: makeEmbedding(0.6)},
 	}
 
-	err := client.StoreAgentMemories(ctx, memories)
+	err := client.StoreAgentMemories(ctx, memories...)
 	require.NoError(t, err)
 
 	results, err := client.SearchAgentMemory(ctx, agentName, userID, makeEmbedding(0.5), 10)
@@ -372,7 +214,7 @@ func TestSearchAgentMemoryLimit(t *testing.T) {
 	userID := "limit-user"
 
 	for i := range 5 {
-		err := client.StoreAgentMemory(ctx, &Memory{
+		err := client.StoreAgentMemories(ctx, &Memory{
 			ID:        fmt.Sprintf("lim-%d", i),
 			AgentName: agentName,
 			UserID:    userID,
@@ -409,9 +251,9 @@ func TestSearchAgentMemoryIsolation(t *testing.T) {
 	ctx := context.Background()
 
 	mem1 := &Memory{AgentName: "agent-a", UserID: "user-1", Content: "agent-a user-1 memory", Embedding: makeEmbedding(0.5)}
-	require.NoError(t, client.StoreAgentMemory(ctx, mem1))
-	require.NoError(t, client.StoreAgentMemory(ctx, &Memory{AgentName: "agent-b", UserID: "user-1", Content: "agent-b user-1 memory", Embedding: makeEmbedding(0.5)}))
-	require.NoError(t, client.StoreAgentMemory(ctx, &Memory{AgentName: "agent-a", UserID: "user-2", Content: "agent-a user-2 memory", Embedding: makeEmbedding(0.5)}))
+	require.NoError(t, client.StoreAgentMemories(ctx, mem1))
+	require.NoError(t, client.StoreAgentMemories(ctx, &Memory{AgentName: "agent-b", UserID: "user-1", Content: "agent-b user-1 memory", Embedding: makeEmbedding(0.5)}))
+	require.NoError(t, client.StoreAgentMemories(ctx, &Memory{AgentName: "agent-a", UserID: "user-2", Content: "agent-a user-2 memory", Embedding: makeEmbedding(0.5)}))
 
 	results, err := client.SearchAgentMemory(ctx, "agent-a", "user-1", makeEmbedding(0.5), 10)
 	require.NoError(t, err)
@@ -428,7 +270,7 @@ func TestSearchAgentMemoryNormalizedName(t *testing.T) {
 	ctx := context.Background()
 
 	stored := &Memory{AgentName: "ns__my_agent", UserID: "user-1", Content: "stored under underscore form", Embedding: makeEmbedding(0.5)}
-	require.NoError(t, client.StoreAgentMemory(ctx, stored))
+	require.NoError(t, client.StoreAgentMemories(ctx, stored))
 
 	results, err := client.SearchAgentMemory(ctx, "ns__my-agent", "user-1", makeEmbedding(0.5), 10)
 	require.NoError(t, err)
@@ -447,7 +289,7 @@ func TestDeleteAgentMemory(t *testing.T) {
 	userID := "del-user"
 
 	for i := range 3 {
-		err := client.StoreAgentMemory(ctx, &Memory{
+		err := client.StoreAgentMemories(ctx, &Memory{
 			ID:        fmt.Sprintf("del-%d", i),
 			AgentName: agentName,
 			UserID:    userID,
@@ -484,16 +326,16 @@ func TestPruneExpiredMemories(t *testing.T) {
 
 	// Memory that is expired and unpopular, should be deleted
 	coldMem := &Memory{AgentName: agentName, UserID: userID, Content: "cold expired memory", Embedding: makeEmbedding(0.1), ExpiresAt: &past, AccessCount: 2}
-	require.NoError(t, client.StoreAgentMemory(ctx, coldMem))
+	require.NoError(t, client.StoreAgentMemories(ctx, coldMem))
 
 	// Memory that is expired but popular (AccessCount >= 10), TTL should be extended
 	hotMem := &Memory{AgentName: agentName, UserID: userID, Content: "hot expired memory", Embedding: makeEmbedding(0.9), ExpiresAt: &past, AccessCount: 15}
-	require.NoError(t, client.StoreAgentMemory(ctx, hotMem))
+	require.NoError(t, client.StoreAgentMemories(ctx, hotMem))
 
 	// Memory that has not expired, should be untouched
 	future := time.Now().Add(24 * time.Hour)
 	liveMem := &Memory{AgentName: agentName, UserID: userID, Content: "non-expired memory", Embedding: makeEmbedding(0.5), ExpiresAt: &future, AccessCount: 0}
-	require.NoError(t, client.StoreAgentMemory(ctx, liveMem))
+	require.NoError(t, client.StoreAgentMemories(ctx, liveMem))
 
 	err := client.PruneExpiredMemories(ctx)
 	require.NoError(t, err)
@@ -532,7 +374,7 @@ func TestSearchAgentMemoryConcurrentAccessCount(t *testing.T) {
 
 	// Small store so every search hits the same top rows (max overlap).
 	for i := range 5 {
-		err := client.StoreAgentMemory(ctx, &Memory{
+		err := client.StoreAgentMemories(ctx, &Memory{
 			AgentName: agentName,
 			UserID:    userID,
 			Content:   fmt.Sprintf("shared memory %d", i),
@@ -570,30 +412,5 @@ func TestSearchAgentMemoryConcurrentAccessCount(t *testing.T) {
 
 	for err := range errs {
 		require.NoError(t, err, "concurrent memory search must not fail")
-	}
-}
-
-// TestSingleRowReadsMapMissingToErrNotFound verifies that every single-row
-// read maps the driver's no-rows error to ErrNotFound, so callers can
-// match with errors.Is without importing pgx.
-func TestSingleRowReadsMapMissingToErrNotFound(t *testing.T) {
-	db := setupTestDB(t)
-	client := NewClient(db)
-	ctx := context.Background()
-
-	tests := []struct {
-		name string
-		read func() error
-	}{
-		{name: "GetTool", read: func() error { _, err := client.GetTool(ctx, "missing"); return err }},
-		{name: "GetToolServer", read: func() error { _, err := client.GetToolServer(ctx, "missing"); return err }},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.read()
-			require.Error(t, err)
-			require.ErrorIs(t, err, ErrNotFound)
-		})
 	}
 }

--- a/go/core/internal/database/memory.go
+++ b/go/core/internal/database/memory.go
@@ -10,32 +10,44 @@ import (
 	pgvector "github.com/pgvector/pgvector-go"
 )
 
-// StoreAgentMemory inserts a memory and assigns its generated ID to the input on success.
-// Creation time comes from the database; the supplied owner, agent, expiration, and access
-// count are stored as given.
-func (c *Client) StoreAgentMemory(ctx context.Context, memory *Memory) error {
-	id, err := insertAgentMemory(ctx, c.db, memory)
-	if err != nil {
-		return err
+// StoreAgentMemories inserts one or more memories atomically and assigns generated IDs
+// only after success. A single insert uses one statement; a batch uses a transaction.
+// Creation time comes from the database. Empty input is a no-op, and failures leave
+// input IDs unchanged.
+func (c *Client) StoreAgentMemories(ctx context.Context, memories ...*Memory) error {
+	for _, memory := range memories {
+		if memory == nil {
+			return fmt.Errorf("missing memory")
+		}
 	}
-	memory.ID = id
-	return nil
-}
-
-// StoreAgentMemories inserts all memories in one transaction and assigns their generated
-// IDs to the inputs. On failure no inserts commit, but inputs already processed can retain
-// IDs from the rolled-back transaction.
-func (c *Client) StoreAgentMemories(ctx context.Context, memories []*Memory) error {
-	return c.withTx(ctx, func(tx pgx.Tx) error {
-		for _, m := range memories {
-			id, err := insertAgentMemory(ctx, tx, m)
+	switch len(memories) {
+	case 0:
+		return nil
+	case 1:
+		id, err := insertAgentMemory(ctx, c.db, memories[0])
+		if err != nil {
+			return err
+		}
+		memories[0].ID = id
+		return nil
+	}
+	ids := make([]string, len(memories))
+	if err := c.withTx(ctx, func(tx pgx.Tx) error {
+		for i, memory := range memories {
+			id, err := insertAgentMemory(ctx, tx, memory)
 			if err != nil {
 				return fmt.Errorf("failed to store memory: %w", err)
 			}
-			m.ID = id
+			ids[i] = id
 		}
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
+	for i, memory := range memories {
+		memory.ID = ids[i]
+	}
+	return nil
 }
 
 // SearchAgentMemory returns up to limit memories for the user and agent, ranked by cosine

--- a/go/core/internal/database/memory_test.go
+++ b/go/core/internal/database/memory_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/pgvector/pgvector-go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,7 +20,7 @@ func TestDeleteAgentMemoryAliasesAreAtomicAndScoped(t *testing.T) {
 		{AgentName: "another-agent", UserID: "owner"},
 	} {
 		memory.Embedding = makeEmbedding(0.5)
-		require.NoError(t, client.StoreAgentMemory(ctx, memory))
+		require.NoError(t, client.StoreAgentMemories(ctx, memory))
 	}
 
 	// A blocked alias deletion must also preserve the original spelling.
@@ -48,4 +49,25 @@ func TestDeleteAgentMemoryAliasesAreAtomicAndScoped(t *testing.T) {
 	memories, err = client.ListAgentMemories(ctx, "another-agent", "owner")
 	require.NoError(t, err)
 	require.Len(t, memories, 1)
+}
+
+func TestStoreAgentMemoriesCommitsIDsWithBatch(t *testing.T) {
+	client := NewClient(setupTestDB(t))
+	first := &Memory{ID: "original", AgentName: "agent", UserID: "owner", Content: "first", Embedding: makeEmbedding(0.5)}
+	invalid := &Memory{AgentName: "agent", UserID: "owner", Content: "second", Embedding: pgvector.NewVector([]float32{1})}
+	require.Error(t, client.StoreAgentMemories(t.Context(), first, invalid))
+	require.Equal(t, "original", first.ID)
+	require.Empty(t, invalid.ID)
+	stored, err := client.ListAgentMemories(t.Context(), "agent", "owner")
+	require.NoError(t, err)
+	require.Empty(t, stored)
+
+	invalid.Embedding = makeEmbedding(0.5)
+	require.NoError(t, client.StoreAgentMemories(t.Context(), first, invalid))
+	require.NotEqual(t, "original", first.ID)
+	require.NotEmpty(t, invalid.ID)
+	require.NotEqual(t, first.ID, invalid.ID)
+	stored, err = client.ListAgentMemories(t.Context(), "agent", "owner")
+	require.NoError(t, err)
+	require.Len(t, stored, 2)
 }

--- a/go/core/internal/database/protobuf_test.go
+++ b/go/core/internal/database/protobuf_test.go
@@ -145,7 +145,7 @@ func TestProtobufPersistenceLifecycle(t *testing.T) {
 	require.NoError(t, err)
 	_, err = client.UpdateAgentInstanceName(ctx, instance.Id, "alice", "renamed while creating")
 	require.NoError(t, err)
-	instance, err = client.MarkAgentInstanceReady(ctx, instance.Id, "runtime:80")
+	instance, err = markAgentInstanceReady(ctx, client, instance.Id, "runtime:80")
 	require.NoError(t, err)
 	require.Equal(t, "renamed while creating", instance.Name)
 	stale := proto.Clone(instance).(*apiv1alpha1.AgentInstance)
@@ -216,13 +216,13 @@ func TestProtobufPersistenceLifecycle(t *testing.T) {
 	fork, created, err := client.ForkAgentInstance(ctx, checkpoint.Id, "alice", "fork", uuid.NewString())
 	require.NoError(t, err)
 	require.True(t, created)
-	tasks, total, err := client.ListAgentInstanceTasks(ctx, fork.Id, "", a2a.TaskStateUnspecified, nil, 10)
+	tasks, total, err := client.ListAgentInstanceTasks(ctx, fork.Id, "", a2a.TaskStateUnspecified, nil, 10, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, total)
 	require.Len(t, tasks[0].History, 2)
 	forkRow, err := readAgentInstance(ctx, q, fork.Id)
 	require.NoError(t, err)
-	forkHistory, err := readTaskMessages(ctx, q, forkRow.HistoryID, []string{string(tasks[0].ID)})
+	forkHistory, err := readTaskMessages(ctx, q, forkRow.HistoryID, []string{string(tasks[0].ID)}, nil)
 	require.NoError(t, err)
 	question := &a2apb.StreamResponse{}
 	require.NoError(t, proto.Unmarshal(forkHistory[1].Data, question))
@@ -258,11 +258,11 @@ func TestShareAndAgentCardProtobufPersistence(t *testing.T) {
 	require.NoError(t, err)
 	addUnknown(card)
 	revision := RuntimeRevision{Revision: "revision", Namespace: "team-a", AgentTemplateName: "assistant", AgentTemplateUID: "template", HarnessName: "kagent", HarnessUID: "harness", SourceSnapshot: []byte(`{}`), AgentCard: card, EgressDestinations: []string{}, ActorTemplateAtespace: "team-a", ActorTemplateName: "template"}
-	require.NoError(t, client.UpsertRuntimeRevision(ctx, revision))
+	require.NoError(t, client.RecordRuntimeRevision(ctx, revision, false))
 	// Reconciliation can update runtime identity, but the pinned card is immutable.
 	revision.AgentCard = &a2apb.AgentCard{Name: "replacement"}
 	revision.ActorTemplateUID = "new-uid"
-	require.NoError(t, client.UpsertRuntimeRevision(ctx, revision))
+	require.NoError(t, client.RecordRuntimeRevision(ctx, revision, false))
 	stored, err := client.GetRuntimeRevision(ctx, "revision")
 	require.NoError(t, err)
 	require.True(t, proto.Equal(card, stored.AgentCard))
@@ -284,7 +284,7 @@ func TestShareAndAgentCardProtobufPersistence(t *testing.T) {
 		digest := sha256.Sum256([]byte(permission.String()))
 		value := &apiv1alpha1.AgentInstanceShare{Id: uuid.NewString(), AgentInstanceId: instance.Id, Permission: permission}
 		addUnknown(value)
-		share, err := client.CreateAgentInstanceShare(ctx, value, digest[:])
+		share, err := client.CreateAgentInstanceShare(ctx, value, digest[:], "alice")
 		require.NoError(t, err)
 		require.Equal(t, value.ProtoReflect().GetUnknown(), share.ProtoReflect().GetUnknown())
 		resolved, ownerUserID, err := client.GetAgentInstanceShareByTokenHash(ctx, digest[:])

--- a/go/core/internal/database/runtime_revisions.go
+++ b/go/core/internal/database/runtime_revisions.go
@@ -30,10 +30,11 @@ func (c *Client) UpsertAgentTemplateHarnessPair(ctx context.Context, pair AgentT
 	)
 }
 
-// UpsertRuntimeRevision stores a prepared revision's configuration and agent card. An
-// existing revision retains those immutable inputs; only its actor-template UID and update
-// time are refreshed.
-func (c *Client) UpsertRuntimeRevision(ctx context.Context, revision RuntimeRevision) error {
+// RecordRuntimeRevision stores a prepared revision and, when ready, atomically promotes
+// it for an active pair that still desires it. Stale readiness reports do not change the
+// pair. Existing revisions retain immutable inputs; only the actor-template UID and
+// update time are refreshed.
+func (c *Client) RecordRuntimeRevision(ctx context.Context, revision RuntimeRevision, ready bool) error {
 	if revision.AgentCard == nil {
 		return fmt.Errorf("runtime revision %s has no Agent Card", revision.Revision)
 	}
@@ -42,23 +43,35 @@ func (c *Client) UpsertRuntimeRevision(ctx context.Context, revision RuntimeRevi
 		return fmt.Errorf("encode runtime revision Agent Card: %w", err)
 	}
 	if err := execSQL(ctx, c.db, `
-		INSERT INTO runtime_revision (
-		    revision, namespace, agent_template_name, agent_template_uid,
-		    harness_name, harness_uid, source_snapshot, agent_card, egress_destinations,
-		    actor_template_atespace, actor_template_name, actor_template_uid
-		) VALUES (
-		    $1, $2, $3, $4, $5, $6, $7, $8,
-		    $9, $10, $11, $12
+		WITH stored AS (
+			INSERT INTO runtime_revision (
+			    revision, namespace, agent_template_name, agent_template_uid,
+			    harness_name, harness_uid, source_snapshot, agent_card, egress_destinations,
+			    actor_template_atespace, actor_template_name, actor_template_uid
+			) VALUES (
+			    $1, $2, $3, $4, $5, $6, $7, $8,
+			    $9, $10, $11, $12
+			)
+			ON CONFLICT (revision) DO UPDATE SET
+			    actor_template_uid = EXCLUDED.actor_template_uid,
+			    updated_at = NOW()
+			RETURNING revision, namespace, agent_template_uid, harness_uid
 		)
-		ON CONFLICT (revision) DO UPDATE SET
-		    actor_template_uid = EXCLUDED.actor_template_uid,
-		    updated_at = NOW()
+		UPDATE agent_template_harness_pair p
+		SET latest_successful_revision = r.revision, updated_at = NOW()
+		FROM stored r
+		WHERE $13::boolean
+		  AND p.namespace = r.namespace
+		  AND p.agent_template_uid = r.agent_template_uid
+		  AND p.harness_uid = r.harness_uid
+		  AND p.desired_revision = r.revision
+		  AND p.retired_at IS NULL
 	`,
 		revision.Revision, revision.Namespace, revision.AgentTemplateName, revision.AgentTemplateUID,
 		revision.HarnessName, revision.HarnessUID, revision.SourceSnapshot, card, revision.EgressDestinations,
-		revision.ActorTemplateAtespace, revision.ActorTemplateName, revision.ActorTemplateUID,
+		revision.ActorTemplateAtespace, revision.ActorTemplateName, revision.ActorTemplateUID, ready,
 	); err != nil {
-		return fmt.Errorf("upsert runtime revision %s: %w", revision.Revision, err)
+		return fmt.Errorf("record runtime revision %s: %w", revision.Revision, err)
 	}
 	return nil
 }
@@ -108,21 +121,6 @@ func (c *Client) ListActorTemplateHarnesses(ctx context.Context) ([]ActorTemplat
 	return rows, nil
 }
 
-// MarkRuntimeRevisionSuccessful promotes a revision only if its pair is still active and
-// still desires that revision. Stale reconciliation results are a successful no-op.
-func (c *Client) MarkRuntimeRevisionSuccessful(ctx context.Context, pair AgentTemplateHarnessPair) error {
-	revision := pair.DesiredRevision
-	return execSQL(ctx, c.db, `
-		UPDATE agent_template_harness_pair
-		SET latest_successful_revision = $1, updated_at = NOW()
-		WHERE namespace = $2
-		  AND agent_template_uid = $3
-		  AND harness_uid = $4
-		  AND desired_revision = $1
-		  AND retired_at IS NULL
-	`, &revision, pair.Namespace, pair.AgentTemplateUID, pair.HarnessUID)
-}
-
 // RetireAgentTemplateHarnessPair excludes matching namespace/template/harness pairs from
 // new instance creation. Existing instances retain their pinned revisions; missing pairs
 // are a no-op.
@@ -132,19 +130,6 @@ func (c *Client) RetireAgentTemplateHarnessPair(ctx context.Context, namespace, 
 		SET retired_at = COALESCE(retired_at, NOW()), updated_at = NOW()
 		WHERE namespace = $1 AND agent_template_name = $2 AND harness_name = $3
 	`, namespace, template, harness)
-}
-
-// RetireOtherAgentTemplateHarnessPairs retires a template's pairs whose harness names are
-// absent from harnesses. An empty non-nil slice retires every pair for that template;
-// a nil slice matches no pairs. Existing instances retain their pinned revisions.
-func (c *Client) RetireOtherAgentTemplateHarnessPairs(ctx context.Context, namespace, templateUID string, harnesses []string) error {
-	return execSQL(ctx, c.db, `
-		UPDATE agent_template_harness_pair
-		SET retired_at = COALESCE(retired_at, NOW()), updated_at = NOW()
-		WHERE namespace = $1
-		  AND agent_template_uid = $2
-		  AND NOT (harness_name = ANY($3::text[]))
-	`, namespace, templateUID, harnesses)
 }
 
 // ListUnreferencedRuntimeRevisions lists revisions unused by instances or active pairs'

--- a/go/core/internal/database/runtime_revisions_test.go
+++ b/go/core/internal/database/runtime_revisions_test.go
@@ -1,0 +1,67 @@
+package database
+
+import (
+	"testing"
+
+	a2apb "github.com/a2aproject/a2a-go/v2/a2apb/v1"
+	"github.com/google/uuid"
+	apiv1alpha1 "github.com/kagent-dev/kagent/go/api/gen/kagent/api/v1alpha1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecordRuntimeRevisionPromotesOnlyCurrentActivePair(t *testing.T) {
+	pool := setupTestDB(t)
+	c := NewClient(pool)
+	ctx := t.Context()
+	revision := RuntimeRevision{
+		Revision: "first", Namespace: "team", AgentTemplateName: "assistant", AgentTemplateUID: "template-uid",
+		HarnessName: "runtime", HarnessUID: "harness-uid", AgentCard: &a2apb.AgentCard{Name: "original"},
+		SourceSnapshot: []byte("{}"), EgressDestinations: []string{},
+		ActorTemplateAtespace: "team", ActorTemplateName: "first", ActorTemplateUID: "actor-uid",
+	}
+	pair := AgentTemplateHarnessPair{
+		Namespace: revision.Namespace, AgentTemplateName: revision.AgentTemplateName, AgentTemplateUID: revision.AgentTemplateUID,
+		HarnessName: revision.HarnessName, HarnessUID: revision.HarnessUID, DesiredRevision: revision.Revision,
+	}
+	assertAvailableRevision := func(want string) {
+		t.Helper()
+		instance, _, err := c.CreateAgentInstance(ctx, &apiv1alpha1.AgentInstance{
+			Id: uuid.NewString(), Creator: "alice",
+			Harness:       &apiv1alpha1.ResourceReference{Namespace: pair.Namespace, Name: pair.HarnessName},
+			AgentTemplate: &apiv1alpha1.ResourceReference{Namespace: pair.Namespace, Name: pair.AgentTemplateName},
+		}, uuid.NewString())
+		if want == "" {
+			require.ErrorIs(t, err, ErrNotFound)
+			return
+		}
+		require.NoError(t, err)
+		require.Equal(t, want, instance.PreparedRevision)
+	}
+	require.NoError(t, c.UpsertAgentTemplateHarnessPair(ctx, pair))
+	require.NoError(t, c.RecordRuntimeRevision(ctx, revision, false))
+	assertAvailableRevision("")
+	stored, err := c.GetRuntimeRevision(ctx, revision.Revision)
+	require.NoError(t, err)
+	require.Equal(t, "original", stored.AgentCard.Name)
+
+	require.NoError(t, c.RecordRuntimeRevision(ctx, revision, true))
+	assertAvailableRevision("first")
+	pair.DesiredRevision = "second"
+	require.NoError(t, c.UpsertAgentTemplateHarnessPair(ctx, pair))
+	revision.Revision, revision.ActorTemplateName = "second", "second"
+	require.NoError(t, c.RecordRuntimeRevision(ctx, revision, true))
+	assertAvailableRevision("second")
+	// A delayed report for the old revision must not replace the newer ready revision.
+	revision.Revision, revision.ActorTemplateName = "first", "first"
+	require.NoError(t, c.RecordRuntimeRevision(ctx, revision, true))
+	assertAvailableRevision("second")
+	pair.DesiredRevision = "third"
+	require.NoError(t, c.UpsertAgentTemplateHarnessPair(ctx, pair))
+	require.NoError(t, c.RetireAgentTemplateHarnessPair(ctx, pair.Namespace, pair.AgentTemplateName, pair.HarnessName))
+	revision.Revision, revision.ActorTemplateName = "third", "third"
+	require.NoError(t, c.RecordRuntimeRevision(ctx, revision, true))
+	assertAvailableRevision("")
+	// Reviving the pair must retain the last success, not a report made while retired.
+	require.NoError(t, c.UpsertAgentTemplateHarnessPair(ctx, pair))
+	assertAvailableRevision("second")
+}

--- a/go/core/internal/database/scheduled_runs.go
+++ b/go/core/internal/database/scheduled_runs.go
@@ -226,7 +226,11 @@ func (c *Client) TriggerScheduledRun(ctx context.Context, id uuid.UUID, creator,
 		if row.DeletedAt != nil {
 			return ErrScheduledRunDeleted
 		}
-		result, err = reserveScheduledRunExecution(ctx, tx, row, nil, &requestID)
+		schedule, err := toScheduledRun(row)
+		if err != nil {
+			return err
+		}
+		result, err = reserveScheduledRunExecution(ctx, tx, schedule, nil, &requestID)
 		return err
 	})
 	if err != nil {
@@ -238,13 +242,12 @@ func (c *Client) TriggerScheduledRun(ctx context.Context, id uuid.UUID, creator,
 // ReserveDueScheduledRuns atomically reserves due occurrences and advances their
 // schedules, skipping rows held by other workers. Limit must be between 1 and 100.
 // Occurrences over thirty seconds late are skipped; malformed schedules are removed from
-// the due queue with their payloads retained for repair. Callers execute the returned
-// reservations separately.
-func (c *Client) ReserveDueScheduledRuns(ctx context.Context, limit int) ([]*apiv1alpha1.ScheduledRunExecution, error) {
+// the due queue with their payloads retained for repair. Execution workers claim the
+// stored reservations separately.
+func (c *Client) ReserveDueScheduledRuns(ctx context.Context, limit int) error {
 	if limit < 1 || limit > 100 {
-		return nil, fmt.Errorf("reservation limit must be between 1 and 100")
+		return fmt.Errorf("reservation limit must be between 1 and 100")
 	}
-	result := []*apiv1alpha1.ScheduledRunExecution{}
 	err := c.withTx(ctx, func(tx pgx.Tx) error {
 		rows, err := queryMany(ctx, tx, `
 			SELECT scheduled_run.id, scheduled_run.creator, scheduled_run.request_hash,
@@ -274,15 +277,10 @@ func (c *Client) ReserveDueScheduledRuns(ctx context.Context, limit int) ([]*api
 			}
 			// ponytail: fixed 30s lateness allowance; configure it if deployments need longer failover tolerance.
 			if now.Sub(*row.NextExecutionTime) <= 30*time.Second {
-				record, err := reserveScheduledRunExecution(ctx, tx, row, row.NextExecutionTime, nil)
+				_, err := reserveScheduledRunExecution(ctx, tx, schedule, row.NextExecutionTime, nil)
 				if err != nil {
 					return err
 				}
-				execution, err := toScheduledRunExecution(record)
-				if err != nil {
-					return err
-				}
-				result = append(result, execution)
 			}
 			if err := advanceScheduledRun(ctx, tx, row.ID, next); err != nil {
 				return err
@@ -291,9 +289,9 @@ func (c *Client) ReserveDueScheduledRuns(ctx context.Context, limit int) ([]*api
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to reserve due executions: %w", err)
+		return fmt.Errorf("failed to reserve due executions: %w", err)
 	}
-	return result, nil
+	return nil
 }
 
 // getScheduledRunForUpdate locks an owned schedule, including tombstones, until the
@@ -311,11 +309,7 @@ func getScheduledRunForUpdate(ctx context.Context, db dbExecutor, id uuid.UUID, 
 // timeout, using either a scheduled time or manual request ID. Callers hold the schedule
 // lock and handle deduplication in the same transaction; this function does not launch
 // runtime work.
-func reserveScheduledRunExecution(ctx context.Context, db dbExecutor, row scheduledRunRow, due *time.Time, manualRequestID *string) (scheduledRunExecutionRow, error) {
-	schedule, err := toScheduledRun(row)
-	if err != nil {
-		return scheduledRunExecutionRow{}, err
-	}
+func reserveScheduledRunExecution(ctx context.Context, db dbExecutor, schedule *apiv1alpha1.ScheduledRun, due *time.Time, manualRequestID *string) (scheduledRunExecutionRow, error) {
 	id, err := uuid.NewV7()
 	if err != nil {
 		return scheduledRunExecutionRow{}, fmt.Errorf("failed to generate execution ID: %w", err)
@@ -341,7 +335,7 @@ func reserveScheduledRunExecution(ctx context.Context, db dbExecutor, row schedu
 		VALUES ($1, $2, $3, $4, $5,
 		    statement_timestamp() + $6::interval) RETURNING id, scheduled_run_id, scheduled_time, manual_request_id, data, created_at, deadline, agent_instance_id, task_id, completed_at, state
 	`,
-		pgx.RowToStructByName[scheduledRunExecutionRow], id, row.ID, due, manualRequestID, data,
+		pgx.RowToStructByName[scheduledRunExecutionRow], id, schedule.Id, due, manualRequestID, data,
 		pgtype.Interval{Microseconds: int64(timeout), Valid: true},
 	)
 }
@@ -420,12 +414,13 @@ func (c *Client) ReserveScheduledRunExecutionInstance(ctx context.Context, id uu
 		if err != nil {
 			return err
 		}
-		expired, err := queryOne(ctx, tx, `
+		completedAt, err := queryOne(ctx, tx, `
 			UPDATE scheduled_run_execution SET state = 'SCHEDULED_RUN_EXECUTION_STATE_TIMED_OUT', completed_at = clock_timestamp(), data = $2
-			WHERE id = $1 AND deadline <= clock_timestamp() RETURNING id, scheduled_run_id, scheduled_time, manual_request_id, data, created_at, deadline, agent_instance_id, task_id, completed_at, state
-		`, pgx.RowToStructByName[scheduledRunExecutionRow], id, data)
+			WHERE id = $1 AND deadline <= clock_timestamp() RETURNING completed_at
+		`, pgx.RowTo[time.Time], id, data)
 		if err == nil {
-			result = expired
+			result.State = "SCHEDULED_RUN_EXECUTION_STATE_TIMED_OUT"
+			result.CompletedAt, result.Data = &completedAt, data
 			return nil
 		}
 		if !errors.Is(err, pgx.ErrNoRows) {
@@ -454,10 +449,17 @@ func (c *Client) ReserveScheduledRunExecutionInstance(ctx context.Context, id uu
 		if err != nil {
 			return err
 		}
-		result, err = queryOne(ctx, tx, `
-			UPDATE scheduled_run_execution SET agent_instance_id = $2 WHERE id = $1 RETURNING id, scheduled_run_id, scheduled_time, manual_request_id, data, created_at, deadline, agent_instance_id, task_id, completed_at, state
-		`, pgx.RowToStructByName[scheduledRunExecutionRow], id, &instance.ID)
-		return err
+		rows, err := tx.Exec(ctx, `
+			UPDATE scheduled_run_execution SET agent_instance_id = $2 WHERE id = $1
+		`, id, instance.ID)
+		if err != nil {
+			return err
+		}
+		if rows.RowsAffected() != 1 {
+			return pgx.ErrNoRows
+		}
+		result.AgentInstanceID = &instance.ID
+		return nil
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to reserve execution instance: %w", err)

--- a/go/core/internal/database/scheduled_runs_test.go
+++ b/go/core/internal/database/scheduled_runs_test.go
@@ -31,6 +31,16 @@ func createTestSchedule(t *testing.T, c *Client) (*apiv1alpha1.ScheduledRun, []b
 	return result, hash[:]
 }
 
+func listTestScheduleExecutions(t *testing.T, c *Client, schedule *apiv1alpha1.ScheduledRun) []*apiv1alpha1.ScheduledRunExecution {
+	t.Helper()
+	executions, err := c.ListScheduledRunExecutions(t.Context(), ScheduledRunExecutionQuery{
+		ScheduledRunQuery: ScheduledRunQuery{Creator: schedule.Creator, Limit: 100},
+		ScheduledRunID:    uuid.MustParse(schedule.Id),
+	})
+	require.NoError(t, err)
+	return executions
+}
+
 func TestScheduledExecutionLeasesFenceExpiredWorkers(t *testing.T) {
 	db := setupTestDB(t)
 	c := NewClient(db)
@@ -233,34 +243,23 @@ func TestScheduledRunConcurrentReservation(t *testing.T) {
 
 	_, err := db.Exec(t.Context(), "UPDATE scheduled_run SET next_execution_time = clock_timestamp() - interval '1 second' WHERE id = $1", schedule.Id)
 	require.NoError(t, err)
-	due := make(chan *apiv1alpha1.ScheduledRunExecution, 12)
 	for range 12 {
 		wg.Go(func() {
-			runs, err := c.ReserveDueScheduledRuns(t.Context(), 100)
-			if err != nil {
+			if err := c.ReserveDueScheduledRuns(t.Context(), 100); err != nil {
 				t.Error(err)
-				return
-			}
-			for _, run := range runs {
-				due <- run
 			}
 		})
 	}
 	wg.Wait()
-	close(due)
-	var runs []*apiv1alpha1.ScheduledRunExecution
-	for run := range due {
-		runs = append(runs, run)
-	}
-	require.Len(t, runs, 1)
+	runs := listTestScheduleExecutions(t, c, schedule)
+	require.Len(t, runs, 2, "one manual execution and one due occurrence")
 	require.NotNil(t, runs[0].GetScheduledTime())
 	require.False(t, unique[runs[0].Id])
 
 	_, err = db.Exec(t.Context(), "UPDATE scheduled_run SET next_execution_time = clock_timestamp() - interval '2 minutes' WHERE id = $1", schedule.Id)
 	require.NoError(t, err)
-	skipped, err := c.ReserveDueScheduledRuns(t.Context(), 100)
-	require.NoError(t, err)
-	require.Empty(t, skipped)
+	require.NoError(t, c.ReserveDueScheduledRuns(t.Context(), 100))
+	require.Len(t, listTestScheduleExecutions(t, c, schedule), 2, "late occurrence must not create an execution")
 	advanced, err := c.GetScheduledRun(t.Context(), uuid.MustParse(schedule.Id), "alice")
 	require.NoError(t, err)
 	require.True(t, advanced.NextExecutionTime.AsTime().After(time.Now()))
@@ -405,9 +404,10 @@ func TestScheduledExecutionWaitsForPreparedRevision(t *testing.T) {
 	// Unready targets no longer roll back due reservations or block other schedules.
 	_, err = db.Exec(t.Context(), "UPDATE scheduled_run SET next_execution_time = clock_timestamp() - interval '1 second' WHERE id = $1", schedule.Id)
 	require.NoError(t, err)
-	due, err := c.ReserveDueScheduledRuns(t.Context(), 100)
-	require.NoError(t, err)
-	require.Len(t, due, 1)
+	require.NoError(t, c.ReserveDueScheduledRuns(t.Context(), 100))
+	due := listTestScheduleExecutions(t, c, schedule)
+	require.Len(t, due, 2, "manual and due executions survive unready targets")
+	require.NotNil(t, due[0].GetScheduledTime())
 	require.Empty(t, due[0].AgentInstanceId)
 	agentInstanceFixture(t, c, t.Context(), "team-a", "scheduled-revision-2", "report", "runtime")
 	linked, err := c.ReserveScheduledRunExecutionInstance(t.Context(), uuid.MustParse(execution.Id), "alice")
@@ -517,12 +517,11 @@ func TestMalformedScheduledRunsDoNotBlockReservation(t *testing.T) {
 	_, err = db.Exec(t.Context(), `UPDATE scheduled_run SET next_execution_time = created_at - interval '1 second'`)
 	require.NoError(t, err)
 	// A full batch of malformed rows must get out of the way of later rows.
-	executions, err := c.ReserveDueScheduledRuns(t.Context(), 2)
-	require.NoError(t, err)
-	require.Empty(t, executions)
+	require.NoError(t, c.ReserveDueScheduledRuns(t.Context(), 2))
+	require.Empty(t, listTestScheduleExecutions(t, c, good))
 	// A malformed config must not roll back a healthy row in the same batch.
-	executions, err = c.ReserveDueScheduledRuns(t.Context(), 2)
-	require.NoError(t, err)
+	require.NoError(t, c.ReserveDueScheduledRuns(t.Context(), 2))
+	executions := listTestScheduleExecutions(t, c, good)
 	require.Len(t, executions, 1)
 	require.Equal(t, good.Id, executions[0].ScheduledRunId)
 	for i, id := range badIDs {
@@ -532,9 +531,8 @@ func TestMalformedScheduledRunsDoNotBlockReservation(t *testing.T) {
 		require.Equal(t, badData[i], data, "preserve malformed payloads for repair")
 		require.Nil(t, next)
 	}
-	executions, err = c.ReserveDueScheduledRuns(t.Context(), 2)
-	require.NoError(t, err)
-	require.Empty(t, executions, "healthy occurrences must not be duplicated")
+	require.NoError(t, c.ReserveDueScheduledRuns(t.Context(), 2))
+	require.Equal(t, executions, listTestScheduleExecutions(t, c, good), "healthy occurrences must not be duplicated")
 }
 
 func TestMalformedScheduledExecutionsDoNotDiscardHealthyLeases(t *testing.T) {

--- a/go/core/internal/database/shares.go
+++ b/go/core/internal/database/shares.go
@@ -26,9 +26,10 @@ func toAgentInstanceShare(row agentInstanceShareRow) (*apiv1alpha1.AgentInstance
 }
 
 // CreateAgentInstanceShare stores a share with the supplied ID, permission, and token hash
-// and sets its creation time. Callers authorize sharing and generate the token; the
-// plaintext token is never stored.
-func (c *Client) CreateAgentInstanceShare(ctx context.Context, share *apiv1alpha1.AgentInstanceShare, tokenHash []byte) (*apiv1alpha1.AgentInstanceShare, error) {
+// for an instance owned by userID and sets its creation time. A missing or unowned
+// instance returns ErrNotFound. Callers authorize sharing and generate the token;
+// the plaintext token is never stored.
+func (c *Client) CreateAgentInstanceShare(ctx context.Context, share *apiv1alpha1.AgentInstanceShare, tokenHash []byte, userID string) (*apiv1alpha1.AgentInstanceShare, error) {
 	if share == nil {
 		return nil, fmt.Errorf("missing AgentInstance share")
 	}
@@ -39,15 +40,16 @@ func (c *Client) CreateAgentInstanceShare(ctx context.Context, share *apiv1alpha
 		return nil, fmt.Errorf("encode AgentInstance share: %w", err)
 	}
 	row, err := queryOne(ctx, c.db, `
-		INSERT INTO agent_instance_share (id, instance_id, permission, token_hash, data) VALUES ($1, $2, $3, $4, $5)
+		INSERT INTO agent_instance_share (id, instance_id, permission, token_hash, data)
+		SELECT $1, id, $3, $4, $5 FROM agent_instance WHERE id = $2 AND user_id = $6
 		RETURNING id, instance_id, permission, data
 	`,
 		pgx.RowToStructByNameLax[agentInstanceShareRow], value.Id,
 		value.AgentInstanceId,
-		value.Permission.String(), tokenHash, data,
+		value.Permission.String(), tokenHash, data, userID,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("create AgentInstance share: %w", err)
+		return nil, fmt.Errorf("create AgentInstance share: %w", notFoundOr(err))
 	}
 	return toAgentInstanceShare(row)
 }

--- a/go/core/internal/database/task_events_test.go
+++ b/go/core/internal/database/task_events_test.go
@@ -20,7 +20,7 @@ func TestTaskViewsRebuildFromEvents(t *testing.T) {
 	agentInstanceFixture(t, client, ctx, "team-a", "revision", "assistant", "kagent")
 	instance, _, err := client.CreateAgentInstance(ctx, newAgentInstanceRequest(uuid.NewString(), "assistant", "kagent", "Source"), uuid.NewString())
 	require.NoError(t, err)
-	_, err = client.MarkAgentInstanceReady(ctx, instance.Id, "source.example")
+	_, err = markAgentInstanceReady(ctx, client, instance.Id, "source.example")
 	require.NoError(t, err)
 	instanceRow, err := readAgentInstance(ctx, q, instance.Id)
 	require.NoError(t, err)
@@ -88,7 +88,7 @@ func TestTaskViewsRebuildFromEvents(t *testing.T) {
 	require.NoError(t, err)
 	boundaryEvents, err := readCheckpointEvents(ctx, q, uuid.MustParse(checkpoint.Id))
 	require.NoError(t, err)
-	before, err := client.GetAgentInstanceTask(ctx, instance.Id, "task")
+	before, err := client.GetAgentInstanceTask(ctx, instance.Id, "task", nil)
 	require.NoError(t, err)
 	// Both a user reply and an immediate message result must persist their status.
 	for _, state := range []a2a.TaskState{a2a.TaskStateSubmitted, a2a.TaskStateCompleted} {
@@ -114,7 +114,7 @@ func TestTaskViewsRebuildFromEvents(t *testing.T) {
 	require.NoError(t, err)
 	fork, _, err := client.ForkAgentInstance(ctx, checkpoint.Id, "alice", "fork", uuid.NewString())
 	require.NoError(t, err)
-	forked, err := client.GetAgentInstanceTask(ctx, fork.Id, "task")
+	forked, err := client.GetAgentInstanceTask(ctx, fork.Id, "task", nil)
 	require.NoError(t, err)
 	require.Equal(t, before, forked)
 	for _, row := range rows {

--- a/go/core/internal/database/task_history_test.go
+++ b/go/core/internal/database/task_history_test.go
@@ -1,0 +1,80 @@
+package database
+
+import (
+	"context"
+	"testing"
+
+	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTaskHistoryLimitsAndInstanceScope(t *testing.T) {
+	client := NewClient(setupTestDB(t))
+	ctx := t.Context()
+	agentInstanceFixture(t, client, ctx, "team-a", "revision", "assistant", "kagent")
+	instance, _, err := client.CreateAgentInstance(ctx, newAgentInstanceRequest(uuid.NewString(), "assistant", "kagent", ""), uuid.NewString())
+	require.NoError(t, err)
+	other, _, err := client.CreateAgentInstance(ctx, newAgentInstanceRequest(uuid.NewString(), "assistant", "kagent", ""), uuid.NewString())
+	require.NoError(t, err)
+
+	for _, id := range []string{"first", "second"} {
+		task := newAgentInstanceTask(id, id+"-1")
+		task.ContextID = instance.ContextId
+		task.Status.State = a2a.TaskStateCompleted
+		for _, suffix := range []string{"-2", "-3"} {
+			message := a2a.NewMessageForTask(a2a.MessageRoleAgent, task, a2a.NewTextPart(suffix))
+			message.ID = id + suffix
+			task.History = append(task.History, message)
+		}
+		require.NoError(t, client.StoreAgentInstanceTaskEvent(ctx, instance.Id, task, task, nil))
+	}
+	for _, test := range []struct {
+		name  string
+		limit *int
+		want  []string
+	}{
+		{name: "all", want: []string{"-1", "-2", "-3"}},
+		{name: "none", limit: new(0)},
+		{name: "latest two", limit: new(2), want: []string{"-2", "-3"}},
+		{name: "larger than history", limit: new(10), want: []string{"-1", "-2", "-3"}},
+		{name: "negative is unlimited", limit: new(-1), want: []string{"-1", "-2", "-3"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			task, err := client.GetAgentInstanceTask(ctx, instance.Id, "first", test.limit)
+			require.NoError(t, err)
+			tasks, total, err := client.ListAgentInstanceTasks(ctx, instance.Id, "", a2a.TaskStateUnspecified, nil, 10, test.limit)
+			require.NoError(t, err)
+			require.Equal(t, 2, total)
+			require.Len(t, tasks, 2)
+			for _, got := range append(tasks, task) {
+				require.Len(t, got.History, len(test.want))
+				for i, suffix := range test.want {
+					require.Equal(t, string(got.ID)+suffix, got.History[i].ID)
+					require.Equal(t, got.ID, got.History[i].TaskID)
+					require.Equal(t, instance.ContextId, got.History[i].ContextID)
+				}
+			}
+		})
+	}
+	_, err = client.GetAgentInstanceTask(ctx, other.Id, "first", nil)
+	require.ErrorIs(t, err, ErrNotFound)
+	_, err = client.GetAgentInstanceTask(ctx, uuid.NewString(), "first", nil)
+	require.ErrorIs(t, err, ErrNotFound)
+	_, err = client.GetAgentInstanceTask(ctx, instance.Id, "absent", nil)
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestZeroTaskHistoryDoesNotQueryMessages(t *testing.T) {
+	task := &a2a.Task{ID: "task", History: []*a2a.Message{{ID: "inline"}}}
+	// No executor is needed when the caller asks to omit history.
+	require.NoError(t, loadAgentInstanceTaskHistories(context.Background(), nil, uuid.New(), []*a2a.Task{task}, new(0)))
+	require.Empty(t, task.History)
+}
+
+func TestTaskHistoryLimitWithInlineMessages(t *testing.T) {
+	client := NewClient(setupTestDB(t))
+	task := &a2a.Task{ID: "task", History: []*a2a.Message{{ID: "first"}, {ID: "second"}, {ID: "third"}}}
+	require.NoError(t, loadAgentInstanceTaskHistories(t.Context(), client.db, uuid.New(), []*a2a.Task{task}, new(2)))
+	require.Equal(t, []*a2a.Message{{ID: "second"}, {ID: "third"}}, task.History)
+}

--- a/go/core/internal/database/tools.go
+++ b/go/core/internal/database/tools.go
@@ -8,98 +8,17 @@ import (
 	"github.com/kagent-dev/kagent/go/api/v1alpha3"
 )
 
-// GetTool returns an undeleted tool with the given name, or ErrNotFound. Names can occur
-// on multiple servers; this lookup does not choose a particular server or group kind.
-func (c *Client) GetTool(ctx context.Context, name string) (*Tool, error) {
-	row, err := queryOne(ctx, c.db, `
-		SELECT id, server_name, group_kind, created_at, updated_at, deleted_at, description FROM tool
-		WHERE id = $1 AND deleted_at IS NULL
-		LIMIT 1
-	`, pgx.RowToStructByName[Tool], name)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get tool %s: %w", name, notFoundOr(err))
-	}
-	return &row, nil
-}
-
 // ListTools returns all undeleted tools in ascending creation-time order.
 func (c *Client) ListTools(ctx context.Context) ([]Tool, error) {
-	return c.listTools(ctx, nil, nil)
-}
-
-// ListToolsForServer returns undeleted tools for the exact server name and group kind in
-// ascending creation-time order.
-func (c *Client) ListToolsForServer(ctx context.Context, serverName, groupKind string) ([]Tool, error) {
-	return c.listTools(ctx, &serverName, &groupKind)
-}
-
-// listTools returns undeleted tools in ascending creation-time order, applying each server
-// filter only when its pointer is non-nil.
-func (c *Client) listTools(ctx context.Context, serverName, groupKind *string) ([]Tool, error) {
 	rows, err := queryMany(ctx, c.db, `
 		SELECT id, server_name, group_kind, created_at, updated_at, deleted_at, description FROM tool
 		WHERE deleted_at IS NULL
-		  AND ($1::text IS NULL OR server_name = $1)
-		  AND ($2::text IS NULL OR group_kind = $2)
-		ORDER BY tool.created_at ASC
-	`, pgx.RowToStructByName[Tool], serverName, groupKind)
+		ORDER BY created_at ASC
+	`, pgx.RowToStructByName[Tool])
 	if err != nil {
 		return nil, fmt.Errorf("failed to list tools: %w", err)
 	}
 	return rows, nil
-}
-
-// DeleteToolsForServer hides all currently visible tools for the server name and group
-// kind. Missing tools are a successful no-op.
-func (c *Client) DeleteToolsForServer(ctx context.Context, serverName, groupKind string) error {
-	return deleteToolsForServer(ctx, c.db, serverName, groupKind)
-}
-
-// deleteToolsForServer hides the server's visible tools using the caller's connection or
-// transaction. Missing tools are a successful no-op.
-func deleteToolsForServer(ctx context.Context, db dbExecutor, serverName, groupKind string) error {
-	return execSQL(ctx, db, `
-		UPDATE tool SET deleted_at = NOW()
-		WHERE server_name = $1 AND group_kind = $2 AND deleted_at IS NULL
-	`, serverName, groupKind)
-}
-
-// RefreshToolsForServer atomically replaces the server's visible tool catalog with the
-// supplied tools. Previously removed tools are revived if listed again; an empty catalog
-// hides every tool for that server.
-func (c *Client) RefreshToolsForServer(ctx context.Context, serverName, groupKind string, tools ...*v1alpha3.MCPTool) error {
-	return c.withTx(ctx, func(tx pgx.Tx) error {
-		if err := deleteToolsForServer(ctx, tx, serverName, groupKind); err != nil {
-			return fmt.Errorf("failed to delete existing tools: %w", err)
-		}
-		for _, tool := range tools {
-			if err := execSQL(ctx, tx, `
-				INSERT INTO tool (id, server_name, group_kind, description, created_at, updated_at)
-				VALUES ($1, $2, $3, $4, NOW(), NOW())
-				ON CONFLICT (id, server_name, group_kind) DO UPDATE SET
-				    description = EXCLUDED.description,
-				    updated_at  = NOW(),
-				    deleted_at  = NULL
-			`, tool.Name, serverName, groupKind, &tool.Description); err != nil {
-				return fmt.Errorf("failed to upsert tool %s: %w", tool.Name, err)
-			}
-		}
-		return nil
-	})
-}
-
-// GetToolServer returns an undeleted server with the given name, or ErrNotFound. If the
-// name occurs in multiple group kinds, this lookup does not select a particular kind.
-func (c *Client) GetToolServer(ctx context.Context, name string) (*ToolServer, error) {
-	row, err := queryOne(ctx, c.db, `
-		SELECT name, group_kind, created_at, updated_at, deleted_at, description, last_connected FROM toolserver
-		WHERE name = $1 AND deleted_at IS NULL
-		LIMIT 1
-	`, pgx.RowToStructByName[ToolServer], name)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get tool server %s: %w", name, notFoundOr(err))
-	}
-	return &row, nil
 }
 
 // ListToolServers returns all undeleted servers in ascending creation-time order.
@@ -115,31 +34,63 @@ func (c *Client) ListToolServers(ctx context.Context) ([]ToolServer, error) {
 	return rows, nil
 }
 
-// StoreToolServer inserts or updates a server by name and group kind, reviving a deleted
-// entry. It preserves the original creation time and returns the stored description,
-// connection time, and timestamps.
-func (c *Client) StoreToolServer(ctx context.Context, ts *ToolServer) (*ToolServer, error) {
-	row, err := queryOne(ctx, c.db, `
-		INSERT INTO toolserver (name, group_kind, description, last_connected, created_at, updated_at)
-		VALUES ($1, $2, $3, $4, NOW(), NOW())
-		ON CONFLICT (name, group_kind) DO UPDATE SET
-		    description    = EXCLUDED.description,
-		    last_connected = EXCLUDED.last_connected,
-		    updated_at     = NOW(),
-		    deleted_at     = NULL
-		RETURNING name, group_kind, created_at, updated_at, deleted_at, description, last_connected
-	`, pgx.RowToStructByName[ToolServer], ts.Name, ts.GroupKind, &ts.Description, ts.LastConnected)
-	if err != nil {
-		return nil, fmt.Errorf("failed to store tool server: %w", err)
-	}
-	return &row, nil
+// RefreshToolServer atomically publishes a server and replaces its visible tools.
+// Removed servers and tools are revived when supplied again, preserving creation times.
+// An empty tool list keeps the server visible and hides its previous tools.
+func (c *Client) RefreshToolServer(ctx context.Context, server *ToolServer, tools ...*v1alpha3.MCPTool) error {
+	return c.withTx(ctx, func(tx pgx.Tx) error {
+		// Lock the server before changing tools, including when its catalog is empty.
+		if err := execSQL(ctx, tx, `
+			INSERT INTO toolserver (name, group_kind, description, last_connected)
+			VALUES ($1, $2, $3, $4)
+			ON CONFLICT (name, group_kind) DO UPDATE SET
+			    description = EXCLUDED.description,
+			    last_connected = EXCLUDED.last_connected,
+			    updated_at = NOW(), deleted_at = NULL
+		`, server.Name, server.GroupKind, server.Description, server.LastConnected); err != nil {
+			return fmt.Errorf("failed to store tool server: %w", err)
+		}
+		if err := deleteToolsForServer(ctx, tx, server.Name, server.GroupKind); err != nil {
+			return fmt.Errorf("failed to delete existing tools: %w", err)
+		}
+		for _, tool := range tools {
+			if err := execSQL(ctx, tx, `
+				INSERT INTO tool (id, server_name, group_kind, description)
+				VALUES ($1, $2, $3, $4)
+				ON CONFLICT (id, server_name, group_kind) DO UPDATE SET
+				    description = EXCLUDED.description, updated_at = NOW(), deleted_at = NULL
+			`, tool.Name, server.Name, server.GroupKind, tool.Description); err != nil {
+				return fmt.Errorf("failed to upsert tool %s: %w", tool.Name, err)
+			}
+		}
+		return nil
+	})
 }
 
-// DeleteToolServer hides the server matching its name and group kind. Missing servers are
-// a no-op; its tool catalog is managed separately.
+// DeleteToolServer atomically hides the server and its tools for the exact name and
+// group kind. A missing server is a successful no-op.
 func (c *Client) DeleteToolServer(ctx context.Context, serverName, groupKind string) error {
-	return execSQL(ctx, c.db, `
-		UPDATE toolserver SET deleted_at = NOW()
-		WHERE name = $1 AND group_kind = $2 AND deleted_at IS NULL
+	return c.withTx(ctx, func(tx pgx.Tx) error {
+		// Lock even deleted servers so a concurrent refresh cannot revive only their tools.
+		result, err := tx.Exec(ctx, `
+			UPDATE toolserver SET deleted_at = COALESCE(deleted_at, NOW())
+			WHERE name = $1 AND group_kind = $2
+		`, serverName, groupKind)
+		if err != nil {
+			return fmt.Errorf("failed to delete tool server: %w", err)
+		}
+		if result.RowsAffected() == 0 {
+			return nil
+		}
+		return deleteToolsForServer(ctx, tx, serverName, groupKind)
+	})
+}
+
+// deleteToolsForServer hides the server's visible tools in the caller's transaction.
+// Missing tools are a successful no-op.
+func deleteToolsForServer(ctx context.Context, tx pgx.Tx, serverName, groupKind string) error {
+	return execSQL(ctx, tx, `
+		UPDATE tool SET deleted_at = NOW()
+		WHERE server_name = $1 AND group_kind = $2 AND deleted_at IS NULL
 	`, serverName, groupKind)
 }

--- a/go/core/internal/database/tools_test.go
+++ b/go/core/internal/database/tools_test.go
@@ -1,0 +1,148 @@
+package database
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/kagent-dev/kagent/go/api/v1alpha3"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToolCatalogLifecycle(t *testing.T) {
+	client := NewClient(setupTestDB(t))
+	ctx := t.Context()
+	connected := time.Now().UTC().Truncate(time.Microsecond)
+	server := &ToolServer{Name: "shared", GroupKind: "remote", Description: "original", LastConnected: &connected}
+	tool := &v1alpha3.MCPTool{Name: "tool", Description: "original"}
+	require.NoError(t, client.RefreshToolServer(ctx, server, tool))
+	originalServers, err := client.ListToolServers(ctx)
+	require.NoError(t, err)
+	originalTools, err := client.ListTools(ctx)
+	require.NoError(t, err)
+	require.Len(t, originalServers, 1)
+	require.Len(t, originalTools, 1)
+	require.True(t, connected.Equal(*originalServers[0].LastConnected))
+
+	// A same-name server of another kind is a separate catalog.
+	require.NoError(t, client.RefreshToolServer(ctx, &ToolServer{Name: "shared", GroupKind: "local"}, &v1alpha3.MCPTool{Name: "other"}))
+	require.NoError(t, client.DeleteToolServer(ctx, "shared", "remote"))
+	require.NoError(t, client.DeleteToolServer(ctx, "shared", "remote"))
+	require.NoError(t, client.DeleteToolServer(ctx, "missing", "remote"))
+	servers, err := client.ListToolServers(ctx)
+	require.NoError(t, err)
+	tools, err := client.ListTools(ctx)
+	require.NoError(t, err)
+	require.Len(t, servers, 1)
+	require.Equal(t, "local", servers[0].GroupKind)
+	require.Len(t, tools, 1)
+	require.Equal(t, "other", tools[0].ID)
+
+	server.Description, server.LastConnected = "updated", nil
+	tool.Description = "updated"
+	require.NoError(t, client.RefreshToolServer(ctx, server, tool))
+	require.NoError(t, client.RefreshToolServer(ctx, server, tool))
+	servers, err = client.ListToolServers(ctx)
+	require.NoError(t, err)
+	tools, err = client.ListTools(ctx)
+	require.NoError(t, err)
+	require.Len(t, servers, 2)
+	require.Len(t, tools, 2)
+	require.Equal(t, originalServers[0].CreatedAt, servers[0].CreatedAt)
+	require.Equal(t, originalTools[0].CreatedAt, tools[0].CreatedAt)
+	require.Equal(t, "updated", servers[0].Description)
+	require.Equal(t, "updated", tools[0].Description)
+	require.Nil(t, servers[0].LastConnected)
+	require.Nil(t, servers[0].DeletedAt)
+	require.Nil(t, tools[0].DeletedAt)
+
+	require.NoError(t, client.RefreshToolServer(ctx, server))
+	servers, err = client.ListToolServers(ctx)
+	require.NoError(t, err)
+	tools, err = client.ListTools(ctx)
+	require.NoError(t, err)
+	require.Len(t, servers, 2)
+	require.Len(t, tools, 1)
+	require.Equal(t, "other", tools[0].ID)
+}
+
+func TestConcurrentToolCatalogReplacement(t *testing.T) {
+	for _, initial := range []string{"missing", "empty", "deleted"} {
+		t.Run(initial, func(t *testing.T) {
+			client := NewClient(setupTestDB(t))
+			ctx := t.Context()
+			if initial != "missing" {
+				require.NoError(t, client.RefreshToolServer(ctx, &ToolServer{Name: "server", GroupKind: "kind"}))
+			}
+			if initial == "deleted" {
+				require.NoError(t, client.DeleteToolServer(ctx, "server", "kind"))
+			}
+			for _, withDeletes := range []bool{false, true} {
+				start := make(chan struct{})
+				errs := make(chan error, 12)
+				for i := range 12 {
+					go func() {
+						<-start
+						if withDeletes && i%3 == 0 {
+							errs <- client.DeleteToolServer(ctx, "server", "kind")
+							return
+						}
+						description := fmt.Sprint(i)
+						errs <- client.RefreshToolServer(ctx, &ToolServer{Name: "server", GroupKind: "kind", Description: description},
+							&v1alpha3.MCPTool{Name: "a-" + description, Description: description},
+							&v1alpha3.MCPTool{Name: "b-" + description, Description: description})
+					}()
+				}
+				close(start)
+				for range 12 {
+					require.NoError(t, <-errs)
+				}
+				servers, err := client.ListToolServers(ctx)
+				require.NoError(t, err)
+				tools, err := client.ListTools(ctx)
+				require.NoError(t, err)
+				if withDeletes && len(servers) == 0 {
+					require.Empty(t, tools)
+					continue
+				}
+				require.Len(t, servers, 1)
+				require.Len(t, tools, 2, "replacement must not leave a union of concurrent catalogs")
+				for _, tool := range tools {
+					require.Equal(t, servers[0].Description, tool.Description)
+				}
+			}
+		})
+	}
+}
+
+func TestToolCatalogWritesRollbackTogether(t *testing.T) {
+	db := setupTestDB(t)
+	client := NewClient(db)
+	ctx := t.Context()
+	server := &ToolServer{Name: "server", GroupKind: "kind", Description: "original"}
+	require.NoError(t, client.RefreshToolServer(ctx, server, &v1alpha3.MCPTool{Name: "original"}))
+	originalServers, err := client.ListToolServers(ctx)
+	require.NoError(t, err)
+	originalTools, err := client.ListTools(ctx)
+	require.NoError(t, err)
+	_, err = db.Exec(ctx, `ALTER TABLE tool ADD CONSTRAINT reject_bad_description CHECK (description <> 'reject')`)
+	require.NoError(t, err)
+	server.Description = "changed"
+	require.Error(t, client.RefreshToolServer(ctx, server, &v1alpha3.MCPTool{Name: "new", Description: "reject"}))
+	servers, err := client.ListToolServers(ctx)
+	require.NoError(t, err)
+	tools, err := client.ListTools(ctx)
+	require.NoError(t, err)
+	require.Equal(t, originalServers, servers)
+	require.Equal(t, originalTools, tools)
+
+	_, err = db.Exec(ctx, `ALTER TABLE tool ADD CONSTRAINT reject_delete CHECK (deleted_at IS NULL)`)
+	require.NoError(t, err)
+	require.Error(t, client.DeleteToolServer(ctx, server.Name, server.GroupKind))
+	servers, err = client.ListToolServers(ctx)
+	require.NoError(t, err)
+	tools, err = client.ListTools(ctx)
+	require.NoError(t, err)
+	require.Equal(t, originalServers, servers)
+	require.Equal(t, originalTools, tools)
+}

--- a/go/core/internal/grpcserver/scheduledrun_controller_test.go
+++ b/go/core/internal/grpcserver/scheduledrun_controller_test.go
@@ -49,7 +49,13 @@ func (s lostTaskLinkStore) UpdateScheduledRunExecution(ctx context.Context, leas
 }
 
 func (w *scheduledControllerWorkflow) Create(ctx context.Context, instance *apiv1alpha1.AgentInstance) (*apiv1alpha1.AgentInstance, error) {
-	return w.store.MarkAgentInstanceReady(ctx, instance.Id, "scheduled-runtime.test")
+	next := proto.CloneOf(instance)
+	next.State = apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_READY
+	next.Operation = apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_UNSPECIFIED
+	next.A2AAuthority = "scheduled-runtime.test"
+	return w.store.TransitionAgentInstance(ctx, next,
+		apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_CREATING,
+		apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_CREATE)
 }
 
 func (w *scheduledControllerWorkflow) Suspend(ctx context.Context, instance *apiv1alpha1.AgentInstance) (*apiv1alpha1.AgentInstance, error) {
@@ -251,7 +257,7 @@ func TestScheduledRunControllerThroughGRPC(t *testing.T) {
 					// the original stream can persist this result: no subscription runs.
 					close(release)
 					require.Eventually(t, func() bool {
-						task, err := store.GetAgentInstanceTask(t.Context(), running.AgentInstanceId, running.TaskId)
+						task, err := store.GetAgentInstanceTask(t.Context(), running.AgentInstanceId, running.TaskId, nil)
 						return err == nil && task.Status.State == a2atype.TaskStateCompleted
 					}, 5*time.Second, 20*time.Millisecond)
 					require.Zero(t, runtime.subscriptions.Load())
@@ -281,7 +287,7 @@ func TestScheduledRunControllerThroughGRPC(t *testing.T) {
 			instance, err := store.GetAgentInstance(t.Context(), execution.AgentInstanceId, "alice")
 			require.NoError(t, err)
 			require.Equal(t, "alice", instance.Creator)
-			task, err := store.GetAgentInstanceTask(t.Context(), instance.Id, execution.TaskId)
+			task, err := store.GetAgentInstanceTask(t.Context(), instance.Id, execution.TaskId, nil)
 			require.NoError(t, err)
 			wantTaskState := tc.state
 			if tc.state == a2atype.TaskStateWorking {

--- a/go/core/internal/grpcserver/scheduledrun_test.go
+++ b/go/core/internal/grpcserver/scheduledrun_test.go
@@ -177,13 +177,12 @@ func scheduledRunTestServer(t *testing.T) (*database.Client, apiv1alpha1.Schedul
 	t.Cleanup(db.Close)
 	store := database.NewClient(db)
 	pair := database.AgentTemplateHarnessPair{Namespace: "team", AgentTemplateName: "report", AgentTemplateUID: "template-uid", HarnessName: "runtime", HarnessUID: "harness-uid", DesiredRevision: "scheduled-revision"}
-	require.NoError(t, store.UpsertRuntimeRevision(t.Context(), database.RuntimeRevision{
+	require.NoError(t, store.UpsertAgentTemplateHarnessPair(t.Context(), pair))
+	require.NoError(t, store.RecordRuntimeRevision(t.Context(), database.RuntimeRevision{
 		Revision: pair.DesiredRevision, Namespace: pair.Namespace, AgentTemplateName: pair.AgentTemplateName, AgentTemplateUID: pair.AgentTemplateUID,
 		HarnessName: pair.HarnessName, HarnessUID: pair.HarnessUID, SourceSnapshot: []byte("{}"), AgentCard: &a2apb.AgentCard{}, EgressDestinations: []string{},
 		ActorTemplateAtespace: "team", ActorTemplateName: "runtime", ActorTemplateUID: "runtime-uid",
-	}))
-	require.NoError(t, store.UpsertAgentTemplateHarnessPair(t.Context(), pair))
-	require.NoError(t, store.MarkRuntimeRevisionSuccessful(t.Context(), pair))
+	}, true))
 	scheme := runtime.NewScheme()
 	require.NoError(t, v1alpha3.AddToScheme(scheme))
 	harness := testHarness("team", "runtime", "pool")

--- a/go/core/internal/grpcserver/tool_test.go
+++ b/go/core/internal/grpcserver/tool_test.go
@@ -36,9 +36,8 @@ import (
 )
 
 type toolGRPCDiscoveryStore struct {
-	tools       []database.Tool
-	servers     []database.ToolServer
-	serverTools map[string][]database.Tool
+	tools   []database.Tool
+	servers []database.ToolServer
 }
 
 func (s *toolGRPCDiscoveryStore) ListTools(context.Context) ([]database.Tool, error) {
@@ -47,10 +46,6 @@ func (s *toolGRPCDiscoveryStore) ListTools(context.Context) ([]database.Tool, er
 
 func (s *toolGRPCDiscoveryStore) ListToolServers(context.Context) ([]database.ToolServer, error) {
 	return s.servers, nil
-}
-
-func (s *toolGRPCDiscoveryStore) ListToolsForServer(_ context.Context, name, groupKind string) ([]database.Tool, error) {
-	return s.serverTools[name+"|"+groupKind], nil
 }
 
 type toolGRPCMCPClient struct {
@@ -118,9 +113,6 @@ func TestToolServiceGeneratedClient(t *testing.T) {
 	store := &toolGRPCDiscoveryStore{
 		tools:   []database.Tool{{ID: "move_task", ServerName: "default/shared", GroupKind: "RemoteMCPServer.kagent.dev", Description: "Move a task"}},
 		servers: []database.ToolServer{{Name: "default/shared", GroupKind: "RemoteMCPServer.kagent.dev"}},
-		serverTools: map[string][]database.Tool{
-			"default/shared|RemoteMCPServer.kagent.dev": {{ID: "move_task", Description: "Move a task"}},
-		},
 	}
 	authorizer := &toolGRPCAuthorizer{}
 	mcpClient := &toolGRPCMCPClient{}

--- a/go/core/internal/mcp/tasks_test.go
+++ b/go/core/internal/mcp/tasks_test.go
@@ -460,7 +460,7 @@ func (*fakeInstanceStore) UpdateAgentInstanceName(context.Context, string, strin
 	return nil, database.ErrNotFound
 }
 
-func (*fakeInstanceStore) CreateAgentInstanceShare(context.Context, *apiv1alpha1.AgentInstanceShare, []byte) (*apiv1alpha1.AgentInstanceShare, error) {
+func (*fakeInstanceStore) CreateAgentInstanceShare(context.Context, *apiv1alpha1.AgentInstanceShare, []byte, string) (*apiv1alpha1.AgentInstanceShare, error) {
 	return nil, database.ErrNotFound
 }
 

--- a/go/core/internal/service/agentinstance/service.go
+++ b/go/core/internal/service/agentinstance/service.go
@@ -27,7 +27,7 @@ type store interface {
 	GetAgentInstance(context.Context, string, string) (*apiv1alpha1.AgentInstance, error)
 	ListAgentInstances(context.Context, database.AgentInstanceQuery) ([]*apiv1alpha1.AgentInstance, error)
 	UpdateAgentInstanceName(context.Context, string, string, string) (*apiv1alpha1.AgentInstance, error)
-	CreateAgentInstanceShare(context.Context, *apiv1alpha1.AgentInstanceShare, []byte) (*apiv1alpha1.AgentInstanceShare, error)
+	CreateAgentInstanceShare(context.Context, *apiv1alpha1.AgentInstanceShare, []byte, string) (*apiv1alpha1.AgentInstanceShare, error)
 	ListAgentInstanceShares(context.Context, string, string, string, int) ([]*apiv1alpha1.AgentInstanceShare, error)
 	DeleteAgentInstanceShare(context.Context, string, string) error
 }
@@ -264,13 +264,6 @@ func (s *Service) CreateShare(ctx context.Context, instanceID string, permission
 	if err != nil {
 		return nil, "", err
 	}
-	_, err = s.store.GetAgentInstance(ctx, instanceID, userID)
-	if err != nil {
-		if errors.Is(err, database.ErrNotFound) {
-			return nil, "", serviceerrors.NewNotFound("AgentInstance not found", err)
-		}
-		return nil, "", serviceerrors.NewInternal("Failed to get AgentInstance", err)
-	}
 	token, tokenHash, err := generateShareToken()
 	if err != nil {
 		return nil, "", serviceerrors.NewInternal("Failed to create share token", err)
@@ -280,7 +273,10 @@ func (s *Service) CreateShare(ctx context.Context, instanceID string, permission
 		return nil, "", serviceerrors.NewInternal("Failed to generate share identifier", err)
 	}
 	share, err := s.store.CreateAgentInstanceShare(ctx, &apiv1alpha1.AgentInstanceShare{Id: id.String(), AgentInstanceId: instanceID,
-		Permission: permission}, tokenHash)
+		Permission: permission}, tokenHash, userID)
+	if errors.Is(err, database.ErrNotFound) {
+		return nil, "", serviceerrors.NewNotFound("AgentInstance not found", err)
+	}
 	if err != nil {
 		return nil, "", serviceerrors.NewInternal("Failed to create AgentInstance share", err)
 	}

--- a/go/core/internal/service/agentinstance/service_test.go
+++ b/go/core/internal/service/agentinstance/service_test.go
@@ -42,6 +42,8 @@ type serviceTestStore struct {
 	renameUserID string
 	renameErr    error
 	getCreator   string
+	shareUserID  string
+	shareErr     error
 }
 
 func (s *serviceTestStore) CreateAgentInstance(_ context.Context, instance *apiv1alpha1.AgentInstance, requestID string) (*apiv1alpha1.AgentInstance, bool, error) {
@@ -73,9 +75,9 @@ func (s *serviceTestStore) UpdateAgentInstanceName(_ context.Context, id, userID
 	return s.renamed, nil
 }
 
-func (s *serviceTestStore) CreateAgentInstanceShare(_ context.Context, share *apiv1alpha1.AgentInstanceShare, tokenHash []byte) (*apiv1alpha1.AgentInstanceShare, error) {
-	s.share, s.tokenHash = share, tokenHash
-	return s.share, nil
+func (s *serviceTestStore) CreateAgentInstanceShare(_ context.Context, share *apiv1alpha1.AgentInstanceShare, tokenHash []byte, userID string) (*apiv1alpha1.AgentInstanceShare, error) {
+	s.share, s.tokenHash, s.shareUserID = share, tokenHash, userID
+	return s.share, s.shareErr
 }
 
 func (s *serviceTestStore) ListAgentInstanceShares(_ context.Context, _, _, afterID string, limit int) ([]*apiv1alpha1.AgentInstanceShare, error) {
@@ -236,6 +238,9 @@ func TestServiceCreateShareGeneratesTokenAndUUID(t *testing.T) {
 	digest := sha256.Sum256([]byte(token))
 	if !bytes.Equal(store.tokenHash, digest[:]) {
 		t.Fatal("stored token hash does not match returned token")
+	}
+	if store.shareUserID != "alice" || store.getCreator != "" {
+		t.Fatalf("share owner = %q, preparatory lookup owner = %q", store.shareUserID, store.getCreator)
 	}
 }
 
@@ -449,5 +454,18 @@ func TestServiceListPassesTheAgentPairThroughToTheStore(t *testing.T) {
 				t.Fatalf("store query pair = %v, want %v", got, test.wantPair)
 			}
 		})
+	}
+}
+
+func TestServiceCreateShareMapsMissingOwnerToNotFound(t *testing.T) {
+	store := &serviceTestStore{shareErr: database.ErrNotFound}
+	service := NewService(store, serviceTestAuthorizer{}, serviceTestWorkflow{})
+	share, token, err := service.CreateShare(serviceTestContext("alice"), uuid.NewString(),
+		apiv1alpha1.AgentInstanceSharePermission_AGENT_INSTANCE_SHARE_PERMISSION_READ_ONLY)
+	if !serviceerrors.IsCode(err, serviceerrors.CodeNotFound) {
+		t.Fatalf("CreateShare error = %v, want NotFound", err)
+	}
+	if share != nil || token != "" {
+		t.Fatal("failed share creation returned credentials")
 	}
 }

--- a/go/core/internal/service/agentinstance/workflow.go
+++ b/go/core/internal/service/agentinstance/workflow.go
@@ -18,7 +18,6 @@ import (
 
 type workflowStore interface {
 	GetRuntimeRevision(context.Context, string) (*database.RuntimeRevision, error)
-	MarkAgentInstanceReady(context.Context, string, string) (*apiv1alpha1.AgentInstance, error)
 	TransitionAgentInstance(context.Context, *apiv1alpha1.AgentInstance, apiv1alpha1.AgentInstanceState, apiv1alpha1.AgentInstanceOperation) (*apiv1alpha1.AgentInstance, error)
 	DeleteAgentInstance(context.Context, string) error
 }
@@ -112,7 +111,7 @@ func (w *ActorWorkflow) Create(ctx context.Context, instance *apiv1alpha1.AgentI
 	if !usesActorTemplate(actor, revision) {
 		return nil, fmt.Errorf("actor %s/%s uses unexpected ActorTemplate %s/%s", atespace, name, actor.GetActorTemplate().GetAtespace(), actor.GetActorTemplate().GetName())
 	}
-	instance, err = w.store.MarkAgentInstanceReady(ctx, instance.GetId(), substrate.ActorHost(atespace, name, ""))
+	instance, err = w.finishCreate(ctx, instance, substrate.ActorHost(atespace, name, ""))
 	if err != nil {
 		return nil, fmt.Errorf("mark AgentInstance ready: %w", err)
 	}
@@ -157,11 +156,28 @@ func (w *ActorWorkflow) Fork(ctx context.Context, instance *apiv1alpha1.AgentIns
 		strings.TrimPrefix(source.GetContentScope().String(), "SNAPSHOT_CONTENT_SCOPE_") != snapshot.ContentScope {
 		return nil, fmt.Errorf("actor %s/%s uses unexpected source snapshot", atespace, name)
 	}
-	instance, err = w.store.MarkAgentInstanceReady(ctx, instance.GetId(), substrate.ActorHost(atespace, name, ""))
+	instance, err = w.finishCreate(ctx, instance, substrate.ActorHost(atespace, name, ""))
 	if err != nil {
 		return nil, fmt.Errorf("mark fork AgentInstance ready: %w", err)
 	}
 	return instance, nil
+}
+
+// finishCreate publishes the runtime authority only while creation owns the instance.
+// A delayed completion returns the current lifecycle unchanged.
+func (w *ActorWorkflow) finishCreate(ctx context.Context, instance *apiv1alpha1.AgentInstance, authority string) (*apiv1alpha1.AgentInstance, error) {
+	next := proto.CloneOf(instance)
+	next.State = apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_READY
+	next.Operation = apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_UNSPECIFIED
+	next.A2AAuthority = authority
+	next.Failure = nil
+	current, err := w.store.TransitionAgentInstance(ctx, next,
+		apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_CREATING,
+		apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_CREATE)
+	if errors.Is(err, database.ErrAgentInstanceConflict) {
+		return current, nil
+	}
+	return current, err
 }
 
 // Suspend completes synchronously: success means both Substrate and the

--- a/go/core/internal/service/agentinstance/workflow_test.go
+++ b/go/core/internal/service/agentinstance/workflow_test.go
@@ -17,6 +17,7 @@ func TestActorWorkflowLifecycle(t *testing.T) {
 	instance := &apiv1alpha1.AgentInstance{
 		Id:               "8bd650a8-9775-488f-8bc1-0d52bf7bdcab",
 		PreparedRevision: "revision-1", State: apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_CREATING,
+		Operation: apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_CREATE,
 	}
 	store := &lifecycleTestStore{
 		instance: instance,
@@ -79,7 +80,8 @@ func TestActorWorkflowLifecycle(t *testing.T) {
 func TestActorWorkflowForkCreatesSuspendedActorFromCheckpoint(t *testing.T) {
 	instance := &apiv1alpha1.AgentInstance{
 		Id: "fork-1", PreparedRevision: "revision-1",
-		State: apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_CREATING,
+		State:     apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_CREATING,
+		Operation: apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_CREATE,
 	}
 	store := &lifecycleTestStore{
 		instance: instance,
@@ -119,13 +121,6 @@ type lifecycleTestStore struct {
 
 func (s *lifecycleTestStore) GetRuntimeRevision(context.Context, string) (*database.RuntimeRevision, error) {
 	return s.revision, nil
-}
-
-func (s *lifecycleTestStore) MarkAgentInstanceReady(_ context.Context, _ string, authority string) (*apiv1alpha1.AgentInstance, error) {
-	s.instance.State = apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_READY
-	s.instance.Operation = apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_UNSPECIFIED
-	s.instance.A2AAuthority = authority
-	return s.instance, nil
 }
 
 func (s *lifecycleTestStore) TransitionAgentInstance(_ context.Context, instance *apiv1alpha1.AgentInstance, expectedState apiv1alpha1.AgentInstanceState, expectedOperation apiv1alpha1.AgentInstanceOperation) (*apiv1alpha1.AgentInstance, error) {
@@ -210,5 +205,39 @@ func TestQuiesceRejectsWrongActorIdentity(t *testing.T) {
 	}}
 	if _, err := NewActorWorkflow(store, actors).Quiesce(t.Context(), instance); err == nil {
 		t.Fatal("Quiesce() accepted the wrong Actor")
+	}
+}
+
+func TestFinishCreatePreservesLaterLifecycle(t *testing.T) {
+	creating := &apiv1alpha1.AgentInstance{
+		Id: "instance", State: apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_CREATING,
+		Operation: apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_CREATE,
+		Failure:   &apiv1alpha1.Failure{Message: "previous failure"},
+	}
+	for name, current := range map[string]*apiv1alpha1.AgentInstance{
+		"creating":          proto.CloneOf(creating),
+		"already ready":     {Id: "instance", State: apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_READY, A2AAuthority: "original"},
+		"deleting":          {Id: "instance", State: apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_DELETING, Operation: apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_DELETE},
+		"another operation": {Id: "instance", State: apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_CREATING, Operation: apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_DELETE},
+	} {
+		t.Run(name, func(t *testing.T) {
+			store := &lifecycleTestStore{instance: current}
+			got, err := NewActorWorkflow(store, nil).finishCreate(t.Context(), creating, "runtime.example")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if name == "creating" {
+				if got.GetState() != apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_READY ||
+					got.GetOperation() != apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_UNSPECIFIED ||
+					got.GetA2AAuthority() != "runtime.example" || got.GetFailure() != nil {
+					t.Fatalf("creation result = %v", got)
+				}
+			} else if !proto.Equal(current, got) {
+				t.Fatalf("late completion changed current state: got %v, want %v", got, current)
+			}
+		})
+	}
+	if creating.GetFailure() == nil || creating.GetState() != apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_CREATING {
+		t.Fatal("creation changed the caller's instance")
 	}
 }

--- a/go/core/internal/service/memory/service.go
+++ b/go/core/internal/service/memory/service.go
@@ -19,8 +19,7 @@ const (
 )
 
 type Store interface {
-	StoreAgentMemory(context.Context, *database.Memory) error
-	StoreAgentMemories(context.Context, []*database.Memory) error
+	StoreAgentMemories(context.Context, ...*database.Memory) error
 	SearchAgentMemory(context.Context, string, string, pgvector.Vector, int) ([]database.AgentMemorySearchResult, error)
 	ListAgentMemories(context.Context, string, string) ([]database.Memory, error)
 	DeleteAgentMemory(context.Context, string, string) error
@@ -83,7 +82,7 @@ func (s *Service) Add(ctx context.Context, input Input) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if err := s.store.StoreAgentMemory(ctx, memory); err != nil {
+	if err := s.store.StoreAgentMemories(ctx, memory); err != nil {
 		return "", serviceerrors.NewInternal("failed to save memory", err)
 	}
 	return memory.ID, nil
@@ -114,7 +113,7 @@ func (s *Service) AddBatch(ctx context.Context, inputs []Input) (int, error) {
 		}
 		memories = append(memories, memory)
 	}
-	if err := s.store.StoreAgentMemories(ctx, memories); err != nil {
+	if err := s.store.StoreAgentMemories(ctx, memories...); err != nil {
 		return 0, serviceerrors.NewInternal("failed to save memory batch", err)
 	}
 	return len(memories), nil

--- a/go/core/internal/service/memory/service_test.go
+++ b/go/core/internal/service/memory/service_test.go
@@ -23,18 +23,12 @@ type memoryStore struct {
 	deletedUser  string
 }
 
-func (store *memoryStore) StoreAgentMemory(_ context.Context, memory *database.Memory) error {
+func (store *memoryStore) StoreAgentMemories(_ context.Context, memories ...*database.Memory) error {
 	if store.err != nil {
 		return store.err
 	}
-	memory.ID = "memory-1"
-	store.stored = append(store.stored, memory)
-	return nil
-}
-
-func (store *memoryStore) StoreAgentMemories(_ context.Context, memories []*database.Memory) error {
-	if store.err != nil {
-		return store.err
+	for _, memory := range memories {
+		memory.ID = "memory-1"
 	}
 	store.stored = append(store.stored, memories...)
 	return nil

--- a/go/core/internal/service/tool/service.go
+++ b/go/core/internal/service/tool/service.go
@@ -37,7 +37,6 @@ var (
 type DiscoveryStore interface {
 	ListTools(context.Context) ([]database.Tool, error)
 	ListToolServers(context.Context) ([]database.ToolServer, error)
-	ListToolsForServer(context.Context, string, string) ([]database.Tool, error)
 }
 
 type MCPClient interface {
@@ -118,24 +117,25 @@ func (s *Service) ListToolServers(ctx context.Context) ([]ToolServer, error) {
 	if err != nil {
 		return nil, serviceerrors.NewInternal("Failed to list ToolServers from database", err)
 	}
+	if len(servers) == 0 {
+		return []ToolServer{}, nil
+	}
+	tools, err := s.discoveryStore.ListTools(ctx)
+	if err != nil {
+		return nil, serviceerrors.NewInternal("Failed to list tools from database", err)
+	}
+	byServer := make(map[[2]string][]*v1alpha3.MCPTool)
+	for _, tool := range tools {
+		key := [2]string{tool.ServerName, tool.GroupKind}
+		byServer[key] = append(byServer[key], &v1alpha3.MCPTool{Name: tool.ID, Description: tool.Description})
+	}
 	result := make([]ToolServer, 0, len(servers))
 	for _, server := range servers {
-		tools, err := s.discoveryStore.ListToolsForServer(ctx, server.Name, server.GroupKind)
-		if err != nil {
-			return nil, serviceerrors.NewInternal("Failed to list tools for ToolServer from database", err)
+		discovered := byServer[[2]string{server.Name, server.GroupKind}]
+		if discovered == nil {
+			discovered = []*v1alpha3.MCPTool{}
 		}
-		discovered := make([]*v1alpha3.MCPTool, 0, len(tools))
-		for _, discoveredTool := range tools {
-			discovered = append(discovered, &v1alpha3.MCPTool{
-				Name:        discoveredTool.ID,
-				Description: discoveredTool.Description,
-			})
-		}
-		result = append(result, ToolServer{
-			Ref:             server.Name,
-			GroupKind:       server.GroupKind,
-			DiscoveredTools: discovered,
-		})
+		result = append(result, ToolServer{Ref: server.Name, GroupKind: server.GroupKind, DiscoveredTools: discovered})
 	}
 	return result, nil
 }

--- a/go/core/internal/service/tool/service_test.go
+++ b/go/core/internal/service/tool/service_test.go
@@ -27,22 +27,21 @@ import (
 )
 
 type fakeDiscoveryStore struct {
-	tools       []database.Tool
-	servers     []database.ToolServer
-	serverTools map[string][]database.Tool
-	err         error
+	toolsErr error
+	tools    []database.Tool
+	servers  []database.ToolServer
+	err      error
 }
 
 func (f *fakeDiscoveryStore) ListTools(context.Context) ([]database.Tool, error) {
+	if f.toolsErr != nil {
+		return nil, f.toolsErr
+	}
 	return f.tools, f.err
 }
 
 func (f *fakeDiscoveryStore) ListToolServers(context.Context) ([]database.ToolServer, error) {
 	return f.servers, f.err
-}
-
-func (f *fakeDiscoveryStore) ListToolsForServer(_ context.Context, name, groupKind string) ([]database.Tool, error) {
-	return f.serverTools[name+"|"+groupKind], f.err
 }
 
 type fakeMCPClient struct {
@@ -88,14 +87,11 @@ func (a *recordingAuthorizer) Check(_ context.Context, _ pkgauth.Principal, verb
 
 func TestServiceDiscoveryAndAuthorization(t *testing.T) {
 	store := &fakeDiscoveryStore{
-		tools: []database.Tool{{ID: "all-tool", Description: "all"}},
+		tools: []database.Tool{{ID: "server-tool", ServerName: "default/server", GroupKind: "RemoteMCPServer.kagent.dev", Description: "server"}},
 		servers: []database.ToolServer{{
 			Name:      "default/server",
 			GroupKind: "RemoteMCPServer.kagent.dev",
 		}},
-		serverTools: map[string][]database.Tool{
-			"default/server|RemoteMCPServer.kagent.dev": {{ID: "server-tool", Description: "server"}},
-		},
 	}
 	authorizer := &recordingAuthorizer{}
 	service := NewService(toolTestKube(t, true), store, authorizer, "default", &fakeMCPClient{})
@@ -106,7 +102,7 @@ func TestServiceDiscoveryAndAuthorization(t *testing.T) {
 	ctx := toolTestContext()
 	tools, err := service.ListTools(ctx)
 	require.NoError(t, err)
-	require.Equal(t, "all-tool", tools[0].ID)
+	require.Equal(t, "server-tool", tools[0].ID)
 
 	servers, err := service.ListToolServers(ctx)
 	require.NoError(t, err)
@@ -283,4 +279,39 @@ func toolTestKube(t *testing.T, withMCPServer bool, objects ...client.Object) cl
 		)
 	}
 	return fake.NewClientBuilder().WithScheme(scheme).WithRESTMapper(restMapper).WithObjects(objects...).Build()
+}
+
+func TestListToolServersGroupsByExactIdentity(t *testing.T) {
+	store := &fakeDiscoveryStore{
+		servers: []database.ToolServer{
+			{Name: "shared", GroupKind: "remote"},
+			{Name: "shared", GroupKind: "local"},
+			{Name: "empty", GroupKind: "remote"},
+		},
+		tools: []database.Tool{
+			{ID: "first", ServerName: "shared", GroupKind: "remote", Description: "first description"},
+			{ID: "local", ServerName: "shared", GroupKind: "local"},
+			{ID: "second", ServerName: "shared", GroupKind: "remote"},
+			{ID: "orphan", ServerName: "absent", GroupKind: "remote"},
+		},
+	}
+	service := NewService(toolTestKube(t, true), store, &recordingAuthorizer{}, "default", &fakeMCPClient{})
+	servers, err := service.ListToolServers(toolTestContext())
+	require.NoError(t, err)
+	require.Equal(t, []ToolServer{
+		{Ref: "shared", GroupKind: "remote", DiscoveredTools: []*v1alpha3.MCPTool{{Name: "first", Description: "first description"}, {Name: "second"}}},
+		{Ref: "shared", GroupKind: "local", DiscoveredTools: []*v1alpha3.MCPTool{{Name: "local"}}},
+		{Ref: "empty", GroupKind: "remote", DiscoveredTools: []*v1alpha3.MCPTool{}},
+	}, servers)
+}
+
+func TestListToolServersSkipsToolReadWithoutServers(t *testing.T) {
+	store := &fakeDiscoveryStore{toolsErr: errors.New("tool read failed")}
+	service := NewService(toolTestKube(t, true), store, &recordingAuthorizer{}, "default", &fakeMCPClient{})
+	servers, err := service.ListToolServers(toolTestContext())
+	require.NoError(t, err)
+	require.Equal(t, []ToolServer{}, servers)
+	store.servers = []database.ToolServer{{Name: "server", GroupKind: "kind"}}
+	_, err = service.ListToolServers(toolTestContext())
+	require.ErrorIs(t, err, store.toolsErr)
 }


### PR DESCRIPTION
The database client still exposed overlapping operations after the sqlc removal, leaving callers to coordinate related writes and perform redundant reads. This reduces its exported methods from 63 to 54 without adding production structs or dependencies.

- Publish and delete each tool server and its catalog atomically, serializing concurrent replacements on the server row. List server catalogs with two reads instead of one per server.
- Combine memory insertion paths and assign batch IDs only after commit; record runtime revisions and conditionally promote readiness in one statement; reuse the existing instance lifecycle transition for creation completion.
- Enforce share ownership in the insert, join task lookup to its instance, and apply requested history limits during reads. Remove unused update results and scheduled reservation decoding.

Ownership, delayed-completion behavior, lifecycle conflicts, and external provisioning phases are preserved. Task-event writes and the schema are unchanged. History limits reduce transferred and decoded messages; database scan costs have not been benchmarked.

Validation: database race suite (including preparation of every inline SQL statement), affected service/controller/gRPC/MCP/A2A race suites, and migration tests passed. Regression coverage includes catalog concurrency and rollback, ownership, stale readiness, memory rollback IDs, and per-task history limits. Repository golangci-lint reports 0 issues; formatting and diff checks pass.
