### PR TITLE
feat(ui): delete a checkpoint from the chat, beside Fork

### DIFF
--- a/ui/playwright/tests/chat/chat-fork.spec.ts
+++ b/ui/playwright/tests/chat/chat-fork.spec.ts
@@ -133,7 +133,7 @@ test("chat: a checkpoint is deleted from the chat, and stays deleted", async ({ 
 
   await test.step("asks before deleting, and cancelling leaves both", async () => {
     await page.getByTestId(`chat-checkpoint-delete-${id}`).click();
-    await expect(page.getByText("Delete this checkpoint?")).toBeVisible();
+    await expect(page.getByText("Remove this checkpoint?")).toBeVisible();
     await page.getByRole("button", { name: "Cancel" }).click();
     await expect(dividers(page)).toHaveCount(2);
   });

--- a/ui/playwright/tests/chat/chat-fork.spec.ts
+++ b/ui/playwright/tests/chat/chat-fork.spec.ts
@@ -106,6 +106,53 @@ test("chat: a fork does not inherit the marks of the page it was made from", asy
   await expect(dividers(page)).toHaveCount(0);
 });
 
+/*
+ * Deleting a boundary, and the reload that proves it.
+ *
+ * The line on screen is drawn from two sources — the controller's list and what this
+ * page has saved since it loaded — so a delete that dropped only the first would leave
+ * the line up until a reload, and one that dropped only the second would bring it back
+ * on the next read. The reload here is what tells those two apart.
+ */
+test("chat: a checkpoint is deleted from the chat, and stays deleted", async ({ page }) => {
+  await page.goto(agentChat(instances.ready));
+  const mine = page.locator('[data-testid="chat-message"][data-role="user"]');
+  await expect(mine.first()).toBeVisible({ timeout: 30_000 });
+
+  // A second boundary, so the delete has to remove one line rather than all of them.
+  await page.getByTestId("chat-input").fill("A second turn, to save a second boundary at.");
+  await page.getByTestId("chat-send").click();
+  await expect(mine).toHaveCount(2, { timeout: 30_000 });
+  await page.getByTestId("chat-checkpoint").click();
+  await expect(dividers(page)).toHaveCount(2);
+
+  // The seeded line, not the new one: the newest sits against the composer, where the
+  // "Checkpoint saved" toast covers it.
+  const doomed = await dividers(page).first().getAttribute("data-testid");
+  const id = (doomed ?? "").replace("chat-checkpoint-mark-", "");
+
+  await test.step("asks before deleting, and cancelling leaves both", async () => {
+    await page.getByTestId(`chat-checkpoint-delete-${id}`).click();
+    await expect(page.getByText("Delete this checkpoint?")).toBeVisible();
+    await page.getByRole("button", { name: "Cancel" }).click();
+    await expect(dividers(page)).toHaveCount(2);
+  });
+
+  await test.step("confirming takes that line and leaves the other", async () => {
+    await page.getByTestId(`chat-checkpoint-delete-${id}`).click();
+    await page.getByTestId(`chat-checkpoint-delete-confirm-${id}`).click();
+    await expect(page.getByTestId(`chat-checkpoint-mark-${id}`)).toHaveCount(0);
+    await expect(dividers(page)).toHaveCount(1);
+  });
+
+  await test.step("and the reload agrees: the boundary is gone from the backend", async () => {
+    await page.reload();
+    await expect(mine).toHaveCount(2, { timeout: 30_000 });
+    await expect(dividers(page)).toHaveCount(1);
+    await expect(page.getByTestId(`chat-checkpoint-mark-${id}`)).toHaveCount(0);
+  });
+});
+
 test("chat: a conversation is duplicated from the rail menu, and the copy opens", async ({
   page,
 }) => {

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -251,6 +251,8 @@ export interface AgentInstancesApi {
     list(id: string, options?: ReadOptions): Promise<Checkpoint[]>;
     create(id: string): Promise<Checkpoint>;
     fork(checkpointId: string, name?: string): Promise<AgentInstance>;
+    /** Releases the snapshot a boundary was holding. Forks already made keep theirs. */
+    remove(checkpointId: string): Promise<void>;
   };
 
   /**
@@ -384,6 +386,8 @@ export function createApiClient(): KagentApiClient {
             requestId: crypto.randomUUID(),
             name,
           }),
+        remove: (checkpointId) =>
+          invoke("agentInstances.checkpoints.delete", { checkpointId }),
       },
       shares: {
         list: (id, options) =>

--- a/ui/src/api/grpc/operations.ts
+++ b/ui/src/api/grpc/operations.ts
@@ -680,6 +680,7 @@ const agentInstances: Pick<
   | "agentInstances.checkpoints.create"
   | "agentInstances.checkpoints.list"
   | "agentInstances.checkpoints.fork"
+  | "agentInstances.checkpoints.delete"
   | "agentInstances.shares.list"
   | "agentInstances.shares.create"
   | "agentInstances.shares.revoke"
@@ -842,6 +843,15 @@ const agentInstances: Pick<
     const instance = toAgentInstance(required(forked.agentInstance, name, "forked agent instance"));
     if (!input.name) return instance;
     return agentInstances["agentInstances.rename"]({ id: instance.id, name: input.name }, options);
+  },
+
+  "agentInstances.checkpoints.delete": async (input, options) => {
+    await rpc("CheckpointService/DeleteCheckpoint", options.signal, () =>
+      serviceClient(CheckpointService).deleteCheckpoint(
+        { checkpointId: input.checkpointId },
+        call("agentInstances.checkpoints.delete", options),
+      ),
+    );
   },
 
   /*

--- a/ui/src/api/operations.ts
+++ b/ui/src/api/operations.ts
@@ -253,6 +253,18 @@ export interface OperationMap {
   };
 
   /**
+   * Removes a saved boundary, and with it the snapshot it was holding.
+   *
+   * A checkpoint pins a copy of the conversation's runtime in the substrate — that is
+   * what makes forking one possible — so this is the only thing that gives that space
+   * back. Forks already made from it are unaffected: they own their own copy.
+   */
+  "agentInstances.checkpoints.delete": {
+    input: { checkpointId: string };
+    output: void;
+  };
+
+  /**
    * Forks a saved boundary: a new conversation holding the transcript up to it.
    *
    * Unlike `agentInstances.fork` this starts from a boundary saved earlier, so the

--- a/ui/src/components/chat/ChatComposer.tsx
+++ b/ui/src/components/chat/ChatComposer.tsx
@@ -165,13 +165,13 @@ export function ChatComposer({
 
       <Space size={8}>
         {onCheckpoint ? (
-          <Tooltip title="Checkpoint this chat">
+          <Tooltip title="Create a checkpoint. Checkpoints can be used to fork a chat from a previous point in the chat history.">
             {/* Icon only: the box beside it is the point of this row, and a second
                 labelled button took enough width from it to wrap the placeholder and
                 grow the whole composer by a line. */}
             <Button
               data-testid="chat-checkpoint"
-              aria-label="Checkpoint this chat"
+              aria-label="Create a checkpoint. Checkpoints can be used to fork a chat from a previous point in the chat history."
               icon={<Save size={14} />}
               loading={isCheckpointing}
               disabled={disabled || isStreaming || !canCheckpoint}

--- a/ui/src/components/chat/ChatTranscript.tsx
+++ b/ui/src/components/chat/ChatTranscript.tsx
@@ -49,11 +49,14 @@ export function ChatTranscript({
   sessionId,
   onAnswered,
   onFork,
+  onDeleteCheckpoint,
   checkpointByMessage,
 }: {
   chat: ChatController;
   /** Forks a saved boundary. Absent when read-only. */
   onFork?: (checkpointId: string) => void;
+  /** Removes a saved boundary. Absent when read-only. */
+  onDeleteCheckpoint?: (checkpointId: string) => void;
   /** Which boundary each message sits inside, for the messages that sit inside one. */
   checkpointByMessage?: ReadonlyMap<string, string>;
   /**
@@ -347,6 +350,7 @@ export function ChatTranscript({
                 <CheckpointDivider
                   checkpointId={checkpointId}
                   onFork={onFork && (() => onFork(checkpointId))}
+                  onDelete={onDeleteCheckpoint && (() => onDeleteCheckpoint(checkpointId))}
                 />
               </div>,
             );

--- a/ui/src/components/chat/ChatTranscript.tsx
+++ b/ui/src/components/chat/ChatTranscript.tsx
@@ -24,6 +24,13 @@ const EMPTY_CHECKPOINTS: ReadonlyMap<string, string> = new Map();
 const CHECKPOINT_GAP = 4;
 
 /**
+ * Less below than above, because below it is not the only space there is: the
+ * transcript's own gap to the next message sits under this one, and the two together
+ * read as a hole in the conversation rather than a division in it.
+ */
+const CHECKPOINT_GAP_BELOW = 2;
+
+/**
  * Turn phases worth naming on screen. The rest are transient enough to skip.
  *
  * Keyed on the machine's phase rather than on the A2A task state, which is what
@@ -344,7 +351,7 @@ export function ChatTranscript({
                   // conversation from the box used to continue it.
                   marginBlockStart: theme.space(CHECKPOINT_GAP),
                   marginBlockEnd:
-                    index === groups.length - 1 ? 0 : theme.space(CHECKPOINT_GAP),
+                    index === groups.length - 1 ? 0 : theme.space(CHECKPOINT_GAP_BELOW),
                 }}
               >
                 <CheckpointDivider

--- a/ui/src/components/chat/CheckpointDivider.tsx
+++ b/ui/src/components/chat/CheckpointDivider.tsx
@@ -1,5 +1,5 @@
 import { Button, Popconfirm, Tooltip, Typography } from "antd";
-import { GitFork, Save, Trash2 } from "lucide-react";
+import { Eraser, GitFork, Save } from "lucide-react";
 import { useTheme } from "@emotion/react";
 
 const { Text } = Typography;
@@ -35,6 +35,12 @@ export function CheckpointDivider({
     paddingInline: theme.space(2),
     background: "transparent",
   } as const;
+  const rule = (
+    <span
+      aria-hidden
+      css={{ width: 14, height: 1, background: theme.color.primaryText, opacity: 0.4 }}
+    />
+  );
 
   return (
     <div
@@ -72,68 +78,73 @@ export function CheckpointDivider({
           word — the tooltip says where from, so the line stays a line. */}
       {onFork || onDelete ? (
         <>
-          {/* The rule carrying on between the two, so the mark and the control read as
-              two things on one line rather than a label with a button stuck to it. */}
-          <span
-            aria-hidden
-            css={{
-              width: 14,
-              height: 1,
-              background: theme.color.primaryText,
-              opacity: 0.4,
-            }}
-          />
+          {/* The rule carrying on between each pair, so the mark and the controls read
+              as things on one line rather than a label with buttons stuck to it. */}
+          {rule}
           {onFork ? (
-            <Tooltip title="Fork the chat from this checkpoint">
+            <Tooltip title="Fork the chat from this checkpoint" placement="bottom">
               <Button
                 size="small"
                 data-testid={`chat-checkpoint-fork-${checkpointId}`}
                 aria-label="Fork the chat from this checkpoint"
+                type="primary"
                 icon={<GitFork size={13} />}
                 onClick={onFork}
                 css={{
                   ...control,
-                  color: theme.color.primaryText,
-                  borderColor: theme.color.primaryText,
+                  background: theme.color.primary,
+                  color: theme.color.textOnPrimary,
+                  borderColor: theme.color.primary,
                   "&:hover, &:focus-visible": {
-                    color: theme.color.primaryText,
-                    borderColor: theme.color.primaryText,
-                    background: theme.color.accentBg,
+                    background: theme.color.primaryHover,
+                    borderColor: theme.color.primaryHover,
+                    color: theme.color.textOnPrimary,
                   },
-                  "&:active": { background: theme.color.accentBg, opacity: 0.85 },
+                  "&:active": { background: theme.color.primaryHover, opacity: 0.85 },
                 }}
               >
                 Fork
               </Button>
             </Tooltip>
           ) : null}
+          {onFork && onDelete ? rule : null}
           {/* Confirmed, because the snapshot behind the boundary goes with it and
               nothing brings it back. */}
           {onDelete ? (
             <Popconfirm
-              title="Delete this checkpoint?"
-              description="The snapshot behind it goes too. Chats already forked from it keep working."
+              title="Remove this checkpoint?"
+              description="The snapshot behind it will be deleted. This chat history and chat sessions already forked from here will be kept."
               // Capped, or the one line of copy sets the popover's width and it spans
               // half the transcript.
               overlayStyle={{ maxWidth: 300 }}
-              okText="Delete"
+              okText="Remove"
               okButtonProps={{
-                danger: true,
                 "data-testid": `chat-checkpoint-delete-confirm-${checkpointId}`,
               }}
               cancelText="Cancel"
               onConfirm={onDelete}
             >
-              <Tooltip title="Delete this checkpoint">
+              <Tooltip title="Remove this checkpoint. This deletes the associated snapshot." placement="bottom">
                 <Button
                   size="small"
-                  danger
                   data-testid={`chat-checkpoint-delete-${checkpointId}`}
-                  aria-label="Delete this checkpoint"
-                  icon={<Trash2 size={13} />}
-                  css={control}
+                  aria-label="Remove this checkpoint. This deletes the associated snapshot."
+                  icon={<Eraser size={13} />}
+                  // Outlined against Fork's fill: forking is what the line is for, and
+                  // this is the one that takes something away.
+                  css={{
+                    ...control,
+                    color: theme.color.primaryText,
+                    borderColor: theme.color.primaryText,
+                    "&:hover, &:focus-visible": {
+                      color: theme.color.primaryText,
+                      borderColor: theme.color.primaryText,
+                      background: theme.color.accentBg,
+                    },
+                    "&:active": { background: theme.color.accentBg, opacity: 0.85 },
+                  }}
                 >
-                  Delete
+                  Remove
                 </Button>
               </Tooltip>
             </Popconfirm>

--- a/ui/src/components/chat/CheckpointDivider.tsx
+++ b/ui/src/components/chat/CheckpointDivider.tsx
@@ -1,5 +1,5 @@
-import { Button, Tooltip, Typography } from "antd";
-import { GitFork, Save } from "lucide-react";
+import { Button, Popconfirm, Tooltip, Typography } from "antd";
+import { GitFork, Save, Trash2 } from "lucide-react";
 import { useTheme } from "@emotion/react";
 
 const { Text } = Typography;
@@ -18,12 +18,23 @@ const { Text } = Typography;
 export function CheckpointDivider({
   checkpointId,
   onFork,
+  onDelete,
 }: {
   checkpointId: string;
   /** Forks this boundary. Absent on a read-only surface, which leaves the line alone. */
   onFork?: () => void;
+  /** Removes this boundary. Absent on a read-only surface, as `onFork` is. */
+  onDelete?: () => void;
 }) {
   const theme = useTheme();
+  // The two controls are drawn the same way, so the line does not read as one button
+  // with something else bolted beside it.
+  const control = {
+    height: 24,
+    fontSize: 12,
+    paddingInline: theme.space(2),
+    background: "transparent",
+  } as const;
 
   return (
     <div
@@ -59,7 +70,7 @@ export function CheckpointDivider({
       {/* Outlined, and named: on the line beside the label a bare icon left what it
           does to a hover, and a filled button pulled the eye off the conversation. One
           word — the tooltip says where from, so the line stays a line. */}
-      {onFork ? (
+      {onFork || onDelete ? (
         <>
           {/* The rule carrying on between the two, so the mark and the control read as
               two things on one line rather than a label with a button stuck to it. */}
@@ -72,31 +83,61 @@ export function CheckpointDivider({
               opacity: 0.4,
             }}
           />
-          <Tooltip title="Fork the chat from this checkpoint">
-            <Button
-              size="small"
-              data-testid={`chat-checkpoint-fork-${checkpointId}`}
-              aria-label="Fork the chat from this checkpoint"
-              icon={<GitFork size={13} />}
-              onClick={onFork}
-              css={{
-                height: 24,
-                fontSize: 12,
-                paddingInline: theme.space(2),
-                color: theme.color.primaryText,
-                borderColor: theme.color.primaryText,
-                background: "transparent",
-                "&:hover, &:focus-visible": {
+          {onFork ? (
+            <Tooltip title="Fork the chat from this checkpoint">
+              <Button
+                size="small"
+                data-testid={`chat-checkpoint-fork-${checkpointId}`}
+                aria-label="Fork the chat from this checkpoint"
+                icon={<GitFork size={13} />}
+                onClick={onFork}
+                css={{
+                  ...control,
                   color: theme.color.primaryText,
                   borderColor: theme.color.primaryText,
-                  background: theme.color.accentBg,
-                },
-                "&:active": { background: theme.color.accentBg, opacity: 0.85 },
+                  "&:hover, &:focus-visible": {
+                    color: theme.color.primaryText,
+                    borderColor: theme.color.primaryText,
+                    background: theme.color.accentBg,
+                  },
+                  "&:active": { background: theme.color.accentBg, opacity: 0.85 },
+                }}
+              >
+                Fork
+              </Button>
+            </Tooltip>
+          ) : null}
+          {/* Confirmed, because the snapshot behind the boundary goes with it and
+              nothing brings it back. */}
+          {onDelete ? (
+            <Popconfirm
+              title="Delete this checkpoint?"
+              description="The snapshot behind it goes too. Chats already forked from it keep working."
+              // Capped, or the one line of copy sets the popover's width and it spans
+              // half the transcript.
+              overlayStyle={{ maxWidth: 300 }}
+              okText="Delete"
+              okButtonProps={{
+                danger: true,
+                "data-testid": `chat-checkpoint-delete-confirm-${checkpointId}`,
               }}
+              cancelText="Cancel"
+              onConfirm={onDelete}
             >
-              Fork
-            </Button>
-          </Tooltip>
+              <Tooltip title="Delete this checkpoint">
+                <Button
+                  size="small"
+                  danger
+                  data-testid={`chat-checkpoint-delete-${checkpointId}`}
+                  aria-label="Delete this checkpoint"
+                  icon={<Trash2 size={13} />}
+                  css={control}
+                >
+                  Delete
+                </Button>
+              </Tooltip>
+            </Popconfirm>
+          ) : null}
         </>
       ) : null}
     </div>

--- a/ui/src/components/chat/CheckpointDivider.tsx
+++ b/ui/src/components/chat/CheckpointDivider.tsx
@@ -113,7 +113,7 @@ export function CheckpointDivider({
           {onDelete ? (
             <Popconfirm
               title="Remove this checkpoint?"
-              description="The snapshot behind it will be deleted. This chat history and chat sessions already forked from here will be kept."
+              description="The snapshot for this checkpoint will be deleted. Chat history and sessions already forked from here will be kept."
               // Capped, or the one line of copy sets the popover's width and it spans
               // half the transcript.
               overlayStyle={{ maxWidth: 300 }}

--- a/ui/src/components/chat/CheckpointDivider.tsx
+++ b/ui/src/components/chat/CheckpointDivider.tsx
@@ -82,11 +82,11 @@ export function CheckpointDivider({
               as things on one line rather than a label with buttons stuck to it. */}
           {rule}
           {onFork ? (
-            <Tooltip title="Fork the chat from this checkpoint" placement="bottom">
+            <Tooltip title="Fork the chat from this checkpoint." placement="bottom">
               <Button
                 size="small"
                 data-testid={`chat-checkpoint-fork-${checkpointId}`}
-                aria-label="Fork the chat from this checkpoint"
+                aria-label="Fork the chat from this checkpoint."
                 type="primary"
                 icon={<GitFork size={13} />}
                 onClick={onFork}

--- a/ui/src/mocks/mockBackend.test.ts
+++ b/ui/src/mocks/mockBackend.test.ts
@@ -21,7 +21,7 @@ import type { OperationId, OperationInput } from "@/api/operations";
 import { setApiTransport } from "@/api/transport";
 import { mockTransport } from "./transport";
 import { MOCK_INSTANCE_CREATOR } from "./fixtures";
-import { SEEDED_CHECKPOINT } from "./state";
+import { DISPOSABLE_CHECKPOINT, SEEDED_CHECKPOINT } from "./state";
 
 beforeAll(() => setApiTransport(mockTransport));
 afterAll(() => setApiTransport(undefined));
@@ -217,6 +217,9 @@ const INPUTS = {
     requestId: "fixture-suite-checkpoint-fork",
     name: "Forked from a checkpoint by the fixture suite",
   },
+
+  // The disposable boundary: deleting the seeded one would race the fork case above.
+  "agentInstances.checkpoints.delete": { checkpointId: DISPOSABLE_CHECKPOINT.id },
 
   "namespaces.list": {},
   "substrate.status": {},

--- a/ui/src/mocks/state.ts
+++ b/ui/src/mocks/state.ts
@@ -462,18 +462,66 @@ export const SEEDED_CHECKPOINT: MockCheckpoint = {
   createdAt: "2025-01-04T10:15:00Z",
 };
 
-const checkpoints: MockCheckpoint[] = [SEEDED_CHECKPOINT];
+/**
+ * A second seeded boundary, there to be deleted.
+ *
+ * On another conversation, so deleting it races nothing that forks the seeded one —
+ * the fixture suite runs every operation at once.
+ */
+export const DISPOSABLE_CHECKPOINT: MockCheckpoint = {
+  id: "8c2d9f14-6b03-4e77-90a5-1c7e3b8d2f60",
+  agentInstanceId: "2b6e0c45-8a71-4f39-9d02-3c85f1a7e6d0",
+  headTaskId: "seed-task-2",
+  createdAt: "2025-01-04T10:20:00Z",
+};
+
+/**
+ * Kept in `sessionStorage`, beside the transcripts.
+ *
+ * A module array would have brought a deleted boundary back on reload while the
+ * controller keeps it gone — the fixture contradicting what it stands in for. `null`
+ * means "never written", so a tab that has deleted the seeded rows keeps them deleted.
+ */
+const CHECKPOINTS_KEY = "kagent.mock.checkpoints";
+
+function readAll(): MockCheckpoint[] {
+  try {
+    const stored = window.sessionStorage.getItem(CHECKPOINTS_KEY);
+    if (stored === null) return [SEEDED_CHECKPOINT, DISPOSABLE_CHECKPOINT];
+    return JSON.parse(stored) as MockCheckpoint[];
+  } catch {
+    return [];
+  }
+}
+
+function writeAll(rows: MockCheckpoint[]): void {
+  try {
+    window.sessionStorage.setItem(CHECKPOINTS_KEY, JSON.stringify(rows));
+  } catch {
+    // Storage can be refused; the list is then whatever this load seeded, which is
+    // the same answer as a tab that has saved nothing.
+  }
+}
 
 /** Every boundary saved against one conversation. */
 export function readCheckpoints(agentInstanceId: string): MockCheckpoint[] {
-  return checkpoints.filter((row) => row.agentInstanceId === agentInstanceId);
+  return readAll().filter((row) => row.agentInstanceId === agentInstanceId);
 }
 
 export function checkpointById(id: string): MockCheckpoint | undefined {
-  return checkpoints.find((row) => row.id === id);
+  return readAll().find((row) => row.id === id);
 }
 
 export function saveCheckpoint(row: MockCheckpoint): MockCheckpoint {
-  checkpoints.push(row);
+  writeAll([...readAll(), row]);
   return row;
+}
+
+/** Removes one, the way `DeleteCheckpoint` releases the snapshot it was holding. */
+export function deleteCheckpoint(id: string): boolean {
+  const rows = readAll();
+  const kept = rows.filter((row) => row.id !== id);
+  if (kept.length === rows.length) return false;
+  writeAll(kept);
+  return true;
 }

--- a/ui/src/mocks/transport.ts
+++ b/ui/src/mocks/transport.ts
@@ -139,6 +139,7 @@ import {
   savePrompt,
   saveToolServer,
   checkpointById,
+  deleteCheckpoint,
   readCheckpoints,
   saveCheckpoint,
 } from "./state";
@@ -969,6 +970,11 @@ on(CheckpointService.method.createCheckpoint, (input, call) => {
     createdAt: new Date().toISOString(),
   });
   return { checkpoint: checkpointMessage(checkpoint) };
+});
+
+on(CheckpointService.method.deleteCheckpoint, (input) => {
+  if (!deleteCheckpoint(input.checkpointId)) throw notFound(`Checkpoint ${input.checkpointId}`);
+  return {};
 });
 
 on(CheckpointService.method.listCheckpoints, (input, call) => {

--- a/ui/src/pages/AgentChatPage.tsx
+++ b/ui/src/pages/AgentChatPage.tsx
@@ -259,6 +259,37 @@ export function AgentChatPage() {
   }, [id, chat.messages, checkpoints]);
 
   /*
+   * Removes a saved boundary.
+   *
+   * The mark this page holds for it goes too: `savedHere` is what draws the line for
+   * a boundary saved since the page loaded, so leaving it would keep the line on
+   * screen over a checkpoint the controller no longer has.
+   */
+  const deleteCheckpoint = useCallback(
+    async (checkpointId: string) => {
+      try {
+        await apiClient.agentInstances.checkpoints.remove(checkpointId);
+        setSavedHere((current) => ({
+          conversation: current.conversation,
+          marks: new Map([...current.marks].filter(([, saved]) => saved !== checkpointId)),
+        }));
+        toast.success("Checkpoint deleted");
+      } catch (cause: unknown) {
+        const reason = cause instanceof Error ? cause.message : String(cause);
+        console.error("Could not delete the checkpoint:", cause);
+        toast.error(`Could not delete: ${reason}`);
+        return;
+      }
+      try {
+        await checkpoints.refresh();
+      } catch (cause: unknown) {
+        console.error("Could not re-read the saved boundaries:", cause);
+      }
+    },
+    [checkpoints],
+  );
+
+  /*
    * A new conversation holding the transcript up to a saved boundary, which is then
    * opened. Forking the same boundary again is allowed and makes another one.
    */
@@ -685,6 +716,7 @@ export function AgentChatPage() {
             chat={chat}
             sessionId={id}
             onFork={forkCheckpoint}
+            onDeleteCheckpoint={deleteCheckpoint}
             checkpointByMessage={checkpointByMessage}
             // The question is answered in a field inside the transcript, and once it
             // has been, the next thing typed is an ordinary message. The transcript


### PR DESCRIPTION
---
*🤖 written by Claude (start)*

A checkpoint's line now carries `Delete` beside `Fork`, behind a confirmation. Deleting releases the snapshot that checkpoint pins; chats already forked from it keep working.

UI only — `CheckpointService/DeleteCheckpoint` already existed, so this wires it through the api layer and the fixture backend. Mock checkpoints move to `sessionStorage`, so a deletion in mock mode survives a reload the way the controller's does.

## Testing

1. `ENABLE_MOCK_UI=true yarn dev`, open a conversation, and save two checkpoints a turn apart.
2. Press `Delete` on the earlier line and confirm. That line goes; the other stays.
3. Reload. The deleted line does not come back.

---
*🤖 written by Claude (end)*
