### PR TITLE
feat(substrate): render BYO extraContainers in the SandboxAgent ActorTemplate

### DIFF
--- a/go/core/pkg/sandboxbackend/substrate/agent_lifecycle.go
+++ b/go/core/pkg/sandboxbackend/substrate/agent_lifecycle.go
@@ -13,6 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -64,10 +65,11 @@ func (p *Lifecycle) buildSandboxAgentActorTemplate(
 	wpKey types.NamespacedName,
 	podTemplate corev1.PodTemplateSpec,
 ) (*atev1alpha1.ActorTemplate, error) {
-	kagentContainer := findKagentContainer(podTemplate.Spec.Containers)
-	if kagentContainer == nil {
+	kagentIdx := findKagentContainerIndex(podTemplate.Spec.Containers)
+	if kagentIdx < 0 {
 		return nil, fmt.Errorf("pod template is missing the kagent container")
 	}
+	kagentContainer := &podTemplate.Spec.Containers[kagentIdx]
 	image, err := pinImageRef(kagentContainer.Image)
 	if err != nil {
 		return nil, err
@@ -77,11 +79,19 @@ func (p *Lifecycle) buildSandboxAgentActorTemplate(
 	if err != nil {
 		return nil, err
 	}
+	// Extra containers (byo.deployment.extraContainers / declarative deployment.extraContainers)
+	// run alongside the agent in the same gVisor sandbox — shared loopback, separate rootfs — so
+	// sidecars keep working on substrate. They are appended AFTER the agent container:
+	// applyDurableDirSessionStore mounts /data on Containers[0], which must stay the agent.
+	extraContainers, err := buildSubstrateExtraContainers(podTemplate.Spec.Containers, kagentIdx)
+	if err != nil {
+		return nil, err
+	}
 
 	spec := atev1alpha1.ActorTemplateSpec{
 		PauseImage:   p.Defaults.PauseImage,
 		SandboxClass: atev1alpha1.SandboxClassGvisor,
-		Containers: []atev1alpha1.Container{{
+		Containers: append([]atev1alpha1.Container{{
 			Name:    defaultKagentContainer,
 			Image:   image,
 			Command: command,
@@ -98,7 +108,7 @@ func (p *Lifecycle) buildSandboxAgentActorTemplate(
 					Port: substrateKagentListenPort,
 				},
 			},
-		}},
+		}}, extraContainers...),
 		WorkerSelector: workerSelectorForPool(wpKey),
 		SnapshotsConfig: atev1alpha1.SnapshotsConfig{
 			Location: sandboxAgentSnapshotsLocation(sa),
@@ -176,16 +186,122 @@ func applyDurableDirSessionStore(spec *atev1alpha1.ActorTemplateSpec) {
 	spec.SnapshotsConfig.OnCommit = atev1alpha1.SnapshotScopeData
 }
 
-func findKagentContainer(containers []corev1.Container) *corev1.Container {
+// findKagentContainerIndex returns the index of the agent's main container: the one named
+// "kagent", falling back to the first container when none carries the reserved name (mirrors
+// the old findKagentContainer pointer semantics).
+func findKagentContainerIndex(containers []corev1.Container) int {
 	for i := range containers {
 		if containers[i].Name == defaultKagentContainer {
-			return &containers[i]
+			return i
 		}
 	}
 	if len(containers) > 0 {
-		return &containers[0]
+		return 0
 	}
-	return nil
+	return -1
+}
+
+// maxActorTemplateContainers mirrors the ActorTemplate CRD's spec.containers MaxItems=10.
+const maxActorTemplateContainers = 10
+
+// buildSubstrateExtraContainers converts the pod template's non-kagent containers (BYO
+// byo.deployment.extraContainers, or a declarative agent's deployment.extraContainers) into
+// ActorTemplate containers, so sidecars keep running alongside the agent inside the same
+// gVisor sandbox: shared loopback network, separate rootfs and mount namespaces.
+//
+// The ActorTemplate container contract is a strict subset of the Kubernetes one:
+//   - the command must be fully explicit (verbatim OCI Process.Args, no image-entrypoint
+//     fallback — the same rule ValidateSubstrateSandboxAgentSpec enforces for the BYO cmd);
+//   - the image must be digest-pinned (pinImageRef);
+//   - env supports literals and secretKeyRef only; envFrom, configMapKeyRef and any other
+//     valueFrom are dropped (sanitizeActorTemplateEnvVar);
+//   - an HTTP readiness probe maps to Readyz so actor readiness keeps gating on the sidecar;
+//     TCP/exec probes and lifecycle hooks have no substrate equivalent and are ignored.
+//
+// Volumes are NOT mapped: ActorTemplate volumes only support durableDir (one per template,
+// already consumed by the agent's /data session store), so secret/configMap/emptyDir mounts
+// would silently misconfigure a sidecar — an extra container carrying volumeMounts is
+// rejected instead.
+func buildSubstrateExtraContainers(containers []corev1.Container, kagentIdx int) ([]atev1alpha1.Container, error) {
+	var out []atev1alpha1.Container
+	for i := range containers {
+		if i == kagentIdx {
+			continue
+		}
+		c := &containers[i]
+		if c.Name == "" {
+			return nil, fmt.Errorf("extra container %d has no name", i)
+		}
+		if len(c.VolumeMounts) > 0 {
+			return nil, fmt.Errorf("extra container %q mounts volumes, which substrate ActorTemplates do not support (durableDir is reserved for the agent's /data session store)", c.Name)
+		}
+		image, err := pinImageRef(c.Image)
+		if err != nil {
+			return nil, fmt.Errorf("extra container %q: %w", c.Name, err)
+		}
+		if len(c.Command) == 0 {
+			return nil, fmt.Errorf("extra container %q on substrate must set command (substrate does not fall back to the image entrypoint)", c.Name)
+		}
+		ec := atev1alpha1.Container{
+			Name:    c.Name,
+			Image:   image,
+			Command: append(append([]string{}, c.Command...), c.Args...),
+			Env:     actorTemplateEnvFromPodEnv(c.Env),
+		}
+		if get := probeHTTPGet(c.ReadinessProbe); get != nil {
+			readyz, err := substrateReadyzFromProbe(c, get)
+			if err != nil {
+				return nil, fmt.Errorf("extra container %q: %w", c.Name, err)
+			}
+			ec.Readyz = readyz
+		}
+		out = append(out, ec)
+	}
+	if 1+len(out) > maxActorTemplateContainers {
+		return nil, fmt.Errorf("substrate ActorTemplates support at most %d containers (the agent plus %d extra)", maxActorTemplateContainers, maxActorTemplateContainers-1)
+	}
+	return out, nil
+}
+
+// probeHTTPGet returns the HTTP handler of a Kubernetes readiness probe, or nil when the
+// probe is absent or is a TCP/exec probe (which have no substrate equivalent).
+func probeHTTPGet(p *corev1.Probe) *corev1.HTTPGetAction {
+	if p == nil {
+		return nil
+	}
+	return p.HTTPGet
+}
+
+// substrateReadyzFromProbe maps an HTTP readiness probe onto an ActorTemplate ContainerReadyz.
+// ActorTemplate probe ports are plain integers: a named port must resolve against the extra
+// container's own containerPorts (the translator only registers the agent container's "http"
+// port). An empty path takes the substrate default, /readyz.
+func substrateReadyzFromProbe(c *corev1.Container, get *corev1.HTTPGetAction) (*atev1alpha1.ContainerReadyz, error) {
+	var port int32
+	switch get.Port.Type {
+	case intstr.Int:
+		port = get.Port.IntVal
+	case intstr.String:
+		for i := range c.Ports {
+			if c.Ports[i].Name == get.Port.StrVal {
+				port = c.Ports[i].ContainerPort
+				break
+			}
+		}
+		if port == 0 {
+			return nil, fmt.Errorf("readiness probe names port %q which the container does not declare", get.Port.StrVal)
+		}
+	}
+	if port < 1 || port > 65535 {
+		return nil, fmt.Errorf("readiness probe port %q is not a valid port", get.Port.String())
+	}
+	path := get.Path
+	if path == "" {
+		path = "/readyz"
+	}
+	return &atev1alpha1.ContainerReadyz{
+		HTTPGet: &atev1alpha1.HTTPGetAction{Path: path, Port: port},
+	}, nil
 }
 
 // buildSubstrateKagentContainerCommand returns the ActorTemplate command and the prepended

--- a/go/core/pkg/sandboxbackend/substrate/agent_lifecycle.go
+++ b/go/core/pkg/sandboxbackend/substrate/agent_lifecycle.go
@@ -106,6 +106,11 @@ func (p *Lifecycle) buildSandboxAgentActorTemplate(
 			OnCommit: atev1alpha1.SnapshotScopeFull,
 		},
 	}
+	extraContainers, err := actorTemplateExtraContainers(podTemplate.Spec.Containers, kagentContainer)
+	if err != nil {
+		return nil, err
+	}
+	spec.Containers = append(spec.Containers, extraContainers...)
 	applyDurableDirSessionStore(&spec)
 
 	actorTemplateHash, err := actorTemplateShapeHash(spec)
@@ -186,6 +191,56 @@ func findKagentContainer(containers []corev1.Container) *corev1.Container {
 		return &containers[0]
 	}
 	return nil
+}
+
+// actorTemplateExtraContainers converts the pod template's extra containers —
+// every container except the agent's own, which buildSandboxAgentActorTemplate
+// renders explicitly — into ActorTemplate containers, preserving order. The
+// agent pointer must come from findKagentContainer on the same slice, so it
+// can be identified by identity.
+//
+// An ActorTemplate container is a restricted pod container: the image must be
+// digest-pinned (snapshots key on it), the command is copied verbatim into the
+// OCI Process.Args with no shell and no image-entrypoint fallback, env supports
+// literal values and secretKeyRef only, and there are no ports, resources,
+// envFrom, probes, or volume sources. Constructs the ActorTemplate cannot
+// express fail the build loudly instead of being silently dropped — a sidecar
+// whose credential source or mount vanished mid-flight is worse than a
+// rejected apply.
+func actorTemplateExtraContainers(containers []corev1.Container, agent *corev1.Container) ([]atev1alpha1.Container, error) {
+	var out []atev1alpha1.Container
+	for i := range containers {
+		c := &containers[i]
+		if c == agent {
+			continue
+		}
+		image, err := pinImageRef(c.Image)
+		if err != nil {
+			return nil, fmt.Errorf("extra container %q: %w", c.Name, err)
+		}
+		command := append(append([]string{}, c.Command...), c.Args...)
+		if len(command) == 0 {
+			return nil, fmt.Errorf("extra container %q must set command and/or args: substrate runs the command verbatim with no image entrypoint fallback", c.Name)
+		}
+		if len(c.EnvFrom) > 0 {
+			return nil, fmt.Errorf("extra container %q uses envFrom, which ActorTemplates do not support", c.Name)
+		}
+		for _, e := range c.Env {
+			if e.Value == "" && e.ValueFrom != nil && e.ValueFrom.SecretKeyRef == nil {
+				return nil, fmt.Errorf("extra container %q env %q: ActorTemplates support literal values and secretKeyRef only", c.Name, e.Name)
+			}
+		}
+		if len(c.VolumeMounts) > 0 {
+			return nil, fmt.Errorf("extra container %q mounts volumes, which ActorTemplates do not support (the only mount is the agent's durableDir session store)", c.Name)
+		}
+		out = append(out, atev1alpha1.Container{
+			Name:    c.Name,
+			Image:   image,
+			Command: command,
+			Env:     actorTemplateEnvFromPodEnv(c.Env),
+		})
+	}
+	return out, nil
 }
 
 // buildSubstrateKagentContainerCommand returns the ActorTemplate command and the prepended

--- a/go/core/pkg/sandboxbackend/substrate/agent_lifecycle_test.go
+++ b/go/core/pkg/sandboxbackend/substrate/agent_lifecycle_test.go
@@ -1,6 +1,8 @@
 package substrate
 
 import (
+	"fmt"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"testing"
 
 	atev1alpha1 "github.com/agent-substrate/substrate/pkg/api/v1alpha1"
@@ -325,4 +327,139 @@ func TestBuildSandboxAgentActorTemplateDurableDirSessions(t *testing.T) {
 			require.Equal(t, atev1alpha1.SnapshotScopeFull, tmpl.Spec.SnapshotsConfig.OnPause)
 		})
 	}
+}
+
+// byoSandboxAgentWithSidecar builds a BYO SandboxAgent whose translated pod template carries a
+// credential-brokering sidecar next to the kagent container, the shape byo.deployment
+// .extraContainers produces.
+func byoSandboxAgentWithSidecar(extra corev1.Container) (*v1alpha2.SandboxAgent, corev1.PodTemplateSpec) {
+	const pinnedImage = "registry.example/kagent-dev/kagent/app@sha256:1111111111111111111111111111111111111111111111111111111111111111111"
+	cmd := "/serve"
+	sa := &v1alpha2.SandboxAgent{
+		ObjectMeta: metav1.ObjectMeta{Name: "byo-sidecar", Namespace: "kagent"},
+		Spec: v1alpha2.SandboxAgentSpec{
+			AgentSpec: v1alpha2.AgentSpec{Type: v1alpha2.AgentType_BYO, BYO: &v1alpha2.BYOAgentSpec{
+				Deployment: &v1alpha2.ByoDeploymentSpec{Image: pinnedImage, Cmd: &cmd},
+			}},
+		},
+	}
+	podTemplate := corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: []corev1.Container{
+		{Name: defaultKagentContainer, Image: pinnedImage, Command: []string{"/serve"}, Env: []corev1.EnvVar{{Name: "ADDR", Value: "0.0.0.0:80"}}},
+		extra,
+	}}}
+	return sa, podTemplate
+}
+
+func TestBuildSandboxAgentActorTemplateExtraContainers(t *testing.T) {
+	t.Parallel()
+	const sidecarImage = "registry.example/videoamp/central@sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	wpKey := types.NamespacedName{Namespace: "kagent", Name: "kagent-default"}
+
+	sidecar := corev1.Container{
+		Name:    "agent-vault",
+		Image:   sidecarImage,
+		Command: []string{"/sidecar"},
+		Env: []corev1.EnvVar{
+			{Name: "AGENT_VAULT_LISTEN_ADDR", Value: "127.0.0.1:14322"},
+			{Name: "AGENT_VAULT_SECRET_ANTHROPIC_AUTH_TOKEN", ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "vault-secrets"}, Key: "anthropic-token"},
+			}},
+			{Name: "DROPPED_CONFIGMAP", ValueFrom: &corev1.EnvVarSource{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "cm"}, Key: "k"},
+			}},
+		},
+		ReadinessProbe: &corev1.Probe{ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/readyz", Port: intstr.FromInt32(8080)}}},
+	}
+
+	t.Run("renders alongside the agent", func(t *testing.T) {
+		t.Parallel()
+		p := newTestLifecycle(t)
+		sa, podTemplate := byoSandboxAgentWithSidecar(sidecar)
+		tmpl, err := p.buildSandboxAgentActorTemplate(sa, wpKey, podTemplate)
+		require.NoError(t, err)
+		require.Len(t, tmpl.Spec.Containers, 2)
+
+		agent := tmpl.Spec.Containers[0]
+		require.Equal(t, defaultKagentContainer, agent.Name, "the agent stays container 0: /data is mounted there")
+		require.Equal(t, durableDataMount, agent.VolumeMounts[0].MountPath)
+		require.Equal(t, "/.well-known/agent-card.json", agent.Readyz.HTTPGet.Path)
+
+		sc := tmpl.Spec.Containers[1]
+		require.Equal(t, "agent-vault", sc.Name)
+		require.Equal(t, sidecarImage, sc.Image, "extra images must stay digest-pinned")
+		require.Equal(t, []string{"/sidecar"}, sc.Command)
+		require.NotNil(t, sc.Readyz, "an HTTP readiness probe maps to readyz so actor readiness gates on the sidecar")
+		require.Equal(t, "/readyz", sc.Readyz.HTTPGet.Path)
+		require.Equal(t, int32(8080), sc.Readyz.HTTPGet.Port)
+		names := actorEnvNames(sc.Env)
+		require.True(t, names["AGENT_VAULT_LISTEN_ADDR"])
+		require.True(t, names["AGENT_VAULT_SECRET_ANTHROPIC_AUTH_TOKEN"], "secretKeyRef env survives (substrate resolves it server-side)")
+		require.False(t, names["DROPPED_CONFIGMAP"], "configMapKeyRef is not expressible in an ActorTemplate and is dropped")
+		require.Empty(t, sc.VolumeMounts, "extra containers get no volume mounts: durableDir belongs to the agent's /data")
+
+		// The sidecar changes the shape hash, so it fans out blue-green like any spec change.
+		p2 := newTestLifecycle(t)
+		sa2, bare := byoSandboxAgentWithSidecar(corev1.Container{})
+		bare.Spec.Containers = bare.Spec.Containers[:1]
+		tmpl2, err := p2.buildSandboxAgentActorTemplate(sa2, wpKey, bare)
+		require.NoError(t, err)
+		require.NotEqual(t, tmpl.Name, tmpl2.Name, "extra containers must change the ActorTemplate name (shape hash)")
+	})
+
+	t.Run("named readiness port resolves against the container ports", func(t *testing.T) {
+		t.Parallel()
+		p := newTestLifecycle(t)
+		named := sidecar
+		named.Ports = []corev1.ContainerPort{{Name: "health", ContainerPort: 8081}}
+		named.ReadinessProbe.HTTPGet.Port = intstr.FromString("health")
+		sa, podTemplate := byoSandboxAgentWithSidecar(named)
+		tmpl, err := p.buildSandboxAgentActorTemplate(sa, wpKey, podTemplate)
+		require.NoError(t, err)
+		require.Equal(t, int32(8081), tmpl.Spec.Containers[1].Readyz.HTTPGet.Port)
+	})
+
+	for _, tc := range []struct {
+		name  string
+		extra corev1.Container
+	}{
+		{
+			name:  "unpinned image is rejected",
+			extra: corev1.Container{Name: "agent-vault", Image: "registry.example/videoamp/central:latest", Command: []string{"/sidecar"}},
+		},
+		{
+			name:  "missing command is rejected",
+			extra: corev1.Container{Name: "agent-vault", Image: sidecarImage},
+		},
+		{
+			name: "volume mounts are rejected",
+			extra: corev1.Container{Name: "agent-vault", Image: sidecarImage, Command: []string{"/sidecar"},
+				VolumeMounts: []corev1.VolumeMount{{Name: "secrets", MountPath: "/etc/agent-vault/secrets"}}},
+		},
+		{
+			name: "unresolvable named readiness port is rejected",
+			extra: corev1.Container{Name: "agent-vault", Image: sidecarImage, Command: []string{"/sidecar"},
+				ReadinessProbe: &corev1.Probe{ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Port: intstr.FromString("nope")}}}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			p := newTestLifecycle(t)
+			sa, podTemplate := byoSandboxAgentWithSidecar(tc.extra)
+			_, err := p.buildSandboxAgentActorTemplate(sa, wpKey, podTemplate)
+			require.Error(t, err)
+		})
+	}
+
+	t.Run("more than 10 containers is rejected", func(t *testing.T) {
+		t.Parallel()
+		p := newTestLifecycle(t)
+		sa, podTemplate := byoSandboxAgentWithSidecar(sidecar)
+		for i := 0; i < maxActorTemplateContainers; i++ {
+			podTemplate.Spec.Containers = append(podTemplate.Spec.Containers, corev1.Container{
+				Name: fmt.Sprintf("extra-%d", i), Image: sidecarImage, Command: []string{"/bin/true"},
+			})
+		}
+		_, err := p.buildSandboxAgentActorTemplate(sa, wpKey, podTemplate)
+		require.Error(t, err)
+	})
 }

