### PR TITLE
fix(ui): light an agent rail conversation only on the page it links to

### DIFF
--- a/ui/playwright/tests/chat/agent-rail.spec.ts
+++ b/ui/playwright/tests/chat/agent-rail.spec.ts
@@ -654,3 +654,42 @@ test("agent rail: a conversation can be renamed from inside it, two ways", async
     ).toContainText("Named from the rail");
   });
 });
+
+test("agent rail: only the page you are on is marked as current", async ({ page }) => {
+  /*
+   * A conversation row used to be lit by id alone, so it claimed to be the current
+   * page on every surface that mounts the rail for an instance — the agent's own
+   * details page included, which is a different page from the chat the row links to.
+   * Two rows then carried `aria-current="page"` at once, which is both wrong on its
+   * face and wrong for a screen reader.
+   *
+   * Asserted from the details page rather than the chat, because the chat is the one
+   * place the old behaviour happened to be right.
+   */
+  await page.goto(AGENT_DETAILS);
+
+  const rail = page.getByTestId("chat-sessions");
+  await expect(rail).toBeVisible({ timeout: 30_000 });
+
+  const row = rail.locator(`a[data-testid="chat-session-${instances.ready}"]`);
+
+  await test.step("1. the conversation is listed, but is not the current page", async () => {
+    await expect(row).toBeVisible();
+    await expect(row).toHaveAttribute("data-active", "false");
+    await expect(row).not.toHaveAttribute("aria-current", "page");
+  });
+
+  await test.step("2. exactly one entry in the rail claims to be current", async () => {
+    // The count is the assertion. Any single row being right is not enough when the
+    // defect was two of them being right at the same time.
+    await expect(page.locator('[data-testid="chat-sessions-nav"] [aria-current="page"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="chat-sessions"] [aria-current="page"]')).toHaveCount(0);
+  });
+
+  await test.step("3. opening the conversation is what makes it current", async () => {
+    await row.click();
+    await expect(page).toHaveURL(new RegExp(`${instances.ready}/chat$`));
+    await expect(row).toHaveAttribute("data-active", "true");
+    await expect(row).toHaveAttribute("aria-current", "page");
+  });
+});

--- a/ui/src/components/agent/AgentRail.tsx
+++ b/ui/src/components/agent/AgentRail.tsx
@@ -1053,7 +1053,10 @@ export function AgentRail({
               overflowY: "auto",
             }}
           >
-            {chats.map((candidate) => (
+            {chats.map((candidate) => {
+              const href = url.chat({ id: candidate.id });
+
+              return (
               <ChatEntry
                 key={candidate.id}
                 instance={candidate}
@@ -1089,15 +1092,30 @@ export function AgentRail({
                     ? pendingOperation ?? instance?.operation
                     : undefined) ?? candidate.operation
                 }
-                href={url.chat({ id: candidate.id })}
-                isActive={candidate.id === ref.id}
+                href={href}
+                /*
+                 * Lit only where the reader actually is, not wherever the id appears.
+                 *
+                 * This was `candidate.id === ref.id`, which is true on every surface
+                 * that mounts the rail for an instance -- the agent's own details page
+                 * included. So a conversation row was highlighted as the page you were
+                 * on while you were on a different page from the one it links to, and
+                 * two entries in the rail could look current at once.
+                 *
+                 * Compared against the row's own href, which is how the entries above
+                 * decide the same thing. The reads that follow keep matching on the id
+                 * on purpose: which conversation's live state to prefer is a question
+                 * about the instance, not about the route.
+                 */
+                isActive={location.pathname === href}
                 onDelete={deleteConversation}
                 isDeleting={deletingId === candidate.id}
                 isSelected={selected.has(candidate.id)}
                 onToggleSelected={toggleSelected}
                 isSelecting={selected.size > 0}
               />
-            ))}
+              );
+            })}
           </ul>
         )}
       </div>
@@ -1433,6 +1451,10 @@ function ChatEntry({
         to={href}
         data-testid={`chat-session-${instance.id}`}
         data-active={isActive}
+        // As `RailEntry` does for the entries above. The row is a link to a page, so
+        // when it is that page a screen reader should be told -- the highlight is the
+        // only other thing that says so.
+        aria-current={isActive ? "page" : undefined}
         css={{ ...rowStyles(theme, isActive), flex: 1, fontSize: 13, minWidth: 0 }}
       >
         <Text ellipsis css={{ color: "inherit", fontSize: "inherit", flex: 1, minWidth: 0 }}>


### PR DESCRIPTION
## Description

`ChatEntry`'s active state in the agent rail was `candidate.id === ref.id` — an id match with no reference to the route. That is true on every surface which mounts the rail for an instance, and one of those is the agent's own details page.

The row links to that conversation's **chat**, so on `/agents/:id` the rail highlights a row for a page you are not on. Two entries in the rail can look current at the same time.

## Reproducing

1. Open any agent conversation, then use **Agent Details** in the rail.
2. On `/agents/:id`, that conversation's row in the rail is still highlighted.
3. Its href is `/agents/:id/chat` — a different page from the one you are on.

## The fix

`isActive` is compared against the row's own href, which is how the nav entries above it already decide the same thing:

```diff
-                href={url.chat({ id: candidate.id })}
-                isActive={candidate.id === ref.id}
+                href={href}
+                isActive={location.pathname === href}
```

`href` is hoisted out of the JSX so the comparison and the link cannot drift apart. The reads beneath it keep matching on the id on purpose — which conversation's live state to prefer is a question about the instance, not about the route.

The row also gained `aria-current="page"` when active, as `RailEntry` already has. Without it the highlight was the only thing indicating the current page.

## Testing

`playwright/tests/chat/agent-rail.spec.ts` gains one case, asserting from the details page — the chat is the one place the old behaviour happened to be right. It checks the row is listed but not current there, that nothing in the rail claims to be current, and that opening the conversation is what makes it so.

- `yarn typecheck` — clean
- `yarn lint` — no errors
- `npx playwright test playwright/tests/chat/ --project=chromium` — 31 passed

---
*🤖 written by Claude*
