### PR TITLE
fix(adk): export a turn's spans before its terminal event leaves the process

### DIFF
--- a/go/adk/pkg/a2a/executor.go
+++ b/go/adk/pkg/a2a/executor.go
@@ -193,11 +193,53 @@ func (e *KAgentExecutor) Execute(ctx context.Context, reqCtx *a2asrv.ExecutorCon
 				}
 				update.Status.Message.SetMeta(apia2a.TimelinePositionMetadataKey, position.Format(time.RFC3339Nano))
 			}
+			if endsTurn(event, err) {
+				flushTurnSpans(ctx, invocationSpan)
+			}
 			if !yield(event, err) {
 				return
 			}
 		}
 	}
+}
+
+// endsTurn reports whether an event is the last one a turn produces: a terminal
+// or waiting task state, or an error, after which the caller ends the stream.
+func endsTurn(event a2atype.Event, err error) bool {
+	if err != nil {
+		return true
+	}
+	var state a2atype.TaskState
+	switch e := event.(type) {
+	case *a2atype.TaskStatusUpdateEvent:
+		state = e.Status.State
+	case *a2atype.Task:
+		state = e.Status.State
+	default:
+		return false
+	}
+	return state.Terminal() || state == a2atype.TaskStateInputRequired || state == a2atype.TaskStateAuthRequired
+}
+
+// flushTurnSpans exports the turn's spans before the event that ends the turn
+// leaves the process, when the runtime asked for pre-response flushing.
+//
+// The server-level flush runs once the handler returns. For a unary request that
+// is before the response is written, so it is early enough. For a streaming
+// request the terminal event has already been sent by then, and the gateway
+// closes its stream to this runtime the moment it arrives; on Agent Substrate the
+// actor is checkpointed right after, with the spans of every streamed turn still
+// buffered and the flush's deadline expiring while the process is frozen. The
+// only window that exists for a streamed turn is before that event is yielded.
+//
+// The invocation span is ended first so it travels in the same export; the
+// deferred End in Execute becomes a no-op.
+func flushTurnSpans(ctx context.Context, invocationSpan trace.Span) {
+	if !telemetry.PreResponseFlushEnabled() {
+		return
+	}
+	invocationSpan.End()
+	telemetry.ForceFlush(ctx)
 }
 
 // ensureSession ensures that a session exists for the given user and session ID.

