### PR TITLE
fix: skip unchanged MCP tool writes to Postgres

### DIFF
--- a/go/core/internal/controller/reconciler/reconciler.go
+++ b/go/core/internal/controller/reconciler/reconciler.go
@@ -1181,6 +1181,7 @@ func (a *kagentReconciler) upsertToolServerForRemoteMCPServer(ctx context.Contex
 		return tools, nil
 	}
 
+	a.evictToolSnapshot(toolServer.Name, toolServer.GroupKind)
 	if _, err := a.dbClient.StoreToolServer(ctx, toolServer); err != nil {
 		return nil, fmt.Errorf("failed to store toolServer %s: %w", toolServer.Name, err)
 	}
@@ -1236,6 +1237,7 @@ func (a *kagentReconciler) ensureToolServerRow(ctx context.Context, ts *database
 	if a.toolSnapshotUnchanged(ts, nil) {
 		return
 	}
+	a.evictToolSnapshot(ts.Name, ts.GroupKind)
 	if _, err := a.dbClient.StoreToolServer(ctx, ts); err != nil {
 		reconcileLog.Error(err, "failed to store toolServer after discovery error", "toolServer", ts.Name)
 		return

--- a/go/core/internal/controller/reconciler/reconciler.go
+++ b/go/core/internal/controller/reconciler/reconciler.go
@@ -1206,14 +1206,20 @@ func mcpToolSnapshot(ts *database.ToolServer, tools []*v1alpha2.MCPTool) string 
 		}
 		return strings.Compare(a.Description, b.Description)
 	})
