### PR TITLE
chore: upgrade Substrate to v0.0.29

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
       - setup
     env:
       VERSION: v0.0.1-test
-      SUBSTRATE_VERSION: 0.0.26
+      SUBSTRATE_VERSION: 0.0.29
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     steps:

--- a/go/core/internal/a2agateway/runtime.go
+++ b/go/core/internal/a2agateway/runtime.go
@@ -12,6 +12,7 @@ import (
 	"github.com/a2aproject/a2a-go/v2/a2aext"
 	a2agrpc "github.com/a2aproject/a2a-go/v2/a2agrpc/v1"
 	apiv1alpha1 "github.com/kagent-dev/kagent/go/api/gen/kagent/api/v1alpha1"
+	"github.com/kagent-dev/kagent/go/core/internal/substrate"
 	"github.com/kagent-dev/kagent/go/core/pkg/auth"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel/propagation"
@@ -31,7 +32,7 @@ type RuntimeDialer struct {
 }
 
 // NewRuntimeDialer configures private A2A gRPC calls through Substrate's
-// shared Atenet router; the selected Actor is carried only in :authority.
+// shared Atenet router; ate-target-actor selects the Actor.
 func NewRuntimeDialer(routerURL string, authenticator auth.AuthProvider) (*RuntimeDialer, error) {
 	router, err := url.Parse(routerURL)
 	if err != nil {
@@ -56,8 +57,9 @@ func NewRuntimeDialer(routerURL string, authenticator auth.AuthProvider) (*Runti
 }
 
 func (d *RuntimeDialer) Dial(ctx context.Context, instance *apiv1alpha1.AgentInstance) (*a2aclient.Client, error) {
-	if instance.GetA2AAuthority() == "" {
-		return nil, fmt.Errorf("runtime authority is empty")
+	targetActor, err := substrate.ActorTargetFromHost(instance.GetA2AAuthority())
+	if err != nil {
+		return nil, err
 	}
 	// ponytail: scope one connection to one public RPC until gateway traffic
 	// justifies a lifecycle-aware per-instance connection pool.
@@ -68,12 +70,11 @@ func (d *RuntimeDialer) Dial(ctx context.Context, instance *apiv1alpha1.AgentIns
 	}},
 		a2agrpc.WithGRPCTransport(
 			grpc.WithTransportCredentials(d.transport),
-			grpc.WithAuthority(instance.GetA2AAuthority()),
 			grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
 		),
 		a2aclient.WithCallInterceptors(
 			a2aext.NewClientPropagator(nil),
-			&upstreamAuthInterceptor{authenticator: d.authenticator, instance: instance},
+			&upstreamAuthInterceptor{authenticator: d.authenticator, instance: instance, targetActor: targetActor},
 		),
 	)
 }
@@ -85,6 +86,7 @@ type upstreamAuthInterceptor struct {
 	a2aclient.PassthroughInterceptor
 	authenticator auth.AuthProvider
 	instance      *apiv1alpha1.AgentInstance
+	targetActor   string
 }
 
 func (u *upstreamAuthInterceptor) Before(ctx context.Context, req *a2aclient.Request) (context.Context, any, error) {
@@ -104,5 +106,6 @@ func (u *upstreamAuthInterceptor) Before(ctx context.Context, req *a2aclient.Req
 			req.ServiceParams.Append(key, value)
 		}
 	}
+	req.ServiceParams["ate-target-actor"] = []string{u.targetActor}
 	return ctx, nil, nil
 }

--- a/go/core/internal/a2agateway/runtime_test.go
+++ b/go/core/internal/a2agateway/runtime_test.go
@@ -1,0 +1,78 @@
+package a2agateway
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	a2atype "github.com/a2aproject/a2a-go/v2/a2a"
+	a2apb "github.com/a2aproject/a2a-go/v2/a2apb/v1"
+	apiv1alpha1 "github.com/kagent-dev/kagent/go/api/gen/kagent/api/v1alpha1"
+	"github.com/kagent-dev/kagent/go/core/internal/substrate"
+	"github.com/kagent-dev/kagent/go/core/pkg/auth"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+type runtimeTestAuth struct{ auth.AuthProvider }
+
+func (runtimeTestAuth) UpstreamAuth(req *http.Request, _ auth.Session, _ auth.Principal) error {
+	req.Header.Set("Authorization", "Bearer runtime-test")
+	req.Header.Set("ate-target-actor", "wrong/actor")
+	return nil
+}
+
+func TestRuntimeDialerRoutesUnaryAndStreamingCalls(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	received := make(chan metadata.MD, 2)
+	observe := func(ctx context.Context) error {
+		md, _ := metadata.FromIncomingContext(ctx)
+		received <- md
+		return status.Error(codes.Unimplemented, "routing observed")
+	}
+	server := grpc.NewServer(
+		grpc.UnaryInterceptor(func(ctx context.Context, _ any, _ *grpc.UnaryServerInfo, _ grpc.UnaryHandler) (any, error) {
+			return nil, observe(ctx)
+		}),
+		grpc.StreamInterceptor(func(_ any, stream grpc.ServerStream, _ *grpc.StreamServerInfo, _ grpc.StreamHandler) error {
+			return observe(stream.Context())
+		}),
+	)
+	a2apb.RegisterA2AServiceServer(server, &a2apb.UnimplementedA2AServiceServer{})
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(server.Stop)
+	dialer, err := NewRuntimeDialer("http://"+listener.Addr().String(), runtimeTestAuth{})
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	ctx = auth.AuthSessionTo(ctx, auth.ControlPlaneSession{})
+	client, err := dialer.Dial(ctx, &apiv1alpha1.AgentInstance{
+		Id: "instance", A2AAuthority: substrate.ActorHost("team", "ai-instance", ""),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Destroy()) })
+
+	_, err = client.GetTask(ctx, &a2atype.GetTaskRequest{ID: "task"})
+	require.Error(t, err)
+	for _, err := range client.SendStreamingMessage(ctx, &a2atype.SendMessageRequest{
+		Message: a2atype.NewMessage(a2atype.MessageRoleUser, a2atype.NewTextPart("hello")),
+	}) {
+		require.Error(t, err)
+	}
+	for range 2 {
+		select {
+		case md := <-received:
+			require.Equal(t, []string{"team/ai-instance"}, md.Get("ate-target-actor"))
+			require.Equal(t, []string{"Bearer runtime-test"}, md.Get("authorization"))
+			require.Equal(t, []string{listener.Addr().String()}, md.Get(":authority"))
+		case <-ctx.Done():
+			t.Fatal("runtime did not receive both calls")
+		}
+	}
+}

