### PR TITLE
fix(ui): decide the agent rail's active state by route, not by id or exact path

### DIFF
--- a/ui/playwright/tests/chat/agent-rail.spec.ts
+++ b/ui/playwright/tests/chat/agent-rail.spec.ts
@@ -654,3 +654,42 @@ test("agent rail: a conversation can be renamed from inside it, two ways", async
     ).toContainText("Named from the rail");
   });
 });
+
+test("agent rail: only the page you are on is marked as current", async ({ page }) => {
+  /*
+   * A conversation row used to be lit by id alone, so it claimed to be the current
+   * page on every surface that mounts the rail for an instance — the agent's own
+   * details page included, which is a different page from the chat the row links to.
+   * Two rows then carried `aria-current="page"` at once, which is both wrong on its
+   * face and wrong for a screen reader.
+   *
+   * Asserted from the details page rather than the chat, because the chat is the one
+   * place the old behaviour happened to be right.
+   */
+  await page.goto(AGENT_DETAILS);
+
+  const rail = page.getByTestId("chat-sessions");
+  await expect(rail).toBeVisible({ timeout: 30_000 });
+
+  const row = rail.locator(`a[data-testid="chat-session-${instances.ready}"]`);
+
+  await test.step("1. the conversation is listed, but is not the current page", async () => {
+    await expect(row).toBeVisible();
+    await expect(row).toHaveAttribute("data-active", "false");
+    await expect(row).not.toHaveAttribute("aria-current", "page");
+  });
+
+  await test.step("2. exactly one entry in the rail claims to be current", async () => {
+    // The count is the assertion. Any single row being right is not enough when the
+    // defect was two of them being right at the same time.
+    await expect(page.locator('[data-testid="chat-sessions-nav"] [aria-current="page"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="chat-sessions"] [aria-current="page"]')).toHaveCount(0);
+  });
+
+  await test.step("3. opening the conversation is what makes it current", async () => {
+    await row.click();
+    await expect(page).toHaveURL(new RegExp(`${instances.ready}/chat$`));
+    await expect(row).toHaveAttribute("data-active", "true");
+    await expect(row).toHaveAttribute("aria-current", "page");
+  });
+});

--- a/ui/src/appExtensions/types.ts
+++ b/ui/src/appExtensions/types.ts
@@ -138,10 +138,17 @@ export interface ExtensionAgentRailItemContribution {
   key: string;
   order: number;
   /**
-   * Used for active-state matching only. The component renders its own link, so
-   * this is optional for entries that do not navigate.
+   * Where this entry leads, as a route pattern, for active-state matching only.
+   * Resolved with `matchPath`, so `/agents/:id/analytics` is active on whichever
+   * agent is open. A pattern with no parameters matches the one path, as before.
    */
   path?: string;
+  /**
+   * Active state this pattern cannot express — several routes, or a search
+   * parameter. Applied in addition to `path`: either matching makes the entry
+   * active, so an entry can declare where it leads and still widen it.
+   */
+  isActive?: (location: { pathname: string; search: string }) => boolean;
   /** What this entry is called, for anything that has to name it rather than draw it. */
   label?: string;
   Component: ComponentType<ExtensionAgentRailItemProps>;

--- a/ui/src/components/agent/AgentRail.tsx
+++ b/ui/src/components/agent/AgentRail.tsx
@@ -48,7 +48,12 @@ import {
   useExtensionAgentRailOverrides,
 } from "@/appExtensions/hooks";
 import { applyAgentRailOverrides, isRailEntryHidden } from "@/appExtensions";
-import { coreRailItems, mergeRailEntries, type RailItem } from "./railItems";
+import {
+  coreRailItems,
+  mergeRailEntries,
+  railItemIsActive,
+  type RailItem,
+} from "./railItems";
 import { agentPageUrl, agentUrl, type AgentRef } from "./agentUrl";
 import { AgentSwitcher } from "./AgentSwitcher";
 import { iconControlStyles, rowStyles, searchInputStyles } from "./controlStyles";
@@ -787,11 +792,7 @@ export function AgentRail({
           ) : (
             <entry.contribution.Component
               key={entry.contribution.key}
-              isActive={
-                entry.contribution.path
-                  ? location.pathname === entry.contribution.path
-                  : false
-              }
+              isActive={railItemIsActive(entry.contribution, location)}
               agent={ref.id ? { id: ref.id } : undefined}
             />
           ),

--- a/ui/src/components/agent/AgentRail.tsx
+++ b/ui/src/components/agent/AgentRail.tsx
@@ -1054,7 +1054,10 @@ export function AgentRail({
               overflowY: "auto",
             }}
           >
-            {chats.map((candidate) => (
+            {chats.map((candidate) => {
+              const href = url.chat({ id: candidate.id });
+
+              return (
               <ChatEntry
                 key={candidate.id}
                 instance={candidate}
@@ -1090,15 +1093,30 @@ export function AgentRail({
                     ? pendingOperation ?? instance?.operation
                     : undefined) ?? candidate.operation
                 }
-                href={url.chat({ id: candidate.id })}
-                isActive={candidate.id === ref.id}
+                href={href}
+                /*
+                 * Lit only where the reader actually is, not wherever the id appears.
+                 *
+                 * This was `candidate.id === ref.id`, which is true on every surface
+                 * that mounts the rail for an instance -- the agent's own details page
+                 * included. So a conversation row was highlighted as the page you were
+                 * on while you were on a different page from the one it links to, and
+                 * two entries in the rail could look current at once.
+                 *
+                 * Compared against the row's own href, which is how the entries above
+                 * decide the same thing. The reads that follow keep matching on the id
+                 * on purpose: which conversation's live state to prefer is a question
+                 * about the instance, not about the route.
+                 */
+                isActive={location.pathname === href}
                 onDelete={deleteConversation}
                 isDeleting={deletingId === candidate.id}
                 isSelected={selected.has(candidate.id)}
                 onToggleSelected={toggleSelected}
                 isSelecting={selected.size > 0}
               />
-            ))}
+              );
+            })}
           </ul>
         )}
       </div>