-	b, _ := json.Marshal([]any{ts.Description, sorted})
+	b, err := json.Marshal([]any{ts.Description, tools == nil, sorted})
+	if err != nil {
+		// Fail open: an unhashable payload must never read as "unchanged",
+		// which would skip the write for as long as the process lives.
+		return ""
+	}
 	sum := sha256.Sum256(b)
 	return hex.EncodeToString(sum[:])
 }
 
 func (a *kagentReconciler) toolSnapshotUnchanged(ts *database.ToolServer, tools []*v1alpha2.MCPTool) bool {
+	snapshot := mcpToolSnapshot(ts, tools)
 	prev, ok := a.toolSnapshots.Load(toolSnapshotKey(ts.Name, ts.GroupKind))
-	return ok && prev.(string) == mcpToolSnapshot(ts, tools)
+	return ok && snapshot != "" && prev.(string) == snapshot
 }
 
 func (a *kagentReconciler) rememberToolSnapshot(ts *database.ToolServer, tools []*v1alpha2.MCPTool) {
@@ -1227,7 +1233,7 @@ func (a *kagentReconciler) evictToolSnapshot(name, groupKind string) {
 // ensureToolServerRow writes the ToolServer once so a discovery failure still
 // shows up in DB-backed APIs. Later failures skip the write.
 func (a *kagentReconciler) ensureToolServerRow(ctx context.Context, ts *database.ToolServer) {
-	if _, ok := a.toolSnapshots.Load(toolSnapshotKey(ts.Name, ts.GroupKind)); ok {
+	if a.toolSnapshotUnchanged(ts, nil) {
 		return
 	}
 	if _, err := a.dbClient.StoreToolServer(ctx, ts); err != nil {

--- a/go/core/internal/controller/reconciler/reconciler.go
+++ b/go/core/internal/controller/reconciler/reconciler.go
@@ -6,12 +6,14 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"reflect"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
@@ -103,6 +105,10 @@ type kagentReconciler struct {
 	// uses s.Spec.URL verbatim. Mirrors the agent translator's config-phase
 	// egress rewrite.
 	mcpEgressPlaintext bool
+
+	// toolSnapshots caches the last persisted tool fingerprint per server so
+	// periodic discovery can skip unchanged Postgres writes.
+	toolSnapshots sync.Map
 }
 
 func NewKagentReconciler(
@@ -387,6 +393,7 @@ func (a *kagentReconciler) ReconcileKagentMCPService(ctx context.Context, req ct
 			if err := a.dbClient.DeleteToolsForServer(ctx, dbService.Name, dbService.GroupKind); err != nil {
 				reconcileLog.Error(err, "failed to delete tools for mcp service", "service", req.String())
 			}
+			a.evictToolSnapshot(dbService.Name, dbService.GroupKind)
 			return nil
 		}
 		return fmt.Errorf("failed to get service %s: %w", req.Name, err)
@@ -604,6 +611,7 @@ func (a *kagentReconciler) ReconcileKagentMCPServer(ctx context.Context, req ctr
 			if err := a.dbClient.DeleteToolsForServer(ctx, dbServer.Name, dbServer.GroupKind); err != nil {
 				reconcileLog.Error(err, "failed to delete tools for mcp server", "mcpServer", req.String())
 			}
+			a.evictToolSnapshot(dbServer.Name, dbServer.GroupKind)
 			return nil
 		}
 		return fmt.Errorf("failed to get mcp server %s: %w", req.Name, err)
@@ -654,6 +662,7 @@ func (a *kagentReconciler) ReconcileKagentRemoteMCPServer(ctx context.Context, r
 			if err := a.dbClient.DeleteToolsForServer(ctx, dbServer.Name, dbServer.GroupKind); err != nil {
 				l.Error(err, "failed to delete tools for remote mcp server")
 			}
+			a.evictToolSnapshot(dbServer.Name, dbServer.GroupKind)
 
 			return nil
 		}
@@ -1146,10 +1155,6 @@ func agentKind(agent v1alpha2.AgentObject) string {
 }
 
 func (a *kagentReconciler) upsertToolServerForRemoteMCPServer(ctx context.Context, toolServer *database.ToolServer, remoteMcpServer *v1alpha2.RemoteMCPServer) ([]*v1alpha2.MCPTool, error) {
-	if _, err := a.dbClient.StoreToolServer(ctx, toolServer); err != nil {
-		return nil, fmt.Errorf("failed to store toolServer %s: %w", toolServer.Name, err)
-	}
-
 	// Bound the entire registration sequence (header resolution + MCP connect +
 	// tool listing) to the effective per-resource timeout so that a hung or
 	// unreachable endpoint cannot block this goroutine — and therefore all
@@ -1167,12 +1172,51 @@ func (a *kagentReconciler) upsertToolServerForRemoteMCPServer(ctx context.Contex
 		return nil, fmt.Errorf("failed to fetch tools for toolServer %s: %w", toolServer.Name, err)
 	}
 
-	// Refresh tools in database - uses transaction for atomicity
+	// Skip the Postgres write when this process already persisted the same
+	// server + tool list. Polling still discovers federated catalog changes;
+	// idle DBs can drop connections and scale to zero.
+	if a.toolSnapshotUnchanged(toolServer, tools) {
+		return tools, nil
+	}
+
+	if _, err := a.dbClient.StoreToolServer(ctx, toolServer); err != nil {
+		return nil, fmt.Errorf("failed to store toolServer %s: %w", toolServer.Name, err)
+	}
+
 	if err := a.dbClient.RefreshToolsForServer(ctx, toolServer.Name, toolServer.GroupKind, tools...); err != nil {
 		return nil, fmt.Errorf("failed to refresh tools for toolServer %s: %w", toolServer.Name, err)
 	}
 
+	a.rememberToolSnapshot(toolServer, tools)
 	return tools, nil
+}
+
+func toolSnapshotKey(name, groupKind string) string {
+	return name + "\x00" + groupKind
+}
+
+// mcpToolSnapshot returns a hash of the tool server description and sorted tool list.
+func mcpToolSnapshot(ts *database.ToolServer, tools []*v1alpha2.MCPTool) string {
+	sorted := slices.Clone(tools)
+	slices.SortFunc(sorted, func(a, b *v1alpha2.MCPTool) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	b, _ := json.Marshal([]any{ts.Description, sorted})
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+func (a *kagentReconciler) toolSnapshotUnchanged(ts *database.ToolServer, tools []*v1alpha2.MCPTool) bool {
+	prev, ok := a.toolSnapshots.Load(toolSnapshotKey(ts.Name, ts.GroupKind))
+	return ok && prev.(string) == mcpToolSnapshot(ts, tools)
+}
+
+func (a *kagentReconciler) rememberToolSnapshot(ts *database.ToolServer, tools []*v1alpha2.MCPTool) {
+	a.toolSnapshots.Store(toolSnapshotKey(ts.Name, ts.GroupKind), mcpToolSnapshot(ts, tools))
+}
+
+func (a *kagentReconciler) evictToolSnapshot(name, groupKind string) {
+	a.toolSnapshots.Delete(toolSnapshotKey(name, groupKind))
 }
 
 func (a *kagentReconciler) isNamespaceWatched(namespace string) bool {

--- a/go/core/internal/controller/reconciler/reconciler.go
+++ b/go/core/internal/controller/reconciler/reconciler.go
@@ -1164,11 +1164,13 @@ func (a *kagentReconciler) upsertToolServerForRemoteMCPServer(ctx context.Contex
 
 	tsp, err := a.createMcpTransport(tCtx, remoteMcpServer)
 	if err != nil {
+		a.ensureToolServerRow(ctx, toolServer)
 		return nil, fmt.Errorf("failed to create client for toolServer %s: %w", toolServer.Name, err)
 	}
 
 	tools, err := a.listTools(tCtx, tsp, toolServer)
 	if err != nil {
+		a.ensureToolServerRow(ctx, toolServer)
 		return nil, fmt.Errorf("failed to fetch tools for toolServer %s: %w", toolServer.Name, err)
 	}
 
@@ -1199,7 +1201,10 @@ func toolSnapshotKey(name, groupKind string) string {
 func mcpToolSnapshot(ts *database.ToolServer, tools []*v1alpha2.MCPTool) string {
 	sorted := slices.Clone(tools)
 	slices.SortFunc(sorted, func(a, b *v1alpha2.MCPTool) int {
-		return strings.Compare(a.Name, b.Name)
+		if n := strings.Compare(a.Name, b.Name); n != 0 {
+			return n
+		}
+		return strings.Compare(a.Description, b.Description)
 	})
 	b, _ := json.Marshal([]any{ts.Description, sorted})
 	sum := sha256.Sum256(b)
@@ -1217,6 +1222,19 @@ func (a *kagentReconciler) rememberToolSnapshot(ts *database.ToolServer, tools [
 
 func (a *kagentReconciler) evictToolSnapshot(name, groupKind string) {
 	a.toolSnapshots.Delete(toolSnapshotKey(name, groupKind))
+}
+
+// ensureToolServerRow writes the ToolServer once so a discovery failure still
+// shows up in DB-backed APIs. Later failures skip the write.
+func (a *kagentReconciler) ensureToolServerRow(ctx context.Context, ts *database.ToolServer) {
+	if _, ok := a.toolSnapshots.Load(toolSnapshotKey(ts.Name, ts.GroupKind)); ok {
+		return
+	}
+	if _, err := a.dbClient.StoreToolServer(ctx, ts); err != nil {
+		reconcileLog.Error(err, "failed to store toolServer after discovery error", "toolServer", ts.Name)
+		return
+	}
+	a.rememberToolSnapshot(ts, nil)
 }
 
 func (a *kagentReconciler) isNamespaceWatched(namespace string) bool {

--- a/go/core/internal/controller/reconciler/reconciler_test.go
+++ b/go/core/internal/controller/reconciler/reconciler_test.go
@@ -1407,9 +1407,28 @@ func TestToolSnapshotCache_SkipUnchangedAndEvict(t *testing.T) {
 	assert.False(t, r.toolSnapshotUnchanged(ts, tools))
 }
 
-func TestEnsureToolServerRow_SkipsWhenCached(t *testing.T) {
+// A failed discovery stores a description-only snapshot. It must not collide
+// with a successful poll that returned zero tools, or the tool rows left over
+// from a previous process would never be cleared.
+func TestMcpToolSnapshot_UndiscoveredDiffersFromEmpty(t *testing.T) {
+	ts := &database.ToolServer{Description: "d"}
+	assert.NotEqual(t, mcpToolSnapshot(ts, nil), mcpToolSnapshot(ts, []*v1alpha2.MCPTool{}))
+}
+
+// ensureToolServerRow uses a nil-tools snapshot, so repeated failures stay
+// write-free but a description edit during an outage still reaches Postgres.
+// dbClient is nil here: reaching it would panic, which is the assertion.
+func TestEnsureToolServerRow_SkipsRepeatsButNotDescriptionChange(t *testing.T) {
 	r := &kagentReconciler{}
 	ts := &database.ToolServer{Name: "ns/s", GroupKind: "kagent.dev/RemoteMCPServer", Description: "d"}
+
 	r.rememberToolSnapshot(ts, nil)
 	r.ensureToolServerRow(context.Background(), ts)
+
+	edited := &database.ToolServer{Name: ts.Name, GroupKind: ts.GroupKind, Description: "edited"}
+	assert.False(t, r.toolSnapshotUnchanged(edited, nil))
+
+	// A successful poll cached tools, so a later failure is a state change.
+	r.rememberToolSnapshot(ts, []*v1alpha2.MCPTool{{Name: "t", Description: "td"}})
+	assert.False(t, r.toolSnapshotUnchanged(ts, nil))
 }

--- a/go/core/internal/controller/reconciler/reconciler_test.go
+++ b/go/core/internal/controller/reconciler/reconciler_test.go
@@ -8,8 +8,10 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"math/big"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -1431,4 +1433,75 @@ func TestEnsureToolServerRow_SkipsRepeatsButNotDescriptionChange(t *testing.T) {
 	// A successful poll cached tools, so a later failure is a state change.
 	r.rememberToolSnapshot(ts, []*v1alpha2.MCPTool{{Name: "t", Description: "td"}})
 	assert.False(t, r.toolSnapshotUnchanged(ts, nil))
+}
+
+func TestEnsureToolServerRow_EvictsSnapshotBeforeFailedStore(t *testing.T) {
+	ts := &database.ToolServer{Name: "ns/s", GroupKind: "kagent.dev/RemoteMCPServer", Description: "old"}
+	r := &kagentReconciler{dbClient: &toolSnapshotTestClient{storeErr: errors.New("injected store failure")}}
+	r.rememberToolSnapshot(ts, nil)
+
+	edited := &database.ToolServer{Name: ts.Name, GroupKind: ts.GroupKind, Description: "new"}
+	r.ensureToolServerRow(context.Background(), edited)
+
+	assert.False(t, r.toolSnapshotUnchanged(ts, nil))
+}
+
+func TestUpsertToolServer_EvictsSnapshotBeforeFailedWrite(t *testing.T) {
+	mcpServer := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1.0.0"}, nil)
+	httpServer := httptest.NewServer(mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
+		return mcpServer
+	}, nil))
+	t.Cleanup(httpServer.Close)
+
+	rms := &v1alpha2.RemoteMCPServer{Spec: v1alpha2.RemoteMCPServerSpec{URL: httpServer.URL}}
+	old := &database.ToolServer{Name: "ns/s", GroupKind: "kagent.dev/RemoteMCPServer", Description: "old"}
+	edited := &database.ToolServer{Name: old.Name, GroupKind: old.GroupKind, Description: "new"}
+	emptyTools := []*v1alpha2.MCPTool{}
+
+	for _, tt := range []struct {
+		name             string
+		storeErr         error
+		refreshErr       error
+		wantRefreshCalls int
+	}{
+		{name: "store failure", storeErr: errors.New("injected store failure"), wantRefreshCalls: 1},
+		{name: "refresh failure", refreshErr: errors.New("injected refresh failure"), wantRefreshCalls: 2},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			db := &toolSnapshotTestClient{storeErr: tt.storeErr, refreshErr: tt.refreshErr}
+			r := &kagentReconciler{dbClient: db}
+			r.rememberToolSnapshot(old, emptyTools)
+
+			_, err := r.upsertToolServerForRemoteMCPServer(context.Background(), edited, rms)
+			require.Error(t, err)
+			assert.False(t, r.toolSnapshotUnchanged(old, emptyTools))
+
+			// A rollback to the old snapshot must attempt persistence again.
+			db.storeErr = nil
+			db.refreshErr = nil
+			_, err = r.upsertToolServerForRemoteMCPServer(context.Background(), old, rms)
+			require.NoError(t, err)
+			assert.Equal(t, 2, db.storeCalls)
+			assert.Equal(t, tt.wantRefreshCalls, db.refreshCalls)
+			assert.True(t, r.toolSnapshotUnchanged(old, emptyTools))
+		})
+	}
+}
+
+type toolSnapshotTestClient struct {
+	database.Client
+	storeErr     error
+	refreshErr   error
+	storeCalls   int
+	refreshCalls int
+}
+
+func (c *toolSnapshotTestClient) StoreToolServer(_ context.Context, ts *database.ToolServer) (*database.ToolServer, error) {
+	c.storeCalls++
+	return ts, c.storeErr
+}
+
+func (c *toolSnapshotTestClient) RefreshToolsForServer(context.Context, string, string, ...*v1alpha2.MCPTool) error {
+	c.refreshCalls++
+	return c.refreshErr
 }

--- a/go/core/internal/controller/reconciler/reconciler_test.go
+++ b/go/core/internal/controller/reconciler/reconciler_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kagent-dev/kagent/go/api/database"
 	"github.com/kagent-dev/kagent/go/api/v1alpha2"
 	"github.com/kagent-dev/kagent/go/core/internal/utils"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -1372,4 +1373,32 @@ func generateTestCAPEM(t *testing.T) []byte {
 	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
 	require.NoError(t, err)
 	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+func TestMcpToolSnapshot_IgnoresOrder(t *testing.T) {
+	ts := &database.ToolServer{Description: "d"}
+	a := []*v1alpha2.MCPTool{{Name: "a", Description: "1"}, {Name: "b", Description: "2"}}
+	b := []*v1alpha2.MCPTool{{Name: "b", Description: "2"}, {Name: "a", Description: "1"}}
+	assert.Equal(t, mcpToolSnapshot(ts, a), mcpToolSnapshot(ts, b))
+}
+
+func TestMcpToolSnapshot_ChangesOnToolOrDescription(t *testing.T) {
+	tools := []*v1alpha2.MCPTool{{Name: "t", Description: "td"}}
+	base := mcpToolSnapshot(&database.ToolServer{Description: "d"}, tools)
+	assert.NotEqual(t, base, mcpToolSnapshot(&database.ToolServer{Description: "other"}, tools))
+	assert.NotEqual(t, base, mcpToolSnapshot(&database.ToolServer{Description: "d"}, []*v1alpha2.MCPTool{{Name: "t", Description: "changed"}}))
+	assert.NotEqual(t, base, mcpToolSnapshot(&database.ToolServer{Description: "d"}, []*v1alpha2.MCPTool{{Name: "t", Description: "td"}, {Name: "u", Description: "ud"}}))
+}
+
+func TestToolSnapshotCache_SkipUnchangedAndEvict(t *testing.T) {
+	r := &kagentReconciler{}
+	ts := &database.ToolServer{Name: "ns/s", GroupKind: "kagent.dev/RemoteMCPServer", Description: "d"}
+	tools := []*v1alpha2.MCPTool{{Name: "t", Description: "td"}}
+
+	assert.False(t, r.toolSnapshotUnchanged(ts, tools))
+	r.rememberToolSnapshot(ts, tools)
+	assert.True(t, r.toolSnapshotUnchanged(ts, tools))
+	assert.False(t, r.toolSnapshotUnchanged(ts, []*v1alpha2.MCPTool{{Name: "other", Description: "td"}}))
+	r.evictToolSnapshot(ts.Name, ts.GroupKind)
+	assert.False(t, r.toolSnapshotUnchanged(ts, tools))
 }

--- a/go/core/internal/controller/reconciler/reconciler_test.go
+++ b/go/core/internal/controller/reconciler/reconciler_test.go
@@ -1380,6 +1380,10 @@ func TestMcpToolSnapshot_IgnoresOrder(t *testing.T) {
 	a := []*v1alpha2.MCPTool{{Name: "a", Description: "1"}, {Name: "b", Description: "2"}}
 	b := []*v1alpha2.MCPTool{{Name: "b", Description: "2"}, {Name: "a", Description: "1"}}
 	assert.Equal(t, mcpToolSnapshot(ts, a), mcpToolSnapshot(ts, b))
+
+	dupA := []*v1alpha2.MCPTool{{Name: "t", Description: "z"}, {Name: "t", Description: "a"}}
+	dupB := []*v1alpha2.MCPTool{{Name: "t", Description: "a"}, {Name: "t", Description: "z"}}
+	assert.Equal(t, mcpToolSnapshot(ts, dupA), mcpToolSnapshot(ts, dupB))
 }
 
 func TestMcpToolSnapshot_ChangesOnToolOrDescription(t *testing.T) {
@@ -1401,4 +1405,11 @@ func TestToolSnapshotCache_SkipUnchangedAndEvict(t *testing.T) {
 	assert.False(t, r.toolSnapshotUnchanged(ts, []*v1alpha2.MCPTool{{Name: "other", Description: "td"}}))
 	r.evictToolSnapshot(ts.Name, ts.GroupKind)
 	assert.False(t, r.toolSnapshotUnchanged(ts, tools))
+}
+
+func TestEnsureToolServerRow_SkipsWhenCached(t *testing.T) {
+	r := &kagentReconciler{}
+	ts := &database.ToolServer{Name: "ns/s", GroupKind: "kagent.dev/RemoteMCPServer", Description: "d"}
+	r.rememberToolSnapshot(ts, nil)
+	r.ensureToolServerRow(context.Background(), ts)
 }


### PR DESCRIPTION
## Summary

- Cache the last persisted MCP tool list "snapshot" in the reconciler and skip `StoreToolServer` / `RefreshToolsForServer` when nothing changed.
- Controllers still poll on the existing refresh interval (which is still configurable through #2480), but idle Postgres is no longer written every cycle.

## Test plan

- [x] Unit tests for snapshot equality, description/tool changes, and cache evict
- [x] On a cluster: confirm periodic `successfully registered remote MCP server` logs, and that `tool` / `toolserver.updated_at` and `n_tup_upd` stay at the first write