### PR TITLE
fix: generalize database conflict errors

### DIFF
--- a/go/core/internal/a2agateway/gateway.go
+++ b/go/core/internal/a2agateway/gateway.go
@@ -534,7 +534,7 @@ func (g *Gateway) prepareSend(ctx context.Context, req *a2atype.SendMessageReque
 	}
 	submitted.Metadata[TaskCreatedAtMetadataKey] = createdAt.Format(time.RFC3339Nano)
 	stored, created, err := g.store.CreateAgentInstanceTask(ctx, instance.GetId(), requestHash, submitted)
-	if errors.Is(err, database.ErrAgentInstanceTaskConflict) {
+	if errors.Is(err, database.ErrConflict) {
 		if err = g.reconcileActiveTask(ctx, instance); err == nil {
 			stored, created, err = g.store.CreateAgentInstanceTask(ctx, instance.GetId(), requestHash, submitted)
 		}
@@ -597,10 +597,11 @@ func (g *Gateway) reconcileActiveTask(ctx context.Context, instance *apiv1alpha1
 	if err != nil {
 		return err
 	}
+	conflict := fmt.Errorf("AgentInstance %s already has an active task: %w", instance.GetId(), database.ErrConflict)
 	client, err := g.dialer.Dial(ctx, instance)
 	if err != nil {
 		logging.FromContext(ctx).ErrorContext(ctx, "failed to reconcile active agent instance task", "error", err, "task_id", active.ID)
-		return database.ErrAgentInstanceTaskConflict
+		return conflict
 	}
 	defer client.Destroy()
 
@@ -610,11 +611,11 @@ func (g *Gateway) reconcileActiveTask(ctx context.Context, instance *apiv1alpha1
 		if errors.Is(eventErr, a2atype.ErrTaskNotFound) {
 			latest, err := client.GetTask(ctx, &a2atype.GetTaskRequest{ID: active.ID})
 			if err != nil || latest == nil {
-				return database.ErrAgentInstanceTaskConflict
+				return conflict
 			}
 			if err := validateTaskInfo(latest, active); err != nil {
 				logging.FromContext(ctx).ErrorContext(ctx, "runtime returned invalid active task", "error", err, "task_id", active.ID)
-				return database.ErrAgentInstanceTaskConflict
+				return conflict
 			}
 			if isQuiescent(latest.Status.State) {
 				return g.storeEvent(ctx, instance, latest, latest)
@@ -623,18 +624,18 @@ func (g *Gateway) reconcileActiveTask(ctx context.Context, instance *apiv1alpha1
 		}
 		if eventErr != nil {
 			logging.FromContext(ctx).ErrorContext(ctx, "failed to query active runtime execution", "error", eventErr, "task_id", active.ID)
-			return database.ErrAgentInstanceTaskConflict
+			return conflict
 		}
 		if event == nil {
-			return database.ErrAgentInstanceTaskConflict
+			return conflict
 		}
 		if err := validateTaskInfo(event, active); err != nil {
 			logging.FromContext(ctx).ErrorContext(ctx, "runtime returned invalid active task event", "error", err, "task_id", active.ID)
-			return database.ErrAgentInstanceTaskConflict
+			return conflict
 		}
-		return database.ErrAgentInstanceTaskConflict
+		return conflict
 	}
-	return database.ErrAgentInstanceTaskConflict
+	return conflict
 }
 
 func (g *Gateway) interruptTask(ctx context.Context, instanceID string, taskID a2atype.TaskID) error {
@@ -643,7 +644,7 @@ func (g *Gateway) interruptTask(ctx context.Context, instanceID string, taskID a
 		return err
 	}
 	if !interrupted {
-		return database.ErrAgentInstanceTaskConflict
+		return fmt.Errorf("AgentInstance %s already has an active task: %w", instanceID, database.ErrConflict)
 	}
 	return nil
 }
@@ -763,8 +764,8 @@ func (g *Gateway) storeError(ctx context.Context, err error) error {
 	if errors.Is(err, database.ErrIdempotencyConflict) {
 		return a2atype.NewError(a2atype.ErrInvalidRequest, "message ID was already used with a different request")
 	}
-	if errors.Is(err, database.ErrAgentInstanceTaskConflict) {
-		return a2atype.NewError(a2atype.ErrUnsupportedOperation, "AgentInstance already has an active task")
+	if errors.Is(err, database.ErrConflict) {
+		return a2atype.NewError(a2atype.ErrUnsupportedOperation, err.Error())
 	}
 	logging.FromContext(ctx).ErrorContext(ctx, "failed to persist agent instance task", "error", err)
 	return a2atype.NewError(a2atype.ErrInternalError, "failed to persist task")

--- a/go/core/internal/a2agateway/gateway_test.go
+++ b/go/core/internal/a2agateway/gateway_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"iter"
 	"net"
 	"strings"
@@ -103,7 +104,7 @@ func (s *gatewayTestStore) CreateAgentInstanceTask(_ context.Context, _ string, 
 		return s.replay, false, nil
 	}
 	if s.active != nil {
-		return nil, false, database.ErrAgentInstanceTaskConflict
+		return nil, false, database.ErrConflict
 	}
 	s.task = task
 	s.created = task
@@ -1003,6 +1004,23 @@ func TestQuiescentTaskStates(t *testing.T) {
 	}
 	if isQuiescent(a2atype.TaskStateWorking) {
 		t.Error("working task is quiescent")
+	}
+}
+
+func TestGatewayPreservesStoreConflictReason(t *testing.T) {
+	for _, reason := range []string{"checkpoint is being created", "instance is suspended", "task is already active"} {
+		t.Run(reason, func(t *testing.T) {
+			store := &gatewayTestStore{instance: gatewayTestInstance(), taskErr: fmt.Errorf("%s: %w", reason, database.ErrConflict)}
+			dialer := &gatewayTestDialer{}
+			gateway := New(store, &gatewayTestAuthorizer{}, dialer, &gatewayTestWorkflow{}, gatewayTestURL)
+			_, err := gateway.SendMessage(gatewayTestContext(), gatewayTestRequest())
+			if !errors.Is(err, a2atype.ErrUnsupportedOperation) || !strings.Contains(err.Error(), reason) {
+				t.Fatalf("SendMessage() = %v, want unsupported operation with reason %q", err, reason)
+			}
+			if dialer.instance != nil {
+				t.Fatal("conflicting request dialed the runtime")
+			}
+		})
 	}
 }
 

--- a/go/core/internal/database/active_task_test.go
+++ b/go/core/internal/database/active_task_test.go
@@ -82,8 +82,8 @@ func TestCheckpointCreationBlocksInstanceTaskWrites(t *testing.T) {
 	next := newAgentInstanceTask("next", "next-message")
 	next.ContextID = instance.GetContextId()
 	_, _, err = client.CreateAgentInstanceTask(ctx, instance.GetId(), []byte("next-request"), next)
-	require.ErrorIs(t, err, ErrAgentInstanceTaskConflict)
-	require.ErrorIs(t, client.StoreAgentInstanceTaskEvent(ctx, instance.GetId(), task, task, nil), ErrAgentInstanceConflict)
+	require.ErrorIs(t, err, ErrConflict)
+	require.ErrorIs(t, client.StoreAgentInstanceTaskEvent(ctx, instance.GetId(), task, task, nil), ErrConflict)
 	_, _, err = client.BeginDeleteAgentInstanceCheckpoint(ctx, checkpoint.GetId(), "alice")
 	require.ErrorIs(t, err, ErrNotFound)
 

--- a/go/core/internal/database/agent_instance_tasks.go
+++ b/go/core/internal/database/agent_instance_tasks.go
@@ -21,7 +21,7 @@ import (
 // messages for a READY instance with no lifecycle operation. It requires an initial
 // message and matching context. Reusing the initial message ID returns the stored task if
 // the request hash matches, or ErrIdempotencyConflict otherwise. An occupied active-task
-// slot or checkpoint creation blocks new tasks with ErrAgentInstanceTaskConflict. The
+// slot or checkpoint creation blocks new tasks with ErrConflict. The
 // boolean reports a new reservation; callers authorize access and invoke the runtime
 // separately.
 func (c *Client) CreateAgentInstanceTask(ctx context.Context, instanceID string, requestHash []byte, task *a2a.Task) (*a2a.Task, bool, error) {
@@ -51,7 +51,7 @@ func (c *Client) CreateAgentInstanceTask(ctx context.Context, instanceID string,
 			return fmt.Errorf("lock AgentInstance %s: %w", instanceID, err)
 		}
 		if instance.State != "AGENT_INSTANCE_STATE_READY" || instance.Operation != "AGENT_INSTANCE_OPERATION_UNSPECIFIED" {
-			return ErrAgentInstanceTaskConflict
+			return fmt.Errorf("AgentInstance %s cannot accept a task in state %s with operation %s: %w", instanceID, instance.State, instance.Operation, ErrConflict)
 		}
 		historyID = instance.HistoryID
 		if task.ContextID != instance.ContextID.String() {
@@ -83,7 +83,7 @@ func (c *Client) CreateAgentInstanceTask(ctx context.Context, instanceID string,
 				WHERE history_id = $1 AND initial_message_id = $2
 			`, pgx.RowToStructByName[agentInstanceTaskRow], historyID, &message.ID)
 			if errors.Is(err, pgx.ErrNoRows) {
-				return ErrAgentInstanceTaskConflict
+				return fmt.Errorf("AgentInstance %s has a checkpoint being created: %w", instanceID, ErrConflict)
 			}
 			if err != nil {
 				return fmt.Errorf("get AgentInstance task for message %s: %w", message.ID, err)
@@ -99,7 +99,7 @@ func (c *Client) CreateAgentInstanceTask(ctx context.Context, instanceID string,
 		}
 		if err != nil {
 			if isActiveTaskConflict(err) {
-				return ErrAgentInstanceTaskConflict
+				return fmt.Errorf("AgentInstance %s already has an active task: %w", instanceID, ErrConflict)
 			}
 			return fmt.Errorf("create AgentInstance task %s: %w", task.ID, err)
 		}
@@ -276,7 +276,7 @@ func (c *Client) StoreAgentInstanceTaskEvent(ctx context.Context, instanceID str
 			return err
 		}
 		if creating {
-			return ErrAgentInstanceConflict
+			return fmt.Errorf("AgentInstance %s has a checkpoint being created: %w", instanceID, ErrConflict)
 		}
 		var sequence int64
 		var stored *a2apb.Task
@@ -323,7 +323,7 @@ func (c *Client) StoreAgentInstanceTaskEvent(ctx context.Context, instanceID str
 		taskRow, err := saveTaskProjection(ctx, tx, historyID, string(task.ID), string(task.Status.State), task.Status.Timestamp, data)
 		if err != nil {
 			if isActiveTaskConflict(err) {
-				return ErrAgentInstanceTaskConflict
+				return fmt.Errorf("AgentInstance %s already has an active task: %w", instanceID, ErrConflict)
 			}
 			return fmt.Errorf("store AgentInstance task %s: %w", task.ID, err)
 		}

--- a/go/core/internal/database/agent_instances.go
+++ b/go/core/internal/database/agent_instances.go
@@ -238,7 +238,7 @@ func (c *Client) UpdateAgentInstanceName(ctx context.Context, id, userID, name s
 
 // TransitionAgentInstance changes lifecycle fields only if the stored state and operation
 // match the expected values. A mismatch, or a creating checkpoint when starting a new
-// operation, returns ErrAgentInstanceConflict. It preserves other instance fields; callers
+// operation, returns ErrConflict. It preserves other instance fields; callers
 // choose a valid transition and authorize it.
 func (c *Client) TransitionAgentInstance(
 	ctx context.Context,
@@ -257,7 +257,7 @@ func (c *Client) TransitionAgentInstance(
 			return err
 		}
 		if result.State != expectedState || result.Operation != expectedOperation {
-			return ErrAgentInstanceConflict
+			return fmt.Errorf("AgentInstance lifecycle state or operation changed: %w", ErrConflict)
 		}
 		// Only lifecycle fields belong to this operation. Keep concurrent renames,
 		// immutable indexed fields and unknown protobuf fields from the locked row.
@@ -292,7 +292,7 @@ func (c *Client) TransitionAgentInstance(
 			return err
 		}
 		if tag.RowsAffected() != 1 {
-			return ErrAgentInstanceConflict
+			return fmt.Errorf("AgentInstance %s has a checkpoint being created: %w", instance.GetId(), ErrConflict)
 		}
 		result = next
 		return nil

--- a/go/core/internal/database/checkpoints.go
+++ b/go/core/internal/database/checkpoints.go
@@ -198,7 +198,7 @@ func (c *Client) ReserveAgentInstanceCheckpoint(ctx context.Context, checkpoint 
 			return fmt.Errorf("lock AgentInstance %s: %w", checkpoint.GetAgentInstanceId(), err)
 		}
 		if instance.State != "AGENT_INSTANCE_STATE_READY" || instance.Operation != "AGENT_INSTANCE_OPERATION_UNSPECIFIED" {
-			return ErrAgentInstanceConflict
+			return fmt.Errorf("AgentInstance %s cannot checkpoint in state %s with operation %s: %w", checkpoint.GetAgentInstanceId(), instance.State, instance.Operation, ErrConflict)
 		}
 		source, err := toAgentInstance(instance)
 		if err != nil {
@@ -229,14 +229,14 @@ func (c *Client) ReserveAgentInstanceCheckpoint(ctx context.Context, checkpoint 
 			)
 		`, pgx.RowToStructByName[agentInstanceTaskRow], instance.HistoryID)
 		if errors.Is(err, pgx.ErrNoRows) {
-			return ErrAgentInstanceNotQuiescent
+			return fmt.Errorf("AgentInstance %s has no quiescent turn boundary: %w", checkpoint.GetAgentInstanceId(), ErrFailedPrecondition)
 		}
 		if err != nil {
 			return fmt.Errorf("get latest AgentInstance task boundary: %w", err)
 		}
 		if boundary.SnapshotAtespace == nil || boundary.SnapshotURI == nil ||
 			boundary.SnapshotContentScope == nil || boundary.HistorySequence == nil {
-			return ErrAgentInstanceNotQuiescent
+			return fmt.Errorf("AgentInstance %s has no quiescent turn boundary: %w", checkpoint.GetAgentInstanceId(), ErrFailedPrecondition)
 		}
 
 		value := proto.Clone(checkpoint).(*apiv1alpha1.Checkpoint)
@@ -275,7 +275,7 @@ func (c *Client) ReserveAgentInstanceCheckpoint(ctx context.Context, checkpoint 
 				return existingErr
 			}
 			if errors.Is(existingErr, pgx.ErrNoRows) {
-				return ErrAgentInstanceConflict
+				return fmt.Errorf("AgentInstance %s has a checkpoint being created: %w", checkpoint.GetAgentInstanceId(), ErrConflict)
 			}
 			return fmt.Errorf("get conflicting AgentInstance checkpoint request: %w", existingErr)
 		}

--- a/go/core/internal/database/client_agent_instance_test.go
+++ b/go/core/internal/database/client_agent_instance_test.go
@@ -141,7 +141,7 @@ func TestAgentInstanceTasksAreDurableAndExclusive(t *testing.T) {
 		t.Fatalf("stored task projection history = %#v, error %v", projection.History, err)
 	}
 	second := &a2a.Task{ID: "task-2", ContextID: "11111111-1111-4111-8111-111111111111", Status: a2a.TaskStatus{State: a2a.TaskStateSubmitted}}
-	if err := client.StoreAgentInstanceTaskEvent(ctx, "11111111-1111-4111-8111-111111111111", second, second, nil); !errors.Is(err, ErrAgentInstanceTaskConflict) {
+	if err := client.StoreAgentInstanceTaskEvent(ctx, "11111111-1111-4111-8111-111111111111", second, second, nil); !errors.Is(err, ErrConflict) {
 		t.Fatalf("second active task error = %v", err)
 	}
 	first.History = append(first.History, a2a.NewMessageForTask(a2a.MessageRoleAgent, first, a2a.NewTextPart("done")))
@@ -329,13 +329,15 @@ func TestAgentInstanceCheckpointRetainsRecordedBoundary(t *testing.T) {
 		*snapshot != (AgentInstanceTaskSnapshot{Atespace: "team-a", URI: "s3://snapshots/snapshot-1", ContentScope: "DATA"}) || checkpoint.HistorySequence == 0 {
 		t.Fatalf("checkpoint boundary = %+v", checkpoint)
 	}
-	if _, _, err := client.CreateAgentInstanceTask(ctx, instanceID, []byte("blocked-request"), newAgentInstanceTask("task-2", "message-2")); !errors.Is(err, ErrAgentInstanceTaskConflict) {
-		t.Fatalf("CreateAgentInstanceTask() during checkpoint = %v, want %v", err, ErrAgentInstanceTaskConflict)
+	if _, _, err := client.CreateAgentInstanceTask(ctx, instanceID, []byte("blocked-request"), newAgentInstanceTask("task-2", "message-2")); !errors.Is(err, ErrConflict) {
+		t.Fatalf("CreateAgentInstanceTask() during checkpoint = %v, want %v", err, ErrConflict)
+	} else {
+		require.ErrorContains(t, err, "checkpoint being created")
 	}
 	suspending := proto.Clone(instance).(*apiv1alpha1.AgentInstance)
 	suspending.Operation = apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_SUSPEND
 	current, err := client.TransitionAgentInstance(ctx, suspending, instance.GetState(), instance.GetOperation())
-	if !errors.Is(err, ErrAgentInstanceConflict) || current.GetOperation() != apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_UNSPECIFIED {
+	if !errors.Is(err, ErrConflict) || current.GetOperation() != apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_UNSPECIFIED {
 		t.Fatalf("lifecycle transition during checkpoint = %+v, error %v", current, err)
 	}
 	replayed, replayedSnapshot, err := client.ReserveAgentInstanceCheckpoint(ctx, &apiv1alpha1.Checkpoint{Id: "33333333-3333-4333-8333-333333333333", AgentInstanceId: instanceID}, "alice", "checkpoint-request")
@@ -611,7 +613,7 @@ func TestAgentInstanceCreateAndTransitions(t *testing.T) {
 	resuming := proto.Clone(ready).(*apiv1alpha1.AgentInstance)
 	resuming.Operation = apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_RESUME
 	current, err := client.TransitionAgentInstance(ctx, resuming, ready.GetState(), ready.GetOperation())
-	if !errors.Is(err, ErrAgentInstanceConflict) || current.GetOperation() != apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_SUSPEND {
+	if !errors.Is(err, ErrConflict) || current.GetOperation() != apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_SUSPEND {
 		t.Fatalf("conflicting transition = instance %v, error %v", current, err)
 	}
 	suspended := proto.Clone(suspending).(*apiv1alpha1.AgentInstance)
@@ -932,7 +934,7 @@ func TestForkTaskOrderAndAuthorityIsolation(t *testing.T) {
 	require.NoError(t, err)
 	waiting, err := client.GetAgentInstanceTask(ctx, source.GetId(), "z-first", nil)
 	require.NoError(t, err)
-	require.ErrorIs(t, client.StoreAgentInstanceTaskEvent(ctx, source.GetId(), waiting, waiting, nil), ErrAgentInstanceConflict)
+	require.ErrorIs(t, client.StoreAgentInstanceTaskEvent(ctx, source.GetId(), waiting, waiting, nil), ErrConflict)
 	_, err = client.FinalizeAgentInstanceCheckpoint(ctx, checkpoint.GetId(), "tag", "tag-snapshot", "")
 	require.NoError(t, err)
 	_, _, err = client.ForkAgentInstance(ctx, checkpoint.GetId(), "bob", uuid.NewString(), uuid.NewString())

--- a/go/core/internal/database/errors.go
+++ b/go/core/internal/database/errors.go
@@ -2,15 +2,15 @@ package database
 
 import "errors"
 
-// ErrNotFound reports that the requested record does not exist (or is not
-// visible to the given user). Match with errors.Is; implementations wrap it
-// with call-site context.
-var ErrNotFound = errors.New("record not found")
-
-var ErrIdempotencyConflict = errors.New("request id was already used with different parameters")
-
-var ErrAgentInstanceConflict = errors.New("AgentInstance lifecycle operation conflicts with its current state")
-
-var ErrAgentInstanceTaskConflict = errors.New("AgentInstance already has an active task")
-
-var ErrAgentInstanceNotQuiescent = errors.New("AgentInstance has no quiescent turn boundary")
+// Store errors describe resource-independent categories. Wrap them with resource
+// and operation context using %w; callers match them with errors.Is.
+var (
+	// ErrNotFound also covers records that are not visible to the given user.
+	ErrNotFound = errors.New("record not found")
+	// ErrConflict reports an operation blocked by current state or a concurrent change.
+	ErrConflict = errors.New("resource conflict")
+	// ErrFailedPrecondition reports an unmet requirement for an operation.
+	ErrFailedPrecondition = errors.New("precondition failed")
+	// ErrIdempotencyConflict is distinct because clients must use a new request ID.
+	ErrIdempotencyConflict = errors.New("request id was already used with different parameters")
+)

--- a/go/core/internal/database/scheduled_run_models.go
+++ b/go/core/internal/database/scheduled_run_models.go
@@ -1,15 +1,9 @@
 package database
 
 import (
-	"errors"
-
 	"github.com/google/uuid"
 	apiv1alpha1 "github.com/kagent-dev/kagent/go/api/gen/kagent/api/v1alpha1"
 )
-
-var ErrScheduledRunConflict = errors.New("ScheduledRun changed since it was read")
-var ErrScheduledRunDeleted = errors.New("ScheduledRun was deleted")
-var ErrScheduledRunTargetNotReady = errors.New("ScheduledRun target has no ready prepared revision")
 
 type ScheduledRunQuery struct {
 	Creator string

--- a/go/core/internal/database/scheduled_runs.go
+++ b/go/core/internal/database/scheduled_runs.go
@@ -110,8 +110,8 @@ func (c *Client) ListScheduledRuns(ctx context.Context, query ScheduledRunQuery)
 }
 
 // UpdateScheduledRun replaces an owned schedule's config and etag only if the supplied
-// etag matches; stale edits return ErrScheduledRunConflict and deleted schedules return
-// ErrScheduledRunDeleted. The next occurrence changes only when the schedule, time zone,
+// etag matches; stale edits return ErrConflict and deleted schedules return
+// ErrFailedPrecondition. The next occurrence changes only when the schedule, time zone,
 // or pause setting changes, so unrelated edits cannot skip an already-due occurrence.
 func (c *Client) UpdateScheduledRun(ctx context.Context, id uuid.UUID, creator, etag string, config *apiv1alpha1.ScheduledRunConfig) (*apiv1alpha1.ScheduledRun, error) {
 	var result scheduledRunRow
@@ -125,10 +125,10 @@ func (c *Client) UpdateScheduledRun(ctx context.Context, id uuid.UUID, creator, 
 			return err
 		}
 		if row.DeletedAt != nil {
-			return ErrScheduledRunDeleted
+			return fmt.Errorf("ScheduledRun %s was deleted: %w", id, ErrFailedPrecondition)
 		}
 		if schedule.Etag != etag {
-			return ErrScheduledRunConflict
+			return fmt.Errorf("ScheduledRun %s changed; reload before updating: %w", id, ErrConflict)
 		}
 		previous := schedule.Config
 		schedule.Config, schedule.Etag = proto.CloneOf(config), uuid.NewString()
@@ -204,7 +204,7 @@ func (c *Client) DeleteScheduledRun(ctx context.Context, id uuid.UUID, creator s
 // TriggerScheduledRun reserves a manual execution for an owned schedule, including when
 // paused, without starting runtime work or changing the next scheduled occurrence. Reusing
 // requestID for that schedule returns the same execution, even after deletion; new
-// triggers on a deleted schedule return ErrScheduledRunDeleted.
+// triggers on a deleted schedule return ErrFailedPrecondition.
 func (c *Client) TriggerScheduledRun(ctx context.Context, id uuid.UUID, creator, requestID string) (*apiv1alpha1.ScheduledRunExecution, error) {
 	var result scheduledRunExecutionRow
 	err := c.withTx(ctx, func(tx pgx.Tx) error {
@@ -224,7 +224,7 @@ func (c *Client) TriggerScheduledRun(ctx context.Context, id uuid.UUID, creator,
 			return err
 		}
 		if row.DeletedAt != nil {
-			return ErrScheduledRunDeleted
+			return fmt.Errorf("ScheduledRun %s was deleted: %w", id, ErrFailedPrecondition)
 		}
 		schedule, err := toScheduledRun(row)
 		if err != nil {
@@ -387,7 +387,7 @@ func (c *Client) ListScheduledRunExecutions(ctx context.Context, query Scheduled
 // ReserveScheduledRunExecutionInstance atomically reserves an owned execution's instance
 // and saves its historical link. Existing links and non-pending executions are returned
 // unchanged, even if the linked instance was deleted. An elapsed deadline marks the
-// execution timed out; an unprepared target returns ErrScheduledRunTargetNotReady for
+// execution timed out; an unprepared target returns ErrFailedPrecondition for
 // retry. Callers provision the runtime separately.
 func (c *Client) ReserveScheduledRunExecutionInstance(ctx context.Context, id uuid.UUID, creator string) (*apiv1alpha1.ScheduledRunExecution, error) {
 	var result scheduledRunExecutionRow
@@ -444,7 +444,7 @@ func (c *Client) ReserveScheduledRunExecutionInstance(ctx context.Context, id uu
 			AgentTemplate: proto.CloneOf(schedule.AgentTemplate),
 		}, "scheduled-run/"+id.String())
 		if errors.Is(err, ErrNotFound) {
-			return ErrScheduledRunTargetNotReady
+			return fmt.Errorf("ScheduledRun %s target has no ready prepared revision: %w", result.ScheduledRunID, ErrFailedPrecondition)
 		}
 		if err != nil {
 			return err
@@ -540,7 +540,7 @@ func (c *Client) LeaseScheduledRunExecutions(ctx context.Context, limit int) ([]
 // UpdateScheduledRunExecution records progress only under a matching, unexpired lease on a
 // pending or running execution. It preserves an existing task ID, records terminal
 // completion time, and releases the lease with a one-second retry delay. A lost lease or
-// conflicting task ID returns ErrScheduledRunConflict.
+// conflicting task ID returns ErrConflict.
 func (c *Client) UpdateScheduledRunExecution(ctx context.Context, lease ScheduledRunExecutionLease, progress ScheduledRunExecutionProgress) error {
 	return c.withTx(ctx, func(tx pgx.Tx) error {
 		row, err := queryOne(ctx, tx, `
@@ -550,7 +550,7 @@ func (c *Client) UpdateScheduledRunExecution(ctx context.Context, lease Schedule
 			  AND state IN ('SCHEDULED_RUN_EXECUTION_STATE_PENDING', 'SCHEDULED_RUN_EXECUTION_STATE_RUNNING') FOR UPDATE
 		`, pgx.RowToStructByName[scheduledRunExecutionRow], lease.ExecutionID, &lease.Token)
 		if errors.Is(err, pgx.ErrNoRows) {
-			return ErrScheduledRunConflict
+			return fmt.Errorf("ScheduledRunExecution %s lease expired or execution changed: %w", lease.ExecutionID, ErrConflict)
 		}
 		if err != nil {
 			return fmt.Errorf("failed to get leased execution: %w", err)
@@ -587,7 +587,7 @@ func (c *Client) UpdateScheduledRunExecution(ctx context.Context, lease Schedule
 			return fmt.Errorf("failed to update scheduled execution: %w", err)
 		}
 		if rows.RowsAffected() == 0 {
-			return ErrScheduledRunConflict
+			return fmt.Errorf("ScheduledRunExecution %s lease expired or execution changed: %w", lease.ExecutionID, ErrConflict)
 		}
 		return nil
 	})

--- a/go/core/internal/database/scheduled_runs_test.go
+++ b/go/core/internal/database/scheduled_runs_test.go
@@ -71,12 +71,12 @@ func TestScheduledExecutionLeasesFenceExpiredWorkers(t *testing.T) {
 	_, err = db.Exec(t.Context(), `UPDATE scheduled_run_execution SET next_attempt_at = clock_timestamp() - interval '1 second' WHERE id = $1`, execution.Id)
 	require.NoError(t, err)
 	oldLease.Execution.State = apiv1alpha1.ScheduledRunExecutionState_SCHEDULED_RUN_EXECUTION_STATE_FAILED
-	require.ErrorIs(t, c.UpdateScheduledRunExecution(t.Context(), oldLease.Lease, ScheduledRunExecutionProgress{State: oldLease.Execution.State}), ErrScheduledRunConflict)
+	require.ErrorIs(t, c.UpdateScheduledRunExecution(t.Context(), oldLease.Lease, ScheduledRunExecutionProgress{State: oldLease.Execution.State}), ErrConflict)
 	batch, err := c.LeaseScheduledRunExecutions(t.Context(), 1)
 	require.NoError(t, err)
 	require.Len(t, batch, 1)
 	require.NotEqual(t, oldLease.Lease.Token, batch[0].Lease.Token)
-	require.ErrorIs(t, c.UpdateScheduledRunExecution(t.Context(), oldLease.Lease, ScheduledRunExecutionProgress{State: oldLease.Execution.State}), ErrScheduledRunConflict)
+	require.ErrorIs(t, c.UpdateScheduledRunExecution(t.Context(), oldLease.Lease, ScheduledRunExecutionProgress{State: oldLease.Execution.State}), ErrConflict)
 	batch[0].Execution.State = apiv1alpha1.ScheduledRunExecutionState_SCHEDULED_RUN_EXECUTION_STATE_FAILED
 	batch[0].Execution.FailureReason = "Controller denied execution"
 	// A worker snapshot is not a write model: only explicit progress is saved.
@@ -113,7 +113,8 @@ func TestScheduledRunRequestsSurviveEditAndDeletion(t *testing.T) {
 	require.Nil(t, updated.NextExecutionTime)
 	require.NotEqual(t, schedule.Etag, updated.Etag)
 	_, err = c.UpdateScheduledRun(t.Context(), uuid.MustParse(schedule.Id), "alice", schedule.Etag, config)
-	require.ErrorIs(t, err, ErrScheduledRunConflict)
+	require.ErrorIs(t, err, ErrConflict)
+	require.ErrorContains(t, err, "changed; reload before updating")
 
 	// Pausing stops cron, but does not forbid an explicit manual run.
 	manual, err := c.TriggerScheduledRun(t.Context(), uuid.MustParse(schedule.Id), "alice", "while-paused")
@@ -131,9 +132,10 @@ func TestScheduledRunRequestsSurviveEditAndDeletion(t *testing.T) {
 	require.True(t, proto.Equal(execution, replayed))
 	require.Equal(t, "original prompt", replayed.Prompt)
 	_, err = c.TriggerScheduledRun(t.Context(), uuid.MustParse(schedule.Id), "alice", "new-request")
-	require.ErrorIs(t, err, ErrScheduledRunDeleted)
+	require.ErrorIs(t, err, ErrFailedPrecondition)
+	require.ErrorContains(t, err, "was deleted")
 	_, err = c.UpdateScheduledRun(t.Context(), uuid.MustParse(schedule.Id), "alice", deleted.Etag, config)
-	require.ErrorIs(t, err, ErrScheduledRunDeleted)
+	require.ErrorIs(t, err, ErrFailedPrecondition)
 
 	found, err := c.FindScheduledRunRequest(t.Context(), "alice", "create", hash)
 	require.NoError(t, err)
@@ -282,7 +284,7 @@ func TestScheduledRunConcurrentUpdateAndDelete(t *testing.T) {
 	for err := range results {
 		if err == nil {
 			successes++
-		} else if errors.Is(err, ErrScheduledRunConflict) {
+		} else if errors.Is(err, ErrConflict) {
 			conflicts++
 		} else {
 			t.Fatal(err)
@@ -294,7 +296,7 @@ func TestScheduledRunConcurrentUpdateAndDelete(t *testing.T) {
 	wg.Go(func() {
 		var err error
 		accepted, err = c.TriggerScheduledRun(t.Context(), uuid.MustParse(schedule.Id), "alice", "racing-delete")
-		if err != nil && !errors.Is(err, ErrScheduledRunDeleted) {
+		if err != nil && !errors.Is(err, ErrFailedPrecondition) {
 			t.Error(err)
 		}
 	})
@@ -394,7 +396,7 @@ func TestScheduledExecutionWaitsForPreparedRevision(t *testing.T) {
 	execution, err := c.TriggerScheduledRun(t.Context(), uuid.MustParse(schedule.Id), "alice", "manual")
 	require.NoError(t, err)
 	_, err = c.ReserveScheduledRunExecutionInstance(t.Context(), uuid.MustParse(execution.Id), "alice")
-	require.ErrorIs(t, err, ErrScheduledRunTargetNotReady)
+	require.ErrorIs(t, err, ErrFailedPrecondition)
 	loaded, err := c.GetScheduledRunExecution(t.Context(), uuid.MustParse(execution.Id), "alice")
 	require.NoError(t, err)
 	require.True(t, proto.Equal(execution, loaded))
@@ -474,14 +476,14 @@ func TestScheduledExecutionTaskIdentityCannotChange(t *testing.T) {
 	require.Len(t, leases, 1)
 	progress := ScheduledRunExecutionProgress{State: apiv1alpha1.ScheduledRunExecutionState_SCHEDULED_RUN_EXECUTION_STATE_RUNNING, TaskID: execution.Id}
 	require.NoError(t, c.UpdateScheduledRunExecution(t.Context(), leases[0].Lease, progress))
-	require.ErrorIs(t, c.UpdateScheduledRunExecution(t.Context(), leases[0].Lease, progress), ErrScheduledRunConflict)
+	require.ErrorIs(t, c.UpdateScheduledRunExecution(t.Context(), leases[0].Lease, progress), ErrConflict)
 	_, err = db.Exec(t.Context(), "UPDATE scheduled_run_execution SET next_attempt_at = clock_timestamp() WHERE id = $1", execution.Id)
 	require.NoError(t, err)
 	leases, err = c.LeaseScheduledRunExecutions(t.Context(), 1)
 	require.NoError(t, err)
 	require.Len(t, leases, 1)
 	progress.TaskID = "another-task"
-	require.ErrorIs(t, c.UpdateScheduledRunExecution(t.Context(), leases[0].Lease, progress), ErrScheduledRunConflict)
+	require.ErrorIs(t, c.UpdateScheduledRunExecution(t.Context(), leases[0].Lease, progress), ErrConflict)
 	// Omitting the already persisted task preserves its identity.
 	progress.TaskID = ""
 	progress.State = apiv1alpha1.ScheduledRunExecutionState_SCHEDULED_RUN_EXECUTION_STATE_SUCCEEDED
@@ -598,7 +600,7 @@ func TestDeleteMalformedScheduledRun(t *testing.T) {
 			require.NoError(t, db.QueryRow(t.Context(), `SELECT data FROM scheduled_run WHERE id = $1`, schedule.Id).Scan(&persisted))
 			require.Equal(t, data, persisted)
 			_, err = c.TriggerScheduledRun(t.Context(), uuid.MustParse(schedule.Id), schedule.Creator, "after-delete")
-			require.ErrorIs(t, err, ErrScheduledRunDeleted)
+			require.ErrorIs(t, err, ErrFailedPrecondition)
 		})
 	}
 }

--- a/go/core/internal/service/agentinstance/service.go
+++ b/go/core/internal/service/agentinstance/service.go
@@ -194,8 +194,8 @@ func (s *Service) Delete(ctx context.Context, id string) (*apiv1alpha1.AgentInst
 		return nil, serviceerrors.NewInternal("Failed to get AgentInstance", err)
 	}
 	instance, err = s.workflow.Delete(ctx, instance)
-	if errors.Is(err, database.ErrAgentInstanceConflict) {
-		return nil, serviceerrors.NewAborted("AgentInstance has a conflicting lifecycle operation", err)
+	if errors.Is(err, database.ErrConflict) {
+		return nil, serviceerrors.NewAborted(err.Error(), err)
 	}
 	if err != nil {
 		return nil, serviceerrors.NewUnavailable("Failed to delete AgentInstance", err)
@@ -219,8 +219,8 @@ func (s *Service) Suspend(ctx context.Context, id string) (*apiv1alpha1.AgentIns
 		return nil, serviceerrors.NewInternal("Failed to get AgentInstance", err)
 	}
 	instance, err = s.workflow.Suspend(ctx, instance)
-	if errors.Is(err, database.ErrAgentInstanceConflict) {
-		return nil, serviceerrors.NewAborted("AgentInstance has a conflicting lifecycle operation", err)
+	if errors.Is(err, database.ErrConflict) {
+		return nil, serviceerrors.NewAborted(err.Error(), err)
 	}
 	if err != nil {
 		return nil, serviceerrors.NewUnavailable("Failed to suspend AgentInstance", err)
@@ -244,8 +244,8 @@ func (s *Service) Resume(ctx context.Context, id string) (*apiv1alpha1.AgentInst
 		return nil, serviceerrors.NewInternal("Failed to get AgentInstance", err)
 	}
 	instance, err = s.workflow.Resume(ctx, instance)
-	if errors.Is(err, database.ErrAgentInstanceConflict) {
-		return nil, serviceerrors.NewAborted("AgentInstance has a conflicting lifecycle operation", err)
+	if errors.Is(err, database.ErrConflict) {
+		return nil, serviceerrors.NewAborted(err.Error(), err)
 	}
 	if err != nil {
 		return nil, serviceerrors.NewUnavailable("Failed to resume AgentInstance", err)

--- a/go/core/internal/service/agentinstance/service_test.go
+++ b/go/core/internal/service/agentinstance/service_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
@@ -174,7 +175,8 @@ func TestServiceCreateRejectsInvalidOrUnauthorizedRequests(t *testing.T) {
 }
 
 func TestServiceLifecycleMethodsMapConflictToAborted(t *testing.T) {
-	service := NewService(&serviceTestStore{}, serviceTestAuthorizer{}, serviceTestWorkflow{err: database.ErrAgentInstanceConflict})
+	conflict := fmt.Errorf("AgentInstance is already suspending: %w", database.ErrConflict)
+	service := NewService(&serviceTestStore{}, serviceTestAuthorizer{}, serviceTestWorkflow{err: conflict})
 	for _, test := range []struct {
 		name string
 		call func(*Service, context.Context, string) (*apiv1alpha1.AgentInstance, error)
@@ -187,6 +189,9 @@ func TestServiceLifecycleMethodsMapConflictToAborted(t *testing.T) {
 			_, err := test.call(service, serviceTestContext("alice"), "8bd650a8-9775-488f-8bc1-0d52bf7bdcab")
 			if !serviceerrors.IsCode(err, serviceerrors.CodeAborted) {
 				t.Fatalf("error = %v, want code %s", err, serviceerrors.CodeAborted)
+			}
+			if serviceerrors.MessageOf(err) != conflict.Error() || !errors.Is(err, database.ErrConflict) {
+				t.Fatalf("error = %v, want preserved conflict reason", err)
 			}
 		})
 	}

--- a/go/core/internal/service/agentinstance/workflow.go
+++ b/go/core/internal/service/agentinstance/workflow.go
@@ -174,7 +174,7 @@ func (w *ActorWorkflow) finishCreate(ctx context.Context, instance *apiv1alpha1.
 	current, err := w.store.TransitionAgentInstance(ctx, next,
 		apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_CREATING,
 		apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_CREATE)
-	if errors.Is(err, database.ErrAgentInstanceConflict) {
+	if errors.Is(err, database.ErrConflict) {
 		return current, nil
 	}
 	return current, err
@@ -277,19 +277,19 @@ func (w *ActorWorkflow) claim(
 	// returned bool reports whether this call installed the marker; a retry
 	// which finds the same operation joins it but must not later clear it.
 	if instance.GetState() != expectedState {
-		return nil, false, database.ErrAgentInstanceConflict
+		return nil, false, fmt.Errorf("AgentInstance %s requires state %s for %s; current state is %s: %w", instance.GetId(), expectedState, operation, instance.GetState(), database.ErrConflict)
 	}
 	if instance.GetOperation() == operation {
 		return instance, false, nil
 	}
 	if instance.GetOperation() != apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_UNSPECIFIED {
-		return nil, false, database.ErrAgentInstanceConflict
+		return nil, false, fmt.Errorf("AgentInstance %s cannot perform %s while %s is in progress: %w", instance.GetId(), operation, instance.GetOperation(), database.ErrConflict)
 	}
 	next := proto.Clone(instance).(*apiv1alpha1.AgentInstance)
 	next.Operation = operation
 	next.UpdatedAt = timestamppb.Now()
 	claimed, err := w.store.TransitionAgentInstance(ctx, next, expectedState, apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_UNSPECIFIED)
-	if errors.Is(err, database.ErrAgentInstanceConflict) && claimed.GetState() == expectedState && claimed.GetOperation() == operation {
+	if errors.Is(err, database.ErrConflict) && claimed.GetState() == expectedState && claimed.GetOperation() == operation {
 		return claimed, false, nil
 	}
 	return claimed, err == nil, err
@@ -308,7 +308,7 @@ func (w *ActorWorkflow) finish(
 	next.Operation = apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_UNSPECIFIED
 	next.UpdatedAt = timestamppb.Now()
 	current, err := w.store.TransitionAgentInstance(ctx, next, expectedState, instance.GetOperation())
-	if errors.Is(err, database.ErrAgentInstanceConflict) && current.GetState() == nextState && current.GetOperation() == apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_UNSPECIFIED {
+	if errors.Is(err, database.ErrConflict) && current.GetState() == nextState && current.GetOperation() == apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_UNSPECIFIED {
 		return current, nil
 	}
 	return current, err
@@ -326,7 +326,7 @@ func (w *ActorWorkflow) release(ctx context.Context, instance *apiv1alpha1.Agent
 	next.Operation = apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_UNSPECIFIED
 	next.UpdatedAt = timestamppb.Now()
 	_, err := w.store.TransitionAgentInstance(ctx, next, state, instance.GetOperation())
-	if errors.Is(err, database.ErrAgentInstanceConflict) {
+	if errors.Is(err, database.ErrConflict) {
 		return operationErr
 	}
 	return errors.Join(operationErr, err)

--- a/go/core/internal/service/agentinstance/workflow_test.go
+++ b/go/core/internal/service/agentinstance/workflow_test.go
@@ -125,7 +125,7 @@ func (s *lifecycleTestStore) GetRuntimeRevision(context.Context, string) (*datab
 
 func (s *lifecycleTestStore) TransitionAgentInstance(_ context.Context, instance *apiv1alpha1.AgentInstance, expectedState apiv1alpha1.AgentInstanceState, expectedOperation apiv1alpha1.AgentInstanceOperation) (*apiv1alpha1.AgentInstance, error) {
 	if s.instance.GetState() != expectedState || s.instance.GetOperation() != expectedOperation {
-		return s.instance, database.ErrAgentInstanceConflict
+		return s.instance, database.ErrConflict
 	}
 	s.instance = proto.Clone(instance).(*apiv1alpha1.AgentInstance)
 	return s.instance, nil

--- a/go/core/internal/service/checkpoint/service.go
+++ b/go/core/internal/service/checkpoint/service.go
@@ -101,8 +101,8 @@ func (s *Service) create(ctx context.Context, userID, instanceID, requestID stri
 	if errors.Is(err, database.ErrNotFound) {
 		return nil, serviceerrors.NewNotFound("AgentInstance not found", err)
 	}
-	if errors.Is(err, database.ErrAgentInstanceConflict) || errors.Is(err, database.ErrAgentInstanceNotQuiescent) {
-		return nil, serviceerrors.NewFailedPrecondition("AgentInstance has no quiescent turn boundary", err)
+	if errors.Is(err, database.ErrConflict) || errors.Is(err, database.ErrFailedPrecondition) {
+		return nil, serviceerrors.NewFailedPrecondition(err.Error(), err)
 	}
 	if err != nil {
 		return nil, serviceerrors.NewInternal("Failed to reserve checkpoint", err)

--- a/go/core/internal/service/checkpoint/service_test.go
+++ b/go/core/internal/service/checkpoint/service_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/agent-substrate/substrate/pkg/proto/ateapipb"
 	apiv1alpha1 "github.com/kagent-dev/kagent/go/api/gen/kagent/api/v1alpha1"
 	"github.com/kagent-dev/kagent/go/core/internal/database"
+	"github.com/kagent-dev/kagent/go/core/internal/service/serviceerrors"
 	"github.com/kagent-dev/kagent/go/core/internal/substrate"
 	"github.com/kagent-dev/kagent/go/core/pkg/auth"
 	"github.com/stretchr/testify/require"
@@ -37,9 +38,13 @@ type testStore struct {
 	failed      string
 	deleted     bool
 	finalizeErr error
+	reserveErr  error
 }
 
 func (s *testStore) ReserveAgentInstanceCheckpoint(_ context.Context, checkpoint *apiv1alpha1.Checkpoint, _, _ string) (*apiv1alpha1.Checkpoint, *database.AgentInstanceTaskSnapshot, error) {
+	if s.reserveErr != nil {
+		return nil, nil, s.reserveErr
+	}
 	if s.prepared != nil {
 		return s.prepared, s.snapshot, nil
 	}
@@ -184,6 +189,20 @@ func (t *testTags) DeleteTag(context.Context, string, string) error {
 	}
 	t.created = nil
 	return nil
+}
+
+func TestCreatePreservesStoreConflictReason(t *testing.T) {
+	for _, cause := range []error{database.ErrConflict, database.ErrFailedPrecondition} {
+		t.Run(cause.Error(), func(t *testing.T) {
+			storeErr := fmt.Errorf("AgentInstance cannot checkpoint in its current state: %w", cause)
+			service := NewService(&testStore{reserveErr: storeErr}, testAuthorizer{}, nil, nil)
+			ctx := auth.AuthSessionTo(t.Context(), testSession{userID: "alice"})
+			_, err := service.Create(ctx, "018f47a2-4efb-7c21-a848-123456789abc", "request-1")
+			require.Equal(t, serviceerrors.CodeFailedPrecondition, serviceerrors.CodeOf(err))
+			require.Equal(t, storeErr.Error(), serviceerrors.MessageOf(err))
+			require.ErrorIs(t, err, cause)
+		})
+	}
 }
 
 func TestCreateTagsRecordedSnapshotBoundary(t *testing.T) {

--- a/go/core/internal/service/scheduledrun/service.go
+++ b/go/core/internal/service/scheduledrun/service.go
@@ -296,12 +296,10 @@ func storeError(err error) error {
 		return serviceerrors.NewNotFound("Scheduled run not found", err)
 	case errors.Is(err, database.ErrIdempotencyConflict):
 		return serviceerrors.NewAlreadyExists("Request ID was already used for different inputs", err)
-	case errors.Is(err, database.ErrScheduledRunConflict):
-		return serviceerrors.NewAborted("Scheduled run changed; reload before updating", err)
-	case errors.Is(err, database.ErrScheduledRunTargetNotReady):
-		return serviceerrors.NewFailedPrecondition("Target pair has no ready prepared revision", err)
-	case errors.Is(err, database.ErrScheduledRunDeleted):
-		return serviceerrors.NewFailedPrecondition("Scheduled run was deleted", err)
+	case errors.Is(err, database.ErrConflict):
+		return serviceerrors.NewAborted(err.Error(), err)
+	case errors.Is(err, database.ErrFailedPrecondition):
+		return serviceerrors.NewFailedPrecondition(err.Error(), err)
 	default:
 		return serviceerrors.NewInternal("Scheduled run operation failed", err)
 	}


### PR DESCRIPTION
Database conflicts use object-specific sentinels, and clients can receive misleading reasons: checkpoint creation is reported as an active task, while lifecycle conflicts are reported as missing quiescent boundaries.

Use shared `ErrConflict` and `ErrFailedPrecondition` categories across agent instances, tasks, checkpoints, and scheduled runs. Wrap them with the resource and blocking condition, preserve that reason in service and A2A responses, and keep idempotency conflicts distinct for their existing client handling.

Validation:
- PostgreSQL database tests and affected service, A2A gateway, gRPC, and scheduled-run controller tests.
- Regression coverage for wrapped conflict classification and client-visible reasons.
- `make -C go lint` and `git diff --check`.