@@ -1434,6 +1452,10 @@ function ChatEntry({
         to={href}
         data-testid={`chat-session-${instance.id}`}
         data-active={isActive}
+        // As `RailEntry` does for the entries above. The row is a link to a page, so
+        // when it is that page a screen reader should be told -- the highlight is the
+        // only other thing that says so.
+        aria-current={isActive ? "page" : undefined}
         css={{ ...rowStyles(theme, isActive), flex: 1, fontSize: 13, minWidth: 0 }}
       >
         <Text ellipsis css={{ color: "inherit", fontSize: "inherit", flex: 1, minWidth: 0 }}>

--- a/ui/src/components/agent/railItems.ts
+++ b/ui/src/components/agent/railItems.ts
@@ -1,5 +1,6 @@
 import { Bot, SquarePen } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
+import { matchPath } from "react-router-dom";
 import type { ExtensionAgentRailItemContribution } from "@/appExtensions";
 
 /**
@@ -101,4 +102,22 @@ export function mergeRailEntries(
     if (left.kind === right.kind) return 0;
     return left.kind === "core" ? -1 : 1;
   });
+}
+
+/**
+ * Whether a contributed rail entry is the page the reader is on.
+ *
+ * Either signal is enough: its own `isActive`, or its `path` as a route pattern. An
+ * exact string compare used to be the whole of this and could not work for a
+ * parameterised path — the pattern a contribution declares never equals a filled-in
+ * location, so such an entry stayed unlit on the page it leads to.
+ */
+export function railItemIsActive(
+  contribution: ExtensionAgentRailItemContribution,
+  location: { pathname: string; search: string },
+): boolean {
+  if (contribution.isActive?.(location)) return true;
+  return contribution.path
+    ? matchPath(contribution.path, location.pathname) !== null
+    : false;
 }


### PR DESCRIPTION
## Description

Two defects in the agent rail's active state, both about the same thing: what the rail treats as "the page you are on".

### 1. A conversation was lit by id rather than by route

`ChatEntry`'s active state was `candidate.id === ref.id` — an id match with no reference to the location. That is true on every surface which mounts the rail for an instance, and one of those is the agent's own details page. The row links to that conversation's **chat**, so on `/agents/:id` the rail highlighted a row for a page you were not on, and two entries in the rail could look current at once.

**Reproducing:** open a conversation, use **Agent Details** in the rail, and its row is still highlighted on `/agents/:id` while its href points at `/agents/:id/chat`.

`isActive` is compared against the row's own href now, which is how the nav entries above it already decide the same thing:

```diff
-                href={url.chat({ id: candidate.id })}
-                isActive={candidate.id === ref.id}
+                href={href}
+                isActive={location.pathname === href}
```

`href` is hoisted out of the JSX so the comparison and the link cannot drift apart. The reads beneath it keep matching on the id on purpose — which conversation's live state to prefer is a question about the instance, not the route. The row also gained `aria-current="page"` when active, as `RailEntry` already had; without it the highlight was the only thing indicating the current page.

### 2. A contributed entry could not express its active state

The extension side had the mirror-image problem — an exact string compare:

```ts
isActive={contribution.path ? location.pathname === contribution.path : false}
```

That works for the static path the bundled example ships with and cannot work for a parameterised one: the pattern a contribution declares is never equal to a filled-in location, so an entry at `/agents/:id/analytics` is unlit on the very page it leads to. Since the rail is per-agent, a parameterised path is the normal case for anything contributed to it.

`path` is resolved with `matchPath` now — the same thing the router resolves routes with — so an entry is active on exactly the addresses its route answers. A pattern with no parameters behaves as before.

`isActive` is added for what one pattern cannot say: several routes, or a search parameter. It is the equivalent of the application's own `alsoActiveOn`, as a function because only the contribution knows the shape of its own addresses.

```ts
export function railItemIsActive(
  contribution: ExtensionAgentRailItemContribution,
  location: { pathname: string; search: string },
): boolean {
  if (contribution.isActive?.(location)) return true;
  return contribution.path
    ? matchPath(contribution.path, location.pathname) !== null
    : false;
}
```

**The two signals are OR-ed**, so an entry can declare where it leads and still widen it rather than restating the path inside a function. Worth flagging as a design decision rather than an accident: it means a contribution can widen its active state but not narrow it — `path` matching wins even if `isActive` returns `false`. Happy to switch to precedence if you would rather have both directions.

## Testing

`playwright/tests/chat/agent-rail.spec.ts` gains one case for the first defect, asserting from the details page — the chat is the one place the old behaviour happened to be right. It checks the row is listed but not current there, that nothing in the rail claims to be current, and that opening the conversation is what makes it so.

The second is verified behaviourally, by pointing the bundled example's rail entry at each signal in turn and then restoring it:

| entry declares | on `/agents/:id/chat` | on `/agents/:id` | with `?lit=1` |
|---|---|---|---|
| `path: "/agents/:id/chat"` | active | not active | — |
| `isActive` reading pathname or search | active | not active | active |
| `path: "/example"` (as shipped) | not active | not active | — |

- `yarn typecheck` — clean
- `yarn lint` — no errors
- `npx playwright test playwright/tests/extensions/ playwright/tests/chat/ --project=chromium --project=chromium-with-extension` — 33 passed

No unit test for the helper; the table above is the behaviour that matters and the existing extension-point specs cover the static case.

---
*🤖 written by Claude*