--- a/go/core/pkg/sandboxbackend/substrate/agent_lifecycle_test.go
+++ b/go/core/pkg/sandboxbackend/substrate/agent_lifecycle_test.go
@@ -326,3 +326,118 @@ func TestBuildSandboxAgentActorTemplateDurableDirSessions(t *testing.T) {
 		})
 	}
 }
+
+// TestBuildSandboxAgentActorTemplateExtraContainers covers the BYO extraContainers
+// translation: the pod template's non-agent containers ride along as ActorTemplate
+// containers (credential-brokering sidecars etc.), with the ActorTemplate's
+// restricted container surface enforced loudly instead of silently dropped.
+func TestBuildSandboxAgentActorTemplateExtraContainers(t *testing.T) {
+	t.Parallel()
+
+	const (
+		pinnedImage  = "registry.example/kagent-dev/kagent/app@sha256:1111111111111111111111111111111111111111111111111111111111111111"
+		sidecarImage = "registry.example/example/credential-proxy@sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	)
+	cmd := "/serve"
+	wpKey := types.NamespacedName{Namespace: "kagent", Name: "kagent-default"}
+	sa := &v1alpha2.SandboxAgent{
+		ObjectMeta: metav1.ObjectMeta{Name: "byo-agent", Namespace: "kagent"},
+		Spec: v1alpha2.SandboxAgentSpec{
+			AgentSpec: v1alpha2.AgentSpec{Type: v1alpha2.AgentType_BYO, BYO: &v1alpha2.BYOAgentSpec{Deployment: &v1alpha2.ByoDeploymentSpec{Image: pinnedImage, Cmd: &cmd}}},
+		},
+	}
+	sidecar := corev1.Container{
+		Name:    "credential-proxy",
+		Image:   sidecarImage,
+		Command: []string{"/sidecar"},
+		Args:    []string{"--listen", "127.0.0.1:14322"},
+		Env: []corev1.EnvVar{
+			{Name: "PROXY_LISTEN_ADDR", Value: "127.0.0.1:14322"},
+			{
+				Name: "PROXY_SECRET_TOKEN",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "creds"},
+						Key:                  "token",
+					},
+				},
+			},
+		},
+	}
+	agent := corev1.Container{Name: defaultKagentContainer, Image: pinnedImage, Command: []string{"/serve"}}
+	podTemplate := corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: []corev1.Container{agent, sidecar}}}
+
+	t.Run("converted", func(t *testing.T) {
+		p := newTestLifecycle(t)
+		tmpl, err := p.buildSandboxAgentActorTemplate(sa, wpKey, podTemplate)
+		require.NoError(t, err)
+		require.Len(t, tmpl.Spec.Containers, 2)
+
+		// The agent container stays first: applyDurableDirSessionStore targets it.
+		require.Equal(t, defaultKagentContainer, tmpl.Spec.Containers[0].Name)
+		require.Equal(t, durableDataVolume, tmpl.Spec.Containers[0].VolumeMounts[0].Name)
+
+		extra := tmpl.Spec.Containers[1]
+		require.Equal(t, "credential-proxy", extra.Name)
+		require.Equal(t, sidecarImage, extra.Image)
+		require.Equal(t, []string{"/sidecar", "--listen", "127.0.0.1:14322"}, extra.Command)
+		require.Len(t, extra.Env, 2)
+		require.Equal(t, "PROXY_LISTEN_ADDR", extra.Env[0].Name)
+		require.NotNil(t, extra.Env[0].Value)
+		require.Equal(t, "PROXY_SECRET_TOKEN", extra.Env[1].Name)
+		require.NotNil(t, extra.Env[1].ValueFrom.SecretKeyRef)
+		require.Equal(t, "creds", extra.Env[1].ValueFrom.SecretKeyRef.Name)
+		require.Empty(t, extra.VolumeMounts, "the durableDir session store is the agent container's alone")
+	})
+
+	for _, tc := range []struct {
+		name    string
+		mutate  func(*corev1.Container)
+		errText string
+	}{
+		{
+			name:    "unpinned image",
+			mutate:  func(c *corev1.Container) { c.Image = "registry.example/example/credential-proxy:latest" },
+			errText: "must be pinned",
+		},
+		{
+			name:    "no command and no args",
+			mutate:  func(c *corev1.Container) { c.Command, c.Args = nil, nil },
+			errText: "no image entrypoint fallback",
+		},
+		{
+			name: "envFrom",
+			mutate: func(c *corev1.Container) {
+				c.EnvFrom = []corev1.EnvFromSource{{SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "creds"}}}}
+			},
+			errText: "envFrom",
+		},
+		{
+			name: "fieldRef env",
+			mutate: func(c *corev1.Container) {
+				c.Env = append(c.Env, corev1.EnvVar{
+					Name:      "POD_NAME",
+					ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"}},
+				})
+			},
+			errText: "secretKeyRef only",
+		},
+		{
+			name: "volumeMounts",
+			mutate: func(c *corev1.Container) {
+				c.VolumeMounts = []corev1.VolumeMount{{Name: "config", MountPath: "/config"}}
+			},
+			errText: "mounts volumes",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bad := sidecar
+			tc.mutate(&bad)
+			pod := corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: []corev1.Container{agent, bad}}}
+			p := newTestLifecycle(t)
+			_, err := p.buildSandboxAgentActorTemplate(sa, wpKey, pod)
+			require.Error(t, err)
+			require.ErrorContains(t, err, tc.errText)
+		})
+	}
+}


