### PR TITLE
feat(helm): add OCI source annotations

### DIFF
--- a/helm/kagent-crds/Chart-template.yaml
+++ b/helm/kagent-crds/Chart-template.yaml
@@ -3,6 +3,8 @@ name: kagent-crds
 description: CRDs for kagent
 type: application
 version: ${VERSION}
+annotations:
+  "org.opencontainers.image.source": "https://github.com/kagent-dev/kagent"
 dependencies:
   - name: kmcp-crds
     version: ${KMCP_VERSION}

--- a/helm/kagent/Chart-template.yaml
+++ b/helm/kagent/Chart-template.yaml
@@ -3,6 +3,8 @@ name: kagent
 description: A Helm chart for kagent, built with Google ADK
 type: application
 version: ${VERSION}
+annotations:
+  "org.opencontainers.image.source": "https://github.com/kagent-dev/kagent"
 dependencies:
   - name: kmcp
     version: ${KMCP_VERSION}


### PR DESCRIPTION
Adds OCI source annotations to the kagent and kagent-crds Helm chart templates. Validated through YAML parsing, Helm packaging, and helm show chart. Closes #2628 