### PR TITLE
fix(adk): reject inputResponses that do not match the current input request

### DIFF
--- a/go/core/internal/mcp/tasks.go
+++ b/go/core/internal/mcp/tasks.go
@@ -171,7 +171,7 @@ func (h *Handler) updateTask(ctx context.Context, _ *mcp.ServerSession, params *
 	key := inputRequestKey(task)
 	inputResponse := params.InputResponses[key]
 	if inputResponse == nil {
-		return &completeTaskResult{ResultType: "complete"}, nil
+		return nil, invalidParams(fmt.Errorf("inputResponses has no entry for the current input request %q", key))
 	}
 	response, ok := inputResponse.(*mcp.ElicitResult)
 	if !ok || response == nil {

--- a/go/core/internal/mcp/tasks_test.go
+++ b/go/core/internal/mcp/tasks_test.go
@@ -146,6 +146,43 @@ func TestTaskUpdateContinuesA2ATask(t *testing.T) {
 	}
 }
 
+func TestTaskUpdateRejectsMismatchedInputResponsesKey(t *testing.T) {
+	message := a2atype.NewMessage(a2atype.MessageRoleAgent, a2atype.NewTextPart("Which database?"))
+	gateway := &fakeGateway{task: &a2atype.Task{
+		ID: testTaskID, ContextID: testInstanceID,
+		Status: a2atype.TaskStatus{State: a2atype.TaskStateInputRequired, Message: message},
+	}}
+	h := &Handler{gateway: gateway}
+	ref, err := encodeTaskReference(taskReference{
+		InstanceID: testInstanceID, TaskID: testTaskID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = h.updateTask(authContext(), nil, &updateTaskParams{
+		ParamsBase: taskParamsBase(),
+		TaskID:     ref,
+		InputResponses: mcp.InputResponseMap{"not-a-real-key": &mcp.ElicitResult{
+			Action: "accept", Content: map[string]any{"response": "PostgreSQL"},
+		}},
+	})
+	if err == nil {
+		t.Fatal("updateTask() succeeded with mismatched inputResponses key")
+	}
+	rpcErr, ok := err.(*jsonrpc.Error)
+	if !ok || rpcErr.Code != jsonrpc.CodeInvalidParams {
+		t.Fatalf("updateTask() error = %#v, want invalidParams", err)
+	}
+	if !strings.Contains(rpcErr.Message, message.ID) {
+		t.Fatalf("updateTask() error = %q, want it to name %q", rpcErr.Message, message.ID)
+	}
+	gateway.mu.Lock()
+	defer gateway.mu.Unlock()
+	if gateway.reply != nil {
+		t.Fatalf("continued message = %#v, want no dispatch", gateway.reply)
+	}
+}
+
 func TestTaskUpdateTranslatesAskUserResponse(t *testing.T) {
 	status := adka2a.AttachHitlExtension(
 		a2atype.NewMessage(a2atype.MessageRoleAgent, a2atype.NewTextPart("Which database?")),


### PR DESCRIPTION
## Description
`tasks/update` answers a paused task by looking up `params.InputResponses` under a key derived from the task. When the map contains no entry for the tasks current input request, the handler returned `{"resultType": "complete"}` after doing nothing: the client saw success, the answer was silently discarded, and the task stayed `input_required` with no error signal.

This change makes a key-miss reject the request with an `invalidParams` error that names the expected key — the same handling the wrong-typed-value branch already applies — instead of returning a success envelope for a write that did not happen.

## Why
A success envelope must not be returned for an answer that was not applied. The only reliable signal today is the task `status`, which made it easy to mistake a dropped answer for a completed one.

## How
`go/core/internal/mcp/tasks.go` — in `updateTask`, the `inputResponse == nil` branch now returns `invalidParams(fmt.Errorf("inputResponses has no entry for the current input request %q", key))` instead of `&completeTaskResult{ResultType: "complete"}`. No other path changes: the not-input-required early return still returns `complete` (correctly, since there is nothing to answer), and the wrong-type branch is untouched.

## Tests
Added `TestTaskUpdateRejectsMismatchedInputResponsesKey` in `go/core/internal/mcp/tasks_test.go`. It drives `updateTask` with an `InputResponses` map keyed by a non-matching key and asserts:
- the error is non-nil and is a `jsonrpc.Error` with `Code == CodeInvalidParams`,
- the message names the expected key,
- no message is dispatched (`gateway.reply == nil`).

`go test ./core/internal/mcp/` passes.

## Mutation check
Reverting only the fixed branch (restoring the silent `{resultType:"complete"}` return) makes the new test fail with `updateTask() succeeded with mismatched inputResponses key`, confirming the test genuinely guards the fix.

Fixes #2761