### PR TITLE
fix(adk): only compact MCP App results that carry a render payload

### DIFF
--- a/go/adk/pkg/agent/mcp_apps.go
+++ b/go/adk/pkg/agent/mcp_apps.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	kagentmcp "github.com/kagent-dev/kagent/go/adk/pkg/mcp"
 	"google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/agent/llmagent"
 	adkmodel "google.golang.org/adk/v2/model"
@@ -61,6 +62,15 @@ func compactMCPAppModelResponse(response map[string]any) map[string]any {
 		// diagnose and recover; only drop the heavy structured payload.
 		result.StructuredContent = nil
 		return encodeCallToolResult(result, response)
+	}
+
+	// Only collapse when the result actually carries an MCP App render payload.
+	// A tool can be App-capable (declared `_meta.ui.resourceUri`) yet return an
+	// ordinary result for a given call — plain text with no `structuredContent`
+	// and no `_meta.ui`. Replacing that with the render notice would hide real
+	// content from the model, so pass it through unchanged.
+	if result.StructuredContent == nil && !kagentmcp.HasUIResource(result.Meta) {
+		return response
 	}
 
 	// On success, collapse the render payload into a terminal directive so the

--- a/go/adk/pkg/agent/mcp_apps_test.go
+++ b/go/adk/pkg/agent/mcp_apps_test.go
@@ -143,3 +143,48 @@ func TestMakeMCPAppModelResultCallbackLeavesNonAppToolsAlone(t *testing.T) {
 		t.Fatalf("non-app tool response modified: %#v", got)
 	}
 }
+
+func TestMakeMCPAppModelResultCallbackPassesThroughPlainResultFromAppTool(t *testing.T) {
+	t.Parallel()
+
+	// An App-capable tool ("jenkins_monitor_build" is in appToolNames) can still
+	// return an ordinary text-only result: no structuredContent and no _meta.ui.
+	// There is nothing to compact, so the text must reach the model unchanged.
+	const text = "No build found for job demo/1: it was deleted."
+	req := &adkmodel.LLMRequest{
+		Contents: []*genai.Content{{
+			Parts: []*genai.Part{{
+				FunctionResponse: &genai.FunctionResponse{
+					Name: "jenkins_monitor_build",
+				Response: map[string]any{
+					"content": []any{map[string]any{
+						"type": "text",
+						"text": text,
+					}},
+				},
+				},
+			}},
+		}},
+	}
+
+	callback := MakeMCPAppModelResultCallback(map[string]bool{"jenkins_monitor_build": true})
+	if _, err := callback(nil, req); err != nil {
+		t.Fatalf("callback returned error: %v", err)
+	}
+
+	got := req.Contents[0].Parts[0].FunctionResponse.Response
+	content, ok := got["content"].([]any)
+	if !ok || len(content) != 1 {
+		t.Fatalf("content unexpectedly rewritten: %#v", got["content"])
+	}
+	part, ok := content[0].(map[string]any)
+	if !ok {
+		t.Fatalf("content part unexpected type: %#v", content[0])
+	}
+	if part["text"] != text {
+		t.Fatalf("plain result text was not preserved: %#v", content[0])
+	}
+	if part["text"] == mcpAppRenderedNotice {
+		t.Fatalf("plain result was collapsed into the render notice")
+	}
+}

--- a/go/adk/pkg/mcp/mcp_ui.go
+++ b/go/adk/pkg/mcp/mcp_ui.go
@@ -141,6 +141,14 @@ func parseMCPUIMetadata(meta mcpsdk.Meta) mcpUIMetadata {
 	return ui
 }
 
+// HasUIResource reports whether an MCP result's metadata points at a UI resource
+// (`_meta.ui.resourceUri`). Callers use it to tell a result that actually carries
+// an MCP App render payload from one produced by an App-capable tool whose call
+// returned ordinary content.
+func HasUIResource(meta mcpsdk.Meta) bool {
+	return parseMCPUIMetadata(meta).ResourceURI != ""
+}
+
 // mcpToolKindOf classifies a tool from its MCP metadata. App-internal takes
 // precedence: a tool hidden from the model is never surfaced to the model even
 // if it also declares a UI resource.


### PR DESCRIPTION
### Summary

`MakeMCPAppModelResultCallback` replaced the result of every MCP App-capable tool with the canned render notice, even when an individual call returned an ordinary text-only result (no `structuredContent`, no `_meta.ui`). That hid real content from the model.

The callback now collapses a successful result only when the result itself carries a render payload — a non-nil `structuredContent` or a `_meta.ui.resourceUri` — and passes plain results through unchanged. This mirrors the Python-side fix in #2579 so Go and Python stop drifting on MCP App semantics.

### What changed

- `go/adk/pkg/mcp/mcp_ui.go`: add an exported `HasUIResource(meta)` helper that reuses the existing `parseMCPUIMetadata` as the single source of truth for `_meta.ui` parsing.
- `go/adk/pkg/agent/mcp_apps.go`: gate the success-path compaction on `result.StructuredContent == nil && !kagentmcp.HasUIResource(result.Meta)`; return the response unchanged when there is no render payload. The `isError` path keeps its existing behaviour.
- `go/adk/pkg/agent/mcp_apps_test.go`: add a regression test using the issue's repro — an app-declared tool returning only `content: [{type: text, text: "No build found for job demo/1: it was deleted."}]` must reach the model unchanged.

### Why not just branch on `IsError`

A tool declaring `_meta.ui.resourceUri` is *capable* of rendering an app; a given call may still return plain content (e.g. "not found"). Deciding from the tool name alone conflates capability with an actual render payload, which is what the regression covers.

### Verification

- `go test ./adk/pkg/agent/... -count=1` — pass (4 MCP App tests: 3 pre-existing + 1 new)
- `go test ./adk/pkg/mcp/... -count=1` — pass
- `go build ./...` — pass
- Mutation check: with the new guard disabled, `TestMakeMCPAppModelResultCallbackPassesThroughPlainResultFromAppTool` fails exactly as expected (the plain text is replaced by the render notice). Restored afterwards.

Fixes #2716