--- a/go/adk/pkg/a2a/executor_test.go
+++ b/go/adk/pkg/a2a/executor_test.go
@@ -3,6 +3,7 @@ package a2a
 import (
 	"context"
 	"iter"
+	"slices"
 	"testing"
 
 	"log/slog"
@@ -11,6 +12,9 @@ import (
 	"github.com/a2aproject/a2a-go/v2/a2asrv"
 	"github.com/kagent-dev/kagent/go/adk/pkg/auth"
 	apia2a "github.com/kagent-dev/kagent/go/api/a2a"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	adkagent "google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/model"
 	"google.golang.org/adk/v2/runner"
@@ -382,5 +386,89 @@ func TestKAgentExecutor_HITLPauseAndResumeFlow(t *testing.T) {
 	}
 	if resumedText != "resumed" || invocations != 2 {
 		t.Fatalf("resumed text = %q, invocations = %d", resumedText, invocations)
+	}
+}
+
+// installRecordingTracer routes the global tracer through a batch processor into
+// an in-memory exporter, so a test can tell "buffered" from "exported": only a
+// flush moves spans from the one to the other within the test's lifetime.
+func installRecordingTracer(t *testing.T) *tracetest.InMemoryExporter {
+	t.Helper()
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithBatcher(exporter))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prev)
+		_ = tp.Shutdown(context.Background())
+	})
+	return exporter
+}
+
+// exportedByState runs one two-event turn and records how many spans the
+// exporter held at the moment each event reached the consumer.
+func exportedByState(t *testing.T, exporter *tracetest.InMemoryExporter) map[a2atype.TaskState]int {
+	t.Helper()
+	reqCtx := &a2asrv.ExecutorContext{
+		TaskID: "task-1", ContextID: "ctx-1",
+		Message: a2atype.NewMessage(a2atype.MessageRoleUser, a2atype.NewTextPart("hello")),
+	}
+	builtin := &recordingExecutor{events: []a2atype.Event{
+		a2atype.NewStatusUpdateEvent(reqCtx, a2atype.TaskStateWorking, nil),
+		a2atype.NewStatusUpdateEvent(reqCtx, a2atype.TaskStateCompleted, nil),
+	}}
+	executor := &KAgentExecutor{builtin: builtin, logger: slog.New(slog.DiscardHandler)}
+
+	seen := map[a2atype.TaskState]int{}
+	for event, err := range executor.Execute(context.Background(), reqCtx) {
+		if err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		update, ok := event.(*a2atype.TaskStatusUpdateEvent)
+		if !ok {
+			t.Fatalf("event = %T, want *TaskStatusUpdateEvent", event)
+		}
+		seen[update.Status.State] = len(exporter.GetSpans())
+	}
+	return seen
+}
+
+// On a checkpoint/suspend runtime the consumer of the terminal event is the
+// gateway, which closes its stream on receipt, and the actor is frozen right
+// after. Whatever is still buffered at that moment never reaches the collector,
+// so the spans must already be exported when the terminal event is yielded, and
+// the invocation span must be among them.
+func TestKAgentExecutor_ExportsSpansBeforeYieldingTheTerminalEvent(t *testing.T) {
+	t.Setenv("KAGENT_PRE_RESPONSE_TRACE_FLUSH", "true")
+	exporter := installRecordingTracer(t)
+
+	seen := exportedByState(t, exporter)
+
+	if seen[a2atype.TaskStateWorking] != 0 {
+		t.Fatalf("spans exported before a working update = %d, want 0 (a mid-turn flush is churn)", seen[a2atype.TaskStateWorking])
+	}
+	if seen[a2atype.TaskStateCompleted] == 0 {
+		t.Fatal("no span exported before the terminal event was yielded; a checkpoint at that point freezes them in the snapshot")
+	}
+	var names []string
+	for _, span := range exporter.GetSpans() {
+		names = append(names, span.Name)
+	}
+	if !slices.Contains(names, "invocation") {
+		t.Fatalf("exported spans = %v, want the invocation span among them", names)
+	}
+}
+
+// Without the opt-in the batch exporter's timer is the export path, as it is
+// everywhere the process is not frozen after a response, and a per-turn flush
+// would add export churn and response-tail latency for nothing.
+func TestKAgentExecutor_LeavesSpansToTheBatcherWithoutTheOptIn(t *testing.T) {
+	t.Setenv("KAGENT_PRE_RESPONSE_TRACE_FLUSH", "")
+	exporter := installRecordingTracer(t)
+
+	seen := exportedByState(t, exporter)
+
+	if seen[a2atype.TaskStateCompleted] != 0 {
+		t.Fatalf("spans exported before the terminal event = %d, want 0 without KAGENT_PRE_RESPONSE_TRACE_FLUSH", seen[a2atype.TaskStateCompleted])
 	}
 }

