### PR TITLE
fix(helm): use kagent-tools namespace in URL

### DIFF
--- a/helm/kagent/templates/toolserver-kagent.yaml
+++ b/helm/kagent/templates/toolserver-kagent.yaml
@@ -1,5 +1,6 @@
 {{- if index .Values "kagent-tools" "enabled" }}
 {{- $toolsValues := index .Values "kagent-tools" }}
+{{- $toolsNamespace := default .Release.Namespace $toolsValues.namespaceOverride }}
 {{- $toolsFullname := "" }}
 {{- if $toolsValues.fullnameOverride }}
   {{- $toolsFullname = $toolsValues.fullnameOverride }}
@@ -16,7 +17,7 @@ metadata:
   labels:
     {{- include "kagent.labels" . | nindent 4 }}
 spec:
-  url: "http://{{ $toolsFullname }}.{{ include "kagent.namespace" . }}:8084/mcp"
+  url: "http://{{ $toolsFullname }}.{{ $toolsNamespace }}:8084/mcp"
   timeout: 30s
   sseReadTimeout: 5m0s
   description: "Official KAgent tool server"

--- a/helm/kagent/tests/toolserver_test.yaml
+++ b/helm/kagent/tests/toolserver_test.yaml
@@ -30,13 +30,24 @@ tests:
           path: spec.url
           value: http://RELEASE-NAME-tools.NAMESPACE:8084/mcp
 
-  - it: should use custom namespace when overridden
+  - it: should keep the tool URL in the release namespace when the parent namespace is overridden
     set:
       namespaceOverride: "custom-namespace"
     asserts:
       - equal:
           path: metadata.namespace
           value: custom-namespace
+      - equal:
+          path: spec.url
+          value: http://RELEASE-NAME-tools.NAMESPACE:8084/mcp
+
+  - it: should use the kagent-tools namespace in the tool URL when overridden
+    set:
+      kagent-tools.namespaceOverride: "tools-namespace"
+    asserts:
+      - equal:
+          path: spec.url
+          value: http://RELEASE-NAME-tools.tools-namespace:8084/mcp
 
   - it: should use custom fullname when overridden
     set:


### PR DESCRIPTION
Fixes #2719

Uses kagent-tools.namespaceOverride, falling back to the release namespace, when building the bundled tool server URL. This keeps the RemoteMCPServer URL aligned with the namespace where the kagent-tools Service is deployed.

Adds Helm unit tests for parent and subchart namespace overrides. All Helm tests pass.