--- a/go/core/internal/grpcserver/scheduledrun_controller_test.go
+++ b/go/core/internal/grpcserver/scheduledrun_controller_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kagent-dev/kagent/go/core/internal/controller/scheduledrun"
 	"github.com/kagent-dev/kagent/go/core/internal/database"
 	authimpl "github.com/kagent-dev/kagent/go/core/internal/httpserver/auth"
+	"github.com/kagent-dev/kagent/go/core/internal/substrate"
 	"github.com/kagent-dev/kagent/go/core/pkg/auth"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -52,7 +53,7 @@ func (w *scheduledControllerWorkflow) Create(ctx context.Context, instance *apiv
 	next := proto.CloneOf(instance)
 	next.State = apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_READY
 	next.Operation = apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_UNSPECIFIED
-	next.A2AAuthority = "scheduled-runtime.test"
+	next.A2AAuthority = substrate.ActorHost("team", substrate.ActorName(instance.GetId()), "")
 	return w.store.TransitionAgentInstance(ctx, next,
 		apiv1alpha1.AgentInstanceState_AGENT_INSTANCE_STATE_CREATING,
 		apiv1alpha1.AgentInstanceOperation_AGENT_INSTANCE_OPERATION_CREATE)

--- a/go/core/internal/substrate/gateway.go
+++ b/go/core/internal/substrate/gateway.go
@@ -1,14 +1,32 @@
 package substrate
 
-// DefaultAtenetRouterURL is the in-cluster HTTP endpoint for Substrate's Envoy router.
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+// DefaultAtenetRouterURL is the in-cluster HTTP endpoint for Substrate's router.
 const DefaultAtenetRouterURL = "http://atenet-router.ate-system.svc:80"
 
 const defaultActorHostSuffix = "actors.resources.substrate.ate.dev"
 
-// ActorHost returns the atenet-router Host header value for an actor.
+// ActorHost returns the logical A2A authority stored for an actor.
 func ActorHost(atespace, actorID, suffix string) string {
 	if suffix == "" {
 		suffix = defaultActorHostSuffix
 	}
 	return actorID + "." + atespace + "." + suffix
+}
+
+// ActorTargetFromHost converts a stored A2A authority to Substrate's
+// ate-target-actor header value. The authority itself is no longer routable.
+func ActorTargetFromHost(authority string) (string, error) {
+	name, ok := strings.CutSuffix(authority, "."+defaultActorHostSuffix)
+	actor, atespace, hasAtespace := strings.Cut(name, ".")
+	if !ok || !hasAtespace || len(validation.IsDNS1123Label(actor)) != 0 || len(validation.IsDNS1123Label(atespace)) != 0 {
+		return "", fmt.Errorf("invalid runtime authority %q", authority)
+	}
+	return atespace + "/" + actor, nil
 }

--- a/go/core/internal/substrate/gateway_test.go
+++ b/go/core/internal/substrate/gateway_test.go
@@ -1,9 +1,40 @@
 package substrate
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestActorHost(t *testing.T) {
 	if got := ActorHost("kagent", "actor-1", ""); got != "actor-1.kagent.actors.resources.substrate.ate.dev" {
 		t.Fatalf("ActorHost() = %q", got)
+	}
+}
+
+func TestActorTargetFromHost(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		authority string
+		want      string
+	}{
+		{name: "actor", authority: ActorHost("kagent", "actor-1", ""), want: "kagent/actor-1"},
+		{name: "empty"},
+		{name: "wrong suffix", authority: "actor-1.kagent.example.com"},
+		{name: "missing actor", authority: ActorHost("kagent", "", "")},
+		{name: "missing atespace", authority: ActorHost("", "actor-1", "")},
+		{name: "extra label", authority: ActorHost("kagent.extra", "actor-1", "")},
+		{name: "invalid actor", authority: ActorHost("kagent", "actor/other", "")},
+		{name: "invalid atespace", authority: ActorHost("kagent/other", "actor-1", "")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ActorTargetFromHost(tc.authority)
+			if tc.want == "" {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
 	}
 }

--- a/go/go.mod
+++ b/go/go.mod
@@ -487,4 +487,4 @@ require (
 
 tool sigs.k8s.io/kube-api-linter/cmd/golangci-lint-kube-api-linter
 
-replace github.com/agent-substrate/substrate => github.com/kagent-dev/substrate v0.0.26
+replace github.com/agent-substrate/substrate => github.com/kagent-dev/substrate v0.0.29

--- a/go/go.sum
+++ b/go/go.sum
@@ -697,8 +697,8 @@ github.com/kagent-dev/mockllm v0.0.7 h1:ofucOQKKqarRICBjxJFKIpxD7NQOjVuA0Frujh96
 github.com/kagent-dev/mockllm v0.0.7/go.mod h1:tDLemRsTZa1NdHaDbg3sgFk9cT1QWvMPlBtLVD6I2mA=
 github.com/kagent-dev/mockmcp v0.0.0-20260520211643-dcd475b74085 h1:5bYxRc6K6+JiFMYGSJpQ7y18PzTGXUmUtVXY7Fqh0Ew=
 github.com/kagent-dev/mockmcp v0.0.0-20260520211643-dcd475b74085/go.mod h1:vTMste7c+XiDOQyhe6iGPKLbMy3chY/h2fL3Dox5fAE=
-github.com/kagent-dev/substrate v0.0.26 h1:oJSerQTvPSHj72FOfi8VK+DVZgRP0kPh1DcUlaxwJds=
-github.com/kagent-dev/substrate v0.0.26/go.mod h1:WBkGfDCbVFbtJTEMpIIbq59yEgko1L4WHJIEVGBdems=
+github.com/kagent-dev/substrate v0.0.29 h1:C3eJHV80M6DnKBIMpU+HJ/VoLYNN8GIjSWcBckA/ZZc=
+github.com/kagent-dev/substrate v0.0.29/go.mod h1:WBkGfDCbVFbtJTEMpIIbq59yEgko1L4WHJIEVGBdems=
 github.com/karamaru-alpha/copyloopvar v1.2.2 h1:yfNQvP9YaGQR7VaWLYcfZUlRP2eo2vhExWKxD/fP6q0=
 github.com/karamaru-alpha/copyloopvar v1.2.2/go.mod h1:oY4rGZqZ879JkJMtX3RRkcXRkmUvH0x35ykgaKgsgJY=
 github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRtuthU=

--- a/scripts/setup-cluster/setup-cluster.sh
+++ b/scripts/setup-cluster/setup-cluster.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 
 # The repo this script lives in, so it works from any checkout and any directory.
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-SUBSTRATE_VERSION=0.0.26
+SUBSTRATE_VERSION=0.0.29
 cd "$REPO"
 
 step() { printf '\n\033[1;36m==> %s\033[0m\n' "$1"; }
@@ -21,7 +21,7 @@ step "2/10  kubectl-ate, the tool that mints the CA and JWT pools"
 # This one runs on *this* machine rather than in the cluster, so it follows the host OS.
 OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
 HOSTARCH="$(uname -m)"; [ "$HOSTARCH" = "x86_64" ] && HOSTARCH=amd64; [ "$HOSTARCH" = "aarch64" ] && HOSTARCH=arm64
-ATE="/tmp/kubectl-ate-v${SUBSTRATE_VERSION}"
+ATE="${TMPDIR:-/var/tmp}/kubectl-ate-v${SUBSTRATE_VERSION}"
 if [ ! -x "$ATE" ]; then
   curl -fsSL -o "$ATE" \
     "https://github.com/kagent-dev/substrate/releases/download/v${SUBSTRATE_VERSION}/kubectl-ate-${OS}-${HOSTARCH}"


### PR DESCRIPTION
Upgrade Substrate from v0.0.26 to v0.0.29 in the Go dependency, CI, and local cluster setup. Helm dependencies inherit the version from go.mod. The setup script also respects TMPDIR for the versioned kubectl-ate download.

Substrate now routes actor ingress using `ate-target-actor` instead of HTTP `:authority`. Translate the stored A2A authority into `<atespace>/<actor>` for every private A2A call and let the connection use the router's authority. Reject malformed authorities and cover unary and streaming requests, authentication forwarding, and routing-header replacement.

Validation:

- `go test -race -skip 'TestE2E.*' ./...` passed, including PostgreSQL tests.
- `make -C go lint` passed with zero issues.
- `make helm-version`, all 285 kagent Helm tests, and chart lint with Substrate disabled and enabled passed.
- Setup-script syntax and `git diff --check` passed.

Cluster E2E was not run locally; no installed kagent cluster was available.
