### PR TITLE
fix(translator): honour a BYO harness's configured PORT so the card and runtime agree

### DIFF
--- a/go/core/internal/translator/byo/compiler.go
+++ b/go/core/internal/translator/byo/compiler.go
@@ -13,6 +13,7 @@ import (
 	v2translator "github.com/kagent-dev/kagent/go/core/internal/translator"
 	"github.com/kagent-dev/kagent/go/core/internal/translator/adkconfig"
 	"istio.io/istio/pkg/kube/krt"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // Compiler translates resolved inputs into a BYO A2A runtime revision.
@@ -38,7 +39,7 @@ func (c *Compiler) Compile(ctx context.Context, input *v2translator.HarnessInput
 	if err != nil {
 		return nil, fmt.Errorf("convert agent card: %w", err)
 	}
-	environment := adkconfig.DedupeEnv(append(compiled.Environment, adkconfig.HarnessEnvironment(harness)...))
+	environment := adkconfig.DedupeEnv(append(append(compiled.Environment, adkconfig.HarnessEnvironment(harness)...), corev1.EnvVar{Name: "PORT", Value: "80"}))
 	provenance, err := c.config.BuildProvenance(ctx, harness, compiled.Templates, compiled.Models, environment)
 	if err != nil {
 		return nil, fmt.Errorf("build revision provenance: %w", err)

--- a/go/core/internal/translator/byo/compiler.go
+++ b/go/core/internal/translator/byo/compiler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 
 	a2atype "github.com/a2aproject/a2a-go/v2/a2a"
@@ -15,6 +16,24 @@ import (
 	"istio.io/istio/pkg/kube/krt"
 	corev1 "k8s.io/api/core/v1"
 )
+
+// defaultPort is injected only when the harness configures no usable PORT.
+const defaultPort = "80"
+
+// configuredPort returns the port the harness configured for itself via PORT.
+func configuredPort(environment []corev1.EnvVar) (string, bool) {
+	for i := len(environment) - 1; i >= 0; i-- {
+		if environment[i].Name != "PORT" {
+			continue
+		}
+		port, err := strconv.Atoi(environment[i].Value)
+		if err != nil || port < 1 || port > 65535 {
+			return "", false
+		}
+		return environment[i].Value, true
+	}
+	return "", false
+}
 
 // Compiler translates resolved inputs into a BYO A2A runtime revision.
 type Compiler struct{ config *adkconfig.Builder }
@@ -35,11 +54,16 @@ func (c *Compiler) Compile(ctx context.Context, input *v2translator.HarnessInput
 	if err != nil {
 		return nil, fmt.Errorf("marshal agent config: %w", err)
 	}
-	card, err := pbconv.ToProtoAgentCard(agentTemplateCard(template))
+	environment := adkconfig.DedupeEnv(append(compiled.Environment, adkconfig.HarnessEnvironment(harness)...))
+	port, ok := configuredPort(environment)
+	if !ok {
+		port = defaultPort
+		environment = adkconfig.DedupeEnv(append(environment, corev1.EnvVar{Name: "PORT", Value: defaultPort}))
+	}
+	card, err := pbconv.ToProtoAgentCard(agentTemplateCard(template, port))
 	if err != nil {
 		return nil, fmt.Errorf("convert agent card: %w", err)
 	}
-	environment := adkconfig.DedupeEnv(append(append(compiled.Environment, adkconfig.HarnessEnvironment(harness)...), corev1.EnvVar{Name: "PORT", Value: "80"}))
 	provenance, err := c.config.BuildProvenance(ctx, harness, compiled.Templates, compiled.Models, environment)
 	if err != nil {
 		return nil, fmt.Errorf("build revision provenance: %w", err)
@@ -59,10 +83,10 @@ func (c *Compiler) Compile(ctx context.Context, input *v2translator.HarnessInput
 	}}, nil
 }
 
-func agentTemplateCard(template *v1alpha3.AgentTemplate) *a2atype.AgentCard {
+func agentTemplateCard(template *v1alpha3.AgentTemplate, port string) *a2atype.AgentCard {
 	return &a2atype.AgentCard{
 		Name: strings.ReplaceAll(template.Name, "-", "_"), Description: template.Spec.Description, Version: "v1",
-		SupportedInterfaces: []*a2atype.AgentInterface{{URL: "http://127.0.0.1:80", ProtocolBinding: a2atype.TransportProtocolGRPC, ProtocolVersion: a2atype.Version}},
+		SupportedInterfaces: []*a2atype.AgentInterface{{URL: fmt.Sprintf("http://127.0.0.1:%s", port), ProtocolBinding: a2atype.TransportProtocolGRPC, ProtocolVersion: a2atype.Version}},
 		Capabilities:        a2atype.AgentCapabilities{Streaming: true}, Skills: []a2atype.AgentSkill{},
 		DefaultInputModes: []string{"text"}, DefaultOutputModes: []string{"text"},
 	}

--- a/go/core/internal/translator/byo/compiler_test.go
+++ b/go/core/internal/translator/byo/compiler_test.go
@@ -43,7 +43,7 @@ func TestCompileOpaqueImage(t *testing.T) {
 	require.True(t, revision.AgentCard.GetCapabilities().GetStreaming())
 }
 
-func TestCompileInjectsPortMatchingAgentCard(t *testing.T) {
+func TestCompilePortResolution(t *testing.T) {
 	compile := func(t *testing.T, env []v1alpha3.HarnessEnvVar) *v2translator.CompileResult {
 		t.Helper()
 		harness := &v1alpha3.Harness{ObjectMeta: metav1.ObjectMeta{Name: "byo", Namespace: "test"}, Spec: v1alpha3.HarnessSpec{
@@ -75,11 +75,29 @@ func TestCompileInjectsPortMatchingAgentCard(t *testing.T) {
 		return ""
 	}
 
+	portValues := func(env []corev1.EnvVar) []string {
+		var values []string
+		for _, v := range env {
+			if v.Name == "PORT" {
+				values = append(values, v.Value)
+			}
+		}
+		return values
+	}
+
 	revision := compile(t, nil)
 	require.Equal(t, "80", envValue(t, revision.Environment, "PORT"))
+	require.Equal(t, []string{"80"}, portValues(revision.Environment))
 	require.Len(t, revision.AgentCard.GetSupportedInterfaces(), 1)
 	require.Equal(t, "http://127.0.0.1:80", revision.AgentCard.GetSupportedInterfaces()[0].GetUrl())
 
-	override := compile(t, []v1alpha3.HarnessEnvVar{{Name: "PORT", Value: new("8080")}})
-	require.Equal(t, "80", envValue(t, override.Environment, "PORT"))
+	custom := compile(t, []v1alpha3.HarnessEnvVar{{Name: "PORT", Value: new("8080")}})
+	require.Equal(t, []string{"8080"}, portValues(custom.Environment))
+	require.Len(t, custom.AgentCard.GetSupportedInterfaces(), 1)
+	require.Equal(t, "http://127.0.0.1:8080", custom.AgentCard.GetSupportedInterfaces()[0].GetUrl())
+
+	invalid := compile(t, []v1alpha3.HarnessEnvVar{{Name: "PORT", Value: new("banana")}})
+	require.Equal(t, []string{"80"}, portValues(invalid.Environment))
+	require.Len(t, invalid.AgentCard.GetSupportedInterfaces(), 1)
+	require.Equal(t, "http://127.0.0.1:80", invalid.AgentCard.GetSupportedInterfaces()[0].GetUrl())
 }

--- a/go/core/internal/translator/byo/compiler_test.go
+++ b/go/core/internal/translator/byo/compiler_test.go
@@ -34,11 +34,52 @@ func TestCompileOpaqueImage(t *testing.T) {
 	require.Equal(t, harness.Spec.Workload.Command, revision.Command)
 	require.Equal(t, harness.Spec.Workload.Args, revision.Args)
 	require.Empty(t, revision.EgressDestinations)
-	require.Equal(t, []corev1.EnvVar{{Name: "MODE", Value: "production"}}, revision.Environment)
+	require.Equal(t, []corev1.EnvVar{{Name: "MODE", Value: "production"}, {Name: "PORT", Value: "80"}}, revision.Environment)
 
 	var config adk.AgentConfig
 	require.NoError(t, json.Unmarshal(revision.ConfigJSON, &config))
 	require.Nil(t, config.Model)
 	require.Equal(t, "be helpful", config.Instruction)
 	require.True(t, revision.AgentCard.GetCapabilities().GetStreaming())
+}
+
+func TestCompileInjectsPortMatchingAgentCard(t *testing.T) {
+	compile := func(t *testing.T, env []v1alpha3.HarnessEnvVar) *v2translator.CompileResult {
+		t.Helper()
+		harness := &v1alpha3.Harness{ObjectMeta: metav1.ObjectMeta{Name: "byo", Namespace: "test"}, Spec: v1alpha3.HarnessSpec{
+			BYO:      &v1alpha3.BYOHarness{},
+			Workload: v1alpha3.HarnessWorkload{Image: "example.com/agent@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+			Env:      env,
+			Substrate: v1alpha3.HarnessSubstratePolicy{
+				WorkerPoolRef: corev1.LocalObjectReference{Name: "default"}, SnapshotPolicy: v1alpha3.HarnessSnapshotPolicy{Location: "snapshots"},
+			},
+		}}
+		template := &v1alpha3.AgentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "custom-agent", Namespace: "test"}, Spec: v1alpha3.AgentTemplateSpec{
+			Description: "custom A2A agent", SystemPrompt: "be helpful",
+		}}
+
+		revision, err := NewCompiler(krt.TestingDummyContext{}, v2translator.Collections{}).Compile(context.Background(), &v2translator.HarnessInput{
+			Harness: harness, Root: &v2translator.AgentInput{Template: template, Instruction: template.Spec.SystemPrompt},
+		})
+		require.NoError(t, err)
+		return revision
+	}
+	envValue := func(t *testing.T, env []corev1.EnvVar, name string) string {
+		t.Helper()
+		for _, v := range env {
+			if v.Name == name {
+				return v.Value
+			}
+		}
+		t.Fatalf("env var %q not found in %v", name, env)
+		return ""
+	}
+
+	revision := compile(t, nil)
+	require.Equal(t, "80", envValue(t, revision.Environment, "PORT"))
+	require.Len(t, revision.AgentCard.GetSupportedInterfaces(), 1)
+	require.Equal(t, "http://127.0.0.1:80", revision.AgentCard.GetSupportedInterfaces()[0].GetUrl())
+
+	override := compile(t, []v1alpha3.HarnessEnvVar{{Name: "PORT", Value: new("8080")}})
+	require.Equal(t, "80", envValue(t, override.Environment, "PORT"))
 }


### PR DESCRIPTION
### What

The `byo` harness compiler advertised the agent card at `http://127.0.0.1:80` while injecting no `PORT`, so a BYO image built with `go/adk/pkg/app` listened on its `8080` default, reported `READY`, and then failed every invoke.

The port is now taken from the harness's own configuration: whatever `PORT` the harness sets in `spec.env` is what both the runtime receives and the card advertises. `PORT=80` is only injected when the harness configures no usable port.

### Why

`go/core/internal/translator/byo/compiler.go` built the card with a hard-coded `http://127.0.0.1:80`, but its environment was only `compiled.Environment` plus `adkconfig.HarnessEnvironment(harness)`. `go/adk/pkg/app` resolves the listen port as `cfg.Port` -> `PORT` env -> default `8080`, so the card and the runtime disagreed. Readiness is probed on `:8081` independently of `PORT`, so nothing surfaced the mismatch and the instance stayed `READY` while unreachable.

BYO is an opaque harness, so the compiler must not force a port it cannot know (review feedback on this PR). At the same time the card and the runtime must not be able to disagree, so the advertised port is derived from the environment that is actually rendered.

### How

- Build the environment as `adkconfig.DedupeEnv(compiled.Environment + HarnessEnvironment(harness))`.
- `configuredPort` reads the last `PORT` entry in that environment (the same last-wins semantics `DedupeEnv` uses). A value in `1..65535` is the harness's port, and nothing is injected.
- Otherwise the default `80` is appended, matching the built-in `kagent` compiler for an unconfigured BYO harness.
- `agentTemplateCard` now takes the resolved port and builds `http://127.0.0.1:<port>`.
- Environment is resolved before `BuildProvenance` so the provenance hashes the same environment that ships.

No API or CRD change.

### Tests

- `TestCompilePortResolution` covers: no `PORT` -> exactly one `PORT=80` and card `http://127.0.0.1:80`; `spec.env PORT=8080` -> exactly one `PORT=8080` and card `http://127.0.0.1:8080`; `PORT=banana` -> falls back to exactly one `PORT=80` and card `http://127.0.0.1:80`.
- `TestCompileOpaqueImage` unchanged in intent.
- `cd go && go test ./core/internal/translator/byo/...` passes; `cd go && go build ./...` passes; `gofmt -l` clean.
- Mutation check: pinning `configuredPort` to always report "not configured" makes the `PORT=8080` case fail, so the regression test guards the behaviour rather than the implementation.

This change was implemented with AI assistance (OpenCode + muse-spark 1.3) and reviewed and verified locally; I understand it and take responsibility for it.

Fixes #2758
