### PR TITLE
feat(models): add prompt caching for the Anthropic provider (backport to release/v0.10.x)

### DIFF
--- a/go/adk/pkg/agent/agent.go
+++ b/go/adk/pkg/agent/agent.go
@@ -288,6 +288,8 @@ func CreateLLM(ctx context.Context, m adk.Model, log logr.Logger) (adkmodel.LLM,
 			Temperature:     m.Temperature,
 			TopP:            m.TopP,
 			TopK:            m.TopK,
+			PromptCaching:   m.PromptCaching,
+			CacheTTL:        m.CacheTTL,
 		}
 		return models.NewAnthropicModelWithLogger(cfg, log)
 

--- a/go/adk/pkg/agent/agent_test.go
+++ b/go/adk/pkg/agent/agent_test.go
@@ -60,7 +60,9 @@ func TestConfigDeserialization_Anthropic(t *testing.T) {
 		"model": {
 			"type": "anthropic",
 			"model": "claude-sonnet-4-20250514",
-			"base_url": "https://api.anthropic.com"
+			"base_url": "https://api.anthropic.com",
+			"prompt_caching": true,
+			"cache_ttl": "1h"
 		},
 		"description": "test agent",
 		"instruction": "you are helpful"
@@ -78,6 +80,38 @@ func TestConfigDeserialization_Anthropic(t *testing.T) {
 
 	if anthropic.Model != "claude-sonnet-4-20250514" {
 		t.Errorf("model name = %q, want %q", anthropic.Model, "claude-sonnet-4-20250514")
+	}
+	if !anthropic.PromptCaching {
+		t.Error("PromptCaching = false, want true")
+	}
+	if anthropic.CacheTTL != "1h" {
+		t.Errorf("CacheTTL = %q, want %q", anthropic.CacheTTL, "1h")
+	}
+}
+
+// TestCreateLLM_AnthropicPromptCaching verifies the prompt caching knobs reach
+// the Anthropic model, which is where the cache_control markers are set.
+func TestCreateLLM_AnthropicPromptCaching(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	m := &adk.Anthropic{
+		BaseModel:     adk.BaseModel{Type: "anthropic", Model: "claude-sonnet-4-6"},
+		PromptCaching: true,
+		CacheTTL:      "1h",
+	}
+
+	llm, err := CreateLLM(context.Background(), m, logr.Discard())
+	if err != nil {
+		t.Fatalf("CreateLLM: %v", err)
+	}
+	am, ok := llm.(*models.AnthropicModel)
+	if !ok {
+		t.Fatalf("model is %T, want *models.AnthropicModel", llm)
+	}
+	if !am.Config.PromptCaching {
+		t.Error("Config.PromptCaching = false, want true")
+	}
+	if am.Config.CacheTTL != "1h" {
+		t.Errorf("Config.CacheTTL = %q, want %q", am.Config.CacheTTL, "1h")
 	}
 }
 

--- a/go/adk/pkg/models/anthropic.go
+++ b/go/adk/pkg/models/anthropic.go
@@ -33,6 +33,15 @@ type AnthropicConfig struct {
 	Temperature *float64
 	TopP        *float64
 	TopK        *int
+	// PromptCaching, when true, marks the last tool definition, the last system
+	// prompt block and the last block of the latest conversation turn with a
+	// cache_control breakpoint so Anthropic bills the stable prefix of an agent
+	// loop as a cache read instead of fresh input. See markAnthropicCacheBreakpoints.
+	PromptCaching bool
+	// CacheTTL selects the cache retention window when PromptCaching is on.
+	// "" or "5m" uses the API's default 5-minute cache; "1h" opts into the
+	// 1-hour cache, which is billed at a higher cache-write rate. See anthropicCacheControl.
+	CacheTTL string
 }
 
 // AnthropicModel implements model.LLM for Anthropic Claude models.

--- a/go/adk/pkg/models/anthropic_adk.go
+++ b/go/adk/pkg/models/anthropic_adk.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"iter"
+	"slices"
 	"strings"
 
 	"github.com/anthropics/anthropic-sdk-go"
@@ -40,44 +41,8 @@ func (m *AnthropicModel) Name() string {
 // GenerateContent implements model.LLM. Uses only ADK/genai types.
 func (m *AnthropicModel) GenerateContent(ctx context.Context, req *model.LLMRequest, stream bool) iter.Seq2[*model.LLMResponse, error] {
 	return func(yield func(*model.LLMResponse, error) bool) {
-		messages, systemPrompt := genaiContentsToAnthropicMessages(req.Contents, req.Config)
-		// Always prefer config model - req.Model may contain the model type ("anthropic") instead of model name
-		modelName := m.Config.Model
-		if modelName == "" {
-			modelName = req.Model
-		}
-		if modelName == "" || modelName == "anthropic" {
-			modelName = "claude-sonnet-4-20250514"
-		}
-		telemetry.SetLLMRequestAttributes(ctx, modelName, req)
-
-		// Build request parameters
-		params := anthropic.MessageNewParams{
-			Model:    anthropic.Model(modelName),
-			Messages: messages,
-		}
-
-		// Set max tokens (required for Anthropic)
-		maxTokens := int64(defaultAnthropicMaxTokens)
-		if m.Config.MaxTokens != nil {
-			maxTokens = int64(*m.Config.MaxTokens)
-		}
-		params.MaxTokens = maxTokens
-
-		// Set system prompt if provided
-		if systemPrompt != "" {
-			params.System = []anthropic.TextBlockParam{
-				{Text: systemPrompt},
-			}
-		}
-
-		// Apply config options
-		applyAnthropicConfig(&params, m.Config)
-
-		// Add tools if provided
-		if req.Config != nil && len(req.Config.Tools) > 0 {
-			params.Tools = genaiToolsToAnthropicTools(req.Config.Tools)
-		}
+		params := buildAnthropicParams(req, m.Config)
+		telemetry.SetLLMRequestAttributes(ctx, string(params.Model), req)
 
 		if stream {
 			runAnthropicStreaming(ctx, m, params, yield)
@@ -87,10 +52,46 @@ func (m *AnthropicModel) GenerateContent(ctx context.Context, req *model.LLMRequ
 	}
 }
 
-func applyAnthropicConfig(params *anthropic.MessageNewParams, cfg *AnthropicConfig) {
+// buildAnthropicParams translates an ADK request into a Messages API request:
+// model, system prompt, conversation, sampling options and tools, plus the
+// prompt-cache breakpoints when cfg enables them.
+func buildAnthropicParams(req *model.LLMRequest, cfg *AnthropicConfig) anthropic.MessageNewParams {
 	if cfg == nil {
-		return
+		cfg = &AnthropicConfig{}
 	}
+	messages, systemPrompt := genaiContentsToAnthropicMessages(req.Contents, req.Config)
+
+	// Always prefer config model - req.Model may contain the model type ("anthropic") instead of model name
+	modelName := cfg.Model
+	if modelName == "" {
+		modelName = req.Model
+	}
+	if modelName == "" || modelName == "anthropic" {
+		modelName = "claude-sonnet-4-20250514"
+	}
+
+	params := anthropic.MessageNewParams{
+		Model:     anthropic.Model(modelName),
+		Messages:  messages,
+		MaxTokens: int64(defaultAnthropicMaxTokens), // required by the Messages API
+	}
+	if cfg.MaxTokens != nil {
+		params.MaxTokens = int64(*cfg.MaxTokens)
+	}
+	if systemPrompt != "" {
+		params.System = []anthropic.TextBlockParam{{Text: systemPrompt}}
+	}
+	applyAnthropicConfig(&params, cfg)
+	if req.Config != nil && len(req.Config.Tools) > 0 {
+		params.Tools = genaiToolsToAnthropicTools(req.Config.Tools)
+	}
+	if cfg.PromptCaching {
+		markAnthropicCacheBreakpoints(&params, anthropicCacheControl(cfg.CacheTTL))
+	}
+	return params
+}
+
+func applyAnthropicConfig(params *anthropic.MessageNewParams, cfg *AnthropicConfig) {
 	if cfg.Temperature != nil {
 		params.Temperature = anthropic.Float(*cfg.Temperature)
 	}
@@ -99,6 +100,69 @@ func applyAnthropicConfig(params *anthropic.MessageNewParams, cfg *AnthropicConf
 	}
 	if cfg.TopK != nil {
 		params.TopK = anthropic.Int(int64(*cfg.TopK))
+	}
+}
+
+// anthropicCacheControl builds the cache_control marker for the configured
+// retention window. "" or "5m" leaves the TTL unset, which is the API's default
+// 5-minute cache; "1h" opts into the 1-hour cache, which is billed at a higher
+// cache-write rate (see v1alpha2.AnthropicConfig.CacheTTL for the trade-off).
+func anthropicCacheControl(cacheTTL string) anthropic.CacheControlEphemeralParam {
+	control := anthropic.NewCacheControlEphemeralParam()
+	if cacheTTL == string(anthropic.CacheControlEphemeralTTLTTL1h) {
+		control.TTL = anthropic.CacheControlEphemeralTTLTTL1h
+	}
+	return control
+}
+
+// markAnthropicCacheBreakpoints places the prompt-cache breakpoints on a request.
+//
+// The Messages API renders tools, then system, then messages, and caches the
+// prefix up to each breakpoint, so marking the last tool definition, the last
+// system block and the last block of the latest turn keeps the stable head of
+// an agent loop cached while the conversation grows: each call reads the
+// previous prefix from the cache and writes only the new turn. That uses three
+// of the four breakpoints Anthropic allows per request.
+//
+// The conversation breakpoint walks back from the end because a turn can end
+// in a block Anthropic refuses to cache (a thinking block, for which the SDK
+// reports no cache_control slot).
+func markAnthropicCacheBreakpoints(params *anthropic.MessageNewParams, control anthropic.CacheControlEphemeralParam) {
+	if n := len(params.Tools); n > 0 {
+		if slot := params.Tools[n-1].GetCacheControl(); slot != nil {
+			*slot = control
+		}
+	}
+	if n := len(params.System); n > 0 {
+		params.System[n-1].CacheControl = control
+	}
+	for _, message := range slices.Backward(params.Messages) {
+		for _, block := range slices.Backward(message.Content) {
+			if slot := block.GetCacheControl(); slot != nil {
+				*slot = control
+				return
+			}
+		}
+	}
+}
+
+// anthropicUsageToGenai folds Anthropic usage into the GenAI shape.
+//
+// Anthropic reports tokens served from the prompt cache and tokens written to
+// it in their own fields, disjoint from input_tokens, whereas GenAI expects one
+// prompt count with the cached portion as a breakdown of it. Folding them in
+// keeps PromptTokenCount equal to the prompt the model actually saw whether or
+// not caching is on, and CachedContentTokenCount says how much of it was a
+// cache read.
+func anthropicUsageToGenai(usage anthropic.Usage) *genai.GenerateContentResponseUsageMetadata {
+	prompt := usage.InputTokens + usage.CacheReadInputTokens + usage.CacheCreationInputTokens
+	if prompt == 0 && usage.OutputTokens == 0 {
+		return nil
+	}
+	return &genai.GenerateContentResponseUsageMetadata{
+		PromptTokenCount:        int32(prompt),
+		CachedContentTokenCount: int32(usage.CacheReadInputTokens),
+		CandidatesTokenCount:    int32(usage.OutputTokens),
 	}
 }
 
@@ -275,14 +339,16 @@ func runAnthropicStreaming(ctx context.Context, m *AnthropicModel, params anthro
 		inputJSON string
 	})
 	var stopReason anthropic.StopReason
-	var inputTokens, outputTokens int64
+	// message_start carries the input-side counts (including the prompt-cache
+	// breakdown); message_delta carries the final output count.
+	var usage anthropic.Usage
 
 	for stream.Next() {
 		event := stream.Current()
 
 		switch e := event.AsAny().(type) {
 		case anthropic.MessageStartEvent:
-			inputTokens = e.Message.Usage.InputTokens
+			usage = e.Message.Usage
 		case anthropic.ContentBlockStartEvent:
 			idx := int(e.Index)
 			if e.ContentBlock.Type == "tool_use" {
@@ -319,7 +385,7 @@ func runAnthropicStreaming(ctx context.Context, m *AnthropicModel, params anthro
 			}
 		case anthropic.MessageDeltaEvent:
 			stopReason = e.Delta.StopReason
-			outputTokens = e.Usage.OutputTokens
+			usage.OutputTokens = e.Usage.OutputTokens
 		}
 	}
 
@@ -349,18 +415,11 @@ func runAnthropicStreaming(ctx context.Context, m *AnthropicModel, params anthro
 		}
 	}
 
-	var usage *genai.GenerateContentResponseUsageMetadata
-	if inputTokens > 0 || outputTokens > 0 {
-		usage = &genai.GenerateContentResponseUsageMetadata{
-			PromptTokenCount:     int32(inputTokens),
-			CandidatesTokenCount: int32(outputTokens),
-		}
-	}
 	resp := &model.LLMResponse{
 		Partial:       false,
 		TurnComplete:  true,
 		FinishReason:  anthropicStopReasonToGenai(stopReason),
-		UsageMetadata: usage,
+		UsageMetadata: anthropicUsageToGenai(usage),
 		Content:       &genai.Content{Role: string(genai.RoleModel), Parts: finalParts},
 	}
 	telemetry.SetLLMResponseAttributes(ctx, resp)
@@ -395,20 +454,11 @@ func runAnthropicNonStreaming(ctx context.Context, m *AnthropicModel, params ant
 		}
 	}
 
-	// Build usage metadata
-	var usage *genai.GenerateContentResponseUsageMetadata
-	if message.Usage.InputTokens > 0 || message.Usage.OutputTokens > 0 {
-		usage = &genai.GenerateContentResponseUsageMetadata{
-			PromptTokenCount:     int32(message.Usage.InputTokens),
-			CandidatesTokenCount: int32(message.Usage.OutputTokens),
-		}
-	}
-
 	resp := &model.LLMResponse{
 		Partial:       false,
 		TurnComplete:  true,
 		FinishReason:  anthropicStopReasonToGenai(message.StopReason),
-		UsageMetadata: usage,
+		UsageMetadata: anthropicUsageToGenai(message.Usage),
 		Content:       &genai.Content{Role: string(genai.RoleModel), Parts: parts},
 	}
 	telemetry.SetLLMResponseAttributes(ctx, resp)

--- a/go/adk/pkg/models/anthropic_adk_test.go
+++ b/go/adk/pkg/models/anthropic_adk_test.go
@@ -1,0 +1,251 @@
+package models
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/genai"
+)
+
+// anthropicAgentLoopRequest is a typical agent-loop request: a system prompt,
+// two tools, a completed tool call and a fresh user turn.
+func anthropicAgentLoopRequest() *model.LLMRequest {
+	return &model.LLMRequest{
+		Model: "anthropic",
+		Contents: []*genai.Content{
+			{Role: "user", Parts: []*genai.Part{{Text: "list the pods"}}},
+			{Role: "model", Parts: []*genai.Part{{FunctionCall: &genai.FunctionCall{ID: "call-1", Name: "list_pods", Args: map[string]any{}}}}},
+			{Role: "user", Parts: []*genai.Part{{FunctionResponse: &genai.FunctionResponse{ID: "call-1", Name: "list_pods", Response: map[string]any{"result": "pod-a"}}}}},
+			{Role: "user", Parts: []*genai.Part{{Text: "anything else?"}}},
+		},
+		Config: &genai.GenerateContentConfig{
+			SystemInstruction: &genai.Content{Parts: []*genai.Part{{Text: "You are a Kubernetes assistant."}}},
+			Tools: []*genai.Tool{{FunctionDeclarations: []*genai.FunctionDeclaration{
+				{Name: "get_weather", Description: "lookup weather"},
+				{Name: "list_pods", Description: "list pods"},
+			}}},
+		},
+	}
+}
+
+// wireRequest is the Messages API body as the SDK serializes it, so the tests
+// assert what Anthropic receives rather than SDK-internal field layout.
+type wireRequest struct {
+	System   []map[string]any `json:"system"`
+	Tools    []map[string]any `json:"tools"`
+	Messages []struct {
+		Role    string           `json:"role"`
+		Content []map[string]any `json:"content"`
+	} `json:"messages"`
+}
+
+func decodeWireRequest(t *testing.T, body []byte) wireRequest {
+	t.Helper()
+	var req wireRequest
+	require.NoError(t, json.Unmarshal(body, &req))
+	return req
+}
+
+func marshalParams(t *testing.T, params anthropic.MessageNewParams) []byte {
+	t.Helper()
+	body, err := json.Marshal(params)
+	require.NoError(t, err)
+	return body
+}
+
+func lastBlock(t *testing.T, blocks []map[string]any) map[string]any {
+	t.Helper()
+	require.NotEmpty(t, blocks)
+	return blocks[len(blocks)-1]
+}
+
+func TestBuildAnthropicParamsWithoutPromptCachingSendsNoBreakpoints(t *testing.T) {
+	params := buildAnthropicParams(anthropicAgentLoopRequest(), &AnthropicConfig{Model: "claude-sonnet-4-6"})
+
+	body := marshalParams(t, params)
+	assert.NotContains(t, string(body), "cache_control")
+	wire := decodeWireRequest(t, body)
+	require.Len(t, wire.System, 1)
+	require.Len(t, wire.Tools, 2)
+	require.Len(t, wire.Messages, 4)
+}
+
+func TestBuildAnthropicParamsPromptCachingMarksToolsSystemAndLatestTurn(t *testing.T) {
+	tests := []struct {
+		name     string
+		cacheTTL string
+		want     map[string]any
+	}{
+		{name: "default TTL leaves ttl unset", cacheTTL: "", want: map[string]any{"type": "ephemeral"}},
+		{name: `"5m" leaves ttl unset`, cacheTTL: "5m", want: map[string]any{"type": "ephemeral"}},
+		{name: `"1h" requests the hour-long cache`, cacheTTL: "1h", want: map[string]any{"type": "ephemeral", "ttl": "1h"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := buildAnthropicParams(anthropicAgentLoopRequest(), &AnthropicConfig{Model: "claude-sonnet-4-6", PromptCaching: true, CacheTTL: tt.cacheTTL})
+
+			body := marshalParams(t, params)
+			assert.Equal(t, 3, strings.Count(string(body), `"cache_control"`), "one breakpoint each for tools, system and the latest turn: %s", body)
+			wire := decodeWireRequest(t, body)
+
+			// Tools render first: the marker sits on the last definition so the whole list is one cached prefix.
+			assert.Equal(t, tt.want, lastBlock(t, wire.Tools)["cache_control"])
+			assert.NotContains(t, wire.Tools[0], "cache_control", "earlier tools must stay unmarked")
+			assert.Equal(t, "list_pods", lastBlock(t, wire.Tools)["name"], "tool order must be preserved")
+
+			assert.Equal(t, tt.want, lastBlock(t, wire.System)["cache_control"])
+
+			last := wire.Messages[len(wire.Messages)-1]
+			assert.Equal(t, "user", last.Role)
+			assert.Equal(t, tt.want, lastBlock(t, last.Content)["cache_control"])
+			for _, message := range wire.Messages[:len(wire.Messages)-1] {
+				for _, block := range message.Content {
+					assert.NotContains(t, block, "cache_control", "only the latest turn carries the moving breakpoint")
+				}
+			}
+		})
+	}
+}
+
+func TestBuildAnthropicParamsPromptCachingMarksTrailingToolResult(t *testing.T) {
+	req := anthropicAgentLoopRequest()
+	req.Contents = req.Contents[:3] // the turn ends with the tool result
+
+	params := buildAnthropicParams(req, &AnthropicConfig{Model: "claude-sonnet-4-6", PromptCaching: true})
+
+	wire := decodeWireRequest(t, marshalParams(t, params))
+	last := wire.Messages[len(wire.Messages)-1]
+	block := lastBlock(t, last.Content)
+	assert.Equal(t, "tool_result", block["type"])
+	assert.Equal(t, map[string]any{"type": "ephemeral"}, block["cache_control"])
+}
+
+func TestBuildAnthropicParamsPromptCachingWithoutToolsOrSystem(t *testing.T) {
+	req := &model.LLMRequest{Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "hi"}}}}}
+
+	params := buildAnthropicParams(req, &AnthropicConfig{Model: "claude-sonnet-4-6", PromptCaching: true})
+
+	body := marshalParams(t, params)
+	assert.Equal(t, 1, strings.Count(string(body), `"cache_control"`), "only the conversation breakpoint applies: %s", body)
+	wire := decodeWireRequest(t, body)
+	assert.Empty(t, wire.System)
+	assert.Empty(t, wire.Tools)
+	assert.Equal(t, map[string]any{"type": "ephemeral"}, lastBlock(t, wire.Messages[0].Content)["cache_control"])
+}
+
+func TestAnthropicUsageToGenai(t *testing.T) {
+	tests := []struct {
+		name  string
+		usage anthropic.Usage
+		want  *genai.GenerateContentResponseUsageMetadata
+	}{
+		{name: "no usage", usage: anthropic.Usage{}, want: nil},
+		{
+			name:  "uncached",
+			usage: anthropic.Usage{InputTokens: 10, OutputTokens: 5},
+			want:  &genai.GenerateContentResponseUsageMetadata{PromptTokenCount: 10, CandidatesTokenCount: 5},
+		},
+		{
+			name:  "cache read and write fold into the prompt count",
+			usage: anthropic.Usage{InputTokens: 4, CacheReadInputTokens: 900, CacheCreationInputTokens: 96, OutputTokens: 5},
+			want:  &genai.GenerateContentResponseUsageMetadata{PromptTokenCount: 1000, CachedContentTokenCount: 900, CandidatesTokenCount: 5},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, anthropicUsageToGenai(tt.usage))
+		})
+	}
+}
+
+// anthropicTestServer serves canned Messages API responses and records the
+// request body the SDK sent.
+func anthropicTestServer(t *testing.T, handler func(w http.ResponseWriter)) (*AnthropicModel, *[]byte) {
+	t.Helper()
+	var captured []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		captured = body
+		handler(w)
+	}))
+	t.Cleanup(server.Close)
+
+	m, err := newAnthropicModelFromConfig(&AnthropicConfig{Model: "claude-sonnet-4-6", BaseUrl: server.URL, PromptCaching: true}, "test-key", logr.Discard())
+	require.NoError(t, err)
+	return m, &captured
+}
+
+func finalResponse(t *testing.T, m *AnthropicModel, stream bool) *model.LLMResponse {
+	t.Helper()
+	var final *model.LLMResponse
+	for resp, err := range m.GenerateContent(context.Background(), anthropicAgentLoopRequest(), stream) {
+		require.NoError(t, err)
+		require.Empty(t, resp.ErrorMessage)
+		if resp.TurnComplete {
+			final = resp
+		}
+	}
+	require.NotNil(t, final, "no final response yielded")
+	return final
+}
+
+func TestAnthropicNonStreamingCarriesBreakpointsAndCacheUsage(t *testing.T) {
+	m, captured := anthropicTestServer(t, func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"msg_1","type":"message","role":"assistant","model":"claude-sonnet-4-6",
+			"content":[{"type":"text","text":"pod-a"}],"stop_reason":"end_turn","stop_sequence":null,
+			"usage":{"input_tokens":4,"cache_creation_input_tokens":96,"cache_read_input_tokens":900,"output_tokens":5}}`)
+	})
+
+	final := finalResponse(t, m, false)
+
+	wire := decodeWireRequest(t, *captured)
+	assert.Equal(t, map[string]any{"type": "ephemeral"}, lastBlock(t, wire.System)["cache_control"])
+	assert.Equal(t, map[string]any{"type": "ephemeral"}, lastBlock(t, wire.Tools)["cache_control"])
+	assert.Equal(t, map[string]any{"type": "ephemeral"}, lastBlock(t, wire.Messages[len(wire.Messages)-1].Content)["cache_control"])
+	assert.Equal(t, &genai.GenerateContentResponseUsageMetadata{PromptTokenCount: 1000, CachedContentTokenCount: 900, CandidatesTokenCount: 5}, final.UsageMetadata)
+	require.Len(t, final.Content.Parts, 1)
+	assert.Equal(t, "pod-a", final.Content.Parts[0].Text)
+}
+
+func TestAnthropicStreamingCarriesBreakpointsAndCacheUsage(t *testing.T) {
+	events := []string{
+		`{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-sonnet-4-6","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":4,"cache_creation_input_tokens":96,"cache_read_input_tokens":900,"output_tokens":1}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"pod-a"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":5}}`,
+		`{"type":"message_stop"}`,
+	}
+	m, captured := anthropicTestServer(t, func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		for _, event := range events {
+			var envelope struct {
+				Type string `json:"type"`
+			}
+			require.NoError(t, json.Unmarshal([]byte(event), &envelope))
+			_, _ = io.WriteString(w, "event: "+envelope.Type+"\ndata: "+event+"\n\n")
+		}
+	})
+
+	final := finalResponse(t, m, true)
+
+	wire := decodeWireRequest(t, *captured)
+	assert.Equal(t, map[string]any{"type": "ephemeral"}, lastBlock(t, wire.System)["cache_control"])
+	assert.Equal(t, map[string]any{"type": "ephemeral"}, lastBlock(t, wire.Tools)["cache_control"])
+	assert.Equal(t, map[string]any{"type": "ephemeral"}, lastBlock(t, wire.Messages[len(wire.Messages)-1].Content)["cache_control"])
+	assert.Equal(t, &genai.GenerateContentResponseUsageMetadata{PromptTokenCount: 1000, CachedContentTokenCount: 900, CandidatesTokenCount: 5}, final.UsageMetadata)
+	require.Len(t, final.Content.Parts, 1)
+	assert.Equal(t, "pod-a", final.Content.Parts[0].Text)
+}

--- a/go/api/adk/types.go
+++ b/go/api/adk/types.go
@@ -159,6 +159,15 @@ type Anthropic struct {
 	TopP        *float64 `json:"top_p,omitempty"`
 	TopK        *int     `json:"top_k,omitempty"`
 	Timeout     *int     `json:"timeout,omitempty"`
+	// PromptCaching enables Anthropic prompt caching by marking the last tool
+	// definition, the last system prompt block and the last block of the latest
+	// conversation turn with a cache_control breakpoint. See the
+	// v1alpha2.AnthropicConfig CRD doc for context.
+	PromptCaching bool `json:"prompt_caching,omitempty"`
+	// CacheTTL selects the cache retention window when PromptCaching is on:
+	// "5m" (default) or "1h". See the v1alpha2.AnthropicConfig CRD doc for the
+	// cost trade-offs of "1h".
+	CacheTTL string `json:"cache_ttl,omitempty"`
 }
 
 func (a *Anthropic) MarshalJSON() ([]byte, error) {

--- a/go/api/config/crd/bases/kagent.dev_modelconfigs.yaml
+++ b/go/api/config/crd/bases/kagent.dev_modelconfigs.yaml
@@ -383,9 +383,55 @@ spec:
                   baseUrl:
                     description: Base URL for the Anthropic API (overrides default)
                     type: string
+                  cacheTTL:
+                    default: 5m
+                    description: |-
+                      CacheTTL controls how long Anthropic retains a cached prefix when
+                      PromptCaching is enabled. Only meaningful when PromptCaching is true.
+
+                        - "5m" (default): the standard 5-minute cache. Each cache hit refreshes
+                          the window, so an agent loop whose calls are less than 5 minutes
+                          apart keeps its prefix cached for the whole task.
+                        - "1h": the extended 1-hour cache, useful for tasks whose model calls
+                          are spaced more than 5 minutes apart.
+
+                      NOTE: "1h" is NOT strictly better than "5m". 1-hour cache writes are
+                      billed at a higher per-token rate than 5-minute writes. Only choose
+                      "1h" when calls are spaced far enough apart that a 5-minute cache would
+                      expire between them; otherwise the higher write cost is wasted. See the
+                      Anthropic prompt-caching docs above.
+                    enum:
+                    - 5m
+                    - 1h
+                    type: string
                   maxTokens:
                     description: Maximum tokens to generate
                     type: integer
+                  promptCaching:
+                    default: false
+                    description: |-
+                      PromptCaching enables Anthropic prompt caching by marking the reusable
+                      prefix of every Messages API request with `cache_control` breakpoints:
+                      the last tool definition, the last system prompt block and the last
+                      content block of the most recent conversation turn. Anthropic caches the
+                      prefix up to each breakpoint and bills a cache hit at a fraction of the
+                      normal input price on later requests within the TTL. Because the
+                      conversation breakpoint moves with every turn, each call of an agent
+                      loop reads the whole previous history from the cache and writes only
+                      the new turn.
+
+                      Recommended for tool-using agents that make many model calls per task
+                      with a stable system prompt and tool set — without it the full history
+                      is billed as fresh input on every call. Cache writes are billed at a
+                      premium over normal input, so a prefix has to be read at least once to
+                      pay off, and each model has a minimum cacheable prefix (1024–4096
+                      tokens depending on the model) below which the markers are silently
+                      ignored.
+
+                      See https://platform.claude.com/docs/en/build-with-claude/prompt-caching
+                      for the current list of supported models, minimum prefix sizes and
+                      pricing.
+                    type: boolean
                   temperature:
                     description: Temperature for sampling
                     type: string

--- a/go/api/v1alpha2/modelconfig_types.go
+++ b/go/api/v1alpha2/modelconfig_types.go
@@ -117,6 +117,50 @@ type AnthropicConfig struct {
 	// Top-k sampling parameter
 	// +optional
 	TopK int `json:"topK,omitempty"`
+
+	// PromptCaching enables Anthropic prompt caching by marking the reusable
+	// prefix of every Messages API request with `cache_control` breakpoints:
+	// the last tool definition, the last system prompt block and the last
+	// content block of the most recent conversation turn. Anthropic caches the
+	// prefix up to each breakpoint and bills a cache hit at a fraction of the
+	// normal input price on later requests within the TTL. Because the
+	// conversation breakpoint moves with every turn, each call of an agent
+	// loop reads the whole previous history from the cache and writes only
+	// the new turn.
+	//
+	// Recommended for tool-using agents that make many model calls per task
+	// with a stable system prompt and tool set — without it the full history
+	// is billed as fresh input on every call. Cache writes are billed at a
+	// premium over normal input, so a prefix has to be read at least once to
+	// pay off, and each model has a minimum cacheable prefix (1024–4096
+	// tokens depending on the model) below which the markers are silently
+	// ignored.
+	//
+	// See https://platform.claude.com/docs/en/build-with-claude/prompt-caching
+	// for the current list of supported models, minimum prefix sizes and
+	// pricing.
+	// +optional
+	// +kubebuilder:default=false
+	PromptCaching bool `json:"promptCaching,omitempty"`
+
+	// CacheTTL controls how long Anthropic retains a cached prefix when
+	// PromptCaching is enabled. Only meaningful when PromptCaching is true.
+	//
+	//   - "5m" (default): the standard 5-minute cache. Each cache hit refreshes
+	//     the window, so an agent loop whose calls are less than 5 minutes
+	//     apart keeps its prefix cached for the whole task.
+	//   - "1h": the extended 1-hour cache, useful for tasks whose model calls
+	//     are spaced more than 5 minutes apart.
+	//
+	// NOTE: "1h" is NOT strictly better than "5m". 1-hour cache writes are
+	// billed at a higher per-token rate than 5-minute writes. Only choose
+	// "1h" when calls are spaced far enough apart that a 5-minute cache would
+	// expire between them; otherwise the higher write cost is wasted. See the
+	// Anthropic prompt-caching docs above.
+	// +optional
+	// +kubebuilder:validation:Enum="5m";"1h"
+	// +kubebuilder:default="5m"
+	CacheTTL string `json:"cacheTTL,omitempty"`
 }
 
 // TokenExchangeType identifies the token exchange mechanism

--- a/go/core/internal/controller/translator/agent/adk_api_translator.go
+++ b/go/core/internal/controller/translator/agent/adk_api_translator.go
@@ -595,6 +595,8 @@ func (a *adkApiTranslator) translateModel(ctx context.Context, namespace, modelC
 			if spec.TopK > 0 {
 				anthropic.TopK = &spec.TopK
 			}
+			anthropic.PromptCaching = spec.PromptCaching
+			anthropic.CacheTTL = spec.CacheTTL
 		}
 		return anthropic, modelDeploymentData, secretHashBytes, nil
 	case v1alpha2.ModelProviderAzureOpenAI:

--- a/go/core/internal/controller/translator/agent/adk_api_translator_test.go
+++ b/go/core/internal/controller/translator/agent/adk_api_translator_test.go
@@ -427,6 +427,64 @@ func Test_AdkApiTranslator_OllamaOptions(t *testing.T) {
 	assert.Equal(t, "0.7", ollamaModel.Options["temperature"])
 }
 
+func Test_AdkApiTranslator_AnthropicPromptCaching(t *testing.T) {
+	scheme := schemev1.Scheme
+	require.NoError(t, v1alpha2.AddToScheme(scheme))
+
+	tests := []struct {
+		name        string
+		config      *v1alpha2.AnthropicConfig
+		wantCaching bool
+		wantTTL     string
+	}{
+		{name: "no provider block", config: nil},
+		// cacheTTL is passed through as configured; the runtime only reads it when caching is on.
+		{name: "disabled", config: &v1alpha2.AnthropicConfig{CacheTTL: "5m"}, wantTTL: "5m"},
+		{name: "enabled with the default TTL", config: &v1alpha2.AnthropicConfig{PromptCaching: true, CacheTTL: "5m"}, wantCaching: true, wantTTL: "5m"},
+		{name: "enabled with the 1h TTL", config: &v1alpha2.AnthropicConfig{PromptCaching: true, CacheTTL: "1h"}, wantCaching: true, wantTTL: "1h"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			namespace := "test-ns"
+			modelName := "anthropic-model"
+			modelConfig := &v1alpha2.ModelConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: namespace},
+				Spec: v1alpha2.ModelConfigSpec{
+					Model:     "claude-sonnet-4-6",
+					Provider:  v1alpha2.ModelProviderAnthropic,
+					Anthropic: tt.config,
+				},
+			}
+			agent := &v1alpha2.Agent{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-agent", Namespace: namespace},
+				Spec: v1alpha2.AgentSpec{
+					Type:        v1alpha2.AgentType_Declarative,
+					Description: "Test Agent",
+					Declarative: &v1alpha2.DeclarativeAgentSpec{
+						SystemMessage: "System message",
+						ModelConfig:   modelName,
+					},
+				},
+			}
+			kubeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}, modelConfig, agent).
+				Build()
+			trans := translator.NewAdkApiTranslator(kubeClient, types.NamespacedName{Namespace: namespace, Name: modelName}, nil, "", nil)
+
+			outputs, err := translator.TranslateAgent(context.Background(), trans, agent)
+			require.NoError(t, err)
+			require.NotNil(t, outputs)
+			require.NotNil(t, outputs.Config)
+
+			anthropicModel, ok := outputs.Config.Model.(*adk.Anthropic)
+			require.True(t, ok, "Expected model to be of type Anthropic, got %T", outputs.Config.Model)
+			assert.Equal(t, tt.wantCaching, anthropicModel.PromptCaching)
+			assert.Equal(t, tt.wantTTL, anthropicModel.CacheTTL)
+		})
+	}
+}
+
 func Test_AdkApiTranslator_AzureOpenAIParams(t *testing.T) {
 	scheme := schemev1.Scheme
 	require.NoError(t, v1alpha2.AddToScheme(scheme))

--- a/helm/kagent-crds/templates/kagent.dev_modelconfigs.yaml
+++ b/helm/kagent-crds/templates/kagent.dev_modelconfigs.yaml
@@ -383,9 +383,55 @@ spec:
                   baseUrl:
                     description: Base URL for the Anthropic API (overrides default)
                     type: string
+                  cacheTTL:
+                    default: 5m
+                    description: |-
+                      CacheTTL controls how long Anthropic retains a cached prefix when
+                      PromptCaching is enabled. Only meaningful when PromptCaching is true.
+
+                        - "5m" (default): the standard 5-minute cache. Each cache hit refreshes
+                          the window, so an agent loop whose calls are less than 5 minutes
+                          apart keeps its prefix cached for the whole task.
+                        - "1h": the extended 1-hour cache, useful for tasks whose model calls
+                          are spaced more than 5 minutes apart.
+
+                      NOTE: "1h" is NOT strictly better than "5m". 1-hour cache writes are
+                      billed at a higher per-token rate than 5-minute writes. Only choose
+                      "1h" when calls are spaced far enough apart that a 5-minute cache would
+                      expire between them; otherwise the higher write cost is wasted. See the
+                      Anthropic prompt-caching docs above.
+                    enum:
+                    - 5m
+                    - 1h
+                    type: string
                   maxTokens:
                     description: Maximum tokens to generate
                     type: integer
+                  promptCaching:
+                    default: false
+                    description: |-
+                      PromptCaching enables Anthropic prompt caching by marking the reusable
+                      prefix of every Messages API request with `cache_control` breakpoints:
+                      the last tool definition, the last system prompt block and the last
+                      content block of the most recent conversation turn. Anthropic caches the
+                      prefix up to each breakpoint and bills a cache hit at a fraction of the
+                      normal input price on later requests within the TTL. Because the
+                      conversation breakpoint moves with every turn, each call of an agent
+                      loop reads the whole previous history from the cache and writes only
+                      the new turn.
+
+                      Recommended for tool-using agents that make many model calls per task
+                      with a stable system prompt and tool set — without it the full history
+                      is billed as fresh input on every call. Cache writes are billed at a
+                      premium over normal input, so a prefix has to be read at least once to
+                      pay off, and each model has a minimum cacheable prefix (1024–4096
+                      tokens depending on the model) below which the markers are silently
+                      ignored.
+
+                      See https://platform.claude.com/docs/en/build-with-claude/prompt-caching
+                      for the current list of supported models, minimum prefix sizes and
+                      pricing.
+                    type: boolean
                   temperature:
                     description: Temperature for sampling
                     type: string

--- a/helm/kagent/values.yaml
+++ b/helm/kagent/values.yaml
@@ -666,6 +666,12 @@ providers:
     apiKeySecretRef: kagent-anthropic
     apiKeySecretKey: ANTHROPIC_API_KEY
     # apiKey: ""
+    # Provider options rendered into spec.anthropic of the generated ModelConfig.
+    # promptCaching bills the stable prefix of every agent-loop call (tools,
+    # system prompt, previous turns) as a cache read instead of fresh input.
+    # config:
+    #   promptCaching: true
+    #   cacheTTL: "5m" # or "1h" for calls spaced more than 5 minutes apart
   azureOpenAI:
     provider: AzureOpenAI
     model: "gpt-4.1-mini"

--- a/python/packages/kagent-adk/src/kagent/adk/models/_anthropic.py
+++ b/python/packages/kagent-adk/src/kagent/adk/models/_anthropic.py
@@ -1,30 +1,193 @@
-"""Anthropic model implementation with api_key_passthrough, base_url, and header support."""
+"""Anthropic model implementation with api_key_passthrough, base_url, header, and prompt caching support."""
 
 from __future__ import annotations
 
 import logging
 import os
+from collections.abc import AsyncGenerator, AsyncIterator
+from contextvars import ContextVar
 from functools import cached_property
-from typing import Optional
+from typing import Any, Literal, Optional
 
 from anthropic import AsyncAnthropic
+from anthropic.resources.messages import AsyncMessages
+from anthropic.types import CacheControlEphemeralParam, Usage
 from google.adk.models.anthropic_llm import AnthropicLlm
+from google.adk.models.llm_request import LlmRequest
+from google.adk.models.llm_response import LlmResponse
+from google.genai import types
 
 from ._ssl import KAgentTLSMixin
 
 logger = logging.getLogger(__name__)
 
+# google-adk 1.x maps only input_tokens/output_tokens for Anthropic and drops the
+# prompt-cache breakdown at the adapter boundary. The request proxy records the
+# raw usage of the request it shaped, per task, so generate_content_async can
+# fold it into the response google-adk builds. A ContextVar keeps concurrent
+# requests on the same model apart.
+_observed_usage: ContextVar[Optional[Usage]] = ContextVar("kagent_anthropic_usage", default=None)
+
+# Anthropic rejects a cache breakpoint on a reasoning block, so the conversation
+# breakpoint skips past them when the latest turn ends in one.
+_UNCACHEABLE_BLOCK_TYPES = frozenset({"thinking", "redacted_thinking"})
+
+
+def cache_control_param(cache_ttl: Optional[str] = None) -> CacheControlEphemeralParam:
+    """Return the ``cache_control`` marker for the configured retention window.
+
+    ``None`` or ``"5m"`` omits ``ttl``, giving the API's default 5-minute cache;
+    ``"1h"`` opts into the 1-hour cache, whose writes are billed at a higher rate
+    (see the ModelConfig CRD's ``anthropic.cacheTTL`` doc for the trade-off).
+    """
+    if cache_ttl == "1h":
+        return {"type": "ephemeral", "ttl": "1h"}
+    return {"type": "ephemeral"}
+
+
+def mark_prompt_cache_breakpoints(kwargs: dict[str, Any], cache_control: CacheControlEphemeralParam) -> None:
+    """Attach the prompt-cache breakpoints to a ``messages.create`` request, in place.
+
+    The Messages API renders tools, then system, then messages, and caches the
+    prefix up to each breakpoint. Marking the last tool definition, the last
+    system block and the last block of the latest turn keeps the stable head of
+    an agent loop cached while the conversation grows: every call reads the
+    previous prefix from the cache and writes only the new turn. That uses three
+    of the four breakpoints Anthropic allows per request.
+
+    Marked blocks are copied rather than mutated so the caller's own message and
+    tool objects stay untouched.
+    """
+    tools = kwargs.get("tools")
+    if isinstance(tools, list) and tools:
+        kwargs["tools"] = [*tools[:-1], {**tools[-1], "cache_control": cache_control}]
+
+    system = kwargs.get("system")
+    if isinstance(system, str) and system:
+        kwargs["system"] = [{"type": "text", "text": system, "cache_control": cache_control}]
+    elif isinstance(system, list) and system:
+        kwargs["system"] = [*system[:-1], {**system[-1], "cache_control": cache_control}]
+
+    messages = kwargs.get("messages")
+    if not isinstance(messages, list):
+        return
+    for index in range(len(messages) - 1, -1, -1):
+        message = messages[index]
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        if isinstance(content, str):
+            content = [{"type": "text", "text": content}] if content else []
+        if not isinstance(content, list):
+            continue
+        for block_index in range(len(content) - 1, -1, -1):
+            block = content[block_index]
+            if not isinstance(block, dict) or block.get("type") in _UNCACHEABLE_BLOCK_TYPES:
+                continue
+            marked = [*content]
+            marked[block_index] = {**block, "cache_control": cache_control}
+            kwargs["messages"] = [*messages[:index], {**message, "content": marked}, *messages[index + 1 :]]
+            return
+
+
+def fold_cache_usage(
+    usage_metadata: types.GenerateContentResponseUsageMetadata, usage: Usage
+) -> types.GenerateContentResponseUsageMetadata:
+    """Fold Anthropic's cache usage into the GenAI usage shape.
+
+    Anthropic reports tokens served from the prompt cache and tokens written to
+    it in their own fields, disjoint from ``input_tokens``, whereas GenAI expects
+    one prompt count with the cached portion as a breakdown of it (this is also
+    how google-adk 2.x maps Anthropic usage). Folding them in keeps the prompt
+    count equal to the prompt the model actually saw whether or not caching is
+    on, and ``cached_content_token_count`` says how much of it was a cache read.
+    """
+    cache_read = usage.cache_read_input_tokens or 0
+    prompt = (usage.input_tokens or 0) + cache_read + (usage.cache_creation_input_tokens or 0)
+    return usage_metadata.model_copy(
+        update={
+            "prompt_token_count": prompt,
+            "cached_content_token_count": cache_read,
+            "total_token_count": prompt + (usage_metadata.candidates_token_count or 0),
+        }
+    )
+
+
+async def _observe_stream_usage(stream: AsyncIterator[Any]) -> AsyncIterator[Any]:
+    """Pass the raw stream events through, recording the usage from ``message_start``."""
+    async for event in stream:
+        if getattr(event, "type", None) == "message_start":
+            _observed_usage.set(event.message.usage)
+        yield event
+
+
+class PromptCachingMessages:
+    """``AsyncMessages`` stand-in that marks the reusable prompt prefix before each request.
+
+    google-adk's ``AnthropicLlm`` builds every request itself and hands it to
+    ``client.messages.create`` on both the streaming and the non-streaming path,
+    so the client is the one seam where kagent can shape the request without
+    re-implementing the request builder. Everything but ``create`` is delegated
+    to the wrapped resource. ``create`` also records the response usage (see
+    ``_observed_usage``) because google-adk 1.x does not surface the cache
+    breakdown itself.
+    """
+
+    def __init__(self, messages: AsyncMessages, cache_control: CacheControlEphemeralParam) -> None:
+        self._messages = messages
+        self._cache_control = cache_control
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._messages, name)
+
+    async def create(self, **kwargs: Any) -> Any:
+        mark_prompt_cache_breakpoints(kwargs, self._cache_control)
+        result = await self._messages.create(**kwargs)
+        if kwargs.get("stream"):
+            return _observe_stream_usage(result)
+        _observed_usage.set(getattr(result, "usage", None))
+        return result
+
 
 class KAgentAnthropicLlm(KAgentTLSMixin, AnthropicLlm):
-    """Anthropic model with api_key_passthrough, custom base_url, header, and TLS support."""
+    """Anthropic model with api_key_passthrough, custom base_url, header, TLS, and prompt caching support."""
 
     api_key_passthrough: Optional[bool] = None
 
     _api_key: Optional[str] = None
     base_url: Optional[str] = None
     extra_headers: Optional[dict[str, str]] = None
+    # When True, every request carries cache_control breakpoints on the last
+    # tool definition, the last system block and the last block of the latest
+    # turn, so Anthropic bills the stable prefix of the agent loop as a cache
+    # read. See mark_prompt_cache_breakpoints.
+    prompt_caching: bool = False
+    # When prompt_caching is on, cache_ttl selects the retention window: "5m"/None
+    # (the API's default 5-minute cache) or "1h" (higher cache-write cost). See
+    # cache_control_param.
+    cache_ttl: Optional[Literal["5m", "1h"]] = None
 
     model_config = {"arbitrary_types_allowed": True}
+
+    async def generate_content_async(
+        self, llm_request: LlmRequest, stream: bool = False
+    ) -> AsyncGenerator[LlmResponse, None]:
+        responses = super().generate_content_async(llm_request, stream)
+        if not self.prompt_caching:
+            async for response in responses:
+                yield response
+            return
+        # The proxy records the raw usage while google-adk consumes the request;
+        # fold it into whatever usage google-adk attached to each response.
+        token = _observed_usage.set(None)
+        try:
+            async for response in responses:
+                usage = _observed_usage.get()
+                if response.usage_metadata is not None and usage is not None:
+                    response.usage_metadata = fold_cache_usage(response.usage_metadata, usage)
+                yield response
+        finally:
+            _observed_usage.reset(token)
 
     def set_passthrough_key(self, token: str) -> None:
         """Forward the Bearer token from the incoming A2A request as the Anthropic API key."""
@@ -57,4 +220,9 @@ class KAgentAnthropicLlm(KAgentTLSMixin, AnthropicLlm):
         if http_client is not None:
             kwargs["http_client"] = http_client
 
-        return AsyncAnthropic(**kwargs)
+        client = AsyncAnthropic(**kwargs)
+        if self.prompt_caching:
+            # `messages` is a functools.cached_property on the SDK client, so the
+            # instance attribute takes precedence for the client's lifetime.
+            client.messages = PromptCachingMessages(client.messages, cache_control_param(self.cache_ttl))
+        return client

--- a/python/packages/kagent-adk/src/kagent/adk/types.py
+++ b/python/packages/kagent-adk/src/kagent/adk/types.py
@@ -298,6 +298,16 @@ class AzureOpenAI(BaseLLM):
 
 class Anthropic(BaseLLM):
     base_url: str | None = None
+    # prompt_caching enables Anthropic prompt caching: cache_control breakpoints
+    # are set on the last tool definition, the last system prompt block and the
+    # last block of the latest conversation turn, so the stable prefix of an
+    # agent loop is billed as a cache read instead of fresh input on every call.
+    prompt_caching: bool = False
+    # cache_ttl selects the cache retention window when prompt_caching is on:
+    # "5m" (default) for the standard 5-minute cache, or "1h" for the 1-hour
+    # cache. 1-hour cache writes are billed at a higher rate, so "1h" only pays
+    # off when the calls sharing a prefix are more than 5 minutes apart.
+    cache_ttl: Literal["5m", "1h"] | None = None
 
     type: Literal["anthropic"]
 
@@ -693,6 +703,8 @@ def _create_llm_from_model_config(model_config: ModelUnion):
             model=model_config.model,
             base_url=base_url,
             extra_headers=extra_headers,
+            prompt_caching=model_config.prompt_caching,
+            cache_ttl=model_config.cache_ttl,
             **_transport_kwargs(model_config),
         )
     if model_config.type == "gemini_vertex_ai":

--- a/python/packages/kagent-adk/tests/unittests/models/test_anthropic.py
+++ b/python/packages/kagent-adk/tests/unittests/models/test_anthropic.py
@@ -1,12 +1,35 @@
 """Tests for KAgentAnthropicLlm."""
 
+import json
 from unittest import mock
 
+import pytest
 from anthropic import AsyncAnthropic
-from anthropic.types import ThinkingBlock
+from anthropic.types import (
+    Message,
+    MessageDeltaUsage,
+    RawContentBlockDeltaEvent,
+    RawContentBlockStartEvent,
+    RawMessageDeltaEvent,
+    RawMessageStartEvent,
+    RawMessageStopEvent,
+    TextBlock,
+    TextDelta,
+    ThinkingBlock,
+    Usage,
+)
+from anthropic.types.raw_message_delta_event import Delta
 from google.adk.models.anthropic_llm import content_block_to_part
+from google.adk.models.llm_request import LlmRequest
+from google.genai import types
 
-from kagent.adk.models._anthropic import KAgentAnthropicLlm
+from kagent.adk.models._anthropic import (
+    KAgentAnthropicLlm,
+    PromptCachingMessages,
+    cache_control_param,
+    fold_cache_usage,
+    mark_prompt_cache_breakpoints,
+)
 
 
 class TestKAgentAnthropicLlm:
@@ -85,3 +108,300 @@ class TestAnthropicThinkingBlock:
 
         assert part.thought is True
         assert part.text == "working through it"
+
+
+class TestPromptCachingConfig:
+    def test_default_construction_has_caching_off(self):
+        llm = KAgentAnthropicLlm(model="claude-sonnet-4-6")
+        assert llm.prompt_caching is False
+        assert llm.cache_ttl is None
+
+    def test_create_llm_forwards_prompt_caching_and_ttl(self):
+        from kagent.adk.types import Anthropic, _create_llm_from_model_config
+
+        config = Anthropic(type="anthropic", model="claude-sonnet-4-6", prompt_caching=True, cache_ttl="1h")
+        result = _create_llm_from_model_config(config)
+        assert isinstance(result, KAgentAnthropicLlm)
+        assert result.prompt_caching is True
+        assert result.cache_ttl == "1h"
+
+    def test_cache_control_default_ttl_omits_ttl(self):
+        assert cache_control_param() == {"type": "ephemeral"}
+        # "5m" is the API default, so it is left implicit.
+        assert cache_control_param("5m") == {"type": "ephemeral"}
+
+    def test_cache_control_one_hour_ttl(self):
+        assert cache_control_param("1h") == {"type": "ephemeral", "ttl": "1h"}
+
+    def test_client_without_caching_keeps_sdk_messages_resource(self):
+        llm = KAgentAnthropicLlm(model="claude-sonnet-4-6")
+        with mock.patch("kagent.adk.models._anthropic.AsyncAnthropic") as mock_anthropic:
+            client = mock.MagicMock(spec=AsyncAnthropic)
+            mock_anthropic.return_value = client
+            assert llm._anthropic_client.messages is client.messages
+
+    def test_client_with_caching_wraps_messages_resource(self):
+        llm = KAgentAnthropicLlm(model="claude-sonnet-4-6", prompt_caching=True, cache_ttl="1h")
+        with mock.patch("kagent.adk.models._anthropic.AsyncAnthropic") as mock_anthropic:
+            client = mock.MagicMock(spec=AsyncAnthropic)
+            mock_anthropic.return_value = client
+            messages = llm._anthropic_client.messages
+        assert isinstance(messages, PromptCachingMessages)
+        assert messages._cache_control == {"type": "ephemeral", "ttl": "1h"}
+
+
+class TestMarkPromptCacheBreakpoints:
+    """Request shaping: which blocks carry the cache_control marker."""
+
+    CC = {"type": "ephemeral"}
+
+    def _agent_loop_kwargs(self):
+        return {
+            "model": "claude-sonnet-4-6",
+            "system": "You are a Kubernetes assistant.",
+            "tools": [
+                {"name": "get_weather", "description": "lookup weather", "input_schema": {"type": "object"}},
+                {"name": "list_pods", "description": "list pods", "input_schema": {"type": "object"}},
+            ],
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "list the pods"}]},
+                {
+                    "role": "assistant",
+                    "content": [{"type": "tool_use", "id": "call-1", "name": "list_pods", "input": {}}],
+                },
+                {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "call-1", "content": "pod-a"}]},
+                {"role": "user", "content": [{"type": "text", "text": "anything else?"}]},
+            ],
+        }
+
+    def test_marks_last_tool_system_and_latest_turn_only(self):
+        kwargs = self._agent_loop_kwargs()
+        mark_prompt_cache_breakpoints(kwargs, self.CC)
+
+        assert kwargs["tools"][-1]["cache_control"] == self.CC
+        assert "cache_control" not in kwargs["tools"][0]
+        assert kwargs["tools"][-1]["name"] == "list_pods", "tool order must be preserved"
+
+        assert kwargs["system"] == [
+            {"type": "text", "text": "You are a Kubernetes assistant.", "cache_control": self.CC},
+        ]
+
+        assert kwargs["messages"][-1]["content"][-1]["cache_control"] == self.CC
+        for message in kwargs["messages"][:-1]:
+            for block in message["content"]:
+                assert "cache_control" not in block, "only the latest turn carries the moving breakpoint"
+
+    def test_marks_trailing_tool_result(self):
+        kwargs = self._agent_loop_kwargs()
+        kwargs["messages"] = kwargs["messages"][:3]
+        mark_prompt_cache_breakpoints(kwargs, self.CC)
+        block = kwargs["messages"][-1]["content"][-1]
+        assert block["type"] == "tool_result"
+        assert block["cache_control"] == self.CC
+
+    def test_skips_thinking_blocks_at_the_end_of_the_turn(self):
+        kwargs = self._agent_loop_kwargs()
+        kwargs["messages"].append(
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "let me check"},
+                    {"type": "thinking", "thinking": "...", "signature": "sig"},
+                    {"type": "redacted_thinking", "data": "..."},
+                ],
+            }
+        )
+        mark_prompt_cache_breakpoints(kwargs, self.CC)
+        content = kwargs["messages"][-1]["content"]
+        assert content[0]["cache_control"] == self.CC
+        assert "cache_control" not in content[1]
+        assert "cache_control" not in content[2]
+
+    def test_system_block_list_marks_last_block(self):
+        kwargs = {"system": [{"type": "text", "text": "a"}, {"type": "text", "text": "b"}], "messages": []}
+        mark_prompt_cache_breakpoints(kwargs, self.CC)
+        assert kwargs["system"] == [
+            {"type": "text", "text": "a"},
+            {"type": "text", "text": "b", "cache_control": self.CC},
+        ]
+
+    def test_string_message_content_becomes_a_marked_text_block(self):
+        kwargs = {"messages": [{"role": "user", "content": "hi"}]}
+        mark_prompt_cache_breakpoints(kwargs, self.CC)
+        assert kwargs["messages"] == [
+            {"role": "user", "content": [{"type": "text", "text": "hi", "cache_control": self.CC}]}
+        ]
+
+    def test_leaves_requests_without_cacheable_content_alone(self):
+        for kwargs in (
+            {},
+            {"system": "", "tools": [], "messages": []},
+            {"messages": [{"role": "user", "content": ""}]},
+        ):
+            before = {k: list(v) if isinstance(v, list) else v for k, v in kwargs.items()}
+            mark_prompt_cache_breakpoints(kwargs, self.CC)
+            assert kwargs == before
+
+    def test_does_not_mutate_caller_objects(self):
+        kwargs = self._agent_loop_kwargs()
+        tools, messages = kwargs["tools"], kwargs["messages"]
+        last_tool, last_message = dict(tools[-1]), dict(messages[-1])
+        mark_prompt_cache_breakpoints(kwargs, self.CC)
+        assert tools[-1] == last_tool
+        assert messages[-1] == last_message
+
+
+class TestPromptCachingRequests:
+    """End to end through google-adk's request builder with the SDK client mocked out."""
+
+    def _request(self):
+        return LlmRequest(
+            model="claude-sonnet-4-6",
+            contents=[
+                types.Content(role="user", parts=[types.Part.from_text(text="list the pods")]),
+                types.Content(
+                    role="model",
+                    parts=[types.Part.from_function_call(name="list_pods", args={})],
+                ),
+                types.Content(
+                    role="user",
+                    parts=[types.Part.from_function_response(name="list_pods", response={"result": "pod-a"})],
+                ),
+                types.Content(role="user", parts=[types.Part.from_text(text="anything else?")]),
+            ],
+            config=types.GenerateContentConfig(
+                system_instruction="You are a Kubernetes assistant.",
+                tools=[
+                    types.Tool(
+                        function_declarations=[
+                            types.FunctionDeclaration(name="get_weather", description="lookup weather"),
+                            types.FunctionDeclaration(name="list_pods", description="list pods"),
+                        ]
+                    )
+                ],
+            ),
+        )
+
+    def _message(self):
+        return Message(
+            id="msg_1",
+            type="message",
+            role="assistant",
+            model="claude-sonnet-4-6",
+            content=[TextBlock(type="text", text="pod-a")],
+            stop_reason="end_turn",
+            stop_sequence=None,
+            usage=Usage(input_tokens=4, output_tokens=5, cache_read_input_tokens=900, cache_creation_input_tokens=96),
+        )
+
+    def _events(self):
+        """The raw stream for the same answer: usage arrives on message_start and message_delta."""
+
+        async def stream():
+            for event in (
+                RawMessageStartEvent(type="message_start", message=self._message().model_copy(update={"content": []})),
+                RawContentBlockStartEvent(
+                    type="content_block_start", index=0, content_block=TextBlock(type="text", text="")
+                ),
+                RawContentBlockDeltaEvent(
+                    type="content_block_delta", index=0, delta=TextDelta(type="text_delta", text="pod-a")
+                ),
+                RawMessageDeltaEvent(
+                    type="message_delta",
+                    delta=Delta(stop_reason="end_turn", stop_sequence=None),
+                    usage=MessageDeltaUsage(output_tokens=5),
+                ),
+                RawMessageStopEvent(type="message_stop"),
+            ):
+                yield event
+
+        return stream()
+
+    async def _run(self, llm, stream=False):
+        create = mock.AsyncMock(
+            side_effect=lambda **kwargs: self._events() if kwargs.get("stream") else self._message()
+        )
+        client = mock.MagicMock(spec=AsyncAnthropic)
+        client.messages = mock.MagicMock()
+        client.messages.create = create
+        with mock.patch("kagent.adk.models._anthropic.AsyncAnthropic", return_value=client):
+            responses = [r async for r in llm.generate_content_async(self._request(), stream=stream)]
+        return create.call_args.kwargs, responses
+
+    @pytest.mark.asyncio
+    async def test_disabled_sends_no_cache_control(self):
+        kwargs, _ = await self._run(KAgentAnthropicLlm(model="claude-sonnet-4-6"))
+        assert "cache_control" not in json.dumps(kwargs, default=str)
+
+    @pytest.mark.asyncio
+    async def test_enabled_marks_tools_system_and_latest_turn(self):
+        cc = {"type": "ephemeral", "ttl": "1h"}
+        kwargs, _ = await self._run(KAgentAnthropicLlm(model="claude-sonnet-4-6", prompt_caching=True, cache_ttl="1h"))
+
+        assert json.dumps(kwargs, default=str).count('"cache_control"') == 3
+        assert kwargs["tools"][-1]["name"] == "list_pods"
+        assert kwargs["tools"][-1]["cache_control"] == cc
+        assert kwargs["system"] == [{"type": "text", "text": "You are a Kubernetes assistant.", "cache_control": cc}]
+        last = kwargs["messages"][-1]
+        assert last["role"] == "user"
+        assert last["content"][-1]["cache_control"] == cc
+
+    @pytest.mark.asyncio
+    async def test_cache_usage_reaches_usage_metadata(self):
+        """Cache reads must surface as cached tokens; that is what the UI's usage view shows.
+
+        google-adk 1.x reports only input_tokens for Anthropic, so the fold is
+        kagent's: cache_read/cache_creation are added to prompt_token_count and
+        the read portion is reported as cached_content_token_count.
+        """
+        _, responses = await self._run(KAgentAnthropicLlm(model="claude-sonnet-4-6", prompt_caching=True))
+        usage = responses[-1].usage_metadata
+        assert usage.prompt_token_count == 1000
+        assert usage.cached_content_token_count == 900
+        assert usage.candidates_token_count == 5
+        assert usage.total_token_count == 1005
+
+    @pytest.mark.asyncio
+    async def test_streaming_cache_usage_reaches_usage_metadata(self):
+        kwargs, responses = await self._run(
+            KAgentAnthropicLlm(model="claude-sonnet-4-6", prompt_caching=True), stream=True
+        )
+        assert kwargs["stream"] is True
+        assert kwargs["system"][-1]["cache_control"] == {"type": "ephemeral"}
+        final = [r for r in responses if not r.partial]
+        assert len(final) == 1
+        usage = final[0].usage_metadata
+        assert usage.prompt_token_count == 1000
+        assert usage.cached_content_token_count == 900
+        assert usage.candidates_token_count == 5
+        assert final[0].content.parts[0].text == "pod-a"
+
+    @pytest.mark.asyncio
+    async def test_usage_is_left_to_google_adk_when_caching_is_off(self):
+        _, responses = await self._run(KAgentAnthropicLlm(model="claude-sonnet-4-6"))
+        usage = responses[-1].usage_metadata
+        assert usage.prompt_token_count == 4
+        assert usage.cached_content_token_count is None
+
+
+class TestFoldCacheUsage:
+    def test_folds_cache_read_and_creation_into_prompt(self):
+        base = types.GenerateContentResponseUsageMetadata(
+            prompt_token_count=4, candidates_token_count=5, total_token_count=9
+        )
+        folded = fold_cache_usage(
+            base, Usage(input_tokens=4, output_tokens=5, cache_read_input_tokens=900, cache_creation_input_tokens=96)
+        )
+        assert folded.prompt_token_count == 1000
+        assert folded.cached_content_token_count == 900
+        assert folded.candidates_token_count == 5
+        assert folded.total_token_count == 1005
+
+    def test_uncached_usage_is_unchanged(self):
+        base = types.GenerateContentResponseUsageMetadata(
+            prompt_token_count=10, candidates_token_count=5, total_token_count=15
+        )
+        folded = fold_cache_usage(base, Usage(input_tokens=10, output_tokens=5))
+        assert folded.prompt_token_count == 10
+        assert folded.cached_content_token_count == 0
+        assert folded.total_token_count == 15

--- a/python/packages/kagent-adk/tests/unittests/models/test_anthropic.py
+++ b/python/packages/kagent-adk/tests/unittests/models/test_anthropic.py
@@ -1,5 +1,6 @@
 """Tests for KAgentAnthropicLlm."""
 
+import copy
 import json
 from unittest import mock
 
@@ -238,17 +239,17 @@ class TestMarkPromptCacheBreakpoints:
             {"system": "", "tools": [], "messages": []},
             {"messages": [{"role": "user", "content": ""}]},
         ):
-            before = {k: list(v) if isinstance(v, list) else v for k, v in kwargs.items()}
+            before = copy.deepcopy(kwargs)
             mark_prompt_cache_breakpoints(kwargs, self.CC)
             assert kwargs == before
 
     def test_does_not_mutate_caller_objects(self):
         kwargs = self._agent_loop_kwargs()
         tools, messages = kwargs["tools"], kwargs["messages"]
-        last_tool, last_message = dict(tools[-1]), dict(messages[-1])
+        before_tools, before_messages = copy.deepcopy(tools), copy.deepcopy(messages)
         mark_prompt_cache_breakpoints(kwargs, self.CC)
-        assert tools[-1] == last_tool
-        assert messages[-1] == last_message
+        assert tools == before_tools
+        assert messages == before_messages
 
 
 class TestPromptCachingRequests:


### PR DESCRIPTION
Backport of #2788 to `release/v0.10.x`. Refs #2787 (the feature request, with measurements) and #1866 (the earlier request whose Bedrock half shipped in #1940).

## Problem

A declarative agent re-sends its full history on every model call. With the Anthropic provider nothing is marked cacheable today: `promptCaching` exists only on `BedrockConfig`, and neither runtime sends `cache_control`, so the whole prefix (system prompt, tool definitions, previous turns) is billed at full input price on every call.

Measured on kagent 0.10.1 on an internal installation, through a gateway that logs `gen_ai.usage.*` per model call (162 calls over 24 h, three agents, `claude-sonnet-4-6` via the Anthropic provider): `cache_read.input_tokens` and `cache_creation.input_tokens` were 0 on every call. One incident-investigation session of a Python (`kagent-app`) agent made 119 model calls whose input grew from 4,423 to 190,809 tokens per call (average 93 k), i.e. roughly 11 M input tokens billed for one session, most of it the same prefix over and over; a Go (`golang-adk`) agent in the same window went 3.6 k → 93 k over 41 calls. Anthropic's prompt caching turns that repeat into cache reads at a fraction of the input price. Full numbers in #2787.

## Change

Same shape as #2788, on the `v1alpha2` API:

- `spec.anthropic.promptCaching` (bool, default `false`) and `spec.anthropic.cacheTTL` (`"5m"` | `"1h"`, default `"5m"`) on `ModelConfig`, with the same names, defaults and doc shape as the Bedrock fields; `adk_api_translator.go` wires them into `adk.Anthropic` (`prompt_caching`, `cache_ttl`). CRDs regenerated (`make controller-manifests`).
- When enabled, every Messages API request carries three `cache_control` breakpoints: the last tool definition, the last system prompt block, and the last content block of the latest conversation turn. Anthropic renders tools → system → messages and caches the prefix up to each breakpoint, so each call of an agent loop reads its whole previous history from the cache and writes only the new turn. Three of the four breakpoints Anthropic allows; the conversation breakpoint skips thinking blocks, which Anthropic refuses to cache.
- **Go runtime** (`go/adk/pkg/models/anthropic_adk.go`): request shaping extracted into `buildAnthropicParams`, `markAnthropicCacheBreakpoints` sets the markers, and usage maps `cache_read_input_tokens` to `CachedContentTokenCount` and folds cache read/creation tokens into `PromptTokenCount`, so the UI's usage view shows the effect. Streaming and non-streaming.
- **Python runtime** (`KAgentAnthropicLlm`): wraps the SDK client's `messages` resource with `PromptCachingMessages`, which marks the same three breakpoints before each `create` call — the one seam google-adk's `AnthropicLlm` hands its request through on both paths.
- **Difference from `main`:** this branch pins google-adk 1.x, which maps only `input_tokens` for Anthropic and drops the cache breakdown, whereas google-adk 2.x on `main` already folds it. Here the wrapper also records the raw response usage per request (a `ContextVar`, so concurrent requests on one model stay apart; for streaming it reads `message_start`) and `generate_content_async` folds it into google-adk's usage metadata the same way google-adk 2.x does (`fold_cache_usage`). With `promptCaching` off nothing changes.
- **Helm**: `providers.anthropic.config.promptCaching` / `cacheTTL` documented in `values.yaml`; the chart already renders `config` into the provider block.

The Claude-harness compiler change from #2788 does not apply here (no harness compilers on 0.10.x).

## Testing

- Go: `go vet` + `go test ./adk/... ./api/... ./core/internal/controller/translator/...` (new `anthropic_adk_test.go` — wire body carries exactly three markers at the expected positions for default/`5m`/`1h`, none when disabled, trailing-tool-result and no-tools/no-system cases, usage fold, and the SSE streaming + non-streaming paths through an `httptest` server; agent wiring and config deserialization; `Test_AdkApiTranslator_AnthropicPromptCaching`). golangci-lint: the full `make -C go lint` crashes locally inside staticcheck's `buildir` on this branch with my toolchain (unrelated to the change); the remaining linters report 0 issues on the changed packages, CI runs the full set.
- Python: `pytest packages/kagent-adk/tests/unittests` (443 passed) — new tests for `mark_prompt_cache_breakpoints`, the client wrapping, `fold_cache_usage`, and end-to-end through google-adk's request builder with the SDK client mocked, for both the non-streaming and the streaming path.
- Against the Anthropic API with the same runtime code on `main` (see #2788): after the first call ~99 % of every prompt is served from the cache and reported as cached tokens, in both runtimes.
- kind end-to-end on this branch (controller, `golang-adk` and `app` images built from this commit; chart installed with `providers.default=anthropic`, `providers.anthropic.config.promptCaching=true`, model `claude-sonnet-4-6`; the rendered `ModelConfig` was accepted with `promptCaching: true` / `cacheTTL: 5m`). Two declarative agents, `runtime: go` and `runtime: python`, with the built-in `kagent-tool-server` Kubernetes tools (~14 k tokens of tool definitions + system prompt), driven through the controller's A2A endpoint (`/api/a2a/kagent/<agent>`, `message/send` with one `contextId`) for three turns. Values are `prompt_token_count / cached_content_token_count` from the usage metadata the runtime attaches to the A2A response, i.e. what the UI shows:

  | runtime | turn 1, first model call | turn 1, call after the tool result | turn 2 | turn 3 |
  |---|---|---|---|---|
  | Go | 14260 / 0 (cache write) | 15665 / 14257 | 16269 / 15664 | 16337 / 16266 |
  | Python | 14321 / 0 (cache write) | 15481 / 14318 | 16237 / 15480 | 16305 / 16234 |

  Every model call after the first, including the tool-result follow-up inside the same turn, reads ~99.5 % of its prompt from the cache.
