### PR TITLE
fix: trace outbound A2A gateway calls

### DIFF
--- a/go/core/internal/a2agateway/runtime.go
+++ b/go/core/internal/a2agateway/runtime.go
@@ -13,6 +13,7 @@ import (
 	a2agrpc "github.com/a2aproject/a2a-go/v2/a2agrpc/v1"
 	apiv1alpha1 "github.com/kagent-dev/kagent/go/api/gen/kagent/api/v1alpha1"
 	"github.com/kagent-dev/kagent/go/core/pkg/auth"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel/propagation"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -68,6 +69,7 @@ func (d *RuntimeDialer) Dial(ctx context.Context, instance *apiv1alpha1.AgentIns
 		a2agrpc.WithGRPCTransport(
 			grpc.WithTransportCredentials(d.transport),
 			grpc.WithAuthority(instance.GetA2AAuthority()),
+			grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
 		),
 		a2aclient.WithCallInterceptors(
 			a2aext.NewClientPropagator(nil),


### PR DESCRIPTION
## What

Add OTel client tracing for outbound A2A calls.

## Why

The gateway was passing trace context without creating its own client span, so the span connecting the gateway request to the actor was missing. This adds that missing span and keeps the trace connected.

Fixes #2757