--- a/go/adk/pkg/a2a/server/server.go
+++ b/go/adk/pkg/a2a/server/server.go
@@ -104,10 +104,14 @@ func NewA2AServer(agentCard a2atype.AgentCard, executor a2asrv.AgentExecutor, lo
 	// a collector outage, response-tail latency.
 	//
 	// When enabled, flush after the otelhttp server span ends (when the inner
-	// handler returns) but before net/http closes the response body — a flush
-	// issued inside the executor can never include the still-open server span.
+	// handler returns) but before net/http closes the response body, which is the
+	// only point the server span itself can be exported from. The executor flushes
+	// the turn's own spans earlier, before yielding the event that ends the turn
+	// (see flushTurnSpans): for a streamed turn that event is on the wire before
+	// this handler returns, and the caller closes the stream on receipt, so a flush
+	// here comes too late for anything but the server span.
 	handler := http.Handler(instrumentedHandler)
-	if strings.EqualFold(strings.TrimSpace(os.Getenv("KAGENT_PRE_RESPONSE_TRACE_FLUSH")), "true") {
+	if telemetry.PreResponseFlushEnabled() {
 		handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			instrumentedHandler.ServeHTTP(w, r)
 			if isA2ARequest(r) {

--- a/go/adk/pkg/telemetry/tracing.go
+++ b/go/adk/pkg/telemetry/tracing.go
@@ -39,6 +39,16 @@ func StartInvocationSpan(ctx context.Context) (context.Context, trace.Span) {
 	return otel.Tracer("gcp.vertex.agent").Start(ctx, "invocation")
 }
 
+// PreResponseFlushEnabled reports whether spans must be exported before a turn's
+// response leaves the process. Set through KAGENT_PRE_RESPONSE_TRACE_FLUSH, which the
+// controller puts on Agent Substrate actors: a checkpoint/suspend runtime freezes as
+// soon as the response is out, so the batch exporter's timer never fires for a
+// session's last message. Everywhere else the timer suffices and a per-turn flush
+// would only add export churn and, during a collector outage, response-tail latency.
+func PreResponseFlushEnabled() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv("KAGENT_PRE_RESPONSE_TRACE_FLUSH")), "true")
+}
+
 // ForceFlush exports any spans still buffered in the tracer provider's batch
 // processor. Call it before an A2A response completes when the process may be
 // suspended right afterwards: Agent Substrate checkpoints the actor as soon as


### PR DESCRIPTION
A streamed A2A turn on Agent Substrate leaves no trace spans, while the same turn sent as a unary `SendMessage` does. The UI's chat page streams its turns, so from the UI every conversation is missing from the trace backend, while `buf curl` unary turns and the Go e2e trace cases pass.

**Why**

`KAGENT_PRE_RESPONSE_TRACE_FLUSH` (#2176) flushes spans in the HTTP wrapper in `go/adk/pkg/a2a/server/server.go`, after the gRPC handler returns. For a unary request that is before the response is written, so it is early enough. For `SendStreamingMessage` the terminal `TaskStatusUpdateEvent` is already on the wire by then, the gateway closes its stream to the runtime as soon as that event arrives (`go/core/internal/a2agateway/task_run.go`), and Substrate checkpoints the actor right after. On a kind cluster the atelet log shows the task completing at 06:02:45.837 and the checkpoint at 06:02:46.013, so the flush is frozen mid-export and its deadline has passed by the next thaw. The spans of every streamed turn stay in the snapshot.

**What changes**

- `KAgentExecutor.Execute` ends the invocation span and force-flushes right before yielding the event that ends the turn (a terminal, input-required or auth-required state, or an error). That is the only window a streamed turn has.
- The flush stays behind `KAGENT_PRE_RESPONSE_TRACE_FLUSH`, now read through `telemetry.PreResponseFlushEnabled()` in both the executor and the server wrapper. Runtimes that are not frozen after a response keep relying on the batch exporter's timer.
- The server wrapper's flush stays, since it is the only point the otelhttp server span can be exported from. Its comment now explains how the two flushes relate.

**Verification**

- With the runtime image built from this change on a kind cluster, a `SendStreamingMessage` turn on a fresh conversation landed its three `gcp.vertex.agent` spans within five seconds. Before the change the same call produced none, while a unary `SendMessage` on the same instance produced three.
- Two turns typed into the UI's chat page were traced, and "View traces" on the answer opened the trace.
- `TestKAgentExecutor_ExportsSpansBeforeYieldingTheTerminalEvent` asserts the export has happened by the time the terminal event reaches the consumer, with the invocation span in it. It fails on the current code. `TestKAgentExecutor_LeavesSpansToTheBatcherWithoutTheOptIn` pins that nothing is flushed per turn without the variable.
- `go build`, `go vet`, `gofmt` and `go test` over `./adk/...`, and `make -C go lint`, are clean.
