### PR TITLE
fix(helm): disable controller metrics when bindAddress is empty or 0

### DIFF
--- a/helm/kagent/templates/controller-deployment.yaml
+++ b/helm/kagent/templates/controller-deployment.yaml
@@ -165,7 +165,7 @@ spec:
             - name: http
               containerPort: {{ .Values.controller.service.ports.targetPort }}
               protocol: TCP
-            {{- if .Values.controller.metrics.enabled }}
+            {{- if include "kagent.controller.metricsEnabled" . }}
             - name: metrics
               containerPort: {{ include "kagent.controller.metricsPort" . | int }}
               protocol: TCP

--- a/helm/kagent/tests/controller-deployment_test.yaml
+++ b/helm/kagent/tests/controller-deployment_test.yaml
@@ -665,6 +665,7 @@ tests:
           path: spec.template.spec.containers[0].ports
           content:
             name: metrics
+          any: true
 
   - it: should not set metrics env vars by default
     template: controller-deployment.yaml
@@ -784,6 +785,29 @@ tests:
           path: spec.template.spec.containers[0].ports
           content:
             name: metrics
+          any: true
+
+  - it: should not gain metrics wiring when bindAddress is empty
+    template: controller-deployment.yaml
+    set:
+      controller.metrics.enabled: true
+      controller.metrics.bindAddress: ""
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: METRICS_BIND_ADDRESS
+          any: true
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: METRICS_SECURE
+          any: true
+      - notContains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: metrics
+          any: true
 
   - it: should let controller.env override the chart-supplied metrics env
     template: controller-deployment.yaml


### PR DESCRIPTION
## Summary

Fixes an issue where the metrics port was still rendered as `containerPort: 0` when metrics were disabled using `bindAddress: "0"` or an empty `bindAddress`.

The deployment was checking `.Values.controller.metrics.enabled` directly, while the other metrics-related resources use the `kagent.controller.metricsEnabled` helper.

## Fix

Use the same helper for the metrics port:

```diff
- {{- if .Values.controller.metrics.enabled }}
+ {{- if include "kagent.controller.metricsEnabled" . }}
```

This keeps all metrics-related resources consistent and does not change the default `:8443` behavior.

## Tests

* Fixed the existing port assertions to use `any: true`.
* Added coverage for an empty `bindAddress`.
* `helm unittest helm/kagent`: **284 passed, 21 suites**
* Verified with `helm template` that the port is omitted for `0` and `""`, and remains `8443` by default.

Fixes #2736
