### PR TITLE
fix(adk): return tool errors to model

### DIFF
--- a/python/packages/kagent-adk/src/kagent/adk/_a2a.py
+++ b/python/packages/kagent-adk/src/kagent/adk/_a2a.py
@@ -36,6 +36,7 @@ from ._agent_executor import A2aAgentExecutor, A2aAgentExecutorConfig
 from ._lifespan import LifespanManager
 from ._memory_service import KagentMemoryService
 from ._token import KAgentTokenService
+from ._tool_error_plugin import ToolErrorPlugin
 from .types import AgentConfig
 
 logger = logging.getLogger(__name__)
@@ -86,7 +87,9 @@ class KAgentApp:
         self.app_name = app_name
         self.agent_card = agent_card
         self._lifespan = lifespan
-        self.plugins = plugins if plugins is not None else []
+        # Custom handlers get the first chance to recover. The final fallback turns
+        # unhandled tool errors into responses the model can reason about.
+        self.plugins = [*(plugins or []), ToolErrorPlugin()]
         self.stream = stream
         self.agent_config = agent_config
 
@@ -248,9 +251,9 @@ class KAgentApp:
         )
 
         root_agent = self.root_agent_factory()
+        adk_app = App(name=self.app_name, root_agent=root_agent, plugins=self.plugins)
         runner = Runner(
-            agent=root_agent,
-            app_name=self.app_name,
+            app=adk_app,
             session_service=session_service,
             artifact_service=InMemoryArtifactService(),
         )

--- a/python/packages/kagent-adk/src/kagent/adk/_tool_error_plugin.py
+++ b/python/packages/kagent-adk/src/kagent/adk/_tool_error_plugin.py
@@ -1,0 +1,23 @@
+"""Convert tool failures into responses that an agent can reason about."""
+
+from typing import Any
+
+from google.adk.plugins import BasePlugin
+from google.adk.tools import BaseTool, ToolContext
+
+
+class ToolErrorPlugin(BasePlugin):
+    """Return tool errors to the model instead of aborting the turn."""
+
+    def __init__(self):
+        super().__init__(name="tool_error")
+
+    async def on_tool_error_callback(
+        self,
+        *,
+        tool: BaseTool,
+        tool_args: dict[str, Any],
+        tool_context: ToolContext,
+        error: Exception,
+    ) -> dict[str, Any]:
+        return {"error": str(error)}

--- a/python/packages/kagent-adk/tests/unittests/test_tool_error_plugin.py
+++ b/python/packages/kagent-adk/tests/unittests/test_tool_error_plugin.py
@@ -1,0 +1,67 @@
+from unittest.mock import MagicMock
+
+import pytest
+from google.adk.agents import LlmAgent
+from google.adk.agents.invocation_context import InvocationContext
+from google.adk.flows.llm_flows import functions
+from google.adk.plugins import BasePlugin
+from google.adk.plugins.plugin_manager import PluginManager
+from google.adk.sessions import InMemorySessionService
+from google.genai import types
+
+from kagent.adk import KAgentApp
+from kagent.adk._tool_error_plugin import ToolErrorPlugin
+
+
+@pytest.mark.asyncio
+async def test_tool_error_is_returned_to_model():
+    plugin = ToolErrorPlugin()
+
+    result = await plugin.on_tool_error_callback(
+        tool=MagicMock(),
+        tool_args={},
+        tool_context=MagicMock(),
+        error=ValueError("Tool 'missing' not found"),
+    )
+
+    assert result == {"error": "Tool 'missing' not found"}
+
+
+@pytest.mark.asyncio
+async def test_unknown_tool_produces_function_response():
+    session_service = InMemorySessionService()
+    session = await session_service.create_session(app_name="test-app", user_id="user", session_id="session")
+    agent = LlmAgent(name="test_agent")
+    invocation_context = InvocationContext(
+        session_service=session_service,
+        invocation_id="invocation",
+        agent=agent,
+        session=session,
+        plugin_manager=PluginManager([ToolErrorPlugin()]),
+    )
+
+    event = await functions._execute_single_function_call_async(
+        invocation_context,
+        types.FunctionCall(name="missing", args={}),
+        {},
+        agent,
+    )
+
+    assert event is not None
+    response = event.content.parts[0].function_response.response
+    assert response["error"].startswith("Tool 'missing' not found")
+
+
+def test_tool_error_fallback_runs_after_custom_plugins():
+    custom_plugin = BasePlugin(name="custom")
+
+    app = KAgentApp(
+        root_agent_factory=MagicMock(),
+        agent_card=MagicMock(),
+        kagent_api_url="http://unused",
+        app_name="test-app",
+        plugins=[custom_plugin],
+    )
+
+    assert app.plugins[0] is custom_plugin
+    assert isinstance(app.plugins[1], ToolErrorPlugin)


### PR DESCRIPTION
## Summary

- add a fallback ADK plugin that returns unhandled tool errors to the model as structured function responses
- preserve custom tool error handlers by running the fallback last
- use the configured plugin set in local CLI test runs as well as served agents
- add coverage for unknown tool calls and plugin ordering

Fixes #2794

## Testing

- `ruff format --check`
- `ruff check`
- `pytest packages/kagent-adk/tests -q` (404 passed, 1 skipped)