### PR TITLE
fix(ui): keep the transcript pinned while it settles, and wait for the app to boot

### DIFF
--- a/ui/playwright/helpers/app.ts
+++ b/ui/playwright/helpers/app.ts
@@ -156,7 +156,17 @@ export function dataRows(page: Page): Locator {
   return page.locator("tbody tr.ant-table-row");
 }
 
-/** Resolves once no loading indicator is left on the page. */
+/** A navigation-sized budget, for the app booting rather than for what it rendered. */
+const APP_BOOT_TIMEOUT = 15_000;
+
+/**
+ * Resolves once the app is on screen and no loading indicator is left on it.
+ *
+ * Waiting for a spinner to be absent is also true of a page that has not started
+ * rendering, so after a `goto` or a `reload` this returned at once and the next
+ * assertion's own five seconds became the app's boot budget.
+ */
 export async function expectSettled(page: Page): Promise<void> {
+  await expect(page.locator("#root")).not.toBeEmpty({ timeout: APP_BOOT_TIMEOUT });
   await expect(page.locator(".ant-spin-spinning")).toHaveCount(0);
 }

--- a/ui/playwright/tests/chat/chat.spec.ts
+++ b/ui/playwright/tests/chat/chat.spec.ts
@@ -344,6 +344,20 @@ test("chat: leaving the foot of a conversation offers a way back to it", async (
      */
     await expect(button).toHaveCount(0, { timeout: 10_000 });
   });
+
+  await test.step("4. and a transcript still growing does not take it away", async () => {
+    /*
+     * Growth landing after the pin, with the scroll event the pin queued behind it.
+     * Dispatched rather than waited for: on an idle machine the two land in the same
+     * frame, which is why this only ever failed on a loaded one.
+     */
+    await box.evaluate((node) => {
+      (node.firstElementChild as HTMLElement).style.paddingBottom = "900px";
+      node.dispatchEvent(new Event("scroll"));
+    });
+
+    await expect(button).toHaveCount(0);
+  });
 });
 
 /**

--- a/ui/src/components/chat/ChatTranscript.tsx
+++ b/ui/src/components/chat/ChatTranscript.tsx
@@ -114,12 +114,22 @@ export function ChatTranscript({
     if (!box) return;
     const atBottom = () =>
       box.scrollHeight - box.scrollTop - box.clientHeight <= AT_BOTTOM_SLACK;
+    /*
+     * Growth moves the foot away without anybody scrolling. A scroll event arriving
+     * mid-growth read that as the reader having left and unset the pin the observer
+     * below needs to close the gap — so the button came back, and stayed.
+     */
+    let lastTop = box.scrollTop;
     const measure = () => {
       const now = atBottom();
+      const movedUp = box.scrollTop < lastTop;
+      lastTop = box.scrollTop;
       if (returningRef.current) {
         if (!now) return;
         returningRef.current = false;
       }
+      // Short of the foot without having scrolled up is growth, not the reader leaving.
+      if (pinnedRef.current && !now && !movedUp) return;
       pinnedRef.current = now;
       setAtBottom(now);
     };


### PR DESCRIPTION
Fixes e2e UI test flake

Closes #2773.

---
*🤖 written by Claude (start)*

Two Playwright specs failed only under parallel load, and each had a real cause rather than a timeout that needed raising.

- **The chat scroll-to-bottom button could strand a reader at the foot.** Content landing below the fold moves the foot away without anybody scrolling, and a scroll event arriving mid-growth read that as the reader having left. That unset the pin, and the resize observer only re-pins while the pin holds — so the button appeared and stayed. Growth no longer unpins; only the reader scrolling up does.
- **`expectSettled` waited for a spinner to be absent**, which is also true of a page that has not started rendering. Straight after a `goto` or a `reload` it returned at once, leaving the next assertion's own five seconds to boot the app. It now waits for the app to be on screen first.

### Testing

1. `cd ui && yarn test:pw`.
2. Step 4 of `chat: leaving the foot of a conversation offers a way back to it` covers the transcript bug — it fails on `main` and passes here.
3. For `lists: a narrowed view is an address`, throttle the CPU (devtools → Performance → 20×) before step 3's reload: on `main` the step spends its whole budget waiting for an app that has not booted.

---
*🤖 written by Claude (end)*
