### PR TITLE
feat(models): add prompt caching for the Anthropic provider (promptCaching, cacheTTL)

### DIFF
--- a/go/adk/pkg/agent/agent.go
+++ b/go/adk/pkg/agent/agent.go
@@ -317,6 +317,8 @@ func CreateLLM(ctx context.Context, m adk.Model) (adkmodel.LLM, error) {
 			Temperature:     m.Temperature,
 			TopP:            m.TopP,
 			TopK:            m.TopK,
+			PromptCaching:   m.PromptCaching,
+			CacheTTL:        m.CacheTTL,
 		}
 		return models.NewAnthropicModel(ctx, cfg)
 

--- a/go/adk/pkg/agent/agent_test.go
+++ b/go/adk/pkg/agent/agent_test.go
@@ -57,7 +57,9 @@ func TestConfigDeserialization_Anthropic(t *testing.T) {
 		"model": {
 			"type": "anthropic",
 			"model": "claude-sonnet-4-20250514",
-			"base_url": "https://api.anthropic.com"
+			"base_url": "https://api.anthropic.com",
+			"prompt_caching": true,
+			"cache_ttl": "1h"
 		},
 		"description": "test agent",
 		"instruction": "you are helpful"
@@ -75,6 +77,38 @@ func TestConfigDeserialization_Anthropic(t *testing.T) {
 
 	if anthropic.Model != "claude-sonnet-4-20250514" {
 		t.Errorf("model name = %q, want %q", anthropic.Model, "claude-sonnet-4-20250514")
+	}
+	if !anthropic.PromptCaching {
+		t.Error("PromptCaching = false, want true")
+	}
+	if anthropic.CacheTTL != "1h" {
+		t.Errorf("CacheTTL = %q, want %q", anthropic.CacheTTL, "1h")
+	}
+}
+
+// TestCreateLLM_AnthropicPromptCaching verifies the prompt caching knobs reach
+// the Anthropic model, which is where the cache_control markers are set.
+func TestCreateLLM_AnthropicPromptCaching(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	m := &adk.Anthropic{
+		BaseModel:     adk.BaseModel{Type: "anthropic", Model: "claude-sonnet-4-6"},
+		PromptCaching: true,
+		CacheTTL:      "1h",
+	}
+
+	llm, err := CreateLLM(context.Background(), m)
+	if err != nil {
+		t.Fatalf("CreateLLM: %v", err)
+	}
+	am, ok := llm.(*models.AnthropicModel)
+	if !ok {
+		t.Fatalf("model is %T, want *models.AnthropicModel", llm)
+	}
+	if !am.Config.PromptCaching {
+		t.Error("Config.PromptCaching = false, want true")
+	}
+	if am.Config.CacheTTL != "1h" {
+		t.Errorf("Config.CacheTTL = %q, want %q", am.Config.CacheTTL, "1h")
 	}
 }
 

--- a/go/adk/pkg/models/anthropic.go
+++ b/go/adk/pkg/models/anthropic.go
@@ -34,6 +34,15 @@ type AnthropicConfig struct {
 	Temperature *float64
 	TopP        *float64
 	TopK        *int
+	// PromptCaching, when true, marks the last tool definition, the last system
+	// prompt block and the last block of the latest conversation turn with a
+	// cache_control breakpoint so Anthropic bills the stable prefix of an agent
+	// loop as a cache read instead of fresh input. See markAnthropicCacheBreakpoints.
+	PromptCaching bool
+	// CacheTTL selects the cache retention window when PromptCaching is on.
+	// "" or "5m" uses the API's default 5-minute cache; "1h" opts into the
+	// 1-hour cache, which is billed at a higher cache-write rate. See anthropicCacheControl.
+	CacheTTL string
 }
 
 // AnthropicModel implements model.LLM for Anthropic Claude models.

--- a/go/adk/pkg/models/anthropic_adk.go
+++ b/go/adk/pkg/models/anthropic_adk.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"iter"
+	"slices"
 	"strings"
 
 	"github.com/anthropics/anthropic-sdk-go"
@@ -40,44 +41,8 @@ func (m *AnthropicModel) Name() string {
 // GenerateContent implements model.LLM. Uses only ADK/genai types.
 func (m *AnthropicModel) GenerateContent(ctx context.Context, req *model.LLMRequest, stream bool) iter.Seq2[*model.LLMResponse, error] {
 	return func(yield func(*model.LLMResponse, error) bool) {
-		messages, systemPrompt := genaiContentsToAnthropicMessages(req.Contents, req.Config)
-		// Always prefer config model - req.Model may contain the model type ("anthropic") instead of model name
-		modelName := m.Config.Model
-		if modelName == "" {
-			modelName = req.Model
-		}
-		if modelName == "" || modelName == "anthropic" {
-			modelName = "claude-sonnet-4-20250514"
-		}
-		telemetry.SetLLMRequestAttributes(ctx, modelName, req)
-
-		// Build request parameters
-		params := anthropic.MessageNewParams{
-			Model:    anthropic.Model(modelName),
-			Messages: messages,
-		}
-
-		// Set max tokens (required for Anthropic)
-		maxTokens := int64(defaultAnthropicMaxTokens)
-		if m.Config.MaxTokens != nil {
-			maxTokens = int64(*m.Config.MaxTokens)
-		}
-		params.MaxTokens = maxTokens
-
-		// Set system prompt if provided
-		if systemPrompt != "" {
-			params.System = []anthropic.TextBlockParam{
-				{Text: systemPrompt},
-			}
-		}
-
-		// Apply config options
-		applyAnthropicConfig(&params, m.Config)
-
-		// Add tools if provided
-		if req.Config != nil && len(req.Config.Tools) > 0 {
-			params.Tools = genaiToolsToAnthropicTools(req.Config.Tools)
-		}
+		params := buildAnthropicParams(req, m.Config)
+		telemetry.SetLLMRequestAttributes(ctx, string(params.Model), req)
 
 		if stream {
 			runAnthropicStreaming(ctx, m, params, yield)
@@ -87,10 +52,46 @@ func (m *AnthropicModel) GenerateContent(ctx context.Context, req *model.LLMRequ
 	}
 }
 
-func applyAnthropicConfig(params *anthropic.MessageNewParams, cfg *AnthropicConfig) {
+// buildAnthropicParams translates an ADK request into a Messages API request:
+// model, system prompt, conversation, sampling options and tools, plus the
+// prompt-cache breakpoints when cfg enables them.
+func buildAnthropicParams(req *model.LLMRequest, cfg *AnthropicConfig) anthropic.MessageNewParams {
 	if cfg == nil {
-		return
+		cfg = &AnthropicConfig{}
 	}
+	messages, systemPrompt := genaiContentsToAnthropicMessages(req.Contents, req.Config)
+
+	// Always prefer config model - req.Model may contain the model type ("anthropic") instead of model name
+	modelName := cfg.Model
+	if modelName == "" {
+		modelName = req.Model
+	}
+	if modelName == "" || modelName == "anthropic" {
+		modelName = "claude-sonnet-4-20250514"
+	}
+
+	params := anthropic.MessageNewParams{
+		Model:     anthropic.Model(modelName),
+		Messages:  messages,
+		MaxTokens: int64(defaultAnthropicMaxTokens), // required by the Messages API
+	}
+	if cfg.MaxTokens != nil {
+		params.MaxTokens = int64(*cfg.MaxTokens)
+	}
+	if systemPrompt != "" {
+		params.System = []anthropic.TextBlockParam{{Text: systemPrompt}}
+	}
+	applyAnthropicConfig(&params, cfg)
+	if req.Config != nil && len(req.Config.Tools) > 0 {
+		params.Tools = genaiToolsToAnthropicTools(req.Config.Tools)
+	}
+	if cfg.PromptCaching {
+		markAnthropicCacheBreakpoints(&params, anthropicCacheControl(cfg.CacheTTL))
+	}
+	return params
+}
+
+func applyAnthropicConfig(params *anthropic.MessageNewParams, cfg *AnthropicConfig) {
 	if cfg.Temperature != nil {
 		params.Temperature = anthropic.Float(*cfg.Temperature)
 	}
@@ -99,6 +100,69 @@ func applyAnthropicConfig(params *anthropic.MessageNewParams, cfg *AnthropicConf
 	}
 	if cfg.TopK != nil {
 		params.TopK = anthropic.Int(int64(*cfg.TopK))
+	}
+}
+
+// anthropicCacheControl builds the cache_control marker for the configured
+// retention window. "" or "5m" leaves the TTL unset, which is the API's default
+// 5-minute cache; "1h" opts into the 1-hour cache, which is billed at a higher
+// cache-write rate (see v1alpha3.AnthropicConfig.CacheTTL for the trade-off).
+func anthropicCacheControl(cacheTTL string) anthropic.CacheControlEphemeralParam {
+	control := anthropic.NewCacheControlEphemeralParam()
+	if cacheTTL == string(anthropic.CacheControlEphemeralTTLTTL1h) {
+		control.TTL = anthropic.CacheControlEphemeralTTLTTL1h
+	}
+	return control
+}
+
+// markAnthropicCacheBreakpoints places the prompt-cache breakpoints on a request.
+//
+// The Messages API renders tools, then system, then messages, and caches the
+// prefix up to each breakpoint, so marking the last tool definition, the last
+// system block and the last block of the latest turn keeps the stable head of
+// an agent loop cached while the conversation grows: each call reads the
+// previous prefix from the cache and writes only the new turn. That uses three
+// of the four breakpoints Anthropic allows per request.
+//
+// The conversation breakpoint walks back from the end because a turn can end
+// in a block Anthropic refuses to cache (a thinking block, for which the SDK
+// reports no cache_control slot).
+func markAnthropicCacheBreakpoints(params *anthropic.MessageNewParams, control anthropic.CacheControlEphemeralParam) {
+	if n := len(params.Tools); n > 0 {
+		if slot := params.Tools[n-1].GetCacheControl(); slot != nil {
+			*slot = control
+		}
+	}
+	if n := len(params.System); n > 0 {
+		params.System[n-1].CacheControl = control
+	}
+	for _, message := range slices.Backward(params.Messages) {
+		for _, block := range slices.Backward(message.Content) {
+			if slot := block.GetCacheControl(); slot != nil {
+				*slot = control
+				return
+			}
+		}
+	}
+}
+
+// anthropicUsageToGenai folds Anthropic usage into the GenAI shape.
+//
+// Anthropic reports tokens served from the prompt cache and tokens written to
+// it in their own fields, disjoint from input_tokens, whereas GenAI expects one
+// prompt count with the cached portion as a breakdown of it. Folding them in
+// keeps PromptTokenCount equal to the prompt the model actually saw whether or
+// not caching is on, and CachedContentTokenCount says how much of it was a
+// cache read.
+func anthropicUsageToGenai(usage anthropic.Usage) *genai.GenerateContentResponseUsageMetadata {
+	prompt := usage.InputTokens + usage.CacheReadInputTokens + usage.CacheCreationInputTokens
+	if prompt == 0 && usage.OutputTokens == 0 {
+		return nil
+	}
+	return &genai.GenerateContentResponseUsageMetadata{
+		PromptTokenCount:        int32(prompt),
+		CachedContentTokenCount: int32(usage.CacheReadInputTokens),
+		CandidatesTokenCount:    int32(usage.OutputTokens),
 	}
 }
 
@@ -264,14 +328,16 @@ func runAnthropicStreaming(ctx context.Context, m *AnthropicModel, params anthro
 		inputJSON string
 	})
 	var stopReason anthropic.StopReason
-	var inputTokens, outputTokens int64
+	// message_start carries the input-side counts (including the prompt-cache
+	// breakdown); message_delta carries the final output count.
+	var usage anthropic.Usage
 
 	for stream.Next() {
 		event := stream.Current()
 
 		switch e := event.AsAny().(type) {
 		case anthropic.MessageStartEvent:
-			inputTokens = e.Message.Usage.InputTokens
+			usage = e.Message.Usage
 		case anthropic.ContentBlockStartEvent:
 			idx := int(e.Index)
 			if e.ContentBlock.Type == "tool_use" {
@@ -308,7 +374,7 @@ func runAnthropicStreaming(ctx context.Context, m *AnthropicModel, params anthro
 			}
 		case anthropic.MessageDeltaEvent:
 			stopReason = e.Delta.StopReason
-			outputTokens = e.Usage.OutputTokens
+			usage.OutputTokens = e.Usage.OutputTokens
 		}
 	}
 
@@ -338,18 +404,11 @@ func runAnthropicStreaming(ctx context.Context, m *AnthropicModel, params anthro
 		}
 	}
 
-	var usage *genai.GenerateContentResponseUsageMetadata
-	if inputTokens > 0 || outputTokens > 0 {
-		usage = &genai.GenerateContentResponseUsageMetadata{
-			PromptTokenCount:     int32(inputTokens),
-			CandidatesTokenCount: int32(outputTokens),
-		}
-	}
 	resp := &model.LLMResponse{
 		Partial:       false,
 		TurnComplete:  true,
 		FinishReason:  anthropicStopReasonToGenai(stopReason),
-		UsageMetadata: usage,
+		UsageMetadata: anthropicUsageToGenai(usage),
 		Content:       &genai.Content{Role: string(genai.RoleModel), Parts: finalParts},
 	}
 	telemetry.SetLLMResponseAttributes(ctx, resp)
@@ -384,20 +443,11 @@ func runAnthropicNonStreaming(ctx context.Context, m *AnthropicModel, params ant
 		}
 	}
 
-	// Build usage metadata
-	var usage *genai.GenerateContentResponseUsageMetadata
-	if message.Usage.InputTokens > 0 || message.Usage.OutputTokens > 0 {
-		usage = &genai.GenerateContentResponseUsageMetadata{
-			PromptTokenCount:     int32(message.Usage.InputTokens),
-			CandidatesTokenCount: int32(message.Usage.OutputTokens),
-		}
-	}
-
 	resp := &model.LLMResponse{
 		Partial:       false,
 		TurnComplete:  true,
 		FinishReason:  anthropicStopReasonToGenai(message.StopReason),
-		UsageMetadata: usage,
+		UsageMetadata: anthropicUsageToGenai(message.Usage),
 		Content:       &genai.Content{Role: string(genai.RoleModel), Parts: parts},
 	}
 	telemetry.SetLLMResponseAttributes(ctx, resp)

--- a/go/adk/pkg/models/anthropic_adk_test.go
+++ b/go/adk/pkg/models/anthropic_adk_test.go
@@ -1,0 +1,250 @@
+package models
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/genai"
+)
+
+// anthropicAgentLoopRequest is a typical agent-loop request: a system prompt,
+// two tools, a completed tool call and a fresh user turn.
+func anthropicAgentLoopRequest() *model.LLMRequest {
+	return &model.LLMRequest{
+		Model: "anthropic",
+		Contents: []*genai.Content{
+			{Role: "user", Parts: []*genai.Part{{Text: "list the pods"}}},
+			{Role: "model", Parts: []*genai.Part{{FunctionCall: &genai.FunctionCall{ID: "call-1", Name: "list_pods", Args: map[string]any{}}}}},
+			{Role: "user", Parts: []*genai.Part{{FunctionResponse: &genai.FunctionResponse{ID: "call-1", Name: "list_pods", Response: map[string]any{"result": "pod-a"}}}}},
+			{Role: "user", Parts: []*genai.Part{{Text: "anything else?"}}},
+		},
+		Config: &genai.GenerateContentConfig{
+			SystemInstruction: &genai.Content{Parts: []*genai.Part{{Text: "You are a Kubernetes assistant."}}},
+			Tools: []*genai.Tool{{FunctionDeclarations: []*genai.FunctionDeclaration{
+				{Name: "get_weather", Description: "lookup weather"},
+				{Name: "list_pods", Description: "list pods"},
+			}}},
+		},
+	}
+}
+
+// wireRequest is the Messages API body as the SDK serializes it, so the tests
+// assert what Anthropic receives rather than SDK-internal field layout.
+type wireRequest struct {
+	System   []map[string]any `json:"system"`
+	Tools    []map[string]any `json:"tools"`
+	Messages []struct {
+		Role    string           `json:"role"`
+		Content []map[string]any `json:"content"`
+	} `json:"messages"`
+}
+
+func decodeWireRequest(t *testing.T, body []byte) wireRequest {
+	t.Helper()
+	var req wireRequest
+	require.NoError(t, json.Unmarshal(body, &req))
+	return req
+}
+
+func marshalParams(t *testing.T, params anthropic.MessageNewParams) []byte {
+	t.Helper()
+	body, err := json.Marshal(params)
+	require.NoError(t, err)
+	return body
+}
+
+func lastBlock(t *testing.T, blocks []map[string]any) map[string]any {
+	t.Helper()
+	require.NotEmpty(t, blocks)
+	return blocks[len(blocks)-1]
+}
+
+func TestBuildAnthropicParamsWithoutPromptCachingSendsNoBreakpoints(t *testing.T) {
+	params := buildAnthropicParams(anthropicAgentLoopRequest(), &AnthropicConfig{Model: "claude-sonnet-4-6"})
+
+	body := marshalParams(t, params)
+	assert.NotContains(t, string(body), "cache_control")
+	wire := decodeWireRequest(t, body)
+	require.Len(t, wire.System, 1)
+	require.Len(t, wire.Tools, 2)
+	require.Len(t, wire.Messages, 4)
+}
+
+func TestBuildAnthropicParamsPromptCachingMarksToolsSystemAndLatestTurn(t *testing.T) {
+	tests := []struct {
+		name     string
+		cacheTTL string
+		want     map[string]any
+	}{
+		{name: "default TTL leaves ttl unset", cacheTTL: "", want: map[string]any{"type": "ephemeral"}},
+		{name: `"5m" leaves ttl unset`, cacheTTL: "5m", want: map[string]any{"type": "ephemeral"}},
+		{name: `"1h" requests the hour-long cache`, cacheTTL: "1h", want: map[string]any{"type": "ephemeral", "ttl": "1h"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := buildAnthropicParams(anthropicAgentLoopRequest(), &AnthropicConfig{Model: "claude-sonnet-4-6", PromptCaching: true, CacheTTL: tt.cacheTTL})
+
+			body := marshalParams(t, params)
+			assert.Equal(t, 3, strings.Count(string(body), `"cache_control"`), "one breakpoint each for tools, system and the latest turn: %s", body)
+			wire := decodeWireRequest(t, body)
+
+			// Tools render first: the marker sits on the last definition so the whole list is one cached prefix.
+			assert.Equal(t, tt.want, lastBlock(t, wire.Tools)["cache_control"])
+			assert.NotContains(t, wire.Tools[0], "cache_control", "earlier tools must stay unmarked")
+			assert.Equal(t, "list_pods", lastBlock(t, wire.Tools)["name"], "tool order must be preserved")
+
+			assert.Equal(t, tt.want, lastBlock(t, wire.System)["cache_control"])
+
+			last := wire.Messages[len(wire.Messages)-1]
+			assert.Equal(t, "user", last.Role)
+			assert.Equal(t, tt.want, lastBlock(t, last.Content)["cache_control"])
+			for _, message := range wire.Messages[:len(wire.Messages)-1] {
+				for _, block := range message.Content {
+					assert.NotContains(t, block, "cache_control", "only the latest turn carries the moving breakpoint")
+				}
+			}
+		})
+	}
+}
+
+func TestBuildAnthropicParamsPromptCachingMarksTrailingToolResult(t *testing.T) {
+	req := anthropicAgentLoopRequest()
+	req.Contents = req.Contents[:3] // the turn ends with the tool result
+
+	params := buildAnthropicParams(req, &AnthropicConfig{Model: "claude-sonnet-4-6", PromptCaching: true})
+
+	wire := decodeWireRequest(t, marshalParams(t, params))
+	last := wire.Messages[len(wire.Messages)-1]
+	block := lastBlock(t, last.Content)
+	assert.Equal(t, "tool_result", block["type"])
+	assert.Equal(t, map[string]any{"type": "ephemeral"}, block["cache_control"])
+}
+
+func TestBuildAnthropicParamsPromptCachingWithoutToolsOrSystem(t *testing.T) {
+	req := &model.LLMRequest{Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "hi"}}}}}
+
+	params := buildAnthropicParams(req, &AnthropicConfig{Model: "claude-sonnet-4-6", PromptCaching: true})
+
+	body := marshalParams(t, params)
+	assert.Equal(t, 1, strings.Count(string(body), `"cache_control"`), "only the conversation breakpoint applies: %s", body)
+	wire := decodeWireRequest(t, body)
+	assert.Empty(t, wire.System)
+	assert.Empty(t, wire.Tools)
+	assert.Equal(t, map[string]any{"type": "ephemeral"}, lastBlock(t, wire.Messages[0].Content)["cache_control"])
+}
+
+func TestAnthropicUsageToGenai(t *testing.T) {
+	tests := []struct {
+		name  string
+		usage anthropic.Usage
+		want  *genai.GenerateContentResponseUsageMetadata
+	}{
+		{name: "no usage", usage: anthropic.Usage{}, want: nil},
+		{
+			name:  "uncached",
+			usage: anthropic.Usage{InputTokens: 10, OutputTokens: 5},
+			want:  &genai.GenerateContentResponseUsageMetadata{PromptTokenCount: 10, CandidatesTokenCount: 5},
+		},
+		{
+			name:  "cache read and write fold into the prompt count",
+			usage: anthropic.Usage{InputTokens: 4, CacheReadInputTokens: 900, CacheCreationInputTokens: 96, OutputTokens: 5},
+			want:  &genai.GenerateContentResponseUsageMetadata{PromptTokenCount: 1000, CachedContentTokenCount: 900, CandidatesTokenCount: 5},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, anthropicUsageToGenai(tt.usage))
+		})
+	}
+}
+
+// anthropicTestServer serves canned Messages API responses and records the
+// request body the SDK sent.
+func anthropicTestServer(t *testing.T, handler func(w http.ResponseWriter)) (*AnthropicModel, *[]byte) {
+	t.Helper()
+	var captured []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		captured = body
+		handler(w)
+	}))
+	t.Cleanup(server.Close)
+
+	m, err := newAnthropicModelFromConfig(context.Background(), &AnthropicConfig{Model: "claude-sonnet-4-6", BaseUrl: server.URL, PromptCaching: true}, "test-key")
+	require.NoError(t, err)
+	return m, &captured
+}
+
+func finalResponse(t *testing.T, m *AnthropicModel, stream bool) *model.LLMResponse {
+	t.Helper()
+	var final *model.LLMResponse
+	for resp, err := range m.GenerateContent(context.Background(), anthropicAgentLoopRequest(), stream) {
+		require.NoError(t, err)
+		require.Empty(t, resp.ErrorMessage)
+		if resp.TurnComplete {
+			final = resp
+		}
+	}
+	require.NotNil(t, final, "no final response yielded")
+	return final
+}
+
+func TestAnthropicNonStreamingCarriesBreakpointsAndCacheUsage(t *testing.T) {
+	m, captured := anthropicTestServer(t, func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"msg_1","type":"message","role":"assistant","model":"claude-sonnet-4-6",
+			"content":[{"type":"text","text":"pod-a"}],"stop_reason":"end_turn","stop_sequence":null,
+			"usage":{"input_tokens":4,"cache_creation_input_tokens":96,"cache_read_input_tokens":900,"output_tokens":5}}`)
+	})
+
+	final := finalResponse(t, m, false)
+
+	wire := decodeWireRequest(t, *captured)
+	assert.Equal(t, map[string]any{"type": "ephemeral"}, lastBlock(t, wire.System)["cache_control"])
+	assert.Equal(t, map[string]any{"type": "ephemeral"}, lastBlock(t, wire.Tools)["cache_control"])
+	assert.Equal(t, map[string]any{"type": "ephemeral"}, lastBlock(t, wire.Messages[len(wire.Messages)-1].Content)["cache_control"])
+	assert.Equal(t, &genai.GenerateContentResponseUsageMetadata{PromptTokenCount: 1000, CachedContentTokenCount: 900, CandidatesTokenCount: 5}, final.UsageMetadata)
+	require.Len(t, final.Content.Parts, 1)
+	assert.Equal(t, "pod-a", final.Content.Parts[0].Text)
+}
+
+func TestAnthropicStreamingCarriesBreakpointsAndCacheUsage(t *testing.T) {
+	events := []string{
+		`{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-sonnet-4-6","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":4,"cache_creation_input_tokens":96,"cache_read_input_tokens":900,"output_tokens":1}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"pod-a"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":5}}`,
+		`{"type":"message_stop"}`,
+	}
+	m, captured := anthropicTestServer(t, func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		for _, event := range events {
+			var envelope struct {
+				Type string `json:"type"`
+			}
+			require.NoError(t, json.Unmarshal([]byte(event), &envelope))
+			_, _ = io.WriteString(w, "event: "+envelope.Type+"\ndata: "+event+"\n\n")
+		}
+	})
+
+	final := finalResponse(t, m, true)
+
+	wire := decodeWireRequest(t, *captured)
+	assert.Equal(t, map[string]any{"type": "ephemeral"}, lastBlock(t, wire.System)["cache_control"])
+	assert.Equal(t, map[string]any{"type": "ephemeral"}, lastBlock(t, wire.Tools)["cache_control"])
+	assert.Equal(t, map[string]any{"type": "ephemeral"}, lastBlock(t, wire.Messages[len(wire.Messages)-1].Content)["cache_control"])
+	assert.Equal(t, &genai.GenerateContentResponseUsageMetadata{PromptTokenCount: 1000, CachedContentTokenCount: 900, CandidatesTokenCount: 5}, final.UsageMetadata)
+	require.Len(t, final.Content.Parts, 1)
+	assert.Equal(t, "pod-a", final.Content.Parts[0].Text)
+}

--- a/go/api/adk/types.go
+++ b/go/api/adk/types.go
@@ -175,6 +175,15 @@ type Anthropic struct {
 	TopP        *float64 `json:"top_p,omitempty"`
 	TopK        *int     `json:"top_k,omitempty"`
 	Timeout     *int     `json:"timeout,omitempty"`
+	// PromptCaching enables Anthropic prompt caching by marking the last tool
+	// definition, the last system prompt block and the last block of the latest
+	// conversation turn with a cache_control breakpoint. See the
+	// v1alpha3.AnthropicConfig CRD doc for context.
+	PromptCaching bool `json:"prompt_caching,omitempty"`
+	// CacheTTL selects the cache retention window when PromptCaching is on:
+	// "5m" (default) or "1h". See the v1alpha3.AnthropicConfig CRD doc for the
+	// cost trade-offs of "1h".
+	CacheTTL string `json:"cache_ttl,omitempty"`
 }
 
 func (a *Anthropic) MarshalJSON() ([]byte, error) {

--- a/go/api/config/crd/bases/kagent.dev_modelconfigs.yaml
+++ b/go/api/config/crd/bases/kagent.dev_modelconfigs.yaml
@@ -56,9 +56,55 @@ spec:
                   baseUrl:
                     description: Base URL for the Anthropic API (overrides default)
                     type: string
+                  cacheTTL:
+                    default: 5m
+                    description: |-
+                      CacheTTL controls how long Anthropic retains a cached prefix when
+                      PromptCaching is enabled. Only meaningful when PromptCaching is true.
+
+                        - "5m" (default): the standard 5-minute cache. Each cache hit refreshes
+                          the window, so an agent loop whose calls are less than 5 minutes
+                          apart keeps its prefix cached for the whole task.
+                        - "1h": the extended 1-hour cache, useful for tasks whose model calls
+                          are spaced more than 5 minutes apart.
+
+                      NOTE: "1h" is NOT strictly better than "5m". 1-hour cache writes are
+                      billed at a higher per-token rate than 5-minute writes. Only choose
+                      "1h" when calls are spaced far enough apart that a 5-minute cache would
+                      expire between them; otherwise the higher write cost is wasted. See the
+                      Anthropic prompt-caching docs above.
+                    enum:
+                    - 5m
+                    - 1h
+                    type: string
                   maxTokens:
                     description: Maximum tokens to generate
                     type: integer
+                  promptCaching:
+                    default: false
+                    description: |-
+                      PromptCaching enables Anthropic prompt caching by marking the reusable
+                      prefix of every Messages API request with `cache_control` breakpoints:
+                      the last tool definition, the last system prompt block and the last
+                      content block of the most recent conversation turn. Anthropic caches the
+                      prefix up to each breakpoint and bills a cache hit at a fraction of the
+                      normal input price on later requests within the TTL. Because the
+                      conversation breakpoint moves with every turn, each call of an agent
+                      loop reads the whole previous history from the cache and writes only
+                      the new turn.
+
+                      Recommended for tool-using agents that make many model calls per task
+                      with a stable system prompt and tool set — without it the full history
+                      is billed as fresh input on every call. Cache writes are billed at a
+                      premium over normal input, so a prefix has to be read at least once to
+                      pay off, and each model has a minimum cacheable prefix (1024–4096
+                      tokens depending on the model) below which the markers are silently
+                      ignored.
+
+                      See https://platform.claude.com/docs/en/build-with-claude/prompt-caching
+                      for the current list of supported models, minimum prefix sizes and
+                      pricing.
+                    type: boolean
                   temperature:
                     description: Temperature for sampling
                     type: string

--- a/go/api/v1alpha3/modelconfig_types.go
+++ b/go/api/v1alpha3/modelconfig_types.go
@@ -118,6 +118,50 @@ type AnthropicConfig struct {
 	// Top-k sampling parameter
 	// +optional
 	TopK int `json:"topK,omitempty"`
+
+	// PromptCaching enables Anthropic prompt caching by marking the reusable
+	// prefix of every Messages API request with `cache_control` breakpoints:
+	// the last tool definition, the last system prompt block and the last
+	// content block of the most recent conversation turn. Anthropic caches the
+	// prefix up to each breakpoint and bills a cache hit at a fraction of the
+	// normal input price on later requests within the TTL. Because the
+	// conversation breakpoint moves with every turn, each call of an agent
+	// loop reads the whole previous history from the cache and writes only
+	// the new turn.
+	//
+	// Recommended for tool-using agents that make many model calls per task
+	// with a stable system prompt and tool set — without it the full history
+	// is billed as fresh input on every call. Cache writes are billed at a
+	// premium over normal input, so a prefix has to be read at least once to
+	// pay off, and each model has a minimum cacheable prefix (1024–4096
+	// tokens depending on the model) below which the markers are silently
+	// ignored.
+	//
+	// See https://platform.claude.com/docs/en/build-with-claude/prompt-caching
+	// for the current list of supported models, minimum prefix sizes and
+	// pricing.
+	// +optional
+	// +kubebuilder:default=false
+	PromptCaching bool `json:"promptCaching,omitempty"`
+
+	// CacheTTL controls how long Anthropic retains a cached prefix when
+	// PromptCaching is enabled. Only meaningful when PromptCaching is true.
+	//
+	//   - "5m" (default): the standard 5-minute cache. Each cache hit refreshes
+	//     the window, so an agent loop whose calls are less than 5 minutes
+	//     apart keeps its prefix cached for the whole task.
+	//   - "1h": the extended 1-hour cache, useful for tasks whose model calls
+	//     are spaced more than 5 minutes apart.
+	//
+	// NOTE: "1h" is NOT strictly better than "5m". 1-hour cache writes are
+	// billed at a higher per-token rate than 5-minute writes. Only choose
+	// "1h" when calls are spaced far enough apart that a 5-minute cache would
+	// expire between them; otherwise the higher write cost is wasted. See the
+	// Anthropic prompt-caching docs above.
+	// +optional
+	// +kubebuilder:validation:Enum="5m";"1h"
+	// +kubebuilder:default="5m"
+	CacheTTL string `json:"cacheTTL,omitempty"`
 }
 
 // TokenExchangeType identifies the token exchange mechanism

--- a/go/core/internal/translator/adkconfig/model.go
+++ b/go/core/internal/translator/adkconfig/model.go
@@ -347,6 +347,8 @@ func (c *Builder) translateModel(ctx context.Context, resolved *v2translator.Res
 			if spec.TopK > 0 {
 				anthropic.TopK = &spec.TopK
 			}
+			anthropic.PromptCaching = spec.PromptCaching
+			anthropic.CacheTTL = spec.CacheTTL
 		}
 		return anthropic, modelDeploymentData, nil
 	case v1alpha3.ModelProviderAzureOpenAI:

--- a/go/core/internal/translator/adkconfig/model_test.go
+++ b/go/core/internal/translator/adkconfig/model_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/kagent-dev/kagent/go/api/adk"
 	"github.com/kagent-dev/kagent/go/api/v1alpha3"
 	v2translator "github.com/kagent-dev/kagent/go/core/internal/translator"
 	"github.com/kagent-dev/kagent/go/core/pkg/env"
@@ -78,4 +79,38 @@ func TestResolveFoundryEndpointFromConfigMap(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, configMap.Data["endpoint"], endpoint)
+}
+
+func TestTranslateAnthropicPromptCaching(t *testing.T) {
+	tests := []struct {
+		name        string
+		spec        *v1alpha3.AnthropicConfig
+		wantCaching bool
+		wantTTL     string
+	}{
+		{name: "no provider block", spec: nil},
+		// cacheTTL is passed through as configured; the runtime only reads it when caching is on.
+		{name: "disabled", spec: &v1alpha3.AnthropicConfig{CacheTTL: "5m"}, wantTTL: "5m"},
+		{name: "enabled with the default TTL", spec: &v1alpha3.AnthropicConfig{PromptCaching: true, CacheTTL: "5m"}, wantCaching: true, wantTTL: "5m"},
+		{name: "enabled with the 1h TTL", spec: &v1alpha3.AnthropicConfig{PromptCaching: true, CacheTTL: "1h"}, wantCaching: true, wantTTL: "1h"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolved := &v2translator.ResolvedModelConfig{
+				Config: &v1alpha3.ModelConfig{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "test"},
+					Spec: v1alpha3.ModelConfigSpec{
+						Provider: v1alpha3.ModelProviderAnthropic, Model: "claude-sonnet-4-6",
+						Anthropic: tt.spec,
+					},
+				},
+			}
+			got, _, err := (&Builder{}).translateModel(context.Background(), resolved)
+			require.NoError(t, err)
+			anthropic, ok := got.(*adk.Anthropic)
+			require.True(t, ok, "model is %T, want *adk.Anthropic", got)
+			require.Equal(t, tt.wantCaching, anthropic.PromptCaching)
+			require.Equal(t, tt.wantTTL, anthropic.CacheTTL)
+		})
+	}
 }

--- a/go/core/internal/translator/claude/compiler.go
+++ b/go/core/internal/translator/claude/compiler.go
@@ -172,6 +172,10 @@ func (c *Compiler) provider(ctx context.Context, model *v1alpha3.ModelConfig) ([
 			options := *model.Spec.Anthropic
 			baseURL = strings.TrimSpace(options.BaseURL)
 			options.BaseURL = ""
+			// "5m" is the CRD default and matches Claude Code's native cache TTL.
+			if options.CacheTTL == "5m" {
+				options.CacheTTL = ""
+			}
 			if !reflect.DeepEqual(options, v1alpha3.AnthropicConfig{}) {
 				return nil, nil, v2translator.NewValidationError("Claude does not support Anthropic provider options beyond baseUrl yet")
 			}

--- a/go/core/internal/translator/claude/compiler_test.go
+++ b/go/core/internal/translator/claude/compiler_test.go
@@ -41,7 +41,8 @@ func TestCompileSupportedProviders(t *testing.T) {
 			name: "Anthropic gateway",
 			model: v1alpha3.ModelConfigSpec{Provider: v1alpha3.ModelProviderAnthropic, Model: "claude-sonnet-4-5",
 				APIKeySecret: "model-auth", APIKeySecretKey: "api-key",
-				Anthropic: &v1alpha3.AnthropicConfig{BaseURL: "http://host.docker.internal:8090/anthropic"}},
+				// cacheTTL is defaulted to "5m" by the CRD whenever the anthropic block is set.
+				Anthropic: &v1alpha3.AnthropicConfig{BaseURL: "http://host.docker.internal:8090/anthropic", CacheTTL: "5m"}},
 			secretData: map[string][]byte{"api-key": []byte(credentialValue)},
 			wantEnv: map[string]string{claudeconfig.AnthropicAPIKeyEnvName: credentialValue,
 				claudeconfig.AnthropicBaseURLEnvName: "http://host.docker.internal:8090/anthropic"},
@@ -132,6 +133,8 @@ func TestCompileRejectsUnsupportedConfiguration(t *testing.T) {
 		{name: "passthrough", model: v1alpha3.ModelConfigSpec{Provider: v1alpha3.ModelProviderAnthropic, Model: "claude", APIKeyPassthrough: true}},
 		{name: "headers", model: v1alpha3.ModelConfigSpec{Provider: v1alpha3.ModelProviderAnthropic, Model: "claude", DefaultHeaders: map[string]string{"x": "y"}}},
 		{name: "Anthropic options", model: v1alpha3.ModelConfigSpec{Provider: v1alpha3.ModelProviderAnthropic, Model: "claude", Anthropic: &v1alpha3.AnthropicConfig{Temperature: "0.5"}}},
+		{name: "Anthropic prompt caching", model: v1alpha3.ModelConfigSpec{Provider: v1alpha3.ModelProviderAnthropic, Model: "claude", APIKeySecret: "model-auth", APIKeySecretKey: "api-key", Anthropic: &v1alpha3.AnthropicConfig{PromptCaching: true, CacheTTL: "5m"}}},
+		{name: "Anthropic cache TTL", model: v1alpha3.ModelConfigSpec{Provider: v1alpha3.ModelProviderAnthropic, Model: "claude", APIKeySecret: "model-auth", APIKeySecretKey: "api-key", Anthropic: &v1alpha3.AnthropicConfig{CacheTTL: "1h"}}},
 		{name: "Anthropic relative base URL", model: v1alpha3.ModelConfigSpec{Provider: v1alpha3.ModelProviderAnthropic, Model: "claude", APIKeySecret: "model-auth", APIKeySecretKey: "api-key", Anthropic: &v1alpha3.AnthropicConfig{BaseURL: "/v1"}}},
 		{name: "Anthropic base URL credentials", model: v1alpha3.ModelConfigSpec{Provider: v1alpha3.ModelProviderAnthropic, Model: "claude", APIKeySecret: "model-auth", APIKeySecretKey: "api-key", Anthropic: &v1alpha3.AnthropicConfig{BaseURL: "https://user:password@example.com"}}},
 		{name: "Bedrock options", model: v1alpha3.ModelConfigSpec{Provider: v1alpha3.ModelProviderBedrock, Model: "claude", APIKeySecret: "model-auth", Bedrock: &v1alpha3.BedrockConfig{Region: "us-east-1", PromptCaching: true}}},

--- a/helm/kagent-crds/templates/kagent.dev_modelconfigs.yaml
+++ b/helm/kagent-crds/templates/kagent.dev_modelconfigs.yaml
@@ -56,9 +56,55 @@ spec:
                   baseUrl:
                     description: Base URL for the Anthropic API (overrides default)
                     type: string
+                  cacheTTL:
+                    default: 5m
+                    description: |-
+                      CacheTTL controls how long Anthropic retains a cached prefix when
+                      PromptCaching is enabled. Only meaningful when PromptCaching is true.
+
+                        - "5m" (default): the standard 5-minute cache. Each cache hit refreshes
+                          the window, so an agent loop whose calls are less than 5 minutes
+                          apart keeps its prefix cached for the whole task.
+                        - "1h": the extended 1-hour cache, useful for tasks whose model calls
+                          are spaced more than 5 minutes apart.
+
+                      NOTE: "1h" is NOT strictly better than "5m". 1-hour cache writes are
+                      billed at a higher per-token rate than 5-minute writes. Only choose
+                      "1h" when calls are spaced far enough apart that a 5-minute cache would
+                      expire between them; otherwise the higher write cost is wasted. See the
+                      Anthropic prompt-caching docs above.
+                    enum:
+                    - 5m
+                    - 1h
+                    type: string
                   maxTokens:
                     description: Maximum tokens to generate
                     type: integer
+                  promptCaching:
+                    default: false
+                    description: |-
+                      PromptCaching enables Anthropic prompt caching by marking the reusable
+                      prefix of every Messages API request with `cache_control` breakpoints:
+                      the last tool definition, the last system prompt block and the last
+                      content block of the most recent conversation turn. Anthropic caches the
+                      prefix up to each breakpoint and bills a cache hit at a fraction of the
+                      normal input price on later requests within the TTL. Because the
+                      conversation breakpoint moves with every turn, each call of an agent
+                      loop reads the whole previous history from the cache and writes only
+                      the new turn.
+
+                      Recommended for tool-using agents that make many model calls per task
+                      with a stable system prompt and tool set — without it the full history
+                      is billed as fresh input on every call. Cache writes are billed at a
+                      premium over normal input, so a prefix has to be read at least once to
+                      pay off, and each model has a minimum cacheable prefix (1024–4096
+                      tokens depending on the model) below which the markers are silently
+                      ignored.
+
+                      See https://platform.claude.com/docs/en/build-with-claude/prompt-caching
+                      for the current list of supported models, minimum prefix sizes and
+                      pricing.
+                    type: boolean
                   temperature:
                     description: Temperature for sampling
                     type: string

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -633,6 +633,12 @@ providers:
     apiKeySecretRef: kagent-anthropic
     apiKeySecretKey: ANTHROPIC_API_KEY
     # apiKey: ""
+    # Provider options rendered into spec.anthropic of the generated ModelConfig.
+    # promptCaching bills the stable prefix of every agent-loop call (tools,
+    # system prompt, previous turns) as a cache read instead of fresh input.
+    # config:
+    #   promptCaching: true
+    #   cacheTTL: "5m" # or "1h" for calls spaced more than 5 minutes apart
   azureOpenAI:
     provider: AzureOpenAI
     model: "gpt-4.1-mini"

--- a/python/packages/kagent-adk/src/kagent/adk/models/_anthropic.py
+++ b/python/packages/kagent-adk/src/kagent/adk/models/_anthropic.py
@@ -1,28 +1,122 @@
-"""Anthropic model implementation with api_key_passthrough, base_url, and header support."""
+"""Anthropic model implementation with api_key_passthrough, base_url, header, and prompt caching support."""
 
 from __future__ import annotations
 
 import logging
 import os
 from functools import cached_property
-from typing import Optional
+from typing import Any, Literal, Optional
 
 from anthropic import AsyncAnthropic
+from anthropic.resources.messages import AsyncMessages
+from anthropic.types import CacheControlEphemeralParam
 from google.adk.models.anthropic_llm import AnthropicLlm
 
 from ._ssl import KAgentTLSMixin
 
 logger = logging.getLogger(__name__)
 
+# Anthropic rejects a cache breakpoint on a reasoning block, so the conversation
+# breakpoint skips past them when the latest turn ends in one.
+_UNCACHEABLE_BLOCK_TYPES = frozenset({"thinking", "redacted_thinking"})
+
+
+def cache_control_param(cache_ttl: Optional[str] = None) -> CacheControlEphemeralParam:
+    """Return the ``cache_control`` marker for the configured retention window.
+
+    ``None`` or ``"5m"`` omits ``ttl``, giving the API's default 5-minute cache;
+    ``"1h"`` opts into the 1-hour cache, whose writes are billed at a higher rate
+    (see the ModelConfig CRD's ``anthropic.cacheTTL`` doc for the trade-off).
+    """
+    if cache_ttl == "1h":
+        return {"type": "ephemeral", "ttl": "1h"}
+    return {"type": "ephemeral"}
+
+
+def mark_prompt_cache_breakpoints(kwargs: dict[str, Any], cache_control: CacheControlEphemeralParam) -> None:
+    """Attach the prompt-cache breakpoints to a ``messages.create`` request, in place.
+
+    The Messages API renders tools, then system, then messages, and caches the
+    prefix up to each breakpoint. Marking the last tool definition, the last
+    system block and the last block of the latest turn keeps the stable head of
+    an agent loop cached while the conversation grows: every call reads the
+    previous prefix from the cache and writes only the new turn. That uses three
+    of the four breakpoints Anthropic allows per request.
+
+    Marked blocks are copied rather than mutated so the caller's own message and
+    tool objects stay untouched.
+    """
+    tools = kwargs.get("tools")
+    if isinstance(tools, list) and tools:
+        kwargs["tools"] = [*tools[:-1], {**tools[-1], "cache_control": cache_control}]
+
+    system = kwargs.get("system")
+    if isinstance(system, str) and system:
+        kwargs["system"] = [{"type": "text", "text": system, "cache_control": cache_control}]
+    elif isinstance(system, list) and system:
+        kwargs["system"] = [*system[:-1], {**system[-1], "cache_control": cache_control}]
+
+    messages = kwargs.get("messages")
+    if not isinstance(messages, list):
+        return
+    for index in range(len(messages) - 1, -1, -1):
+        message = messages[index]
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        if isinstance(content, str):
+            content = [{"type": "text", "text": content}] if content else []
+        if not isinstance(content, list):
+            continue
+        for block_index in range(len(content) - 1, -1, -1):
+            block = content[block_index]
+            if not isinstance(block, dict) or block.get("type") in _UNCACHEABLE_BLOCK_TYPES:
+                continue
+            marked = [*content]
+            marked[block_index] = {**block, "cache_control": cache_control}
+            kwargs["messages"] = [*messages[:index], {**message, "content": marked}, *messages[index + 1 :]]
+            return
+
+
+class PromptCachingMessages:
+    """``AsyncMessages`` stand-in that marks the reusable prompt prefix before each request.
+
+    google-adk's ``AnthropicLlm`` builds every request itself and hands it to
+    ``client.messages.create`` on both the streaming and the non-streaming path,
+    so the client is the one seam where kagent can shape the request without
+    re-implementing the request builder. Everything but ``create`` is delegated
+    to the wrapped resource.
+    """
+
+    def __init__(self, messages: AsyncMessages, cache_control: CacheControlEphemeralParam) -> None:
+        self._messages = messages
+        self._cache_control = cache_control
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._messages, name)
+
+    async def create(self, **kwargs: Any) -> Any:
+        mark_prompt_cache_breakpoints(kwargs, self._cache_control)
+        return await self._messages.create(**kwargs)
+
 
 class KAgentAnthropicLlm(KAgentTLSMixin, AnthropicLlm):
-    """Anthropic model with api_key_passthrough, custom base_url, header, and TLS support."""
+    """Anthropic model with api_key_passthrough, custom base_url, header, TLS, and prompt caching support."""
 
     api_key_passthrough: Optional[bool] = None
 
     _api_key: Optional[str] = None
     base_url: Optional[str] = None
     extra_headers: Optional[dict[str, str]] = None
+    # When True, every request carries cache_control breakpoints on the last
+    # tool definition, the last system block and the last block of the latest
+    # turn, so Anthropic bills the stable prefix of the agent loop as a cache
+    # read. See mark_prompt_cache_breakpoints.
+    prompt_caching: bool = False
+    # When prompt_caching is on, cache_ttl selects the retention window: "5m"/None
+    # (the API's default 5-minute cache) or "1h" (higher cache-write cost). See
+    # cache_control_param.
+    cache_ttl: Optional[Literal["5m", "1h"]] = None
 
     model_config = {"arbitrary_types_allowed": True}
 
@@ -57,4 +151,9 @@ class KAgentAnthropicLlm(KAgentTLSMixin, AnthropicLlm):
         if http_client is not None:
             kwargs["http_client"] = http_client
 
-        return AsyncAnthropic(**kwargs)
+        client = AsyncAnthropic(**kwargs)
+        if self.prompt_caching:
+            # `messages` is a functools.cached_property on the SDK client, so the
+            # instance attribute takes precedence for the client's lifetime.
+            client.messages = PromptCachingMessages(client.messages, cache_control_param(self.cache_ttl))
+        return client

--- a/python/packages/kagent-adk/src/kagent/adk/types.py
+++ b/python/packages/kagent-adk/src/kagent/adk/types.py
@@ -295,6 +295,16 @@ class AzureOpenAI(BaseLLM):
 
 class Anthropic(BaseLLM):
     base_url: str | None = None
+    # prompt_caching enables Anthropic prompt caching: cache_control breakpoints
+    # are set on the last tool definition, the last system prompt block and the
+    # last block of the latest conversation turn, so the stable prefix of an
+    # agent loop is billed as a cache read instead of fresh input on every call.
+    prompt_caching: bool = False
+    # cache_ttl selects the cache retention window when prompt_caching is on:
+    # "5m" (default) for the standard 5-minute cache, or "1h" for the 1-hour
+    # cache. 1-hour cache writes are billed at a higher rate, so "1h" only pays
+    # off when the calls sharing a prefix are more than 5 minutes apart.
+    cache_ttl: Literal["5m", "1h"] | None = None
 
     type: Literal["anthropic"]
 
@@ -689,6 +699,8 @@ def _create_llm_from_model_config(model_config: ModelUnion):
             model=model_config.model,
             base_url=base_url,
             extra_headers=extra_headers,
+            prompt_caching=model_config.prompt_caching,
+            cache_ttl=model_config.cache_ttl,
             **_transport_kwargs(model_config),
         )
     if model_config.type == "gemini_vertex_ai":

--- a/python/packages/kagent-adk/tests/unittests/models/test_anthropic.py
+++ b/python/packages/kagent-adk/tests/unittests/models/test_anthropic.py
@@ -1,12 +1,21 @@
 """Tests for KAgentAnthropicLlm."""
 
+import json
 from unittest import mock
 
+import pytest
 from anthropic import AsyncAnthropic
-from anthropic.types import ThinkingBlock
+from anthropic.types import Message, TextBlock, ThinkingBlock, Usage
 from google.adk.models.anthropic_llm import content_block_to_part
+from google.adk.models.llm_request import LlmRequest
+from google.genai import types
 
-from kagent.adk.models._anthropic import KAgentAnthropicLlm
+from kagent.adk.models._anthropic import (
+    KAgentAnthropicLlm,
+    PromptCachingMessages,
+    cache_control_param,
+    mark_prompt_cache_breakpoints,
+)
 
 
 class TestKAgentAnthropicLlm:
@@ -85,3 +94,229 @@ class TestAnthropicThinkingBlock:
 
         assert part.thought is True
         assert part.text == "working through it"
+
+
+class TestPromptCachingConfig:
+    def test_default_construction_has_caching_off(self):
+        llm = KAgentAnthropicLlm(model="claude-sonnet-4-6")
+        assert llm.prompt_caching is False
+        assert llm.cache_ttl is None
+
+    def test_create_llm_forwards_prompt_caching_and_ttl(self):
+        from kagent.adk.types import Anthropic, _create_llm_from_model_config
+
+        config = Anthropic(type="anthropic", model="claude-sonnet-4-6", prompt_caching=True, cache_ttl="1h")
+        result = _create_llm_from_model_config(config)
+        assert isinstance(result, KAgentAnthropicLlm)
+        assert result.prompt_caching is True
+        assert result.cache_ttl == "1h"
+
+    def test_cache_control_default_ttl_omits_ttl(self):
+        assert cache_control_param() == {"type": "ephemeral"}
+        # "5m" is the API default, so it is left implicit.
+        assert cache_control_param("5m") == {"type": "ephemeral"}
+
+    def test_cache_control_one_hour_ttl(self):
+        assert cache_control_param("1h") == {"type": "ephemeral", "ttl": "1h"}
+
+    def test_client_without_caching_keeps_sdk_messages_resource(self):
+        llm = KAgentAnthropicLlm(model="claude-sonnet-4-6")
+        with mock.patch("kagent.adk.models._anthropic.AsyncAnthropic") as mock_anthropic:
+            client = mock.MagicMock(spec=AsyncAnthropic)
+            mock_anthropic.return_value = client
+            assert llm._anthropic_client.messages is client.messages
+
+    def test_client_with_caching_wraps_messages_resource(self):
+        llm = KAgentAnthropicLlm(model="claude-sonnet-4-6", prompt_caching=True, cache_ttl="1h")
+        with mock.patch("kagent.adk.models._anthropic.AsyncAnthropic") as mock_anthropic:
+            client = mock.MagicMock(spec=AsyncAnthropic)
+            mock_anthropic.return_value = client
+            messages = llm._anthropic_client.messages
+        assert isinstance(messages, PromptCachingMessages)
+        assert messages._cache_control == {"type": "ephemeral", "ttl": "1h"}
+
+
+class TestMarkPromptCacheBreakpoints:
+    """Request shaping: which blocks carry the cache_control marker."""
+
+    CC = {"type": "ephemeral"}
+
+    def _agent_loop_kwargs(self):
+        return {
+            "model": "claude-sonnet-4-6",
+            "system": "You are a Kubernetes assistant.",
+            "tools": [
+                {"name": "get_weather", "description": "lookup weather", "input_schema": {"type": "object"}},
+                {"name": "list_pods", "description": "list pods", "input_schema": {"type": "object"}},
+            ],
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "list the pods"}]},
+                {
+                    "role": "assistant",
+                    "content": [{"type": "tool_use", "id": "call-1", "name": "list_pods", "input": {}}],
+                },
+                {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "call-1", "content": "pod-a"}]},
+                {"role": "user", "content": [{"type": "text", "text": "anything else?"}]},
+            ],
+        }
+
+    def test_marks_last_tool_system_and_latest_turn_only(self):
+        kwargs = self._agent_loop_kwargs()
+        mark_prompt_cache_breakpoints(kwargs, self.CC)
+
+        assert kwargs["tools"][-1]["cache_control"] == self.CC
+        assert "cache_control" not in kwargs["tools"][0]
+        assert kwargs["tools"][-1]["name"] == "list_pods", "tool order must be preserved"
+
+        assert kwargs["system"] == [
+            {"type": "text", "text": "You are a Kubernetes assistant.", "cache_control": self.CC},
+        ]
+
+        assert kwargs["messages"][-1]["content"][-1]["cache_control"] == self.CC
+        for message in kwargs["messages"][:-1]:
+            for block in message["content"]:
+                assert "cache_control" not in block, "only the latest turn carries the moving breakpoint"
+
+    def test_marks_trailing_tool_result(self):
+        kwargs = self._agent_loop_kwargs()
+        kwargs["messages"] = kwargs["messages"][:3]
+        mark_prompt_cache_breakpoints(kwargs, self.CC)
+        block = kwargs["messages"][-1]["content"][-1]
+        assert block["type"] == "tool_result"
+        assert block["cache_control"] == self.CC
+
+    def test_skips_thinking_blocks_at_the_end_of_the_turn(self):
+        kwargs = self._agent_loop_kwargs()
+        kwargs["messages"].append(
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "let me check"},
+                    {"type": "thinking", "thinking": "...", "signature": "sig"},
+                    {"type": "redacted_thinking", "data": "..."},
+                ],
+            }
+        )
+        mark_prompt_cache_breakpoints(kwargs, self.CC)
+        content = kwargs["messages"][-1]["content"]
+        assert content[0]["cache_control"] == self.CC
+        assert "cache_control" not in content[1]
+        assert "cache_control" not in content[2]
+
+    def test_system_block_list_marks_last_block(self):
+        kwargs = {"system": [{"type": "text", "text": "a"}, {"type": "text", "text": "b"}], "messages": []}
+        mark_prompt_cache_breakpoints(kwargs, self.CC)
+        assert kwargs["system"] == [
+            {"type": "text", "text": "a"},
+            {"type": "text", "text": "b", "cache_control": self.CC},
+        ]
+
+    def test_string_message_content_becomes_a_marked_text_block(self):
+        kwargs = {"messages": [{"role": "user", "content": "hi"}]}
+        mark_prompt_cache_breakpoints(kwargs, self.CC)
+        assert kwargs["messages"] == [
+            {"role": "user", "content": [{"type": "text", "text": "hi", "cache_control": self.CC}]}
+        ]
+
+    def test_leaves_requests_without_cacheable_content_alone(self):
+        for kwargs in (
+            {},
+            {"system": "", "tools": [], "messages": []},
+            {"messages": [{"role": "user", "content": ""}]},
+        ):
+            before = {k: list(v) if isinstance(v, list) else v for k, v in kwargs.items()}
+            mark_prompt_cache_breakpoints(kwargs, self.CC)
+            assert kwargs == before
+
+    def test_does_not_mutate_caller_objects(self):
+        kwargs = self._agent_loop_kwargs()
+        tools, messages = kwargs["tools"], kwargs["messages"]
+        last_tool, last_message = dict(tools[-1]), dict(messages[-1])
+        mark_prompt_cache_breakpoints(kwargs, self.CC)
+        assert tools[-1] == last_tool
+        assert messages[-1] == last_message
+
+
+class TestPromptCachingRequests:
+    """End to end through google-adk's request builder with the SDK client mocked out."""
+
+    def _request(self):
+        return LlmRequest(
+            model="claude-sonnet-4-6",
+            contents=[
+                types.Content(role="user", parts=[types.Part.from_text(text="list the pods")]),
+                types.Content(
+                    role="model",
+                    parts=[types.Part.from_function_call(name="list_pods", args={})],
+                ),
+                types.Content(
+                    role="user",
+                    parts=[types.Part.from_function_response(name="list_pods", response={"result": "pod-a"})],
+                ),
+                types.Content(role="user", parts=[types.Part.from_text(text="anything else?")]),
+            ],
+            config=types.GenerateContentConfig(
+                system_instruction="You are a Kubernetes assistant.",
+                tools=[
+                    types.Tool(
+                        function_declarations=[
+                            types.FunctionDeclaration(name="get_weather", description="lookup weather"),
+                            types.FunctionDeclaration(name="list_pods", description="list pods"),
+                        ]
+                    )
+                ],
+            ),
+        )
+
+    def _message(self):
+        return Message(
+            id="msg_1",
+            type="message",
+            role="assistant",
+            model="claude-sonnet-4-6",
+            content=[TextBlock(type="text", text="pod-a")],
+            stop_reason="end_turn",
+            stop_sequence=None,
+            usage=Usage(input_tokens=4, output_tokens=5, cache_read_input_tokens=900, cache_creation_input_tokens=96),
+        )
+
+    async def _run(self, llm):
+        create = mock.AsyncMock(return_value=self._message())
+        client = mock.MagicMock(spec=AsyncAnthropic)
+        client.messages = mock.MagicMock()
+        client.messages.create = create
+        with mock.patch("kagent.adk.models._anthropic.AsyncAnthropic", return_value=client):
+            responses = [r async for r in llm.generate_content_async(self._request())]
+        return create.call_args.kwargs, responses
+
+    @pytest.mark.asyncio
+    async def test_disabled_sends_no_cache_control(self):
+        kwargs, _ = await self._run(KAgentAnthropicLlm(model="claude-sonnet-4-6"))
+        assert "cache_control" not in json.dumps(kwargs, default=str)
+
+    @pytest.mark.asyncio
+    async def test_enabled_marks_tools_system_and_latest_turn(self):
+        cc = {"type": "ephemeral", "ttl": "1h"}
+        kwargs, _ = await self._run(KAgentAnthropicLlm(model="claude-sonnet-4-6", prompt_caching=True, cache_ttl="1h"))
+
+        assert json.dumps(kwargs, default=str).count('"cache_control"') == 3
+        assert kwargs["tools"][-1]["name"] == "list_pods"
+        assert kwargs["tools"][-1]["cache_control"] == cc
+        assert kwargs["system"] == [{"type": "text", "text": "You are a Kubernetes assistant.", "cache_control": cc}]
+        last = kwargs["messages"][-1]
+        assert last["role"] == "user"
+        assert last["content"][-1]["cache_control"] == cc
+
+    @pytest.mark.asyncio
+    async def test_cache_usage_reaches_usage_metadata(self):
+        """Regression guard for the google-adk floor: cache reads must surface as cached tokens.
+
+        google-adk folds Anthropic's cache_read/cache_creation counts into
+        prompt_token_count and reports the read portion as
+        cached_content_token_count; that is what the UI's usage view shows.
+        """
+        _, responses = await self._run(KAgentAnthropicLlm(model="claude-sonnet-4-6", prompt_caching=True))
+        usage = responses[-1].usage_metadata
+        assert usage.prompt_token_count == 1000
+        assert usage.cached_content_token_count == 900
+        assert usage.candidates_token_count == 5

--- a/python/packages/kagent-adk/tests/unittests/models/test_anthropic.py
+++ b/python/packages/kagent-adk/tests/unittests/models/test_anthropic.py
@@ -1,5 +1,6 @@
 """Tests for KAgentAnthropicLlm."""
 
+import copy
 import json
 from unittest import mock
 
@@ -224,17 +225,17 @@ class TestMarkPromptCacheBreakpoints:
             {"system": "", "tools": [], "messages": []},
             {"messages": [{"role": "user", "content": ""}]},
         ):
-            before = {k: list(v) if isinstance(v, list) else v for k, v in kwargs.items()}
+            before = copy.deepcopy(kwargs)
             mark_prompt_cache_breakpoints(kwargs, self.CC)
             assert kwargs == before
 
     def test_does_not_mutate_caller_objects(self):
         kwargs = self._agent_loop_kwargs()
         tools, messages = kwargs["tools"], kwargs["messages"]
-        last_tool, last_message = dict(tools[-1]), dict(messages[-1])
+        before_tools, before_messages = copy.deepcopy(tools), copy.deepcopy(messages)
         mark_prompt_cache_breakpoints(kwargs, self.CC)
-        assert tools[-1] == last_tool
-        assert messages[-1] == last_message
+        assert tools == before_tools
+        assert messages == before_messages
 
 
 class TestPromptCachingRequests:


### PR DESCRIPTION
Closes #2787. Picks up the Anthropic half of #1866, whose Bedrock half shipped in #1940.

## Problem

A declarative agent re-sends its full history on every model call. With the Anthropic provider nothing is marked cacheable today: `promptCaching` exists only on `BedrockConfig`, and neither runtime sends `cache_control`, so the whole prefix (system prompt, tool definitions, previous turns) is billed at full input price on every call.

Measured on kagent 0.10.1 on an internal installation, through a gateway that logs `gen_ai.usage.*` per model call (162 calls over 24 h, three agents, `claude-sonnet-4-6` via the Anthropic provider): `cache_read.input_tokens` and `cache_creation.input_tokens` were 0 on every call. One incident-investigation session of a Python (`kagent-app`) agent made 119 model calls whose input grew from 4,423 to 190,809 tokens per call (average 93 k), i.e. roughly 11 M input tokens billed for one session, most of it the same prefix over and over; a Go (`golang-adk`) agent in the same window went 3.6 k → 93 k over 41 calls. Anthropic's prompt caching turns that repeat into cache reads at a fraction of the input price. Full numbers in #2787.

## Change

- `spec.anthropic.promptCaching` (bool, default `false`) and `spec.anthropic.cacheTTL` (`"5m"` | `"1h"`, default `"5m"`) on `ModelConfig`, with the same names, defaults and doc shape as the Bedrock fields, wired through `adk.Anthropic` (`prompt_caching`, `cache_ttl`) to both runtimes. CRDs regenerated (`make controller-manifests`).
- When enabled, every Messages API request carries three `cache_control` breakpoints: the last tool definition, the last system prompt block, and the last content block of the latest conversation turn. Anthropic renders tools → system → messages and caches the prefix up to each breakpoint, so each call of an agent loop reads its whole previous history from the cache and writes only the new turn. That is three of the four breakpoints Anthropic allows; the conversation breakpoint skips thinking blocks, which Anthropic refuses to cache.
- **Go runtime** (`go/adk/pkg/models/anthropic_adk.go`): the request shaping moves into `buildAnthropicParams` so it can be unit-tested, `markAnthropicCacheBreakpoints` sets the markers, and usage now maps `cache_read_input_tokens` to `CachedContentTokenCount` and folds cache read/creation tokens into `PromptTokenCount` (the GenAI shape treats cached as a breakdown of prompt, which is also how google-adk maps Anthropic usage on the Python side), so the UI's usage view shows the effect. Streaming and non-streaming.
- **Python runtime** (`KAgentAnthropicLlm`): wraps the SDK client's `messages` resource with `PromptCachingMessages`, which marks the same three breakpoints before each `create` call. That is the one seam google-adk's `AnthropicLlm` hands its request through on both the streaming and the non-streaming path, so the request builder is not duplicated. google-adk ≥ 2.x already maps `cache_read_input_tokens` into `cached_content_token_count`; a regression guard for that is added.
- **Claude harness compiler**: treats the CRD-defaulted `cacheTTL: "5m"` like the Bedrock one (without this every `spec.anthropic` block would now fail the "no options beyond baseUrl" check, because the CRD defaults the field whenever the block is present) and keeps rejecting `promptCaching: true`, since Claude Code caches natively.
- **Helm**: `providers.anthropic.config.promptCaching` / `cacheTTL` documented in `values.yaml`; the chart already renders `config` into the provider block.

Design notes: opt-in like the Bedrock knob. A per-model minimum cacheable prefix applies (1024–4096 tokens; below it the markers are silently ignored) and 5-minute cache writes cost 1.25× normal input, so a prefix has to be read at least once to pay off. One knob enables all three breakpoints: the moving conversation breakpoint is what makes agent loops cheap, and a separate switch for it would be extra API surface for no realistic configuration. This is complementary to compaction (#2728): compaction bounds the growth of the prefix, caching removes the per-call repeat cost.

## Testing

- Go: `go test ./adk/... ./api/... ./core/internal/translator/...`, `make -C go lint`. New `anthropic_adk_test.go` asserts the wire body (as the SDK serializes it) carries exactly three markers at the expected positions for the default, `"5m"` and `"1h"` TTLs, none when disabled, the trailing-tool-result and no-tools/no-system cases, the usage fold, and drives both the SSE streaming and the non-streaming path through an `httptest` server. Plus agent wiring and config deserialization, translator wiring, and Claude compiler accept (`cacheTTL: "5m"`) / reject (`promptCaching`) cases.
- Python: `pytest packages/kagent-adk/tests/unittests` (228 passed; `test_grpc_health` fails locally only because port 8081 is taken on my machine). New tests for `mark_prompt_cache_breakpoints` (positions, thinking blocks skipped, no mutation of caller objects), the client wrapping, and end-to-end through google-adk's request builder with the SDK client mocked, including the usage-mapping guard.
- Against the Anthropic API (`claude-sonnet-4-6`, ~2.7 k-token system prompt + 2 tools, three consecutive agent-loop calls alternating non-streaming/streaming, both runtimes, values are `prompt_token_count / cached_content_token_count` as reported by the runtime):

  | runtime | promptCaching | call 1 | call 2 | call 3 |
  |---|---|---|---|---|
  | Go | off | 2739 / 0 | 2751 / 0 | 2763 / 0 |
  | Go | on, 5m | 2739 / 0 (cache write) | 2751 / 2736 | 2763 / 2748 |
  | Python | off | 2740 / 0 | 2756 / 0 | 2772 / 0 |
  | Python | on, 5m | 2740 / 0 (cache write) | 2756 / 2737 | 2772 / 2753 |

  After the first call ~99 % of every prompt is served from the cache and surfaces as cached tokens.
- Not run here: a kind-based run of an `AgentTemplate` on `main` (the kind flow on `main` has Substrate disabled by default). The kind end-to-end run was done on the `release/v0.10.x` backport, #2789, which runs agents as Deployments: Go and Python declarative agents with the built-in Kubernetes tools (~14 k-token prefix), three turns through the controller's A2A endpoint — every model call after the first reads ~99.5 % of its prompt from the cache (e.g. Go 15665 / 14257 cached on the tool-result follow-up, 16337 / 16266 on turn 3), reported in the A2A usage metadata. Table in #2789.

Follow-ups, not in this PR: the UI model form exposes neither this nor Bedrock's `promptCaching`; a docs note for kagent-dev/website `supported-providers/anthropic.md` once this lands.