### PR DESCRIPTION
Supersedes #2691 and #2750 — this is the same change, combined into one PR so it can be reviewed and landed as a unit. Both earlier PRs are closed in favor of this one.

## Problem

`byo.deployment.extraContainers` (and the declarative `deployment.extraContainers`) render into the translator's pod template and work on the plain Deployment path, but on substrate `buildSandboxAgentActorTemplate` picked out only the kagent container and built a one-element `Containers` slice — every extra container was silently dropped. Nothing fails: the CRD accepts them, the ActorTemplate CRD supports up to ten containers, the sidecars are just gone at runtime.

Concrete case: an agent plus a credential-brokering forward proxy on `127.0.0.1` — on substrate the proxy never starts and the agent loses all outbound API access.

## Fix

Render the pod template's remaining containers as additional ActorTemplate containers, appended after the agent container:

- **Index-based agent lookup** (`findKagentContainerIndex`) — the agent container stays `Containers[0]`, so the durableDir session-store mount (`applyDurableDirSessionStore`) remains agent-private.
- **Image must be digest-pinned** (`pinImageRef`, per container — snapshots key on the image).
- **Command must be explicit** — command and args are concatenated; the combined command must be non-empty (atelet copies `Command` verbatim into the OCI `Process.Args` with no shell and no image-entrypoint fallback).
- **Env is fail-closed**: literals and `secretKeyRef` survive; `envFrom` and any other `valueFrom` source (`configMapKeyRef`, `fieldRef`, ...) are **rejected with a named-container error** instead of silently dropped — a sidecar whose credential source vanished mid-flight is worse than a rejected apply.
- **VolumeMounts are rejected** — ActorTemplate volumes only support the single `durableDir` already consumed by the agent's `/data` session store.
- **HTTP readiness probes map to `Readyz`**, so actor readiness keeps gating on the sidecar; named ports resolve against the extra container's own `containerPorts` (the translator only registers the agent container's `http` port). Resources, container ports, and TCP/exec probes have no ActorTemplate equivalent and are ignored.
- **At most 10 containers** (the CRD's `MaxItems`).
- The extras feed `actorTemplateShapeHash`, so adding/removing a sidecar fans out blue-green to a new template + actors like any spec change.

## Resolution of the two approaches

#2691 contributed the structure (index refactor, Readyz mapping, named-port resolution, 10-container cap, shape-hash assertion); #2750 contributed the fail-closed env policy and the concatenated command/args emptiness check. Two semantic deltas from #2691 as originally written, both toward #2750's stricter behavior:

- `configMapKeyRef`/other `valueFrom` env is now **rejected** rather than silently dropped;
- the command check runs on the **concatenated** command+args, so an args-only sidecar is accepted instead of being required to set `command`.

Scoped to the SandboxAgent path; the AgentHarness substrate path has no extra-container field today. Based on the current `release/v0.10.x` tip (both earlier PRs were behind).

## Testing

- `TestBuildSandboxAgentActorTemplateExtraContainers`: happy path (command/args concat, literal + `secretKeyRef` env, agent stays container 0 with the durableDir mount, readyz mapped, no mounts), named readiness-port resolution, and the failure modes (unpinned image, missing command/args, `envFrom`, `configMapKeyRef`, `fieldRef`, volume mounts, unresolvable named port, >10 containers) — plus the shape-hash template-name change.
- `go test ./core/pkg/sandboxbackend/...` green (4 packages), `go vet` clean.